### PR TITLE
fix(conversations): include private note as last message seed

### DIFF
--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -27,13 +27,19 @@ json.meta do
 end
 
 json.id conversation.display_id
-last_card_message = conversation.messages.where(account_id: conversation.account_id)
-                                .chat
-                                .hide_removed_reactions
-                                .includes([{ attachments: [{ file_attachment: [:blob] }] }])
-                                .reorder(created_at: :desc)
-                                .first
-json.messages last_card_message ? [last_card_message.push_event_data] : []
+# Seeds `currentChat.messages` and is also the source for the `before` cursor
+# in setActiveChat → fetchPreviousMessages. Must include private notes: the
+# `chat` scope filters them out, so a trailing private note would never enter
+# the store on cold open and the bubble wouldn't render until a non-private
+# message arrived after it.
+last_message = conversation.messages
+                           .where(account_id: conversation.account_id)
+                           .non_activity_messages
+                           .hide_removed_reactions
+                           .includes([{ attachments: [{ file_attachment: [:blob] }] }])
+                           .reorder(created_at: :desc)
+                           .first
+json.messages last_message ? [last_message.push_event_data] : []
 
 json.account_id conversation.account_id
 json.uuid conversation.uuid
@@ -53,17 +59,11 @@ json.updated_at conversation.updated_at.to_f
 json.timestamp conversation.last_activity_at.to_i
 json.first_reply_created_at conversation.first_reply_created_at.to_i
 json.unread_count conversation.unread_incoming_messages.count
-last_non_activity = conversation.messages
-                                .where(account_id: conversation.account_id)
-                                .non_activity_messages
-                                .hide_removed_reactions
-                                .reorder(created_at: :desc)
-                                .first
-if last_non_activity
+if last_message
   json.last_non_activity_message do
-    json.merge! last_non_activity.push_event_data
-    if last_non_activity.reaction?
-      target_id = last_non_activity.content_attributes['in_reply_to']
+    json.merge! last_message.push_event_data
+    if last_message.reaction?
+      target_id = last_message.content_attributes['in_reply_to']
       target = target_id.present? ? conversation.messages.find_by(id: target_id) : nil
       # strip_tags so the preview of an HTML/email target doesn't render as
       # literal "<p>..." markup in the chat list card. Wrap with `String.new`

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -35,6 +35,23 @@ RSpec.describe 'Conversations API', type: :request do
         expect(body[:data][:payload].first[:messages].first[:id]).to eq(message.id)
       end
 
+      # Regression: when the latest message is a private note, the seed is the
+      # cursor for setActiveChat → fetchPreviousMessages(before: id). Filtering
+      # private notes here would leave the trailing note out of the store on
+      # cold open, so the bubble wouldn't render until a non-private message
+      # arrived after it.
+      it 'seeds the latest message even when it is a private note' do
+        create(:message, conversation: conversation, account: account)
+        private_note = create(:message, conversation: conversation, account: account, private: true)
+
+        get "/api/v1/accounts/#{account.id}/conversations",
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        body = JSON.parse(response.body, symbolize_names: true)
+        expect(body[:data][:payload].first[:messages].first[:id]).to eq(private_note.id)
+      end
+
       it 'returns conversations with empty messages array for conversations with out messages' do
         get "/api/v1/accounts/#{account.id}/conversations",
             headers: agent.create_new_auth_token,


### PR DESCRIPTION
Notas privadas que eram a última mensagem da conversa só apareciam após chegar uma mensagem normal depois delas. Agora a lista de conversas semeia o store com a última mensagem visível independente de ser privada, então a bolha aparece corretamente já no primeiro carregamento.

## Closes

N/A

## How to reproduce

1. Em uma conta com mensagens normais e privadas, certificar que a última mensagem de uma conversa seja uma nota privada (sem nenhuma mensagem após).
2. Abrir essa conversa pela primeira vez (cold open: refresh da página, depois clicar na conversa).
3. **Antes da correção**: a nota privada não aparece. Só passa a aparecer se chegar/existir uma mensagem normal depois dela.
4. **Depois da correção**: a nota privada aparece imediatamente.

## What changed

- `app/views/api/v1/conversations/partials/_conversation.json.jbuilder`: o seed de `messages` deixou de usar o scope `chat` (que filtra `private: false`) e passou a usar `non_activity_messages`. Reaproveitada a mesma query para `last_non_activity_message`.
- `setActiveChat` em `store/modules/conversations/actions.js` usa `data.messages[0].id` como cursor `before` em `fetchPreviousMessages`. Com o scope antigo, o cursor era a última mensagem não privada, e `MessageFinder#messages_before` (`id < before`) deixava notas privadas posteriores fora do store.
- Regression spec adicionada em `spec/controllers/api/v1/accounts/conversations_controller_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/281)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Private notes now display correctly as the latest message in conversations
  * Attachments are properly included in conversation message payloads

* **Tests**
  * Added test coverage for private note behavior in conversation API responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->