### PR TITLE
fix(branding): add SuperAdmin-only notice on upgrade gates

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewGroupForm.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewGroupForm.vue
@@ -167,20 +167,25 @@ defineExpose({ resetForm });
     <div class="flex-1 divide-y divide-n-strong overflow-visible">
       <div
         v-if="isGroupsDisabled"
-        class="flex items-center gap-2 mx-4 mt-3 px-3 py-2 rounded-lg text-sm text-n-amber-11 bg-n-amber-2"
+        class="flex items-start gap-2 mx-4 mt-3 px-3 py-2 rounded-lg text-sm text-n-amber-11 bg-n-amber-2"
       >
-        <span class="i-lucide-triangle-alert text-base flex-shrink-0" />
-        <span v-if="isSuperAdmin">
-          {{ t('GROUP.CREATE.GROUPS_DISABLED') }}
-          <a
-            :href="wootConstants.FAZER_AI_GUIDES_URL"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="underline font-medium"
-          >
-            {{ t('GROUP.CREATE.GROUPS_DISABLED_CTA') }}
-          </a>
-        </span>
+        <span class="i-lucide-triangle-alert text-base flex-shrink-0 mt-0.5" />
+        <div v-if="isSuperAdmin" class="flex flex-col gap-0.5">
+          <span>
+            {{ t('GROUP.CREATE.GROUPS_DISABLED') }}
+            <a
+              :href="wootConstants.FAZER_AI_GUIDES_URL"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="underline font-medium"
+            >
+              {{ t('GROUP.CREATE.GROUPS_DISABLED_CTA') }}
+            </a>
+          </span>
+          <span class="text-xs opacity-70">
+            {{ t('GENERAL_SETTINGS.SUPER_ADMIN_ONLY_NOTICE') }}
+          </span>
+        </div>
         <span v-else>
           {{ t('GROUP.CREATE.GROUPS_DISABLED_NON_ADMIN') }}
         </span>

--- a/app/javascript/dashboard/components/ui/Banner.vue
+++ b/app/javascript/dashboard/components/ui/Banner.vue
@@ -42,6 +42,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    noticeMessage: {
+      type: String,
+      default: '',
+    },
   },
   emits: ['primaryAction', 'close'],
   computed: {
@@ -92,6 +96,9 @@ export default {
       >
         {{ hrefLinkText }}
       </a>
+      <span v-if="noticeMessage" class="banner-notice">
+        {{ noticeMessage }}
+      </span>
     </span>
     <div class="actions">
       <NextButton
@@ -153,6 +160,10 @@ export default {
 
   .banner-message {
     @apply inline;
+  }
+
+  .banner-notice {
+    @apply ml-2 italic opacity-70;
   }
 
   .actions {

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -693,6 +693,7 @@ export default {
         color-scheme="warning"
         class="mx-2 mt-2 overflow-hidden rounded-lg"
         :banner-message="$t('CONVERSATION.GROUPS_DISABLED_BANNER')"
+        :notice-message="$t('GENERAL_SETTINGS.SUPER_ADMIN_ONLY_NOTICE')"
         has-action-button
         :action-button-label="$t('CONVERSATION.GROUPS_DISABLED_CTA')"
         @primary-action="onOpenGroupsEnabledLink"
@@ -703,12 +704,6 @@ export default {
         class="mx-2 mt-2 overflow-hidden rounded-lg"
         :banner-message="$t('CONVERSATION.GROUPS_DISABLED_BANNER_NON_ADMIN')"
       />
-      <p
-        v-if="isGroupsDisabled && isSuperAdmin"
-        class="mx-2 mt-1 text-xs text-center text-n-slate-10"
-      >
-        {{ $t('GENERAL_SETTINGS.SUPER_ADMIN_ONLY_NOTICE') }}
-      </p>
     </div>
     <MessageList
       ref="conversationPanelRef"

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -703,6 +703,12 @@ export default {
         class="mx-2 mt-2 overflow-hidden rounded-lg"
         :banner-message="$t('CONVERSATION.GROUPS_DISABLED_BANNER_NON_ADMIN')"
       />
+      <p
+        v-if="isGroupsDisabled && isSuperAdmin"
+        class="mx-2 mt-1 text-xs text-center text-n-slate-10"
+      >
+        {{ $t('GENERAL_SETTINGS.SUPER_ADMIN_ONLY_NOTICE') }}
+      </p>
     </div>
     <MessageList
       ref="conversationPanelRef"

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -10,6 +10,7 @@
     "SUBMIT": "Update settings",
     "BACK": "Back",
     "DISMISS": "Dismiss",
+    "SUPER_ADMIN_ONLY_NOTICE": "Only system administrators can see this message.",
     "UPDATE": {
       "ERROR": "Could not update settings, try again!",
       "SUCCESS": "Successfully updated account settings"

--- a/app/javascript/dashboard/i18n/locale/pt_BR/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/generalSettings.json
@@ -10,6 +10,7 @@
     "SUBMIT": "Atualizar configurações",
     "BACK": "Anterior",
     "DISMISS": "Recusar",
+    "SUPER_ADMIN_ONLY_NOTICE": "Esta mensagem só é visível para administradores do sistema.",
     "UPDATE": {
       "ERROR": "Não foi possível atualizar as configurações, tente novamente!",
       "SUCCESS": "Configurações de conta atualizadas com sucesso"

--- a/app/javascript/dashboard/routes/dashboard/kanban/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/kanban/Index.vue
@@ -60,6 +60,9 @@ const upgradeUrl = 'https://fazer.ai/kanban';
           {{ t('KANBAN.PAYWALL.UPGRADE_NOW') }}
         </Button>
       </a>
+      <p v-if="isSuperAdmin" class="mt-3 text-xs text-center text-n-slate-10">
+        {{ t('GENERAL_SETTINGS.SUPER_ADMIN_ONLY_NOTICE') }}
+      </p>
     </div>
   </section>
 </template>


### PR DESCRIPTION
Adds a discreet "Only system administrators can see this message" line under upgrade prompts that are exclusively rendered to SuperAdmin (Kanban paywall, group creation form, group-disabled banner in conversation view). This avoids confusion from admins who worried that the fazer.ai link in those screens was also visible to their agents.

## How to test

1. Log in as SuperAdmin and visit any conversation in a Baileys WhatsApp inbox where group support is disabled. The orange banner should now show the new line under the warning.
2. Try to create a new group from the same inbox. The "Group creation is disabled" notice should also show the new line.
3. Visit the Kanban tab as SuperAdmin. The paywall should display the new line under the upgrade button.
4. Repeat the three flows as a regular admin or agent. The new line should not appear; only the existing role-specific copy is shown.

## What changed

- New shared i18n key `GENERAL_SETTINGS.SUPER_ADMIN_ONLY_NOTICE` (en + pt_BR).
- Notice rendered in `kanban/Index.vue`, `ComposeNewGroupForm.vue`, and the groups-disabled banner in `MessagesView.vue`, only when `isSuperAdmin` is true.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/278)
<!-- Reviewable:end -->
