### PR TITLE
feat: add localized date format for scheduled messages

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -424,6 +424,7 @@
       "MESSAGE_PLACEHOLDER": "Write your message...",
       "DATETIME_LABEL": "Date and time to send",
       "DATETIME_PLACEHOLDER": "Select date and time",
+      "DATETIME_FORMAT": "MMM D, YYYY h:mm A",
       "ATTACHMENT_LABEL": "Attachment",
       "ATTACHMENT_ADD": "Attach file",
       "ATTACHMENT_CURRENT": "Current attachment: {filename}",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/conversation.json
@@ -423,6 +423,7 @@
       "MESSAGE_PLACEHOLDER": "Escreva sua mensagem...",
       "DATETIME_LABEL": "Data e hora de envio",
       "DATETIME_PLACEHOLDER": "Selecione data e hora",
+      "DATETIME_FORMAT": "D [de] MMM, YYYY HH:mm",
       "ATTACHMENT_LABEL": "Anexo",
       "ATTACHMENT_ADD": "Anexar arquivo",
       "ATTACHMENT_CURRENT": "Anexo atual: {filename}",

--- a/app/javascript/dashboard/routes/dashboard/conversation/scheduledMessages/ScheduledMessageModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/scheduledMessages/ScheduledMessageModal.vue
@@ -544,10 +544,11 @@ watch(
               type="datetime"
               :placeholder="t('SCHEDULED_MESSAGES.MODAL.DATETIME_PLACEHOLDER')"
               :lang="datePickerLang"
-              format="MMM D, YYYY h:mm A"
+              :format="t('SCHEDULED_MESSAGES.MODAL.DATETIME_FORMAT')"
               value-type="date"
               :disabled-date="disablePastDates"
               :show-second="false"
+              editable
               clearable
               append-to-body
               popup-class="z-[10000]"


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/206)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Scheduled message dates and times now display in locale-specific formats for English and Brazilian Portuguese
  * Date/time picker in the Schedule Message modal is now directly editable, streamlining the scheduling workflow for setting precise message times

<!-- end of auto-generated comment: release notes by coderabbit.ai -->