### PR TITLE
fix(whatsapp): include baileys and z-api in multi-attachment split

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -899,10 +899,7 @@ export default {
       }
       if (!this.showMentions) {
         const copilotAcceptedMessage = this.getCopilotAcceptedMessage();
-        const isOnWhatsApp =
-          this.isATwilioWhatsAppChannel ||
-          this.isAWhatsAppCloudChannel ||
-          this.is360DialogWhatsAppChannel;
+        const isOnWhatsApp = this.isAWhatsAppChannel;
         // Instagram and TikTok do not support sending text and attachments in the same message.
         // For Instagram, combining them causes duplicate messages due to separate echo events per component.
         // For TikTok, the API rejects messages that mix text and media.


### PR DESCRIPTION
Corrige o envio de múltiplos attachments via WhatsApp para os providers Baileys e Z-API.

O split de múltiplos attachments no ReplyBox listava explicitamente apenas Twilio, Cloud e 360Dialog. Baileys e Z-API foram adicionados depois e ficaram de fora, fazendo com que attachments extras fossem silenciosamente ignorados. Substituído pelos checks específicos pelo flag genérico `isAWhatsAppChannel`.

Closes #256

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/256)
<!-- Reviewable:end -->
