### PR TITLE
fix(reactions): teleport pickers via floating-vue to escape scroll clipping

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages/reactions_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages/reactions_controller.rb
@@ -38,7 +38,12 @@ class Api::V1::Accounts::Conversations::Messages::ReactionsController < Api::V1:
     # `updated_at` first so the frontend's out-of-order guard in
     # UPDATE_CONVERSATION can drop stale cables when the user toggles fast.
     @conversation.update_columns(updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
-    @conversation.dispatch_conversation_updated_event
+    # Tag the broadcast so the frontend's UPDATE_CONVERSATION mutation can skip
+    # the SCROLL_TO_MESSAGE side-effect: when a reaction is toggled and there
+    # are newer non-reaction messages in the conversation, `last_non_activity_message`
+    # remains a regular message, so the heuristics on `is_reaction` / id-revert
+    # alone can't tell this dispatch apart from a fresh outgoing/incoming.
+    @conversation.dispatch_conversation_updated_event(broadcast_metadata: { source: 'reaction_toggle' })
 
     head :ok
   end

--- a/app/javascript/dashboard/components-next/message/EmojiReactionPicker.vue
+++ b/app/javascript/dashboard/components-next/message/EmojiReactionPicker.vue
@@ -82,7 +82,7 @@ onBeforeUnmount(() => emitter.off(BUS_EVENTS.ON_MESSAGE_LIST_SCROLL, close));
     theme="naked-popover"
     :placement="props.alignment === 'right' ? 'top-end' : 'top-start'"
     :distance="8"
-    popper-class="naked-popover-popper"
+    popper-class="[&_.v-popper\_\_arrow-container]:hidden"
     @apply-hide="close"
   >
     <button
@@ -142,9 +142,3 @@ onBeforeUnmount(() => emitter.off(BUS_EVENTS.ON_MESSAGE_LIST_SCROLL, close));
     </template>
   </Dropdown>
 </template>
-
-<style>
-.naked-popover-popper .v-popper__arrow-container {
-  display: none;
-}
-</style>

--- a/app/javascript/dashboard/components-next/message/EmojiReactionPicker.vue
+++ b/app/javascript/dashboard/components-next/message/EmojiReactionPicker.vue
@@ -1,12 +1,14 @@
 <script setup>
-import { ref } from 'vue';
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { vOnClickOutside } from '@vueuse/components';
 import { useEventListener } from '@vueuse/core';
+import { Dropdown } from 'floating-vue';
+import { emitter } from 'shared/helpers/mitt';
+import { BUS_EVENTS } from 'shared/constants/busEvents';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import EmojiInput from 'shared/components/emoji/EmojiInput.vue';
 
-defineProps({
+const props = defineProps({
   alignment: {
     type: String,
     default: 'right',
@@ -18,7 +20,7 @@ defineProps({
   },
 });
 
-const emit = defineEmits(['select']);
+const emit = defineEmits(['select', 'update:open']);
 
 const { t } = useI18n();
 
@@ -59,70 +61,90 @@ function openFullPicker() {
   showFullPicker.value = true;
 }
 
+watch(isOpen, value => emit('update:open', value));
+
 // Switching apps / Alt-Tab fires window blur but not a click event, so
-// vOnClickOutside cannot reach it. Without this the picker stays open in
-// the background and reappears on next hover.
+// the dropdown's auto-hide cannot reach it. Without this the picker stays
+// open in the background and reappears on next hover.
 useEventListener(window, 'blur', close);
+
+// Close the picker when the message list scrolls so the popover does not
+// drift visually away from the anchoring message.
+onMounted(() => emitter.on(BUS_EVENTS.ON_MESSAGE_LIST_SCROLL, close));
+onBeforeUnmount(() => emitter.off(BUS_EVENTS.ON_MESSAGE_LIST_SCROLL, close));
 </script>
 
 <template>
-  <div v-on-click-outside="close" class="relative">
+  <Dropdown
+    :shown="isOpen"
+    :triggers="[]"
+    auto-hide
+    theme="naked-popover"
+    :placement="props.alignment === 'right' ? 'top-end' : 'top-start'"
+    :distance="8"
+    popper-class="naked-popover-popper"
+    @apply-hide="close"
+  >
     <button
       type="button"
       class="flex items-center justify-center rounded-full p-1 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12"
       :title="t('CONVERSATION.REACTIONS.ADD_REACTION')"
       :aria-label="t('CONVERSATION.REACTIONS.ADD_REACTION')"
+      :aria-expanded="isOpen"
+      aria-haspopup="dialog"
       @click="toggle"
     >
       <Icon icon="i-lucide-smile-plus" class="size-4" />
     </button>
-    <div
-      v-if="isOpen && !showFullPicker"
-      class="absolute bottom-[calc(100%+0.5rem)] z-50 flex w-max items-center gap-1 rounded-full border border-n-slate-6 bg-n-solid-2 p-1 shadow-lg"
-      :class="
-        alignment === 'right' ? '-right-1 left-auto' : '-left-1 right-auto'
-      "
-    >
-      <button
-        v-for="item in QUICK_EMOJIS"
-        :key="item.labelKey"
-        type="button"
-        class="flex size-7 items-center justify-center rounded-full text-base hover:bg-n-alpha-2"
-        :class="{
-          'ring-2 ring-n-brand bg-n-alpha-2': item.emoji === currentUserEmoji,
-        }"
-        :title="
-          item.emoji === currentUserEmoji
-            ? t('CONVERSATION.REACTIONS.CLICK_TO_REMOVE')
-            : t(item.labelKey)
-        "
-        :aria-label="
-          item.emoji === currentUserEmoji
-            ? t('CONVERSATION.REACTIONS.CLICK_TO_REMOVE')
-            : t(item.labelKey)
-        "
-        :aria-pressed="item.emoji === currentUserEmoji"
-        @click="pickEmoji(item.emoji)"
+    <template #popper>
+      <div
+        v-if="!showFullPicker"
+        class="flex w-max items-center gap-1 rounded-full border border-n-slate-6 bg-n-solid-2 p-1 shadow-lg"
       >
-        {{ item.emoji }}
-      </button>
-      <button
-        type="button"
-        class="flex size-7 items-center justify-center rounded-full text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12"
-        :title="t('CONVERSATION.REACTIONS.MORE_EMOJIS')"
-        :aria-label="t('CONVERSATION.REACTIONS.MORE_EMOJIS')"
-        @click="openFullPicker"
-      >
-        <Icon icon="i-lucide-plus" class="size-4" />
-      </button>
-    </div>
-    <EmojiInput
-      v-if="isOpen && showFullPicker"
-      class="!bottom-[calc(100%+1.25rem)] !top-auto"
-      :class="
-        alignment === 'right' ? '!right-0 !left-auto' : '!left-0 !right-auto'
-      "
-      :on-click="pickEmoji"
-    />
-  </div>
+        <button
+          v-for="item in QUICK_EMOJIS"
+          :key="item.labelKey"
+          type="button"
+          class="flex size-7 items-center justify-center rounded-full text-base hover:bg-n-alpha-2"
+          :class="{
+            'ring-2 ring-n-brand bg-n-alpha-2': item.emoji === currentUserEmoji,
+          }"
+          :title="
+            item.emoji === currentUserEmoji
+              ? t('CONVERSATION.REACTIONS.CLICK_TO_REMOVE')
+              : t(item.labelKey)
+          "
+          :aria-label="
+            item.emoji === currentUserEmoji
+              ? t('CONVERSATION.REACTIONS.CLICK_TO_REMOVE')
+              : t(item.labelKey)
+          "
+          :aria-pressed="item.emoji === currentUserEmoji"
+          @click="pickEmoji(item.emoji)"
+        >
+          {{ item.emoji }}
+        </button>
+        <button
+          type="button"
+          class="flex size-7 items-center justify-center rounded-full text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12"
+          :title="t('CONVERSATION.REACTIONS.MORE_EMOJIS')"
+          :aria-label="t('CONVERSATION.REACTIONS.MORE_EMOJIS')"
+          @click="openFullPicker"
+        >
+          <Icon icon="i-lucide-plus" class="size-4" />
+        </button>
+      </div>
+      <EmojiInput
+        v-else
+        class="!static !top-auto !right-auto !left-auto [&::before]:hidden"
+        :on-click="pickEmoji"
+      />
+    </template>
+  </Dropdown>
 </template>
+
+<style>
+.naked-popover-popper .v-popper__arrow-container {
+  display: none;
+}
+</style>

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -375,6 +375,8 @@ const componentToRender = computed(() => {
   return TextBubble;
 });
 
+const isAudioBubble = computed(() => componentToRender.value === AudioBubble);
+
 const shouldShowContextMenu = computed(() => {
   return !props.contentAttributes?.isUnsupported;
 });
@@ -782,6 +784,7 @@ provideMessageContext({
             :pending-emojis="pendingEmojis"
             :alignment="orientation === ORIENTATION.RIGHT ? 'right' : 'left'"
             :read-only="!inboxSupportsReactions"
+            :overlap="!isAudioBubble"
             @toggle="handleToggleReaction"
           />
         </div>

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -150,6 +150,7 @@ const emit = defineEmits(['retry', 'toggleReaction']);
 const contextMenuPosition = ref({});
 const showBackgroundHighlight = ref(false);
 const showContextMenu = ref(false);
+const reactionPickerOpen = ref(false);
 const { t } = useI18n();
 const route = useRoute();
 const inboxGetter = useMapGetter('inboxes/getInbox');
@@ -746,12 +747,15 @@ provideMessageContext({
             <Component :is="componentToRender" />
             <div
               v-if="canShowReactionToolbar"
-              class="absolute top-1/2 -translate-y-1/2 z-10 flex items-center gap-0.5 rounded-full border border-n-slate-6 bg-n-solid-2 shadow-sm p-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity [@media(hover:none)]:opacity-100"
-              :class="
+              class="absolute top-1/2 -translate-y-1/2 z-10 flex items-center gap-0.5 rounded-full border border-n-slate-6 bg-n-solid-2 shadow-sm p-0.5 transition-opacity [@media(hover:none)]:opacity-100"
+              :class="[
+                reactionPickerOpen
+                  ? 'opacity-100'
+                  : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
                 orientation === ORIENTATION.RIGHT
                   ? 'ltr:right-full ltr:mr-2 rtl:left-full rtl:ml-2'
-                  : 'ltr:left-full ltr:ml-2 rtl:right-full rtl:mr-2'
-              "
+                  : 'ltr:left-full ltr:ml-2 rtl:right-full rtl:mr-2',
+              ]"
             >
               <EmojiReactionPicker
                 :alignment="
@@ -759,6 +763,7 @@ provideMessageContext({
                 "
                 :current-user-emoji="currentUserReactionEmoji"
                 @select="handleToggleReaction"
+                @update:open="value => (reactionPickerOpen = value)"
               />
             </div>
           </div>

--- a/app/javascript/dashboard/components-next/message/ReactionDisplay.vue
+++ b/app/javascript/dashboard/components-next/message/ReactionDisplay.vue
@@ -92,78 +92,73 @@ onBeforeUnmount(() =>
 
 <!-- eslint-disable-next-line vue/no-root-v-if -->
 <template>
-  <div
+  <Dropdown
     v-if="groupedReactions.length"
+    :shown="showPopover"
+    :triggers="[]"
+    auto-hide
+    theme="naked-popover"
+    :placement="alignment === 'right' ? 'top-end' : 'top-start'"
+    :distance="4"
     class="-mt-1 flex flex-wrap items-center gap-1"
+    popper-class="[&_.v-popper\_\_arrow-container]:hidden"
+    @apply-hide="closePopover"
   >
-    <Dropdown
-      :shown="showPopover"
-      :triggers="[]"
-      auto-hide
-      theme="naked-popover"
-      :placement="alignment === 'right' ? 'top-end' : 'top-start'"
-      :distance="4"
-      popper-class="[&_.v-popper\_\_arrow-container]:hidden"
-      @apply-hide="closePopover"
+    <button
+      type="button"
+      class="inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+      :class="
+        isMine
+          ? 'border-n-brand bg-n-alpha-2 text-n-brand'
+          : 'border-n-slate-6 bg-n-alpha-1 text-n-slate-12 hover:bg-n-alpha-2'
+      "
+      :disabled="isAnyPending"
+      :aria-expanded="showPopover"
+      aria-haspopup="dialog"
+      @click="togglePopover"
     >
-      <button
-        type="button"
-        class="inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
-        :class="
-          isMine
-            ? 'border-n-brand bg-n-alpha-2 text-n-brand'
-            : 'border-n-slate-6 bg-n-alpha-1 text-n-slate-12 hover:bg-n-alpha-2'
-        "
-        :disabled="isAnyPending"
-        :aria-expanded="showPopover"
-        aria-haspopup="dialog"
-        @click="togglePopover"
+      <span class="inline-flex items-center gap-0.5">
+        <span v-for="emoji in uniqueEmojis" :key="emoji">{{ emoji }}</span>
+      </span>
+      <span>{{ totalCount }}</span>
+    </button>
+    <template #popper>
+      <div
+        class="min-w-48 rounded-lg border border-n-slate-6 bg-n-solid-2 p-2 shadow-lg"
       >
-        <span class="inline-flex items-center gap-0.5">
-          <span v-for="emoji in uniqueEmojis" :key="emoji">{{ emoji }}</span>
-        </span>
-        <span>{{ totalCount }}</span>
-      </button>
-      <template #popper>
         <div
-          class="min-w-48 rounded-lg border border-n-slate-6 bg-n-solid-2 p-2 shadow-lg"
+          v-for="(group, groupIdx) in groupedReactions"
+          :key="group.emoji"
+          :class="{ 'mt-2 border-t border-n-slate-5 pt-2': groupIdx > 0 }"
         >
-          <div
-            v-for="(group, groupIdx) in groupedReactions"
-            :key="group.emoji"
-            :class="{ 'mt-2 border-t border-n-slate-5 pt-2': groupIdx > 0 }"
+          <component
+            :is="user.isMine && !readOnly ? 'button' : 'div'"
+            v-for="(user, userIdx) in group.users"
+            :key="`${group.emoji}-${user.id ?? userIdx}`"
+            :type="user.isMine && !readOnly ? 'button' : null"
+            class="flex w-full items-center gap-2 rounded px-1 py-1 text-left"
+            :class="
+              user.isMine && !readOnly
+                ? 'cursor-pointer hover:bg-n-alpha-2'
+                : ''
+            "
+            @click="handleRowClick(group.emoji, user)"
           >
-            <component
-              :is="user.isMine && !readOnly ? 'button' : 'div'"
-              v-for="(user, userIdx) in group.users"
-              :key="`${group.emoji}-${user.id ?? userIdx}`"
-              :type="user.isMine && !readOnly ? 'button' : null"
-              class="flex w-full items-center gap-2 rounded px-1 py-1 text-left"
-              :class="
-                user.isMine && !readOnly
-                  ? 'cursor-pointer hover:bg-n-alpha-2'
-                  : ''
-              "
-              @click="handleRowClick(group.emoji, user)"
-            >
-              <span class="w-5 text-center text-sm">{{ group.emoji }}</span>
-              <div class="flex-1 min-w-0">
-                <div class="text-xs text-n-slate-12 truncate">
-                  {{
-                    user.isMine ? t('CONVERSATION.REACTIONS.YOU') : user.name
-                  }}
-                </div>
-                <div
-                  v-if="user.isMine && !readOnly"
-                  class="text-[10px] text-n-slate-11"
-                >
-                  {{ t('CONVERSATION.REACTIONS.CLICK_TO_REMOVE') }}
-                </div>
+            <span class="w-5 text-center text-sm">{{ group.emoji }}</span>
+            <div class="flex-1 min-w-0">
+              <div class="text-xs text-n-slate-12 truncate">
+                {{ user.isMine ? t('CONVERSATION.REACTIONS.YOU') : user.name }}
               </div>
-            </component>
-          </div>
+              <div
+                v-if="user.isMine && !readOnly"
+                class="text-[10px] text-n-slate-11"
+              >
+                {{ t('CONVERSATION.REACTIONS.CLICK_TO_REMOVE') }}
+              </div>
+            </div>
+          </component>
         </div>
-      </template>
-    </Dropdown>
-  </div>
+      </div>
+    </template>
+  </Dropdown>
 </template>

--- a/app/javascript/dashboard/components-next/message/ReactionDisplay.vue
+++ b/app/javascript/dashboard/components-next/message/ReactionDisplay.vue
@@ -103,7 +103,7 @@ onBeforeUnmount(() =>
       theme="naked-popover"
       :placement="alignment === 'right' ? 'top-end' : 'top-start'"
       :distance="4"
-      popper-class="naked-popover-popper"
+      popper-class="[&_.v-popper\_\_arrow-container]:hidden"
       @apply-hide="closePopover"
     >
       <button

--- a/app/javascript/dashboard/components-next/message/ReactionDisplay.vue
+++ b/app/javascript/dashboard/components-next/message/ReactionDisplay.vue
@@ -27,6 +27,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  overlap: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const emit = defineEmits(['toggle']);
@@ -100,7 +104,8 @@ onBeforeUnmount(() =>
     theme="naked-popover"
     :placement="alignment === 'right' ? 'top-end' : 'top-start'"
     :distance="4"
-    class="-mt-1 flex flex-wrap items-center gap-1"
+    class="relative flex flex-wrap items-center gap-1"
+    :class="overlap ? '-mt-1' : ''"
     popper-class="[&_.v-popper\_\_arrow-container]:hidden"
     @apply-hide="closePopover"
   >

--- a/app/javascript/dashboard/components-next/message/ReactionDisplay.vue
+++ b/app/javascript/dashboard/components-next/message/ReactionDisplay.vue
@@ -1,7 +1,9 @@
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { vOnClickOutside } from '@vueuse/components';
+import { Dropdown } from 'floating-vue';
+import { emitter } from 'shared/helpers/mitt';
+import { BUS_EVENTS } from 'shared/constants/busEvents';
 
 const props = defineProps({
   reactions: {
@@ -81,66 +83,87 @@ function handleRowClick(emoji, user) {
   emit('toggle', emoji);
   closePopover();
 }
+
+onMounted(() => emitter.on(BUS_EVENTS.ON_MESSAGE_LIST_SCROLL, closePopover));
+onBeforeUnmount(() =>
+  emitter.off(BUS_EVENTS.ON_MESSAGE_LIST_SCROLL, closePopover)
+);
 </script>
 
 <!-- eslint-disable-next-line vue/no-root-v-if -->
 <template>
   <div
     v-if="groupedReactions.length"
-    class="relative -mt-1 flex flex-wrap items-center gap-1"
+    class="-mt-1 flex flex-wrap items-center gap-1"
   >
-    <button
-      type="button"
-      class="inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
-      :class="
-        isMine
-          ? 'border-n-brand bg-n-alpha-2 text-n-brand'
-          : 'border-n-slate-6 bg-n-alpha-1 text-n-slate-12 hover:bg-n-alpha-2'
-      "
-      :disabled="isAnyPending"
-      @click="togglePopover"
+    <Dropdown
+      :shown="showPopover"
+      :triggers="[]"
+      auto-hide
+      theme="naked-popover"
+      :placement="alignment === 'right' ? 'top-end' : 'top-start'"
+      :distance="4"
+      popper-class="naked-popover-popper"
+      @apply-hide="closePopover"
     >
-      <span class="inline-flex items-center gap-0.5">
-        <span v-for="emoji in uniqueEmojis" :key="emoji">{{ emoji }}</span>
-      </span>
-      <span>{{ totalCount }}</span>
-    </button>
-    <div
-      v-if="showPopover"
-      v-on-click-outside="closePopover"
-      class="absolute bottom-full z-50 mb-1 min-w-48 rounded-lg border border-n-slate-6 bg-n-solid-2 p-2 shadow-lg"
-      :class="alignment === 'right' ? 'right-0' : 'left-0'"
-    >
-      <div
-        v-for="(group, groupIdx) in groupedReactions"
-        :key="group.emoji"
-        :class="{ 'mt-2 border-t border-n-slate-5 pt-2': groupIdx > 0 }"
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        :class="
+          isMine
+            ? 'border-n-brand bg-n-alpha-2 text-n-brand'
+            : 'border-n-slate-6 bg-n-alpha-1 text-n-slate-12 hover:bg-n-alpha-2'
+        "
+        :disabled="isAnyPending"
+        :aria-expanded="showPopover"
+        aria-haspopup="dialog"
+        @click="togglePopover"
       >
-        <component
-          :is="user.isMine && !readOnly ? 'button' : 'div'"
-          v-for="(user, userIdx) in group.users"
-          :key="`${group.emoji}-${user.id ?? userIdx}`"
-          :type="user.isMine && !readOnly ? 'button' : null"
-          class="flex w-full items-center gap-2 rounded px-1 py-1 text-left"
-          :class="
-            user.isMine && !readOnly ? 'cursor-pointer hover:bg-n-alpha-2' : ''
-          "
-          @click="handleRowClick(group.emoji, user)"
+        <span class="inline-flex items-center gap-0.5">
+          <span v-for="emoji in uniqueEmojis" :key="emoji">{{ emoji }}</span>
+        </span>
+        <span>{{ totalCount }}</span>
+      </button>
+      <template #popper>
+        <div
+          class="min-w-48 rounded-lg border border-n-slate-6 bg-n-solid-2 p-2 shadow-lg"
         >
-          <span class="w-5 text-center text-sm">{{ group.emoji }}</span>
-          <div class="flex-1 min-w-0">
-            <div class="text-xs text-n-slate-12 truncate">
-              {{ user.isMine ? t('CONVERSATION.REACTIONS.YOU') : user.name }}
-            </div>
-            <div
-              v-if="user.isMine && !readOnly"
-              class="text-[10px] text-n-slate-11"
+          <div
+            v-for="(group, groupIdx) in groupedReactions"
+            :key="group.emoji"
+            :class="{ 'mt-2 border-t border-n-slate-5 pt-2': groupIdx > 0 }"
+          >
+            <component
+              :is="user.isMine && !readOnly ? 'button' : 'div'"
+              v-for="(user, userIdx) in group.users"
+              :key="`${group.emoji}-${user.id ?? userIdx}`"
+              :type="user.isMine && !readOnly ? 'button' : null"
+              class="flex w-full items-center gap-2 rounded px-1 py-1 text-left"
+              :class="
+                user.isMine && !readOnly
+                  ? 'cursor-pointer hover:bg-n-alpha-2'
+                  : ''
+              "
+              @click="handleRowClick(group.emoji, user)"
             >
-              {{ t('CONVERSATION.REACTIONS.CLICK_TO_REMOVE') }}
-            </div>
+              <span class="w-5 text-center text-sm">{{ group.emoji }}</span>
+              <div class="flex-1 min-w-0">
+                <div class="text-xs text-n-slate-12 truncate">
+                  {{
+                    user.isMine ? t('CONVERSATION.REACTIONS.YOU') : user.name
+                  }}
+                </div>
+                <div
+                  v-if="user.isMine && !readOnly"
+                  class="text-[10px] text-n-slate-11"
+                >
+                  {{ t('CONVERSATION.REACTIONS.CLICK_TO_REMOVE') }}
+                </div>
+              </div>
+            </component>
           </div>
-        </component>
-      </div>
-    </div>
+        </div>
+      </template>
+    </Dropdown>
   </div>
 </template>

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -269,17 +269,20 @@ export const mutations = {
         return;
       }
 
-      const { messages, ...updates } = conversation;
+      const {
+        messages,
+        event_metadata: eventMetadata,
+        ...updates
+      } = conversation;
       allConversations[index] = { ...selectedConversation, ...updates };
-      // The reactions controller bumps `updated_at` and dispatches
-      // CONVERSATION_UPDATED so the chat list preview refreshes; without this
-      // guard every emoji toggle would yank the open conversation back to the
-      // bottom via the SCROLL_TO_MESSAGE listener. When the latest preview row
-      // is a reaction, treat the update as preview-only and skip the scroll.
-      const lastIsReaction =
-        updates.last_non_activity_message?.content_attributes?.is_reaction ===
-        true;
-      if (_state.selectedChatId === conversation.id && !lastIsReaction) {
+      // The reactions controller dispatches CONVERSATION_UPDATED solely to
+      // refresh the chat list preview after a toggle (add/replace/remove); the
+      // open conversation should stay put. The backend tags the broadcast with
+      // `event_metadata.source = 'reaction_toggle'` so we can skip scroll
+      // unconditionally — heuristics on `last_non_activity_message` miss the
+      // case where newer non-reaction messages exist after the reacted target.
+      const isReactionUpdate = eventMetadata?.source === 'reaction_toggle';
+      if (_state.selectedChatId === conversation.id && !isReactionUpdate) {
         emitter.emit(BUS_EVENTS.SCROLL_TO_MESSAGE);
       }
     } else {

--- a/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/mutations.spec.js
@@ -244,7 +244,30 @@ describe('#mutations', () => {
       expect(emitter.emit).toHaveBeenCalledWith('SCROLL_TO_MESSAGE');
     });
 
-    it('skips SCROLL_TO_MESSAGE when the update was triggered by a reaction', () => {
+    it('skips SCROLL_TO_MESSAGE when the broadcast is tagged as a reaction toggle', () => {
+      const state = {
+        allConversations: [
+          { id: 1, updated_at: 1, last_non_activity_message: null },
+        ],
+        selectedChatId: 1,
+      };
+      // Newer non-reaction messages exist after the reacted target, so
+      // `last_non_activity_message` is a regular message — the explicit
+      // metadata is what tells us this update is preview-only.
+      mutations[types.UPDATE_CONVERSATION](state, {
+        id: 1,
+        updated_at: 2,
+        last_non_activity_message: {
+          id: 256,
+          content: 'Hello',
+          content_attributes: {},
+        },
+        event_metadata: { source: 'reaction_toggle' },
+      });
+      expect(emitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('does not persist the event_metadata field onto the cached conversation', () => {
       const state = {
         allConversations: [
           { id: 1, updated_at: 1, last_non_activity_message: null },
@@ -254,13 +277,10 @@ describe('#mutations', () => {
       mutations[types.UPDATE_CONVERSATION](state, {
         id: 1,
         updated_at: 2,
-        last_non_activity_message: {
-          id: 99,
-          content: '👍',
-          content_attributes: { is_reaction: true, in_reply_to: 42 },
-        },
+        last_non_activity_message: null,
+        event_metadata: { source: 'reaction_toggle' },
       });
-      expect(emitter.emit).not.toHaveBeenCalled();
+      expect(state.allConversations[0]).not.toHaveProperty('event_metadata');
     });
   });
 

--- a/app/javascript/entrypoints/dashboard.js
+++ b/app/javascript/entrypoints/dashboard.js
@@ -88,6 +88,12 @@ app.use(FloatingVue, {
   instantMove: true,
   arrowOverflow: false,
   disposeTimeout: 5000000,
+  themes: {
+    'naked-popover': {
+      $extend: 'dropdown',
+      $resetCss: true,
+    },
+  },
 });
 app.use(hljsVuePlugin);
 

--- a/app/jobs/action_cable_broadcast_job.rb
+++ b/app/jobs/action_cable_broadcast_job.rb
@@ -27,7 +27,13 @@ class ActionCableBroadcastJob < ApplicationJob
 
     account = Account.find(data[:account_id])
     conversation = account.conversations.find_by!(display_id: data[:id])
-    conversation.push_event_data.merge(account_id: data[:account_id])
+    fresh_data = conversation.push_event_data.merge(account_id: data[:account_id])
+    # The refreshed payload comes from the conversation row; transient per-event
+    # metadata set by the listener (eg. `source: 'reaction_toggle'` so the
+    # frontend skips SCROLL_TO_MESSAGE) lives only on the original `data` hash,
+    # so carry it forward explicitly.
+    fresh_data[:event_metadata] = data[:event_metadata] if data[:event_metadata].present?
+    fresh_data
   end
 
   def broadcast_to_members(members, event_name, broadcast_data)

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -135,7 +135,10 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
     conversation, account = extract_conversation_and_account(event)
     tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox)
 
-    broadcast(account, tokens, CONVERSATION_UPDATED, conversation.push_event_data)
+    payload = conversation.push_event_data
+    metadata = event.data[:broadcast_metadata]
+    payload = payload.merge(event_metadata: metadata) if metadata.present?
+    broadcast(account, tokens, CONVERSATION_UPDATED, payload)
   end
 
   def conversation_typing_on(event)

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -218,8 +218,8 @@ class Conversation < ApplicationRecord
     "#{ENV.fetch('FRONTEND_URL', nil)}/survey/responses/#{uuid}"
   end
 
-  def dispatch_conversation_updated_event(previous_changes = nil)
-    dispatcher_dispatch(CONVERSATION_UPDATED, previous_changes)
+  def dispatch_conversation_updated_event(previous_changes = nil, broadcast_metadata: nil)
+    dispatcher_dispatch(CONVERSATION_UPDATED, previous_changes, broadcast_metadata: broadcast_metadata)
   end
 
   private
@@ -315,10 +315,11 @@ class Conversation < ApplicationRecord
     end
   end
 
-  def dispatcher_dispatch(event_name, changed_attributes = nil)
+  def dispatcher_dispatch(event_name, changed_attributes = nil, broadcast_metadata: nil)
     Rails.configuration.dispatcher.dispatch(event_name, Time.zone.now, conversation: self, notifiable_assignee_change: notifiable_assignee_change?,
                                                                        changed_attributes: changed_attributes,
-                                                                       performed_by: Current.executed_by)
+                                                                       performed_by: Current.executed_by,
+                                                                       broadcast_metadata: broadcast_metadata)
   end
 
   def conversation_status_changed_to_open?

--- a/spec/jobs/action_cable_broadcast_job_spec.rb
+++ b/spec/jobs/action_cable_broadcast_job_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ActionCableBroadcastJob do
-  subject(:job) { described_class.perform_later(members, event_name, data) }
-
   let(:account) { create(:account) }
   let(:conversation) { create(:conversation, account: account) }
   let(:members) { ['agent-token'] }

--- a/spec/jobs/action_cable_broadcast_job_spec.rb
+++ b/spec/jobs/action_cable_broadcast_job_spec.rb
@@ -26,6 +26,24 @@ RSpec.describe ActionCableBroadcastJob do
       end
     end
 
+    context 'when the event is a conversation update without event_metadata' do
+      let(:event_name) { 'conversation.updated' }
+      let(:data) { base_data }
+
+      # Regression guard: a missing `event_metadata` must NOT be assigned as `nil`
+      # on the refreshed payload. The frontend uses optional chaining today, but
+      # locking the absence here protects against a future loosening of the
+      # `present?` check on the job side.
+      it 'does not inject a nil event_metadata key' do
+        expect(ActionCable.server).to receive(:broadcast) do |_member, payload|
+          expect(payload[:event]).to eq('conversation.updated')
+          expect(payload[:data]).not_to have_key(:event_metadata)
+          expect(payload[:data][:id]).to eq(conversation.display_id)
+        end
+        described_class.new.perform(members, event_name, data)
+      end
+    end
+
     context 'when the event is not in the refresh list' do
       let(:event_name) { 'message.created' }
       let(:data) { base_data.merge(event_metadata: { source: 'reaction_toggle' }) }

--- a/spec/jobs/action_cable_broadcast_job_spec.rb
+++ b/spec/jobs/action_cable_broadcast_job_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe ActionCableBroadcastJob do
+  subject(:job) { described_class.perform_later(members, event_name, data) }
+
+  let(:account) { create(:account) }
+  let(:conversation) { create(:conversation, account: account) }
+  let(:members) { ['agent-token'] }
+  let(:base_data) { { id: conversation.display_id, account_id: account.id } }
+
+  describe '#perform' do
+    context 'when the event is a conversation update' do
+      let(:event_name) { 'conversation.updated' }
+      let(:data) { base_data.merge(event_metadata: { source: 'reaction_toggle' }) }
+
+      # The job re-fetches `conversation.push_event_data` to drop stale
+      # snapshots in race conditions, but transient per-event tags (eg. the
+      # `reaction_toggle` source the frontend reads to skip auto-scroll) live
+      # only on the original payload — they have to be carried forward.
+      it 'preserves event_metadata after refreshing the payload' do
+        expect(ActionCable.server).to receive(:broadcast) do |_member, payload|
+          expect(payload[:event]).to eq('conversation.updated')
+          expect(payload[:data][:event_metadata]).to eq(source: 'reaction_toggle')
+          # And the refresh still happened — id comes from the reloaded record.
+          expect(payload[:data][:id]).to eq(conversation.display_id)
+        end
+        described_class.new.perform(members, event_name, data)
+      end
+    end
+
+    context 'when the event is not in the refresh list' do
+      let(:event_name) { 'message.created' }
+      let(:data) { base_data.merge(event_metadata: { source: 'reaction_toggle' }) }
+
+      it 'broadcasts the original data verbatim' do
+        expect(ActionCable.server).to receive(:broadcast) do |member, payload|
+          expect(member).to eq('agent-token')
+          expect(payload[:event]).to eq('message.created')
+          expect(payload[:data]).to eq(data)
+        end
+        described_class.new.perform(members, event_name, data)
+      end
+    end
+  end
+end

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -230,6 +230,18 @@ describe ActionCableListener do
       )
       listener.conversation_updated(event)
     end
+
+    it 'merges broadcast_metadata into the payload as event_metadata' do
+      metadata = { source: 'reaction_toggle' }
+      tagged_event = Events::Base.new(event_name, Time.zone.now, conversation: conversation, broadcast_metadata: metadata)
+
+      expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+        [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],
+        'conversation.updated',
+        conversation.push_event_data.merge(account_id: account.id, event_metadata: metadata)
+      )
+      listener.conversation_updated(tagged_event)
+    end
   end
 
   shared_examples 'scheduled message event broadcast' do |method_name, event_name|


### PR DESCRIPTION
The compact and full emoji reaction pickers, plus the "who reacted" popover, were being cut off depending on the message position in the conversation list and the viewport size.

## Closes

n/a (visual regression on top of #276)

## How to reproduce

1. Open any conversation with WhatsApp messages.
2. Hover the most recent message and add a reaction → picker opens upward (worked already).
3. Scroll up so the message is near the top of the visible list, hover and try to react → previously the picker was clipped by the scroll container; now it flips to open downward without clipping.
4. Repeat near the right/left edges and on a narrow viewport (mobile width) → picker now shifts horizontally so it never overflows the screen.
5. Click an existing reaction chip → the "who reacted" popover follows the same flip/shift logic.
6. Scroll the message list while a picker is open → it closes automatically.

## What changed

- Migrated `EmojiReactionPicker` and `ReactionDisplay` from manual `position: absolute` to floating-vue's `<Dropdown>`. The popper now teleports to `body`, escaping the scroll container's clipping context, and gets automatic flip/shift via `@floating-ui/dom`.
- Registered a `naked-popover` theme in `entrypoints/dashboard.js` that extends the dropdown behavior (auto-hide, click-outside, etc.) but uses `$resetCss: true` so the default visual styling (white bg, border, shadow, arrow) is not inherited.
- The compact picker, the full `EmojiInput`, and the "who reacted" popover all close when the message list scrolls (via the existing `BUS_EVENTS.ON_MESSAGE_LIST_SCROLL`).
- Kept the reaction toolbar visible while a picker is open, since the teleported popper is no longer inside the message's `group-hover` scope.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/283)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reaction picker and popovers now use a unified popover component with proper ARIA state and an explicit open state; picker stays visible when open and quick/full views switch inside the popover.
  * Visual overlap of reaction badges adjusted based on message type.
  * Added a lightweight popover theme for consistent styling.

* **Bug Fixes**
  * Popovers reliably close on window blur and during message-list scroll.
  * Conversation updates mark reaction toggles to prevent unwanted scrolling.

* **Tests**
  * Added specs covering broadcast payload handling and conversation-update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->