### PR TITLE
fix(conversations): enforce NOT NULL on contact_id + cleanup orphans

### DIFF
--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -30,23 +30,29 @@ class ContactMergeAction
     @account.id == contact.account_id
   end
 
-  # rubocop:disable Rails/SkipsModelValidations
   def merge_conversations
-    Conversation.where(contact_id: @mergee_contact.id).update_all(contact_id: @base_contact.id)
+    Conversation.where(contact_id: @mergee_contact.id).find_each do |conversation|
+      conversation.update!(contact_id: @base_contact.id)
+    end
   end
 
   def merge_contact_notes
-    Note.where(contact_id: @mergee_contact.id, account_id: @mergee_contact.account_id).update_all(contact_id: @base_contact.id)
+    Note.where(contact_id: @mergee_contact.id, account_id: @mergee_contact.account_id).find_each do |note|
+      note.update!(contact_id: @base_contact.id)
+    end
   end
 
   def merge_messages
-    Message.where(sender: @mergee_contact).update_all(sender_type: @base_contact.class.name, sender_id: @base_contact.id)
+    Message.where(sender: @mergee_contact).find_each do |message|
+      message.update!(sender: @base_contact)
+    end
   end
 
   def merge_contact_inboxes
-    ContactInbox.where(contact_id: @mergee_contact.id).update_all(contact_id: @base_contact.id)
+    ContactInbox.where(contact_id: @mergee_contact.id).find_each do |contact_inbox|
+      contact_inbox.update!(contact_id: @base_contact.id)
+    end
   end
-  # rubocop:enable Rails/SkipsModelValidations
 
   def merge_and_remove_mergee_contact
     mergable_attribute_keys = %w[identifier name email phone_number additional_attributes custom_attributes]

--- a/app/actions/contact_merge_action.rb
+++ b/app/actions/contact_merge_action.rb
@@ -30,21 +30,23 @@ class ContactMergeAction
     @account.id == contact.account_id
   end
 
+  # rubocop:disable Rails/SkipsModelValidations
   def merge_conversations
-    Conversation.where(contact_id: @mergee_contact.id).update(contact_id: @base_contact.id)
+    Conversation.where(contact_id: @mergee_contact.id).update_all(contact_id: @base_contact.id)
   end
 
   def merge_contact_notes
-    Note.where(contact_id: @mergee_contact.id, account_id: @mergee_contact.account_id).update(contact_id: @base_contact.id)
+    Note.where(contact_id: @mergee_contact.id, account_id: @mergee_contact.account_id).update_all(contact_id: @base_contact.id)
   end
 
   def merge_messages
-    Message.where(sender: @mergee_contact).update(sender: @base_contact)
+    Message.where(sender: @mergee_contact).update_all(sender_type: @base_contact.class.name, sender_id: @base_contact.id)
   end
 
   def merge_contact_inboxes
-    ContactInbox.where(contact_id: @mergee_contact.id).update(contact_id: @base_contact.id)
+    ContactInbox.where(contact_id: @mergee_contact.id).update_all(contact_id: @base_contact.id)
   end
+  # rubocop:enable Rails/SkipsModelValidations
 
   def merge_and_remove_mergee_contact
     mergable_attribute_keys = %w[identifier name email phone_number additional_attributes custom_attributes]

--- a/app/jobs/conversations/resolution_job.rb
+++ b/app/jobs/conversations/resolution_job.rb
@@ -16,12 +16,10 @@ class Conversations::ResolutionJob < ApplicationJob
   private
 
   def conversation_scope(account)
-    base_scope = if account.auto_resolve_ignore_waiting
-                   account.conversations.resolvable_not_waiting(account.auto_resolve_after)
-                 else
-                   account.conversations.resolvable_all(account.auto_resolve_after)
-                 end
-    # Exclude orphan conversations where contact was deleted but conversation cleanup is pending
-    base_scope.where.not(contact_id: nil)
+    if account.auto_resolve_ignore_waiting
+      account.conversations.resolvable_not_waiting(account.auto_resolve_after)
+    else
+      account.conversations.resolvable_all(account.auto_resolve_after)
+    end
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -24,7 +24,7 @@
 #  assignee_agent_bot_id  :bigint
 #  assignee_id            :integer
 #  campaign_id            :bigint
-#  contact_id             :bigint
+#  contact_id             :bigint           not null
 #  contact_inbox_id       :bigint
 #  display_id             :integer          not null
 #  inbox_id               :integer          not null

