### PR TITLE
fix(new-conversation): stop writing literal "undefined" as mail_subject

### DIFF
--- a/app/javascript/dashboard/store/modules/contactConversations.js
+++ b/app/javascript/dashboard/store/modules/contactConversations.js
@@ -25,7 +25,9 @@ export const createConversationPayload = ({ params, contactId, files }) => {
   payload.append('inbox_id', inboxId);
   payload.append('contact_id', contactId);
   payload.append('source_id', sourceId);
-  payload.append('additional_attributes[mail_subject]', mailSubject);
+  if (mailSubject) {
+    payload.append('additional_attributes[mail_subject]', mailSubject);
+  }
   payload.append('assignee_id', assigneeId);
 
   return payload;

--- a/app/javascript/dashboard/store/modules/specs/contactConversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contactConversations/actions.spec.js
@@ -282,6 +282,24 @@ describe('createConversationPayload', () => {
     expect(payload.get('assignee_id')).toBe(options.params.assigneeId);
     expect(payload.getAll('message[attachments][]')).toEqual([]);
   });
+
+  it('omits mail_subject when mailSubject is undefined', () => {
+    const options = {
+      params: {
+        inboxId: '1',
+        message: {
+          content: 'Test message content',
+        },
+        sourceId: '12',
+        assigneeId: '123',
+      },
+      contactId: '23',
+    };
+
+    const payload = createConversationPayload(options);
+
+    expect(payload.has('additional_attributes[mail_subject]')).toBe(false);
+  });
 });
 
 describe('createWhatsAppConversationPayload', () => {

--- a/db/migrate/20260506120000_clean_undefined_mail_subject_in_conversations.rb
+++ b/db/migrate/20260506120000_clean_undefined_mail_subject_in_conversations.rb
@@ -3,11 +3,19 @@ class CleanUndefinedMailSubjectInConversations < ActiveRecord::Migration[7.1]
   # via FormData, writing the literal string "undefined" when the field was
   # absent. Strip those bogus values so search results stop rendering
   # "Subject: undefined".
+  #
+  # Scoped to non-email inboxes only: email channels legitimately use
+  # `mail_subject`, and "undefined" could in principle be a subject the user
+  # actually typed. Other channel types have no concept of subject, so the
+  # value can only have come from the bug.
   def up
     execute(<<~SQL.squish)
       UPDATE conversations
       SET additional_attributes = additional_attributes - 'mail_subject'
-      WHERE additional_attributes->>'mail_subject' = 'undefined'
+      FROM inboxes
+      WHERE conversations.inbox_id = inboxes.id
+        AND inboxes.channel_type <> 'Channel::Email'
+        AND conversations.additional_attributes->>'mail_subject' = 'undefined'
     SQL
   end
 

--- a/db/migrate/20260506120000_clean_undefined_mail_subject_in_conversations.rb
+++ b/db/migrate/20260506120000_clean_undefined_mail_subject_in_conversations.rb
@@ -1,0 +1,17 @@
+class CleanUndefinedMailSubjectInConversations < ActiveRecord::Migration[7.1]
+  # A frontend bug appended `additional_attributes[mail_subject]` unconditionally
+  # via FormData, writing the literal string "undefined" when the field was
+  # absent. Strip those bogus values so search results stop rendering
+  # "Subject: undefined".
+  def up
+    execute(<<~SQL.squish)
+      UPDATE conversations
+      SET additional_attributes = additional_attributes - 'mail_subject'
+      WHERE additional_attributes->>'mail_subject' = 'undefined'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_22_170000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_06_120000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"


### PR DESCRIPTION
Conversas criadas pelo "Nova conversa" sem assunto preenchido apareciam na busca como `Assunto: undefined`. O fix corrige a origem (frontend não envia mais `undefined` como string) e limpa o lixo já gravado no banco.

## Closes

- N/A (regressão interna observada após o merge da 4.13.0)

## How to reproduce

1. Antes do fix: abrir "Nova conversa", escolher um canal não-email (ex.: WhatsApp), criar a conversa sem informar assunto.
2. Buscar a conversa na barra de busca global.
3. O resultado mostra `Assunto: undefined`.

## What changed

- `createConversationPayload` só adiciona `additional_attributes[mail_subject]` ao `FormData` quando `mailSubject` é truthy. Sem isso, `FormData.append` convertia `undefined` para a string literal `"undefined"` e persistia no banco.
- Data migration remove `mail_subject` das conversas onde o valor gravado é exatamente a string `"undefined"`.
- Spec novo cobrindo o caso ausente.

## Histórico

A escrita corrompida começou com o `composeConversationHelper` (PR upstream chatwoot/chatwoot#10457, dez/2024), que substituiu o formulário antigo, o qual sempre passava `mailSubject: ''`. O sintoma só ficou visível na fork após o merge da 4.13.0 (17/04/2026), que trouxe o PR upstream chatwoot/chatwoot#10843, exibindo `mail_subject` nos resultados de busca.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/282)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents saving an "undefined" mail subject for new conversations.
  * Cleans up existing conversations that have invalid mail-subject entries.

* **Tests**
  * Added a test to ensure the mail subject is omitted when not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->