### PR TITLE
feat(whatsapp): get contact profile picture when using Baileys service

### DIFF
--- a/app/services/whatsapp/baileys_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_upsert.rb
@@ -1,4 +1,4 @@
-module Whatsapp::BaileysHandlers::MessagesUpsert
+module Whatsapp::BaileysHandlers::MessagesUpsert # rubocop:disable Metrics/ModuleLength
   include Whatsapp::BaileysHandlers::Helpers
   include BaileysHelper
 
@@ -44,17 +44,31 @@ module Whatsapp::BaileysHandlers::MessagesUpsert
   def set_contact
     push_name = contact_name
     source_id = phone_number_from_jid
+    profile_pic_url = fetch_profile_picture_url(source_id)
     contact_inbox = ::ContactInboxWithContactBuilder.new(
       # FIXME: update the source_id to complete jid in future
       source_id: source_id,
       inbox: inbox,
-      contact_attributes: { name: push_name, phone_number: "+#{source_id}" }
+      contact_attributes: {
+        name: push_name,
+        phone_number: "+#{source_id}",
+        avatar_url: profile_pic_url
+      }
     ).perform
 
     @contact_inbox = contact_inbox
     @contact = contact_inbox.contact
 
-    @contact.update!(name: push_name) if @contact.name == source_id
+    @contact.update!(name: push_name) if @contact&.name == source_id
+  end
+
+  def fetch_profile_picture_url(phone_number)
+    jid = "#{phone_number}@s.whatsapp.net"
+    response = inbox.channel.provider_service.get_profile_pic(jid)
+    response&.dig('data', 'profilePictureUrl')
+  rescue StandardError => e
+    Rails.logger.error "Failed to fetch profile picture for #{phone_number}: #{e.message}"
+    nil
   end
 
   def handle_create_message

--- a/app/services/whatsapp/baileys_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_upsert.rb
@@ -44,22 +44,18 @@ module Whatsapp::BaileysHandlers::MessagesUpsert # rubocop:disable Metrics/Modul
   def set_contact
     push_name = contact_name
     source_id = phone_number_from_jid
-    profile_pic_url = fetch_profile_picture_url(source_id)
     contact_inbox = ::ContactInboxWithContactBuilder.new(
       # FIXME: update the source_id to complete jid in future
       source_id: source_id,
       inbox: inbox,
-      contact_attributes: {
-        name: push_name,
-        phone_number: "+#{source_id}",
-        avatar_url: profile_pic_url
-      }
+      contact_attributes: { name: push_name, phone_number: "+#{source_id}" }
     ).perform
 
     @contact_inbox = contact_inbox
     @contact = contact_inbox.contact
 
     @contact.update!(name: push_name) if @contact&.name == source_id
+    try_update_contact_avatar
   end
 
   def fetch_profile_picture_url(phone_number)
@@ -69,6 +65,13 @@ module Whatsapp::BaileysHandlers::MessagesUpsert # rubocop:disable Metrics/Modul
   rescue StandardError => e
     Rails.logger.error "Failed to fetch profile picture for #{phone_number}: #{e.message}"
     nil
+  end
+
+  def try_update_contact_avatar
+    return if @contact.avatar.attached?
+
+    profile_pic_url = fetch_profile_picture_url(phone_number_from_jid)
+    ::Avatar::AvatarFromUrlJob.perform_later(@contact, profile_pic_url) if profile_pic_url
   end
 
   def handle_create_message

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -87,7 +87,11 @@ class Whatsapp::IncomingMessageBaseService
     contact_inbox = ::ContactInboxWithContactBuilder.new(
       source_id: waid,
       inbox: inbox,
-      contact_attributes: { name: contact_params.dig(:profile, :name), phone_number: "+#{@processed_params[:messages].first[:from]}" }
+      contact_attributes: {
+        name: contact_params.dig(:profile, :name),
+        phone_number: "+#{@processed_params[:messages].first[:from]}",
+        avatar_url: contact_params.dig(:profile, :avatar_url)
+      }
     ).perform
 
     @contact_inbox = contact_inbox

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -189,6 +189,21 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     true
   end
 
+  def get_profile_pic(jid)
+    response = HTTParty.get(
+      "#{provider_url}/connections/#{whatsapp_channel.phone_number}/profile-pic",
+      headers: api_headers,
+      query: { jid: jid }
+    )
+
+    return nil unless process_response(response)
+
+    JSON.parse(response.body)
+  rescue JSON::ParserError => e
+    Rails.logger.error "Failed to parse profile pic response: #{e.message}"
+    nil
+  end
+
   def on_whatsapp(phone_number)
     @phone_number = phone_number
 

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -146,6 +146,8 @@ describe Whatsapp::IncomingMessageBaileysService do
     end
 
     context 'when processing messages.upsert event' do