--- a/db/migrate/20260422170000_enforce_contact_fk_on_conversations.rb
+++ b/db/migrate/20260422170000_enforce_contact_fk_on_conversations.rb
@@ -1,27 +1,19 @@
 class EnforceContactFkOnConversations < ActiveRecord::Migration[7.1]
   def up
-    orphan_count = select_value(<<~SQL.squish).to_i
-      SELECT COUNT(*) FROM conversations
-      WHERE contact_id IS NULL
-         OR NOT EXISTS (SELECT 1 FROM contacts WHERE contacts.id = conversations.contact_id)
-    SQL
+    orphan_scope = Conversation.where(contact_id: nil).or(
+      Conversation.where('NOT EXISTS (SELECT 1 FROM contacts WHERE contacts.id = conversations.contact_id)')
+    )
 
-    if orphan_count.positive?
-      say "Deleting #{orphan_count} orphan conversations (contact_id NULL or pointing to missing contact)"
-      execute <<~SQL.squish
-        DELETE FROM conversations
-        WHERE contact_id IS NULL
-           OR NOT EXISTS (SELECT 1 FROM contacts WHERE contacts.id = conversations.contact_id)
-      SQL
+    count = orphan_scope.count
+    if count.positive?
+      say "Destroying #{count} orphan conversations via Rails so dependent associations are cleaned up"
+      orphan_scope.find_each(&:destroy!)
     end
 
     change_column_null :conversations, :contact_id, false
-    add_foreign_key :conversations, :contacts, on_delete: :cascade, validate: false
-    validate_foreign_key :conversations, :contacts
   end
 
   def down
-    remove_foreign_key :conversations, :contacts
     change_column_null :conversations, :contact_id, true
   end
 end

--- a/db/migrate/20260422170000_enforce_contact_fk_on_conversations.rb
+++ b/db/migrate/20260422170000_enforce_contact_fk_on_conversations.rb
@@ -1,0 +1,27 @@
+class EnforceContactFkOnConversations < ActiveRecord::Migration[7.1]
+  def up
+    orphan_count = select_value(<<~SQL.squish).to_i
+      SELECT COUNT(*) FROM conversations
+      WHERE contact_id IS NULL
+         OR NOT EXISTS (SELECT 1 FROM contacts WHERE contacts.id = conversations.contact_id)
+    SQL
+
+    if orphan_count.positive?
+      say "Deleting #{orphan_count} orphan conversations (contact_id NULL or pointing to missing contact)"
+      execute <<~SQL.squish
+        DELETE FROM conversations
+        WHERE contact_id IS NULL
+           OR NOT EXISTS (SELECT 1 FROM contacts WHERE contacts.id = conversations.contact_id)
+      SQL
+    end
+
+    change_column_null :conversations, :contact_id, false
+    add_foreign_key :conversations, :contacts, on_delete: :cascade, validate: false
+    validate_foreign_key :conversations, :contacts
+  end
+
+  def down
+    remove_foreign_key :conversations, :contacts
+    change_column_null :conversations, :contact_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_18_020000) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_22_170000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -704,7 +704,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_18_020000) do
     t.integer "assignee_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.bigint "contact_id"
+    t.bigint "contact_id", null: false
     t.integer "display_id", null: false
     t.datetime "contact_last_seen_at", precision: nil
     t.datetime "agent_last_seen_at", precision: nil
@@ -1565,6 +1565,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_18_020000) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "conversations", "contacts", on_delete: :cascade
   add_foreign_key "group_members", "contacts"
   add_foreign_key "group_members", "contacts", column: "group_contact_id"
   add_foreign_key "inboxes", "portals"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1565,7 +1565,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_22_170000) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "conversations", "contacts", on_delete: :cascade
   add_foreign_key "group_members", "contacts"
   add_foreign_key "group_members", "contacts", column: "group_contact_id"
   add_foreign_key "inboxes", "portals"

--- a/spec/jobs/conversations/resolution_job_spec.rb
+++ b/spec/jobs/conversations/resolution_job_spec.rb
@@ -48,21 +48,6 @@ RSpec.describe Conversations::ResolutionJob do
     end
   end
 
