### PR TITLE
fix(internal-chat): deleted messages and reactions not updating via ActionCable

### DIFF
--- a/app/controllers/api/v1/accounts/internal_chat/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/internal_chat/messages_controller.rb
@@ -40,7 +40,7 @@ class Api::V1::Accounts::InternalChat::MessagesController < Api::V1::Accounts::I
     authorize @message, :destroy?, policy_class: InternalChat::MessagePolicy
     message_data = {
       id: @message.id,
-      channel_id: @message.internal_chat_channel_id,
+      internal_chat_channel_id: @message.internal_chat_channel_id,
       account_id: @message.account_id
     }
     @message.update!(content: I18n.t('internal_chat.messages.deleted'), content_attributes: { deleted: true })

--- a/app/controllers/api/v1/accounts/internal_chat/reactions_controller.rb
+++ b/app/controllers/api/v1/accounts/internal_chat/reactions_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::Accounts::InternalChat::ReactionsController < Api::V1::Accounts::
     reaction_data = {
       id: @reaction.id,
       message_id: @reaction.internal_chat_message_id,
-      channel_id: @message.internal_chat_channel_id,
+      internal_chat_channel_id: @message.internal_chat_channel_id,
       account_id: @message.account_id,
       user_id: @reaction.user_id,
       emoji: @reaction.emoji

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -342,7 +342,7 @@ class ActionCableConnector extends BaseActionCableConnector {
 
   onInternalChatReactionDeleted = data => {
     this.app.$store.dispatch('internalChat/messages/removeReactionFromCable', {
-      channelId: data.internal_chat_channel_id || data.channel_id,
+      channelId: data.internal_chat_channel_id,
       messageId: data.message_id,
       reactionId: data.id,
     });

--- a/app/listeners/internal_chat_listener.rb
+++ b/app/listeners/internal_chat_listener.rb
@@ -24,7 +24,7 @@ class InternalChatListener < BaseListener
   def internal_chat_message_deleted(event)
     message_data = event.data[:message_data]
     account = Account.find_by(id: message_data[:account_id])
-    channel = InternalChat::Channel.find_by(id: message_data[:channel_id])
+    channel = InternalChat::Channel.find_by(id: message_data[:internal_chat_channel_id])
     return if account.blank? || channel.blank?
     return unless channel.account_id == account.id
 
@@ -93,7 +93,7 @@ class InternalChatListener < BaseListener
   def internal_chat_reaction_deleted(event)
     reaction_data = event.data[:reaction_data]
     account = Account.find_by(id: reaction_data[:account_id])
-    channel = InternalChat::Channel.find_by(id: reaction_data[:channel_id])
+    channel = InternalChat::Channel.find_by(id: reaction_data[:internal_chat_channel_id])
     return if account.blank? || channel.blank?
     return unless channel.account_id == account.id
 

--- a/spec/listeners/internal_chat_listener_spec.rb
+++ b/spec/listeners/internal_chat_listener_spec.rb
@@ -148,7 +148,7 @@ describe InternalChatListener do
 
   describe '#internal_chat_message_deleted' do
     let!(:channel) { create(:internal_chat_channel, :public_channel, account: account) }
-    let(:message_data) { { account_id: account.id, channel_id: channel.id, id: 999 } }
+    let(:message_data) { { account_id: account.id, internal_chat_channel_id: channel.id, id: 999 } }
     let!(:event) { Events::Base.new(:'internal_chat.message.deleted', Time.zone.now, message_data: message_data) }
 
     it 'broadcasts to all channel members' do
@@ -157,14 +157,14 @@ describe InternalChatListener do
         'internal_chat.message.deleted',
         hash_including(
           account_id: account.id,
-          channel_id: channel.id
+          internal_chat_channel_id: channel.id
         )
       )
       listener.internal_chat_message_deleted(event)
     end
 
     context 'when account or channel is not found' do
-      let(:message_data) { { account_id: 0, channel_id: 0, id: 999 } }
+      let(:message_data) { { account_id: 0, internal_chat_channel_id: 0, id: 999 } }
 
       it 'does not broadcast' do
         expect(ActionCableBroadcastJob).not_to receive(:perform_later)
@@ -175,7 +175,7 @@ describe InternalChatListener do
     context 'when account and channel belong to different accounts' do
       let(:other_account) { create(:account) }
       let(:other_channel) { create(:internal_chat_channel, :public_channel, account: other_account) }
-      let(:message_data) { { account_id: account.id, channel_id: other_channel.id, id: 999 } }
+      let(:message_data) { { account_id: account.id, internal_chat_channel_id: other_channel.id, id: 999 } }
 
       it 'does not broadcast' do
         expect(ActionCableBroadcastJob).not_to receive(:perform_later)
@@ -186,7 +186,7 @@ describe InternalChatListener do
 
   describe '#internal_chat_reaction_deleted' do
     let!(:channel) { create(:internal_chat_channel, :public_channel, account: account) }
-    let(:reaction_data) { { account_id: account.id, channel_id: channel.id, id: 999 } }
+    let(:reaction_data) { { account_id: account.id, internal_chat_channel_id: channel.id, id: 999 } }
     let!(:event) { Events::Base.new(:'internal_chat.reaction.deleted', Time.zone.now, reaction_data: reaction_data) }
 
     it 'broadcasts to all channel members' do
@@ -195,14 +195,14 @@ describe InternalChatListener do
         'internal_chat.reaction.deleted',
         hash_including(
           account_id: account.id,
-          channel_id: channel.id
+          internal_chat_channel_id: channel.id
         )
       )
       listener.internal_chat_reaction_deleted(event)
     end
 
     context 'when account or channel is not found' do
-      let(:reaction_data) { { account_id: 0, channel_id: 0, id: 999 } }
+      let(:reaction_data) { { account_id: 0, internal_chat_channel_id: 0, id: 999 } }
 
       it 'does not broadcast' do
         expect(ActionCableBroadcastJob).not_to receive(:perform_later)
@@ -213,7 +213,7 @@ describe InternalChatListener do
     context 'when account and channel belong to different accounts' do
       let(:other_account) { create(:account) }
       let(:other_channel) { create(:internal_chat_channel, :public_channel, account: other_account) }
-      let(:reaction_data) { { account_id: account.id, channel_id: other_channel.id, id: 999 } }
+      let(:reaction_data) { { account_id: account.id, internal_chat_channel_id: other_channel.id, id: 999 } }
 
       it 'does not broadcast' do
         expect(ActionCableBroadcastJob).not_to receive(:perform_later)


### PR DESCRIPTION
Fixes a bug in the internal-chat feature where deleting a message or removing a reaction did not update in real time. The UI only refreshed the state after a manual page reload.

## Closes

- Internal bug report: deletions not processed via ActionCable.

## How to reproduce

1. Open two browser sessions (users A and B) in the same internal-chat channel.
2. As user A, send a message; as user B, add a reaction.
3. As user A, delete the message; as user B, remove the reaction.
4. Before the fix: the other session does not update until the page is refreshed.
5. After the fix: the message disappears and the reaction is removed in real time.

## What changed

Backend broadcast payloads for `internal_chat.message.deleted` and `internal_chat.reaction.deleted` used `channel_id`, but the frontend ActionCable handlers (and every other internal-chat event) expect `internal_chat_channel_id`. The mismatch caused the Vuex mutation to short-circuit because `channelId` arrived as `undefined`.

- Rename the key in both delete payloads so they match the convention shared by `message.created/updated` and `reaction.created`.
- Update the listener lookup and specs accordingly.
- Remove the defensive `|| data.channel_id` fallback from the reaction-deleted handler on the frontend, now that the payload is consistent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/270)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized channel identifier naming across internal chat message and reaction handling for improved consistency.

* **Tests**
  * Updated test suite to align with refactored data model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->