### PR TITLE
fix: improve handling of empty custom attributes list in settings

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/attributes/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/attributes/Index.vue
@@ -150,8 +150,6 @@ const derivedAttributes = computed(() =>
   <SettingsLayout
     :is-loading="uiFlags.isFetching"
     :loading-message="$t('ATTRIBUTES_MGMT.LOADING')"
-    :no-records-found="!attributes.length"
-    :no-records-message="$t('ATTRIBUTES_MGMT.LIST.EMPTY_RESULT.404')"
   >
     <template #header>
       <BaseSettingsHeader
@@ -177,7 +175,7 @@ const derivedAttributes = computed(() =>
           class="max-w-xl"
           @tab-changed="onClickTabChange"
         />
-        <div class="grid gap-3">
+        <div v-if="derivedAttributes.length" class="grid gap-3">
           <AttributeListItem
             v-for="attribute in derivedAttributes"
             :key="attribute.id"
@@ -187,6 +185,12 @@ const derivedAttributes = computed(() =>
             @delete="handleDeleteAttribute"
           />
         </div>
+        <p
+          v-else
+          class="flex-1 py-20 text-n-slate-12 flex items-center justify-center text-base"
+        >
+          {{ $t('ATTRIBUTES_MGMT.LIST.EMPTY_RESULT.404') }}
+        </p>
       </div>
     </template>
     <AddAttribute


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/171)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-state handling in the attributes settings page. When no attributes exist, a centered empty-state message now displays to guide users, replacing the previous behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->