### PR TITLE
fix(db): include f_unaccent function in schema.rb for test DB setup

### DIFF
--- a/config/initializers/schema_dumper_functions.rb
+++ b/config/initializers/schema_dumper_functions.rb
@@ -1,0 +1,27 @@
+# Extends the Rails schema dumper to include custom SQL functions that are
+# required by indices but not natively supported by schema.rb format.
+#
+# Without this, db:schema:load (used by db:test:prepare) fails because
+# schema.rb references indices that depend on f_unaccent() but the function
+# definition is lost during the dump (schema.rb only captures tables,
+# indices, and extensions, not custom functions).
+module SchemaDumperFunctions
+  private
+
+  def extensions(stream)
+    super
+    dump_custom_functions(stream)
+  end
+
+  def dump_custom_functions(stream)
+    stream.puts
+    stream.puts '  # Custom SQL functions (required before index creation)'
+    stream.puts '  execute <<~SQL'
+    stream.puts '    CREATE OR REPLACE FUNCTION f_unaccent(text)'
+    stream.puts '      RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT'
+    stream.puts "      AS $func$ SELECT public.unaccent('public.unaccent', $1) $func$"
+    stream.puts '  SQL'
+  end
+end
+
+ActiveRecord::SchemaDumper.prepend(SchemaDumperFunctions)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,6 +19,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_10_170003) do
   enable_extension "unaccent"
   enable_extension "vector"
 
+  # Custom SQL functions (required before index creation)
+  execute <<~SQL
+    CREATE OR REPLACE FUNCTION f_unaccent(text)
+      RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+      AS $func$ SELECT public.unaccent('public.unaccent', $1) $func$
+  SQL
+
   create_table "access_tokens", force: :cascade do |t|
     t.string "owner_type"
     t.bigint "owner_id"


### PR DESCRIPTION
The `f_unaccent` SQL function created by the internal chat migration (`20260410170003`) is not natively captured by `schema.rb`, causing `db:test:prepare` to fail when creating indices that depend on it.

This is a known Rails limitation: `schema.rb` format does not support custom SQL functions, only tables, indices, and extensions.

Closes #263

## What changed

- **`db/schema.rb`**: Added `execute` block that creates the `f_unaccent` function right after the extensions are enabled, before any table/index creation.
- **`config/initializers/schema_dumper_functions.rb`**: Extends `ActiveRecord::SchemaDumper` via `prepend` so that future `db:schema:dump` runs (after migrations) automatically include the function definition. Without this, the manual `schema.rb` edit would be lost on the next dump.

## How to reproduce

Run `RAILS_ENV=test rails db:test:prepare` on a fresh test database. Without the fix, it fails with: `PG::UndefinedFunction: ERROR: function f_unaccent(text) does not exist`. With the fix, it succeeds and specs run normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/263)
<!-- Reviewable:end -->