-  # When a contact is deleted, there's a brief window (~50-150ms) where contact_id becomes nil
-  # but conversations still exist. If ResolutionJob runs during this window, muted? can crash
-  # trying to call blocked? on nil. Fixes # (issue).
-  it 'skips orphan conversations without a contact' do
-    account.update!(auto_resolve_after: 14_400, auto_resolve_ignore_waiting: false) # 10 days in minutes
-    orphan_conversation = create(:conversation, account: account, last_activity_at: 13.days.ago, waiting_since: nil)
-    orphan_conversation.update_columns(contact_id: nil, contact_inbox_id: nil) # rubocop:disable Rails/SkipsModelValidations
-    resolvable_conversation = create(:conversation, account: account, last_activity_at: 13.days.ago, waiting_since: nil)
-
-    described_class.perform_now(account: account)
-
-    expect(orphan_conversation.reload.status).to eq('open')
-    expect(resolvable_conversation.reload.status).to eq('resolved')
-  end
-
   it 'adds a label after resolution' do
     account.update!(auto_resolve_label: 'auto-resolved', auto_resolve_after: 14_400)
     conversation = create(:conversation, account: account, last_activity_at: 13.days.ago, waiting_since: 13.days.ago)

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -434,7 +434,7 @@ RSpec.describe Conversation do
 
     context 'when contact is missing' do
       before do
-        conversation.update_columns(contact_id: nil, contact_inbox_id: nil) # rubocop:disable Rails/SkipsModelValidations
+        allow(conversation).to receive(:contact).and_return(nil)
       end
 
       it 'does not change conversation status' do
@@ -478,7 +478,7 @@ RSpec.describe Conversation do
       let(:conversation) { create(:conversation) }
 
       before do
-        conversation.update_columns(contact_id: nil, contact_inbox_id: nil) # rubocop:disable Rails/SkipsModelValidations
+        allow(conversation).to receive(:contact).and_return(nil)
       end
 
       it 'does not change conversation status' do
@@ -507,7 +507,7 @@ RSpec.describe Conversation do
 
     context 'when contact is missing' do
       before do
-        conversation.update_columns(contact_id: nil, contact_inbox_id: nil) # rubocop:disable Rails/SkipsModelValidations
+        allow(conversation).to receive(:contact).and_return(nil)
       end
 
       it 'returns false' do


### PR DESCRIPTION
Some production requests to `GET /api/v1/accounts/:id/conversations` were returning 500 with `undefined method 'additional_attributes' for nil` from `api/v1/models/_contact.json.jbuilder`. The cause is a conversation that lost its contact: `conversations.contact_id` was nullable and had no foreign key, so a contact could be destroyed (or the `dependent: :destroy_async` cleanup could fail) and leave conversations pointing to a contact that no longer exists.

## How to reproduce

1. Create a contact with a conversation.
2. Update `conversations.contact_id` to `NULL` (or to an id that does not exist) via SQL. Before this PR, both were accepted.
3. Hit the conversations index endpoint for that account. API responds 500.

## What changed

- `db/migrate/..._enforce_contact_fk_on_conversations.rb` cleans up any existing orphan conversations (rows with `contact_id` NULL or pointing to a missing contact) via `Conversation#destroy!` so `dependent:` associations (scheduled_messages, recurring_scheduled_messages sync + messages, mentions, reporting_events, csat_survey_response, conversation_participants, notifications async) are propagated. It then sets `contact_id` to `NOT NULL`. No new foreign key is added — several conversation-owned tables still have `conversation_id` references without `ON DELETE CASCADE`, so adding a DB-level cascade from `contacts` to `conversations` would replace one orphan problem with several others. The invariant stays at the Rails layer (`NOT NULL` + `validates :contact_id, presence: true` + `Contact#has_many :conversations, dependent: :destroy_async`).
- `ContactMergeAction` uses per-record `update!` for conversations, messages, notes and contact_inboxes. Previously it used `Relation#update`, which iterates record by record and silently skips updates when a callback or validation fails, leaving rows pointing to the mergee right before it is destroyed. The bang form keeps callbacks firing (notably `CONVERSATION_CONTACT_CHANGED`) while surfacing any failure instead of swallowing it.
- `Conversations::ResolutionJob` dropped the `where.not(contact_id: nil)` filter and its spec. The scenario it guarded against is now impossible because of the `NOT NULL` constraint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/273)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced data integrity by ensuring all conversations are properly associated with contacts; orphaned conversations without valid contact references are now removed.
  * Improved conversation resolution job to handle contact requirements more reliably.

* **Tests**
  * Updated test coverage to reflect stricter contact association requirements for conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->