### PR TITLE
fix(mailer): fall back to user account for devise email locale

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,7 +132,8 @@ class User < ApplicationRecord
   end
 
   def send_devise_notification(notification, *)
-    devise_mailer.with(account: Current.account).send(notification, self, *).deliver_later
+    account = Current.account || accounts.first
+    devise_mailer.with(account: account).send(notification, self, *).deliver_later
   end
 
   def set_password_and_uid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -283,6 +283,33 @@ RSpec.describe User do
     end
   end
 
+  describe '#send_devise_notification' do
+    let(:account) { create(:account, locale: 'pt_BR') }
+    let(:recipient) { create(:user, account: account) }
+    let(:mailer_double) { double(reset_password_instructions: double(deliver_later: nil)) } # rubocop:disable RSpec/VerifiedDoubles
+
+    before do
+      Current.reset
+      allow(Devise::Mailer).to receive(:with).and_return(mailer_double)
+    end
+
+    it 'falls back to the user account when Current.account is nil' do
+      recipient.send_reset_password_instructions
+
+      expect(Devise::Mailer).to have_received(:with).with(account: account)
+    end
+
+    it 'prefers Current.account when it is set' do
+      other_account = create(:account)
+      create(:account_user, user: recipient, account: other_account)
+      Current.account = other_account
+
+      recipient.send_reset_password_instructions
+
+      expect(Devise::Mailer).to have_received(:with).with(account: other_account)
+    end
+  end
+
   describe 'destroy' do
     it 'nullifies scheduled messages author when user has sent scheduled messages' do
       account = create(:account)


### PR DESCRIPTION
Emails transacionais do Devise (reset de senha, desbloqueio, reenvio de confirmação) estavam sendo sempre enviados em inglês, mesmo quando a conta do usuário estava configurada com locale pt_BR. A infra de i18n introduzida no #255 depende de `Current.account` para escolher o locale, mas nos fluxos não autenticados `Current.account` é nil, então o mailer caía em `I18n.default_locale`.

## Closes

N/A (regressão identificada após merge do #255)

## How to reproduce

1. Garanta que uma conta tem `locale: 'pt_BR'`
2. Faça logout
3. Na tela de login, clique em "Esqueci minha senha" e informe o email de um usuário dessa conta
4. Antes do fix: o email chega em inglês. Depois do fix: o email chega em português.

## What changed

- `User#send_devise_notification` agora faz fallback para `accounts.first` quando `Current.account` não está setado, preservando o comportamento existente quando há conta no contexto
- Specs cobrindo os dois caminhos (com e sem `Current.account`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/267)
<!-- Reviewable:end -->
