### PR TITLE
feat(brand): add centralized brand config initializer

### DIFF
--- a/config/initializers/eagletalks_brand.rb
+++ b/config/initializers/eagletalks_brand.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# EagleTalks - Brand Config Central
+# Single source of truth for whitelabel values.
+#
+# Keep changes minimal for easy upstream rebases.
+# Do not reference /enterprise code.
+
+Rails.application.config.x.brand = ActiveSupport::OrderedOptions.new
+
+brand = Rails.application.config.x.brand
+
+brand.name = ENV.fetch("APP_BRAND_NAME", "EagleTalks")
+brand.url = ENV.fetch("APP_BRAND_URL", "https://eagletelecom.cloud")
+brand.support_url = ENV["APP_SUPPORT_URL"].presence || brand.url
+brand.docs_url = ENV["APP_DOCS_URL"].presence
+brand.terms_url = ENV["APP_TERMS_URL"].presence
+brand.privacy_url = ENV["APP_PRIVACY_URL"].presence
+
+brand.hide_powered_by = ActiveModel::Type::Boolean.new.cast(ENV.fetch("APP_HIDE_POWERED_BY", "true"))
+brand.hide_docs_links = ActiveModel::Type::Boolean.new.cast(ENV.fetch("APP_HIDE_DOCS_LINKS", "true"))
+
+brand.email_footer_text = ENV.fetch("APP_EMAIL_FOOTER_TEXT", "#{brand.name} • Eagle Telecom")


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/176)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added centralized brand configuration system supporting name, support/documentation/terms/privacy URLs, email footer text, and visibility toggles for powered-by and documentation links. All settings configurable via environment variables with default values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->