### PR TITLE
fix: Remove `phone_number_id` param from WhatsApp media retrieval for…

### DIFF
--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -10,10 +10,7 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
 
   def download_attachment_file(attachment_payload)
     url_response = HTTParty.get(
-      inbox.channel.media_url(
-        attachment_payload[:id],
-        inbox.channel.provider_config['phone_number_id']
-      ),
+      inbox.channel.media_url(attachment_payload[:id]),
       headers: inbox.channel.api_headers
     )
     # This url response will be failure if the access token has expired.

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -77,10 +77,8 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     csat_template_service.get_template_status(template_name)
   end
 
-  def media_url(media_id, phone_number_id = nil)
-    url = "#{api_base_path}/v13.0/#{media_id}"
-    url += "?phone_number_id=#{phone_number_id}" if phone_number_id
-    url
+  def media_url(media_id)
+    "#{api_base_path}/v13.0/#{media_id}"
   end
 
   def toggle_typing_status(typing_status, last_message:, **)

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -41,10 +41,7 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
       it 'increments reauthorization count if fetching attachment fails' do
         stub_request(
           :get,
-          whatsapp_channel.media_url(
-            'b1c68f38-8734-4ad3-b4a1-ef0c10d683',
-            whatsapp_channel.provider_config['phone_number_id']
-          )
+          whatsapp_channel.media_url('b1c68f38-8734-4ad3-b4a1-ef0c10d683')
         ).to_return(
           status: 401
         )
@@ -112,10 +109,7 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
   def stub_media_url_request
     stub_request(
       :get,
-      whatsapp_channel.media_url(
-        'b1c68f38-8734-4ad3-b4a1-ef0c10d683',
-        whatsapp_channel.provider_config['phone_number_id']
-      )
+      whatsapp_channel.media_url('b1c68f38-8734-4ad3-b4a1-ef0c10d683')
     ).to_return(
       status: 200,
       body: {


### PR DESCRIPTION
… incoming messages (#13319)

Fixes https://github.com/chatwoot/chatwoot/issues/13317 Fixes an issue where WhatsApp attachment messages (images, audio, video, documents) were failing to download. Messages were being created but without attachments.

The `phone_number_id` parameter was being passed to the `GET /<MEDIA_ID>` endpoint when downloading incoming media. According to Meta's documentation:

> "Note that `phone_number_id` is optional. If included, the request
will only be processed if the business phone number ID included in the query matches the ID of the business
  phone number **that the media was uploaded on**."

For incoming messages, media is uploaded by the customer, not by the business phone number. Passing the business's `phone_number_id` causes validation to fail with error: `Param phone_number_id is not a valid whatsapp business phone number id ID`

This PR removes the `phone_number_id` parameter from the media URL request for incoming messages.

# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/192)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined WhatsApp media URL retrieval by simplifying internal parameter handling in the media fetching process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->