### PR TITLE
fix(compose-conversation): allow modal to shrink on narrow viewports

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
@@ -383,7 +383,7 @@ useKeyboardEvents(keyboardEvents);
       <div
         v-if="!isGroupMode"
         :class="[{ 'mt-2': !viewInModal }, composePopoverClass]"
-        class="w-[42rem] flex flex-col"
+        class="w-[42rem] flex flex-col min-w-0"
       >
         <div
           v-if="hasGroupInboxes"
@@ -442,7 +442,7 @@ useKeyboardEvents(keyboardEvents);
       <div
         v-else
         :class="[{ 'mt-2': !viewInModal }, composePopoverClass]"
-        class="w-[42rem] flex flex-col"
+        class="w-[42rem] flex flex-col min-w-0"
       >
         <div
           class="flex gap-1 px-4 pt-3 pb-0 bg-n-alpha-3 border border-b-0 border-n-strong backdrop-blur-[100px] rounded-t-xl"

--- a/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
@@ -335,7 +335,7 @@ useKeyboardEvents({
 
 <template>
   <div
-    class="w-[42rem] divide-y divide-n-strong overflow-visible transition-all duration-300 ease-in-out top-full flex flex-col bg-n-alpha-3 border border-n-strong shadow-sm backdrop-blur-[100px] rounded-xl min-w-0 max-h-[calc(100vh-8rem)]"
+    class="w-full divide-y divide-n-strong overflow-visible transition-all duration-300 ease-in-out top-full flex flex-col bg-n-alpha-3 border border-n-strong shadow-sm backdrop-blur-[100px] rounded-xl min-w-0 max-h-[calc(100vh-8rem)]"
   >
     <div class="flex-1 overflow-y-auto divide-y divide-n-strong">
       <ContactSelector

--- a/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewGroupForm.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewGroupForm.vue
@@ -162,7 +162,7 @@ defineExpose({ resetForm });
 
 <template>
   <div
-    class="w-[42rem] divide-y divide-n-strong overflow-visible transition-all duration-300 ease-in-out top-full flex flex-col bg-n-alpha-3 border border-n-strong shadow-sm backdrop-blur-[100px] rounded-xl min-w-0 max-h-[calc(100vh-8rem)]"
+    class="w-full divide-y divide-n-strong overflow-visible transition-all duration-300 ease-in-out top-full flex flex-col bg-n-alpha-3 border border-n-strong shadow-sm backdrop-blur-[100px] rounded-xl min-w-0 max-h-[calc(100vh-8rem)]"
   >
     <div class="flex-1 divide-y divide-n-strong overflow-visible">
       <div


### PR DESCRIPTION
O modal de "Nova conversa" voltou a se ajustar corretamente em viewports estreitos (telas pequenas / janelas redimensionadas). Antes, em larguras abaixo de 672px, ele transbordava a tela.

## Closes

N/A (regressão local)

## How to reproduce

1. Abrir o dashboard em uma janela larga.
2. Clicar no ícone de "Nova conversa" na sidebar.
3. Reduzir a janela do navegador para algo abaixo de ~700px de largura (ou abrir direto em um viewport pequeno).
4. Antes: o modal vazava para fora da tela em ambos os lados.
5. Agora: o modal encolhe junto com a viewport e permanece visível inteiro.

## What changed

- `ComposeConversation.vue`: adicionado `min-w-0` aos dois wrappers (modos conversa e grupo). Sem isso, o `w-[42rem]` do wrapper não conseguia encolher quando flex-child do backdrop centralizado.
- `ComposeNewConversationForm.vue` e `ComposeNewGroupForm.vue`: a raiz passou de `w-[42rem]` para `w-full`. Como o form vive dentro de um wrapper `flex flex-col`, sua largura é cross-axis e não respondia ao `min-w-0`; agora segue a largura do wrapper, que já carrega `w-[42rem] min-w-0`.

A regressão veio com a introdução das abas Conversa/Grupo, que envolveram o form em uma `<div>` extra para acomodar a barra de tabs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/280)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved layout responsiveness for the new conversation and group creation forms, enhancing their behavior across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->