### PR TITLE
fix(guides): point FAZER_AI_GUIDES_URL to /#/guides

### DIFF
--- a/app/javascript/dashboard/constants/globals.js
+++ b/app/javascript/dashboard/constants/globals.js
@@ -44,7 +44,7 @@ export default {
     'https://testimonials.cdn.chatwoot.com/testimonial-content.json',
   WHATSAPP_EMBEDDED_SIGNUP_DOCS_URL:
     'https://developers.facebook.com/docs/whatsapp/embedded-signup/custom-flows/onboarding-business-app-users#limitations',
-  FAZER_AI_GUIDES_URL: 'https://app.fazer.ai/#/dashboard#guides',
+  FAZER_AI_GUIDES_URL: 'https://app.fazer.ai/#/guides',
   SMALL_SCREEN_BREAKPOINT: 768,
   AVAILABILITY_STATUS_KEYS: ['online', 'busy', 'offline'],
   SNOOZE_OPTIONS: {


### PR DESCRIPTION
Updates the in-app guides link to the new hub route. The old `/#/dashboard#guides` path still redirects, but fresh installs now open the correct page directly.

## What changed
- `FAZER_AI_GUIDES_URL` now points to `https://app.fazer.ai/#/guides`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/271)
<!-- Reviewable:end -->
