### PR TITLE
fix(dispatcher): omit broadcast_metadata kwarg when nil

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -316,10 +316,10 @@ class Conversation < ApplicationRecord
   end
 
   def dispatcher_dispatch(event_name, changed_attributes = nil, broadcast_metadata: nil)
-    Rails.configuration.dispatcher.dispatch(event_name, Time.zone.now, conversation: self, notifiable_assignee_change: notifiable_assignee_change?,
-                                                                       changed_attributes: changed_attributes,
-                                                                       performed_by: Current.executed_by,
-                                                                       broadcast_metadata: broadcast_metadata)
+    payload = { conversation: self, notifiable_assignee_change: notifiable_assignee_change?,
+                changed_attributes: changed_attributes, performed_by: Current.executed_by }
+    payload[:broadcast_metadata] = broadcast_metadata unless broadcast_metadata.nil?
+    Rails.configuration.dispatcher.dispatch(event_name, Time.zone.now, **payload)
   end
 
   def conversation_status_changed_to_open?


### PR DESCRIPTION
Fixes the wave of model/controller spec failures introduced after #283 (`broadcast_metadata` plumbing for the reaction-toggle scroll skip).

## Why

`Conversation#dispatcher_dispatch` started passing `broadcast_metadata: broadcast_metadata` unconditionally, so even callers that don't tag metadata (every CONVERSATION_* event other than reaction toggles, plus account / inbox / team / label events that the dispatcher mocks observe) ended up with `:broadcast_metadata => nil` in the payload. That's a noop on the listener side, but specs across the suite mock `Rails.configuration.dispatcher.dispatch` with the historical payload shape, so they all started failing with `received :dispatch with unexpected arguments`.

## What changed

Build the dispatch payload conditionally and only attach `broadcast_metadata` when the caller actually passed something. Default-nil callers see exactly the pre-#283 payload shape; the reaction-toggle path keeps tagging `source: 'reaction_toggle'` as before.

## How to reproduce

```bash
bundle exec rspec spec/models/conversation_spec.rb \
                  spec/models/concerns/cache_keys_spec.rb \
                  spec/models/inbox_spec.rb \
                  spec/models/team_spec.rb \
                  spec/jobs/action_cable_broadcast_job_spec.rb \
                  spec/listeners/action_cable_listener_spec.rb \
                  spec/controllers/api/v1/accounts/conversations/messages/reactions_controller_spec.rb
```

All green on this branch (204 examples, 0 failures locally).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/286)
<!-- Reviewable:end -->