+      before { stub_profile_pic_fetch }
+
       let(:timestamp) { Time.current.to_i }
       let(:raw_message) do
         {
@@ -166,14 +168,20 @@ describe Whatsapp::IncomingMessageBaileysService do
         }
       end
 
-      it 'creates message with external_created_at' do
+      it 'creates message with external_created_at and processes avatar' do
+        stub_avatar_job
+
         described_class.new(inbox: inbox, params: params).perform
 
         conversation = inbox.conversations.last
         message = conversation.messages.last
+        contact = conversation.contact
 
         expect(message).to be_present
         expect(message.content_attributes[:external_created_at]).to eq(timestamp)
+        expect(contact.name).to eq('John Doe')
+        expect(Avatar::AvatarFromUrlJob).to have_received(:perform_later)
+          .with(contact, 'https://example.com/avatar.jpg')
       end
 
       context 'when message type is unsupported' do
@@ -828,5 +836,17 @@ describe Whatsapp::IncomingMessageBaileysService do
     allow(Down).to receive(:download)
       .with('https://baileys.api/media/msg_123', headers: inbox.channel.api_headers)
       .and_return(StringIO.new('Media data'))
+  end
+
+  def stub_profile_pic_fetch
+    stub_request(:get, /profile-pic/)
+      .to_return(
+        status: 200,
+        body: { data: { profilePictureUrl: 'https://example.com/avatar.jpg' } }.to_json
+      )
+  end
+
+  def stub_avatar_job
+    allow(Avatar::AvatarFromUrlJob).to receive(:perform_later)
   end
 end

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -850,6 +850,83 @@ describe Whatsapp::Providers::WhatsappBaileysService do
     end
   end
 
+  describe '#get_profile_pic' do
+    let(:test_jid) { '551187654321@s.whatsapp.net' }
+
+    context 'when response is successful' do
+      it 'returns parsed JSON response with profile picture URL' do
+        stub_request(:get, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/profile-pic")
+          .with(
+            headers: stub_headers(whatsapp_channel),
+            query: { jid: test_jid }
+          )
+          .to_return(
+            status: 200,
+            body: { data: { profilePictureUrl: 'https://pps.whatsapp.net/v/t61.24694-24/avatar.jpg', jid: test_jid } }.to_json
+          )
+
+        result = service.get_profile_pic(test_jid)
+
+        expect(result).to eq({
+                               'data' => {
+                                 'profilePictureUrl' => 'https://pps.whatsapp.net/v/t61.24694-24/avatar.jpg',
+                                 'jid' => test_jid
+                               }
+                             })
+      end
+
+      it 'returns parsed JSON response when no profile picture exists' do
+        stub_request(:get, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/profile-pic")
+          .with(
+            headers: stub_headers(whatsapp_channel),
+            query: { jid: test_jid }
+          )
+          .to_return(
+            status: 200,
+            body: { data: { jid: test_jid } }.to_json
+          )
+
+        result = service.get_profile_pic(test_jid)
+
+        expect(result).to eq({
+                               'data' => {
+                                 'jid' => test_jid
+                               }
+                             })
+      end
+    end
+
+    context 'when response fails' do
+      it 'returns nil when API returns error status' do
+        stub_request(:get, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/profile-pic")
+          .with(
+            headers: stub_headers(whatsapp_channel),
+            query: { jid: test_jid }
+          )
+          .to_return(status: 400, body: 'Bad Request')
+
+        result = service.get_profile_pic(test_jid)
+
+        expect(result).to be_nil
+      end
+
+      it 'returns nil and logs error when JSON parsing fails' do
+        stub_request(:get, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/profile-pic")
+          .with(
+            headers: stub_headers(whatsapp_channel),
+            query: { jid: test_jid }
+          )
+          .to_return(status: 200, body: 'invalid json')
+
+        expect(Rails.logger).to receive(:error).with(/Failed to parse profile pic response/)
+
+        result = service.get_profile_pic(test_jid)
+
+        expect(result).to be_nil
+      end
+    end
+  end
+
   def stub_headers(channel)
     {
       'Content-Type' => 'application/json',


### PR DESCRIPTION
# Pull Request Template

## Description

Implements support for getting WhatsApp contact profile pictures when using the Baileys service.  

- Retrieve the contact's profile picture during contact creation or update if no avatar is present.
- Update the avatar for both new and existing contact inboxes.

Closes #93  

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Performed manual E2E testing locally by sending and receiving WhatsApp messages to verify avatar creation and updates.
- Added unit tests to ensure contacts get their avatar updated with the profile picture.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
