### PR TITLE
feat(custom-filters): add personal/global visibility

### DIFF
--- a/app/controllers/api/v1/accounts/custom_filters_controller.rb
+++ b/app/controllers/api/v1/accounts/custom_filters_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Accounts::CustomFiltersController < Api::V1::Accounts::BaseController
   before_action :fetch_custom_filter, only: [:show, :update, :destroy]
-  before_action :check_authorization, only: [:show, :update, :destroy]
+  before_action :check_authorization
   before_action :fetch_custom_filters, only: [:index]
 
   def index; end
@@ -35,7 +35,7 @@ class Api::V1::Accounts::CustomFiltersController < Api::V1::Accounts::BaseContro
   end
 
   def check_authorization
-    authorize(@custom_filter)
+    authorize(@custom_filter || CustomFilter)
   end
 
   def permitted_payload

--- a/app/controllers/api/v1/accounts/custom_filters_controller.rb
+++ b/app/controllers/api/v1/accounts/custom_filters_controller.rb
@@ -1,22 +1,23 @@
 class Api::V1::Accounts::CustomFiltersController < Api::V1::Accounts::BaseController
-  before_action :check_authorization
-  before_action :fetch_custom_filters, only: [:index]
   before_action :fetch_custom_filter, only: [:show, :update, :destroy]
-  DEFAULT_FILTER_TYPE = 'conversation'.freeze
+  before_action :check_authorization, only: [:show, :update, :destroy]
+  before_action :fetch_custom_filters, only: [:index]
 
   def index; end
 
   def show; end
 
   def create
-    @custom_filter = Current.account.custom_filters.create!(
-      permitted_payload.merge(user: Current.user)
-    )
+    @custom_filter = Current.account.custom_filters.new(permitted_payload.merge(user: Current.user))
+    @custom_filter.set_visibility(Current.user, permitted_payload)
+    @custom_filter.save!
     render json: { error: @custom_filter.errors.messages }, status: :unprocessable_entity and return unless @custom_filter.valid?
   end
 
   def update
-    @custom_filter.update!(permitted_payload)
+    @custom_filter.assign_attributes(permitted_payload)
+    @custom_filter.set_visibility(Current.user, permitted_payload)
+    @custom_filter.save!
   end
 
   def destroy
@@ -27,24 +28,19 @@ class Api::V1::Accounts::CustomFiltersController < Api::V1::Accounts::BaseContro
   private
 
   def fetch_custom_filters
-    @custom_filters = Current.account.custom_filters.where(
-      user: Current.user,
-      filter_type: permitted_params[:filter_type] || DEFAULT_FILTER_TYPE
-    )
+    @custom_filters = CustomFilter.with_visibility(Current.user, permitted_params)
   end
 
   def fetch_custom_filter
-    @custom_filter = Current.account.custom_filters.where(
-      user: Current.user
-    ).find(permitted_params[:id])
+    @custom_filter = Current.account.custom_filters.find(permitted_params[:id])
+  end
+
+  def check_authorization
+    authorize(@custom_filter)
   end
 
   def permitted_payload
-    params.require(:custom_filter).permit(
-      :name,
-      :filter_type,
-      query: {}
-    )
+    params.require(:custom_filter).permit(:name, :filter_type, :visibility, query: {})
   end
 
   def permitted_params

--- a/app/controllers/api/v1/accounts/custom_filters_controller.rb
+++ b/app/controllers/api/v1/accounts/custom_filters_controller.rb
@@ -11,7 +11,6 @@ class Api::V1::Accounts::CustomFiltersController < Api::V1::Accounts::BaseContro
     @custom_filter = Current.account.custom_filters.new(permitted_payload.merge(user: Current.user))
     @custom_filter.set_visibility(Current.user, permitted_payload)
     @custom_filter.save!
-    render json: { error: @custom_filter.errors.messages }, status: :unprocessable_entity and return unless @custom_filter.valid?
   end
 
   def update

--- a/app/javascript/dashboard/components-next/Contacts/ContactsForm/CreateSegmentDialog.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsForm/CreateSegmentDialog.vue
@@ -1,26 +1,33 @@
 <script setup>
 import { ref, reactive, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useStore } from 'vuex';
 import { useMapGetter } from 'dashboard/composables/store';
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 
 import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
 import Input from 'dashboard/components-next/input/Input.vue';
+import VisibilitySelector from 'dashboard/components-next/filter/VisibilitySelector.vue';
 
 const emit = defineEmits(['create']);
 
 const FILTER_TYPE_CONTACT = 1;
 
 const { t } = useI18n();
+const store = useStore();
 
 const uiFlags = useMapGetter('customViews/getUIFlags');
 const isCreating = computed(() => uiFlags.value.isCreating);
+const isAdmin = computed(
+  () => store.getters.getCurrentRole === 'administrator'
+);
 
 const dialogRef = ref(null);
 
 const state = reactive({
   name: '',
+  visibility: 'personal',
 });
 
 const validationRules = {
@@ -35,8 +42,10 @@ const handleDialogConfirm = async () => {
   emit('create', {
     name: state.name,
     filter_type: FILTER_TYPE_CONTACT,
+    visibility: state.visibility,
   });
   state.name = '';
+  state.visibility = 'personal';
   v$.value.$reset();
 };
 
@@ -66,6 +75,12 @@ defineExpose({ dialogRef });
           : ''
       "
       :message-type="v$.name.$error ? 'error' : 'info'"
+    />
+    <VisibilitySelector
+      v-if="isAdmin"
+      v-model="state.visibility"
+      class="mt-4"
+      i18n-prefix="CONTACTS_LAYOUT.HEADER.ACTIONS.FILTERS.CREATE_SEGMENT.VISIBILITY"
     />
   </Dialog>
 </template>

--- a/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactHeader.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactHeader.vue
@@ -17,6 +17,7 @@ defineProps({
   hasActiveFilters: { type: Boolean, default: false },
   isLabelView: { type: Boolean, default: false },
   isActiveView: { type: Boolean, default: false },
+  canManageActiveSegment: { type: Boolean, default: true },
 });
 
 const emit = defineEmits([
@@ -61,7 +62,14 @@ const emit = defineEmits([
         </div>
         <div class="flex items-center flex-shrink-0 gap-4">
           <div class="flex items-center gap-2">
-            <div v-if="!isLabelView && !isActiveView" class="relative">
+            <div
+              v-if="
+                !isLabelView &&
+                !isActiveView &&
+                (!isSegmentsView || canManageActiveSegment)
+              "
+              class="relative"
+            >
               <Button
                 id="toggleContactsFilterButton"
                 :icon="
@@ -94,12 +102,34 @@ const emit = defineEmits([
               @click="emit('createSegment')"
             />
             <Button
-              v-if="isSegmentsView && !isLabelView && !isActiveView"
+              v-if="
+                isSegmentsView &&
+                !isLabelView &&
+                !isActiveView &&
+                canManageActiveSegment
+              "
               icon="i-lucide-trash"
               color="slate"
               size="sm"
               variant="ghost"
               @click="emit('deleteSegment')"
+            />
+            <Button
+              v-if="
+                isSegmentsView &&
+                !isLabelView &&
+                !isActiveView &&
+                !canManageActiveSegment
+              "
+              v-tooltip.bottom-end="
+                $t(
+                  'CONTACTS_LAYOUT.HEADER.ACTIONS.FILTERS.CREATE_SEGMENT.READ_ONLY_TOOLTIP'
+                )
+              "
+              icon="i-lucide-info"
+              color="slate"
+              size="sm"
+              variant="ghost"
             />
             <ContactSortMenu
               :active-sort="activeSort"

--- a/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactHeader.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactHeader.vue
@@ -126,6 +126,11 @@ const emit = defineEmits([
                   'CONTACTS_LAYOUT.HEADER.ACTIONS.FILTERS.CREATE_SEGMENT.READ_ONLY_TOOLTIP'
                 )
               "
+              :aria-label="
+                $t(
+                  'CONTACTS_LAYOUT.HEADER.ACTIONS.FILTERS.CREATE_SEGMENT.READ_ONLY_TOOLTIP'
+                )
+              "
               icon="i-lucide-info"
               color="slate"
               size="sm"

--- a/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
@@ -67,6 +67,17 @@ const hasActiveSegments = computed(
   () => props.activeSegment && props.segmentsId !== 0
 );
 const activeSegmentName = computed(() => props.activeSegment?.name);
+const activeSegmentVisibility = computed(
+  () => props.activeSegment?.visibility ?? 'personal'
+);
+const currentRole = useMapGetter('getCurrentRole');
+const canManageActiveSegment = computed(() => {
+  if (!props.activeSegment) return true;
+  if (props.activeSegment.visibility === 'global') {
+    return currentRole.value === 'administrator';
+  }
+  return true;
+});
 
 const openCreateNewContactDialog = () => {
   createNewContactDialogRef.value?.dialogRef.open();
@@ -199,11 +210,13 @@ const onApplyFilter = async payload => {
   showFiltersModal.value = false;
 };
 
-const onUpdateSegment = async (payload, segmentName) => {
+const onUpdateSegment = async (payload, segmentName, segmentVisibility) => {
   payload = useSnakeCase(payload);
   const payloadData = {
     ...props.activeSegment,
     name: segmentName,
+    visibility:
+      segmentVisibility ?? props.activeSegment?.visibility ?? 'personal',
     query: filterQueryGenerator(payload),
   };
   await store.dispatch('customViews/update', payloadData);
@@ -281,6 +294,7 @@ defineExpose({
     :is-label-view="isLabelView"
     :is-active-view="isActiveView"
     :has-active-filters="hasAppliedFilters"
+    :can-manage-active-segment="canManageActiveSegment"
     :button-label="t('CONTACTS_LAYOUT.HEADER.MESSAGE_BUTTON')"
     @search="emit('search', $event)"
     @update:sort="emit('update:sort', $event)"
@@ -299,6 +313,7 @@ defineExpose({
           v-if="showFiltersModal"
           v-model="appliedFilter"
           :segment-name="activeSegmentName"
+          :segment-visibility="activeSegmentVisibility"
           :is-segment-view="hasActiveSegments"
           @apply-filter="onApplyFilter"
           @update-segment="onUpdateSegment"

--- a/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
@@ -224,8 +224,7 @@ const onUpdateSegment = async (payload, segmentName, segmentVisibility) => {
     closeAdvanceFiltersModal();
   } catch (error) {
     useAlert(
-      error?.message ??
-        t('CONTACTS_LAYOUT.HEADER.ACTIONS.FILTERS.CREATE_SEGMENT.ERROR_MESSAGE')
+      error?.message ?? t('FILTER.CUSTOM_VIEWS.EDIT.API_SEGMENTS.ERROR_MESSAGE')
     );
   }
 };

--- a/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
@@ -219,8 +219,15 @@ const onUpdateSegment = async (payload, segmentName, segmentVisibility) => {
       segmentVisibility ?? props.activeSegment?.visibility ?? 'personal',
     query: filterQueryGenerator(payload),
   };
-  await store.dispatch('customViews/update', payloadData);
-  closeAdvanceFiltersModal();
+  try {
+    await store.dispatch('customViews/update', payloadData);
+    closeAdvanceFiltersModal();
+  } catch (error) {
+    useAlert(
+      error?.message ??
+        t('CONTACTS_LAYOUT.HEADER.ACTIONS.FILTERS.CREATE_SEGMENT.ERROR_MESSAGE')
+    );
+  }
 };
 
 const setParamsForEditSegmentModal = () => {

--- a/app/javascript/dashboard/components-next/filter/ContactsFilter.vue
+++ b/app/javascript/dashboard/components-next/filter/ContactsFilter.vue
@@ -11,10 +11,13 @@ import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 import Button from 'next/button/Button.vue';
 import Input from 'dashboard/components-next/input/Input.vue';
 import ConditionRow from './ConditionRow.vue';
+import VisibilitySelector from './VisibilitySelector.vue';
+import { useMapGetter } from 'dashboard/composables/store';
 
 const props = defineProps({
   isSegmentView: { type: Boolean, default: false },
   segmentName: { type: String, default: '' },
+  segmentVisibility: { type: String, default: 'personal' },
 });
 
 const emit = defineEmits([
@@ -30,6 +33,9 @@ const filters = defineModel({
   default: [],
 });
 const segmentNameLocal = ref(props.segmentName);
+const segmentVisibilityLocal = ref(props.segmentVisibility);
+const currentRole = useMapGetter('getCurrentRole');
+const isAdmin = computed(() => currentRole.value === 'administrator');
 
 const DEFAULT_FILTER = {
   attributeKey: 'name',
@@ -67,7 +73,12 @@ const isConditionsValid = () => {
 
 const updateSavedSegment = () => {
   if (isConditionsValid()) {
-    emit('updateSegment', filters.value, segmentNameLocal.value);
+    emit(
+      'updateSegment',
+      filters.value,
+      segmentNameLocal.value,
+      segmentVisibilityLocal.value
+    );
   }
 };
 
@@ -110,11 +121,16 @@ const outsideClickHandler = [
       {{ filterModalHeaderTitle }}
     </h3>
     <div v-if="props.isSegmentView">
-      <div class="pb-6 border-b border-n-weak">
+      <div class="pb-6 border-b border-n-weak grid gap-4">
         <Input
           v-model="segmentNameLocal"
           :label="$t('CONTACTS_LAYOUT.FILTER.SEGMENT.LABEL')"
           :placeholder="t('CONTACTS_LAYOUT.FILTER.SEGMENT.INPUT_PLACEHOLDER')"
+        />
+        <VisibilitySelector
+          v-if="isAdmin"
+          v-model="segmentVisibilityLocal"
+          i18n-prefix="CONTACTS_LAYOUT.HEADER.ACTIONS.FILTERS.CREATE_SEGMENT.VISIBILITY"
         />
       </div>
     </div>

--- a/app/javascript/dashboard/components-next/filter/ConversationFilter.vue
+++ b/app/javascript/dashboard/components-next/filter/ConversationFilter.vue
@@ -11,6 +11,8 @@ import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 import Button from 'next/button/Button.vue';
 import Input from 'dashboard/components-next/input/Input.vue';
 import ConditionRow from './ConditionRow.vue';
+import VisibilitySelector from './VisibilitySelector.vue';
+import { useMapGetter } from 'dashboard/composables/store';
 
 const props = defineProps({
   isFolderView: {
@@ -20,6 +22,10 @@ const props = defineProps({
   folderName: {
     type: String,
     default: '',
+  },
+  folderVisibility: {
+    type: String,
+    default: 'personal',
   },
 });
 
@@ -31,6 +37,9 @@ const filters = defineModel({
   default: [],
 });
 const folderNameLocal = ref(props.folderName);
+const folderVisibilityLocal = ref(props.folderVisibility);
+const currentRole = useMapGetter('getCurrentRole');
+const isAdmin = computed(() => currentRole.value === 'administrator');
 
 const DEFAULT_FILTER = {
   attributeKey: 'status',
@@ -66,7 +75,12 @@ const isConditionsValid = () => {
 
 const updateSavedCustomViews = () => {
   if (isConditionsValid()) {
-    emit('updateFolder', filters.value, folderNameLocal.value);
+    emit(
+      'updateFolder',
+      filters.value,
+      folderNameLocal.value,
+      folderVisibilityLocal.value
+    );
   }
 };
 
@@ -111,11 +125,16 @@ const outsideClickHandler = [
       {{ filterModalHeaderTitle }}
     </h3>
     <div v-if="props.isFolderView">
-      <div class="border-b border-n-weak pb-6">
+      <div class="border-b border-n-weak pb-6 grid gap-4">
         <Input
           v-model="folderNameLocal"
           :label="t('FILTER.FOLDER_LABEL')"
           :placeholder="t('FILTER.INPUT_PLACEHOLDER')"
+        />
+        <VisibilitySelector
+          v-if="isAdmin"
+          v-model="folderVisibilityLocal"
+          i18n-prefix="FILTER.CUSTOM_VIEWS.VISIBILITY"
         />
       </div>
     </div>

--- a/app/javascript/dashboard/components-next/filter/SaveCustomView.vue
+++ b/app/javascript/dashboard/components-next/filter/SaveCustomView.vue
@@ -86,11 +86,11 @@ export default {
           type: this.filterType === 0 ? 'folder' : 'segment',
         });
       } catch (error) {
-        const errorMessage = error?.message;
-        this.alertMessage =
-          errorMessage || this.filterType === 0
-            ? errorMessage
+        const fallbackMessage =
+          this.filterType === 0
+            ? this.$t('FILTER.CUSTOM_VIEWS.ADD.API_FOLDERS.ERROR_MESSAGE')
             : this.$t('FILTER.CUSTOM_VIEWS.ADD.API_SEGMENTS.ERROR_MESSAGE');
+        this.alertMessage = error?.message || fallbackMessage;
       } finally {
         useAlert(this.alertMessage);
       }

--- a/app/javascript/dashboard/components-next/filter/SaveCustomView.vue
+++ b/app/javascript/dashboard/components-next/filter/SaveCustomView.vue
@@ -85,6 +85,7 @@ export default {
         useTrack(CONTACTS_EVENTS.SAVE_FILTER, {
           type: this.filterType === 0 ? 'folder' : 'segment',
         });
+        this.openLastSavedItem();
       } catch (error) {
         const fallbackMessage =
           this.filterType === 0
@@ -94,7 +95,6 @@ export default {
       } finally {
         useAlert(this.alertMessage);
       }
-      this.openLastSavedItem();
     },
   },
 };

--- a/app/javascript/dashboard/components-next/filter/SaveCustomView.vue
+++ b/app/javascript/dashboard/components-next/filter/SaveCustomView.vue
@@ -7,11 +7,13 @@ import { vOnClickOutside } from '@vueuse/components';
 import { useTrack } from 'dashboard/composables';
 import NextButton from 'next/button/Button.vue';
 import NextInput from 'dashboard/components-next/input/Input.vue';
+import VisibilitySelector from 'dashboard/components-next/filter/VisibilitySelector.vue';
 
 export default {
   components: {
     NextButton,
     NextInput,
+    VisibilitySelector,
   },
   directives: {
     onClickOutside: vOnClickOutside,
@@ -38,12 +40,16 @@ export default {
     return {
       show: true,
       name: '',
+      visibility: 'personal',
     };
   },
 
   computed: {
     isButtonDisabled() {
       return this.v$.name.$invalid;
+    },
+    isAdmin() {
+      return this.$store.getters.getCurrentRole === 'administrator';
     },
   },
 
@@ -67,6 +73,7 @@ export default {
         await this.$store.dispatch('customViews/create', {
           name: this.name,
           filter_type: this.filterType,
+          visibility: this.visibility,
           query: this.customViewsQuery,
         });
         this.alertMessage =
@@ -111,6 +118,11 @@ export default {
         :message="v$.name.$error && $t('FILTER.CUSTOM_VIEWS.ADD.ERROR_MESSAGE')"
         :message-type="v$.name.$error && 'error'"
         @blur="v$.name.$touch"
+      />
+      <VisibilitySelector
+        v-if="isAdmin"
+        v-model="visibility"
+        i18n-prefix="FILTER.CUSTOM_VIEWS.VISIBILITY"
       />
       <div class="flex flex-row justify-end w-full gap-2">
         <NextButton faded slate sm @click.prevent="onClose">

--- a/app/javascript/dashboard/components-next/filter/VisibilitySelector.vue
+++ b/app/javascript/dashboard/components-next/filter/VisibilitySelector.vue
@@ -46,6 +46,7 @@ const select = value => emit('update:modelValue', value);
         type="button"
         class="p-2 relative rounded-md border border-solid justify-between items-start gap-2 flex flex-col text-start cursor-pointer"
         :class="isActive('global')"
+        :aria-pressed="modelValue === 'global'"
         @click.prevent="select('global')"
       >
         <div class="flex items-center gap-2 min-w-0 justify-between w-full">
@@ -66,6 +67,7 @@ const select = value => emit('update:modelValue', value);
         type="button"
         class="p-2 relative rounded-md border border-solid justify-between items-start gap-2 flex flex-col text-start cursor-pointer"
         :class="isActive('personal')"
+        :aria-pressed="modelValue === 'personal'"
         @click.prevent="select('personal')"
       >
         <div class="flex items-center gap-2 min-w-0 justify-between w-full">

--- a/app/javascript/dashboard/components-next/filter/VisibilitySelector.vue
+++ b/app/javascript/dashboard/components-next/filter/VisibilitySelector.vue
@@ -1,0 +1,87 @@
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Icon from 'dashboard/components-next/icon/Icon.vue';
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: 'personal',
+  },
+  i18nPrefix: {
+    type: String,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const { t } = useI18n();
+
+const label = computed(() => t(`${props.i18nPrefix}.LABEL`));
+const globalLabel = computed(() => t(`${props.i18nPrefix}.GLOBAL.LABEL`));
+const globalDescription = computed(() =>
+  t(`${props.i18nPrefix}.GLOBAL.DESCRIPTION`)
+);
+const personalLabel = computed(() => t(`${props.i18nPrefix}.PERSONAL.LABEL`));
+const personalDescription = computed(() =>
+  t(`${props.i18nPrefix}.PERSONAL.DESCRIPTION`)
+);
+
+const isActive = key =>
+  props.modelValue === key
+    ? 'bg-n-blue-2 dark:bg-n-blue-1 border-n-blue-3 dark:border-n-blue-4'
+    : 'bg-white dark:bg-n-solid-2 border-n-weak dark:border-n-strong';
+
+const select = value => emit('update:modelValue', value);
+</script>
+
+<template>
+  <div>
+    <p class="block m-0 text-sm font-medium leading-[1.8] text-n-slate-12">
+      {{ label }}
+    </p>
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+      <button
+        type="button"
+        class="p-2 relative rounded-md border border-solid justify-between items-start gap-2 flex flex-col text-start cursor-pointer"
+        :class="isActive('global')"
+        @click.prevent="select('global')"
+      >
+        <div class="flex items-center gap-2 min-w-0 justify-between w-full">
+          <p class="block m-0 text-heading-3 text-n-slate-12 line-clamp-1">
+            {{ globalLabel }}
+          </p>
+          <Icon
+            v-if="modelValue === 'global'"
+            icon="i-lucide-circle-check-big"
+            class="text-n-brand size-4"
+          />
+        </div>
+        <p class="text-n-slate-11 text-label-small">
+          {{ globalDescription }}
+        </p>
+      </button>
+      <button
+        type="button"
+        class="p-2 relative rounded-md border border-solid justify-between items-start gap-2 flex flex-col text-start cursor-pointer"
+        :class="isActive('personal')"
+        @click.prevent="select('personal')"
+      >
+        <div class="flex items-center gap-2 min-w-0 justify-between w-full">
+          <p class="block m-0 text-heading-3 text-n-slate-12 line-clamp-1">
+            {{ personalLabel }}
+          </p>
+          <Icon
+            v-if="modelValue === 'personal'"
+            icon="i-lucide-circle-check-big"
+            class="text-n-brand size-4"
+          />
+        </div>
+        <p class="text-n-slate-11 text-label-small">
+          {{ personalDescription }}
+        </p>
+      </button>
+    </div>
+  </div>
+</template>

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -182,6 +182,19 @@ const activeFolderName = computed(() => {
   return activeFolder.value?.name;
 });
 
+const activeFolderVisibility = computed(() => {
+  return activeFolder.value?.visibility ?? 'personal';
+});
+
+const currentRole = useMapGetter('getCurrentRole');
+const canManageActiveFolder = computed(() => {
+  if (!activeFolder.value) return true;
+  if (activeFolder.value.visibility === 'global') {
+    return currentRole.value === 'administrator';
+  }
+  return true;
+});
+
 const hasActiveFolders = computed(() => {
   return Boolean(activeFolder.value && props.foldersId !== 0);
 });
@@ -461,11 +474,13 @@ function closeAdvanceFiltersModal() {
   appliedFilter.value = [];
 }
 
-function onUpdateSavedFilter(payload, folderName) {
+function onUpdateSavedFilter(payload, folderName, folderVisibility) {
   const transformedPayload = useSnakeCase(payload);
   const payloadData = {
     ...unref(activeFolder),
     name: unref(folderName),
+    visibility:
+      folderVisibility ?? unref(activeFolder)?.visibility ?? 'personal',
     query: filterQueryGenerator(transformedPayload),
   };
   store.dispatch('customViews/update', payloadData);
@@ -968,6 +983,7 @@ watch(conversationFilters, (newVal, oldVal) => {
       :page-title="pageTitle"
       :has-applied-filters="hasAppliedFilters"
       :has-active-folders="hasActiveFolders"
+      :can-manage-active-folder="canManageActiveFolder"
       :active-status="activeStatus"
       :is-on-expanded-layout="isOnExpandedLayout"
       :conversation-stats="conversationStats"
@@ -1085,6 +1101,7 @@ watch(conversationFilters, (newVal, oldVal) => {
       <ConversationFilter
         v-model="appliedFilter"
         :folder-name="activeFolderName"
+        :folder-visibility="activeFolderVisibility"
         :is-folder-view="hasActiveFolders"
         @apply-filter="onApplyFilter"
         @update-folder="onUpdateSavedFilter"

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -488,7 +488,7 @@ async function onUpdateSavedFilter(payload, folderName, folderVisibility) {
     closeAdvanceFiltersModal();
   } catch (error) {
     useAlert(
-      error?.message ?? t('FILTER.CUSTOM_VIEWS.ADD.API_FOLDERS.ERROR_MESSAGE')
+      error?.message ?? t('FILTER.CUSTOM_VIEWS.EDIT.API_FOLDERS.ERROR_MESSAGE')
     );
   }
 }

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -474,7 +474,7 @@ function closeAdvanceFiltersModal() {
   appliedFilter.value = [];
 }
 
-function onUpdateSavedFilter(payload, folderName, folderVisibility) {
+async function onUpdateSavedFilter(payload, folderName, folderVisibility) {
   const transformedPayload = useSnakeCase(payload);
   const payloadData = {
     ...unref(activeFolder),
@@ -483,8 +483,14 @@ function onUpdateSavedFilter(payload, folderName, folderVisibility) {
       folderVisibility ?? unref(activeFolder)?.visibility ?? 'personal',
     query: filterQueryGenerator(transformedPayload),
   };
-  store.dispatch('customViews/update', payloadData);
-  closeAdvanceFiltersModal();
+  try {
+    await store.dispatch('customViews/update', payloadData);
+    closeAdvanceFiltersModal();
+  } catch (error) {
+    useAlert(
+      error?.message ?? t('FILTER.CUSTOM_VIEWS.ADD.API_FOLDERS.ERROR_MESSAGE')
+    );
+  }
 }
 
 function onClickOpenAddFoldersModal() {

--- a/app/javascript/dashboard/components/ChatListHeader.vue
+++ b/app/javascript/dashboard/components/ChatListHeader.vue
@@ -116,7 +116,7 @@ const toggleConversationLayout = () => {
         <template v-if="canManageActiveFolder">
           <div class="relative">
             <NextButton
-              id="toggleConversationFilterButton"
+              id="editConversationFilterButton"
               v-tooltip.top-end="$t('FILTER.CUSTOM_VIEWS.EDIT.EDIT_BUTTON')"
               icon="i-lucide-pen-line"
               slate
@@ -131,7 +131,7 @@ const toggleConversationLayout = () => {
             />
           </div>
           <NextButton
-            id="toggleConversationFilterButton"
+            id="deleteConversationFilterButton"
             v-tooltip.top-end="$t('FILTER.CUSTOM_VIEWS.DELETE.DELETE_BUTTON')"
             icon="i-lucide-trash-2"
             ruby

--- a/app/javascript/dashboard/components/ChatListHeader.vue
+++ b/app/javascript/dashboard/components/ChatListHeader.vue
@@ -143,6 +143,7 @@ const toggleConversationLayout = () => {
         <NextButton
           v-else
           v-tooltip.top-end="$t('FILTER.CUSTOM_VIEWS.READ_ONLY_TOOLTIP')"
+          :aria-label="$t('FILTER.CUSTOM_VIEWS.READ_ONLY_TOOLTIP')"
           icon="i-lucide-info"
           slate
           xs

--- a/app/javascript/dashboard/components/ChatListHeader.vue
+++ b/app/javascript/dashboard/components/ChatListHeader.vue
@@ -12,6 +12,7 @@ const props = defineProps({
   pageTitle: { type: String, required: true },
   hasAppliedFilters: { type: Boolean, required: true },
   hasActiveFolders: { type: Boolean, required: true },
+  canManageActiveFolder: { type: Boolean, default: true },
   activeStatus: { type: String, required: true },
   isOnExpandedLayout: { type: Boolean, required: true },
   conversationStats: { type: Object, required: true },
@@ -112,30 +113,40 @@ const toggleConversationLayout = () => {
         />
       </template>
       <template v-if="hasActiveFolders">
-        <div class="relative">
+        <template v-if="canManageActiveFolder">
+          <div class="relative">
+            <NextButton
+              id="toggleConversationFilterButton"
+              v-tooltip.top-end="$t('FILTER.CUSTOM_VIEWS.EDIT.EDIT_BUTTON')"
+              icon="i-lucide-pen-line"
+              slate
+              xs
+              faded
+              @click="emit('filtersModal')"
+            />
+            <div
+              id="conversationFilterTeleportTarget"
+              class="absolute z-50 mt-2"
+              :class="{ 'ltr:right-0 rtl:left-0': isOnExpandedLayout }"
+            />
+          </div>
           <NextButton
             id="toggleConversationFilterButton"
-            v-tooltip.top-end="$t('FILTER.CUSTOM_VIEWS.EDIT.EDIT_BUTTON')"
-            icon="i-lucide-pen-line"
-            slate
+            v-tooltip.top-end="$t('FILTER.CUSTOM_VIEWS.DELETE.DELETE_BUTTON')"
+            icon="i-lucide-trash-2"
+            ruby
             xs
             faded
-            @click="emit('filtersModal')"
+            @click="emit('deleteFolders')"
           />
-          <div
-            id="conversationFilterTeleportTarget"
-            class="absolute z-50 mt-2"
-            :class="{ 'ltr:right-0 rtl:left-0': isOnExpandedLayout }"
-          />
-        </div>
+        </template>
         <NextButton
-          id="toggleConversationFilterButton"
-          v-tooltip.top-end="$t('FILTER.CUSTOM_VIEWS.DELETE.DELETE_BUTTON')"
-          icon="i-lucide-trash-2"
-          ruby
+          v-else
+          v-tooltip.top-end="$t('FILTER.CUSTOM_VIEWS.READ_ONLY_TOOLTIP')"
+          icon="i-lucide-info"
+          slate
           xs
           faded
-          @click="emit('deleteFolders')"
         />
       </template>
       <div v-else class="relative">

--- a/app/javascript/dashboard/i18n/locale/en/advancedFilters.json
+++ b/app/javascript/dashboard/i18n/locale/en/advancedFilters.json
@@ -94,7 +94,13 @@
         }
       },
       "EDIT": {
-        "EDIT_BUTTON": "Edit folder"
+        "EDIT_BUTTON": "Edit folder",
+        "API_FOLDERS": {
+          "ERROR_MESSAGE": "Error while updating folder."
+        },
+        "API_SEGMENTS": {
+          "ERROR_MESSAGE": "Error while updating segment."
+        }
       },
       "DELETE": {
         "DELETE_BUTTON": "Delete filter",

--- a/app/javascript/dashboard/i18n/locale/en/advancedFilters.json
+++ b/app/javascript/dashboard/i18n/locale/en/advancedFilters.json
@@ -114,7 +114,19 @@
           "SUCCESS_MESSAGE": "Segment deleted successfully.",
           "ERROR_MESSAGE": "Error while deleting segment."
         }
-      }
+      },
+      "VISIBILITY": {
+        "LABEL": "Visibility",
+        "GLOBAL": {
+          "LABEL": "Public",
+          "DESCRIPTION": "Available to all agents in this account."
+        },
+        "PERSONAL": {
+          "LABEL": "Private",
+          "DESCRIPTION": "Only you will be able to see and manage this filter."
+        }
+      },
+      "READ_ONLY_TOOLTIP": "Public folder. Ask an administrator to edit or delete it."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/en/contact.json
+++ b/app/javascript/dashboard/i18n/locale/en/contact.json
@@ -370,7 +370,19 @@
             "PLACEHOLDER": "Enter the name of the filter",
             "ERROR": "Enter a valid name",
             "SUCCESS_MESSAGE": "Filter saved successfully",
-            "ERROR_MESSAGE": "Unable to save filter. Please try again later."
+            "ERROR_MESSAGE": "Unable to save filter. Please try again later.",
+            "VISIBILITY": {
+              "LABEL": "Visibility",
+              "GLOBAL": {
+                "LABEL": "Public",
+                "DESCRIPTION": "Available to all agents in this account."
+              },
+              "PERSONAL": {
+                "LABEL": "Private",
+                "DESCRIPTION": "Only you will be able to see and manage this segment."
+              }
+            },
+            "READ_ONLY_TOOLTIP": "Public segment. Ask an administrator to edit or delete it."
           },
           "DELETE_SEGMENT": {
             "TITLE": "Confirm Deletion",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/advancedFilters.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/advancedFilters.json
@@ -114,7 +114,19 @@
           "SUCCESS_MESSAGE": "Segmento apagado com sucesso.",
           "ERROR_MESSAGE": "Erro ao excluir segmento."
         }
-      }
+      },
+      "VISIBILITY": {
+        "LABEL": "Visibilidade",
+        "GLOBAL": {
+          "LABEL": "Pública",
+          "DESCRIPTION": "Disponível para todos os agentes desta conta."
+        },
+        "PERSONAL": {
+          "LABEL": "Privada",
+          "DESCRIPTION": "Apenas você poderá ver e gerenciar este filtro."
+        }
+      },
+      "READ_ONLY_TOOLTIP": "Pasta pública. Peça a um administrador para editar ou excluir."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/locale/pt_BR/advancedFilters.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/advancedFilters.json
@@ -94,7 +94,13 @@
         }
       },
       "EDIT": {
-        "EDIT_BUTTON": "Alterar Pasta"
+        "EDIT_BUTTON": "Alterar Pasta",
+        "API_FOLDERS": {
+          "ERROR_MESSAGE": "Erro ao atualizar a pasta."
+        },
+        "API_SEGMENTS": {
+          "ERROR_MESSAGE": "Erro ao atualizar o segmento."
+        }
       },
       "DELETE": {
         "DELETE_BUTTON": "Excluir filtro",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/contact.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/contact.json
@@ -369,7 +369,19 @@
             "PLACEHOLDER": "Informe o nome para esse filtro",
             "ERROR": "Informe um nome válido",
             "SUCCESS_MESSAGE": "Filtro salvo com sucesso",
-            "ERROR_MESSAGE": "Não foi possível salvar o filtro. Por favor, tente mais tarde."
+            "ERROR_MESSAGE": "Não foi possível salvar o filtro. Por favor, tente mais tarde.",
+            "VISIBILITY": {
+              "LABEL": "Visibilidade",
+              "GLOBAL": {
+                "LABEL": "Pública",
+                "DESCRIPTION": "Disponível para todos os agentes desta conta."
+              },
+              "PERSONAL": {
+                "LABEL": "Privada",
+                "DESCRIPTION": "Apenas você poderá ver e gerenciar este segmento."
+              }
+            },
+            "READ_ONLY_TOOLTIP": "Segmento público. Peça a um administrador para editar ou excluir."
           },
           "DELETE_SEGMENT": {
             "TITLE": "Confirmar exclusão",

--- a/app/javascript/dashboard/routes/dashboard/customviews/DeleteCustomViews.vue
+++ b/app/javascript/dashboard/routes/dashboard/customviews/DeleteCustomViews.vue
@@ -71,13 +71,14 @@ export default {
         const filterType = this.activeCustomViews;
         await this.$store.dispatch('customViews/delete', { id, filterType });
         this.closeDeletePopup();
+        this.openLastItemAfterDelete();
         useAlert(
           this.activeFilterType === 0
             ? this.$t('FILTER.CUSTOM_VIEWS.DELETE.API_FOLDERS.SUCCESS_MESSAGE')
             : this.$t('FILTER.CUSTOM_VIEWS.DELETE.API_SEGMENTS.SUCCESS_MESSAGE')
         );
         useTrack(CONTACTS_EVENTS.DELETE_FILTER, {
-          type: this.filterType === 0 ? 'folder' : 'segment',
+          type: this.activeFilterType === 0 ? 'folder' : 'segment',
         });
       } catch (error) {
         const fallbackMessage =
@@ -86,7 +87,6 @@ export default {
             : this.$t('FILTER.CUSTOM_VIEWS.DELETE.API_SEGMENTS.ERROR_MESSAGE');
         useAlert(error?.response?.data?.error || fallbackMessage);
       }
-      this.openLastItemAfterDelete();
     },
     closeDeletePopup() {
       this.$emit('close');

--- a/app/javascript/dashboard/routes/dashboard/customviews/DeleteCustomViews.vue
+++ b/app/javascript/dashboard/routes/dashboard/customviews/DeleteCustomViews.vue
@@ -80,13 +80,11 @@ export default {
           type: this.filterType === 0 ? 'folder' : 'segment',
         });
       } catch (error) {
-        const errorMessage =
-          error?.response?.message || this.activeFilterType === 0
-            ? this.$t('FILTER.CUSTOM_VIEWS.DELETE.API_FOLDERS.SUCCESS_MESSAGE')
-            : this.$t(
-                'FILTER.CUSTOM_VIEWS.DELETE.API_SEGMENTS.SUCCESS_MESSAGE'
-              );
-        useAlert(errorMessage);
+        const fallbackMessage =
+          this.activeFilterType === 0
+            ? this.$t('FILTER.CUSTOM_VIEWS.DELETE.API_FOLDERS.ERROR_MESSAGE')
+            : this.$t('FILTER.CUSTOM_VIEWS.DELETE.API_SEGMENTS.ERROR_MESSAGE');
+        useAlert(error?.response?.data?.error || fallbackMessage);
       }
       this.openLastItemAfterDelete();
     },

--- a/app/javascript/dashboard/store/modules/customViews.js
+++ b/app/javascript/dashboard/store/modules/customViews.js
@@ -98,8 +98,6 @@ export const actions = {
     try {
       await CustomViewsAPI.deleteCustomViews(id, filterType);
       commit(types.DELETE_CUSTOM_VIEW, { data: id, filterType });
-    } catch (error) {
-      throw new Error(error);
     } finally {
       commit(types.SET_CUSTOM_VIEW_UI_FLAG, { isDeleting: false });
     }

--- a/app/javascript/dashboard/store/modules/specs/customViews/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/customViews/actions.spec.js
@@ -67,7 +67,9 @@ describe('#actions', () => {
     });
     it('sends correct actions if API is error', async () => {
       axios.delete.mockRejectedValue({ message: 'Incorrect header' });
-      await expect(actions.delete({ commit }, 1)).rejects.toThrow(Error);
+      await expect(
+        actions.delete({ commit }, { id: 1, filterType: 'contact' })
+      ).rejects.toEqual({ message: 'Incorrect header' });
       expect(commit.mock.calls).toEqual([
         [types.default.SET_CUSTOM_VIEW_UI_FLAG, { isDeleting: true }],
         [types.default.SET_CUSTOM_VIEW_UI_FLAG, { isDeleting: false }],

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -22,7 +22,7 @@ class CustomFilter < ApplicationRecord
   belongs_to :account
 
   enum filter_type: { conversation: 0, contact: 1, report: 2 }
-  enum visibility: { personal: 0, global: 1 }
+  enum :visibility, { personal: 0, global: 1 }, validate: true
 
   validate :validate_number_of_filters
 

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -6,6 +6,7 @@
 #  filter_type :integer          default("conversation"), not null
 #  name        :string           not null
 #  query       :jsonb            not null
+#  visibility  :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  account_id  :bigint           not null
@@ -21,7 +22,20 @@ class CustomFilter < ApplicationRecord
   belongs_to :account
 
   enum filter_type: { conversation: 0, contact: 1, report: 2 }
+  enum visibility: { personal: 0, global: 1 }
+
   validate :validate_number_of_filters
+
+  def set_visibility(user, params)
+    self.visibility = params[:visibility] if params.key?(:visibility)
+    self.visibility = :personal if user.agent?
+  end
+
+  def self.with_visibility(user, params)
+    filter_type = params[:filter_type] || 'conversation'
+    scope = Current.account.custom_filters.where(filter_type: filter_type)
+    scope.global.or(scope.personal.where(user_id: user.id)).order(:id)
+  end
 
   def validate_number_of_filters
     return true if account.custom_filters.where(user_id: user_id).size < Limits::MAX_CUSTOM_FILTERS_PER_USER

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -32,7 +32,8 @@ class CustomFilter < ApplicationRecord
   end
 
   def self.with_visibility(user, params)
-    filter_type = params[:filter_type] || 'conversation'
+    filter_type = params[:filter_type].to_s
+    filter_type = 'conversation' unless filter_types.key?(filter_type)
     scope = Current.account.custom_filters.where(filter_type: filter_type)
     scope.global.or(scope.personal.where(user_id: user.id)).order(:id)
   end

--- a/app/policies/custom_filter_policy.rb
+++ b/app/policies/custom_filter_policy.rb
@@ -12,11 +12,15 @@ class CustomFilterPolicy < ApplicationPolicy
   end
 
   def update?
-    author? || (@account_user.administrator? && @record.global?)
+    return @account_user.administrator? if @record.global?
+
+    author?
   end
 
   def destroy?
-    author? || (@account_user.administrator? && @record.global?)
+    return @account_user.administrator? if @record.global?
+
+    author?
   end
 
   private

--- a/app/policies/custom_filter_policy.rb
+++ b/app/policies/custom_filter_policy.rb
@@ -1,21 +1,27 @@
 class CustomFilterPolicy < ApplicationPolicy
+  def index?
+    @account_user.administrator? || @account_user.agent?
+  end
+
   def create?
     @account_user.administrator? || @account_user.agent?
   end
 
   def show?
-    @account_user.administrator? || @account_user.agent?
-  end
-
-  def index?
-    @account_user.administrator? || @account_user.agent?
+    @record.global? || author?
   end
 
   def update?
-    @account_user.administrator? || @account_user.agent?
+    author? || (@account_user.administrator? && @record.global?)
   end
 
   def destroy?
-    @account_user.administrator? || @account_user.agent?
+    author? || (@account_user.administrator? && @record.global?)
+  end
+
+  private
+
+  def author?
+    @record.user == @account_user.user
   end
 end

--- a/app/views/api/v1/models/_custom_filter.json.jbuilder
+++ b/app/views/api/v1/models/_custom_filter.json.jbuilder
@@ -1,6 +1,7 @@
 json.id resource.id
 json.name resource.name
 json.filter_type resource.filter_type
+json.visibility resource.visibility
 json.query resource.query
 json.created_at resource.created_at
 json.updated_at resource.updated_at

--- a/db/migrate/20260510160215_add_visibility_to_custom_filters.rb
+++ b/db/migrate/20260510160215_add_visibility_to_custom_filters.rb
@@ -1,0 +1,5 @@
+class AddVisibilityToCustomFilters < ActiveRecord::Migration[7.1]
+  def change
+    add_column :custom_filters, :visibility, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260510160215_add_visibility_to_custom_filters.rb
+++ b/db/migrate/20260510160215_add_visibility_to_custom_filters.rb
@@ -1,5 +1,8 @@
 class AddVisibilityToCustomFilters < ActiveRecord::Migration[7.1]
   def change
     add_column :custom_filters, :visibility, :integer, default: 0, null: false
+    add_index :custom_filters,
+              [:account_id, :filter_type, :visibility, :user_id],
+              name: 'index_custom_filters_on_account_type_visibility_user'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -725,7 +725,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
     t.text "cached_label_list"
     t.bigint "assignee_agent_bot_id"
     t.integer "group_type", default: 0, null: false
-    t.bigint "kanban_task_id"
     t.index ["account_id", "display_id"], name: "index_conversations_on_account_id_and_display_id", unique: true
     t.index ["account_id", "group_type"], name: "index_conversations_on_account_id_and_group_type"
     t.index ["account_id", "id"], name: "index_conversations_on_id_and_account_id"
@@ -739,7 +738,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
     t.index ["identifier", "account_id"], name: "index_conversations_on_identifier_and_account_id"
     t.index ["inbox_id", "group_type"], name: "index_conversations_on_inbox_id_and_group_type"
     t.index ["inbox_id"], name: "index_conversations_on_inbox_id"
-    t.index ["kanban_task_id"], name: "index_conversations_on_kanban_task_id"
     t.index ["priority"], name: "index_conversations_on_priority"
     t.index ["status", "account_id"], name: "index_conversations_on_status_and_account_id"
     t.index ["status", "priority"], name: "index_conversations_on_status_and_priority"
@@ -818,6 +816,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "visibility", default: 0, null: false
+    t.index ["account_id", "filter_type", "visibility", "user_id"], name: "index_custom_filters_on_account_type_visibility_user"
     t.index ["account_id"], name: "index_custom_filters_on_account_id"
     t.index ["user_id"], name: "index_custom_filters_on_user_id"
   end
@@ -1130,152 +1129,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
     t.index ["internal_chat_message_id", "user_id", "emoji"], name: "idx_ic_reactions_message_user_emoji", unique: true
     t.index ["internal_chat_message_id"], name: "idx_ic_reactions_message"
     t.index ["user_id"], name: "index_internal_chat_reactions_on_user_id"
-  end
-
-  create_table "kanban_account_user_preferences", force: :cascade do |t|
-    t.bigint "account_user_id", null: false
-    t.jsonb "preferences", default: {}, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["account_user_id"], name: "index_kanban_account_user_preferences_on_account_user_id", unique: true
-  end
-
-  create_table "kanban_audit_events", force: :cascade do |t|
-    t.bigint "account_id", null: false
-    t.bigint "task_id", null: false
-    t.bigint "performed_by_id"
-    t.string "action", null: false
-    t.jsonb "metadata", default: {}, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["account_id", "created_at"], name: "index_kanban_audit_events_on_account_id_and_created_at"
-    t.index ["account_id"], name: "index_kanban_audit_events_on_account_id"
-    t.index ["performed_by_id"], name: "index_kanban_audit_events_on_performed_by_id"
-    t.index ["task_id"], name: "index_kanban_audit_events_on_task_id"
-  end
-
-  create_table "kanban_board_agents", force: :cascade do |t|
-    t.bigint "board_id", null: false
-    t.bigint "agent_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["agent_id"], name: "index_kanban_board_agents_on_agent_id"
-    t.index ["board_id", "agent_id"], name: "index_kanban_board_agents_on_board_id_and_agent_id", unique: true
-    t.index ["board_id"], name: "index_kanban_board_agents_on_board_id"
-  end
-
-  create_table "kanban_board_inboxes", force: :cascade do |t|
-    t.bigint "board_id", null: false
-    t.bigint "inbox_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["board_id", "inbox_id"], name: "index_kanban_board_inboxes_on_board_id_and_inbox_id", unique: true
-    t.index ["board_id"], name: "index_kanban_board_inboxes_on_board_id"
-    t.index ["inbox_id"], name: "index_kanban_board_inboxes_on_inbox_id"
-  end
-
-  create_table "kanban_board_steps", force: :cascade do |t|
-    t.bigint "board_id", null: false
-    t.string "name", null: false
-    t.text "description"
-    t.string "color", default: "#475569", null: false
-    t.integer "tasks_count", default: 0, null: false
-    t.boolean "cancelled", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.decimal "probability", precision: 5, scale: 2, default: "100.0", null: false
-    t.index ["board_id"], name: "index_kanban_board_steps_on_board_id"
-  end
-
-  create_table "kanban_boards", force: :cascade do |t|
-    t.bigint "account_id", null: false
-    t.string "name", null: false
-    t.text "description"
-    t.jsonb "settings", default: {}, null: false
-    t.integer "steps_order", default: [], array: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "currency", limit: 3, default: "USD", null: false
-    t.index ["account_id", "created_at"], name: "index_kanban_boards_on_account_id_and_created_at"
-    t.index ["account_id", "name"], name: "index_kanban_boards_on_account_id_and_name", unique: true
-    t.index ["account_id", "updated_at"], name: "index_kanban_boards_on_account_id_and_updated_at"
-    t.index ["account_id"], name: "index_kanban_boards_on_account_id"
-  end
-
-  create_table "kanban_products", force: :cascade do |t|
-    t.bigint "board_id", null: false
-    t.string "name", limit: 255, null: false
-    t.text "description"
-    t.decimal "unit_price", precision: 15, scale: 2, default: "0.0", null: false
-    t.boolean "archived", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["board_id", "archived"], name: "index_kanban_products_on_board_id_and_archived"
-    t.index ["board_id", "name"], name: "index_kanban_products_on_board_id_and_name"
-    t.index ["board_id"], name: "index_kanban_products_on_board_id"
-  end
-
-  create_table "kanban_task_agents", force: :cascade do |t|
-    t.bigint "task_id", null: false
-    t.bigint "agent_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["agent_id"], name: "index_kanban_task_agents_on_agent_id"
-    t.index ["task_id", "agent_id"], name: "index_kanban_task_agents_on_task_id_and_agent_id", unique: true
-    t.index ["task_id"], name: "index_kanban_task_agents_on_task_id"
-  end
-
-  create_table "kanban_task_contacts", force: :cascade do |t|
-    t.bigint "task_id", null: false
-    t.bigint "contact_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["contact_id"], name: "index_kanban_task_contacts_on_contact_id"
-    t.index ["task_id", "contact_id"], name: "index_kanban_task_contacts_on_task_id_and_contact_id", unique: true
-    t.index ["task_id"], name: "index_kanban_task_contacts_on_task_id"
-  end
-
-  create_table "kanban_task_products", force: :cascade do |t|
-    t.bigint "task_id", null: false
-    t.bigint "product_id", null: false
-    t.decimal "quantity", precision: 12, scale: 4, default: "1.0", null: false
-    t.decimal "unit_price", precision: 15, scale: 2, null: false
-    t.decimal "discount_percentage", precision: 5, scale: 2, default: "0.0", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["product_id"], name: "index_kanban_task_products_on_product_id"
-    t.index ["task_id"], name: "index_kanban_task_products_on_task_id"
-  end
-
-  create_table "kanban_tasks", force: :cascade do |t|
-    t.bigint "account_id", null: false
-    t.bigint "board_id", null: false
-    t.bigint "board_step_id", null: false
-    t.bigint "created_by_id"
-    t.string "title", null: false
-    t.text "description"
-    t.string "priority"
-    t.datetime "start_date"
-    t.datetime "due_date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "cached_label_list"
-    t.datetime "step_changed_at"
-    t.datetime "overdue_notified_at"
-    t.decimal "value", precision: 15, scale: 2
-    t.jsonb "custom_attributes", default: {}, null: false
-    t.index ["account_id", "created_at"], name: "index_kanban_tasks_on_account_id_and_created_at"
-    t.index ["account_id"], name: "index_kanban_tasks_on_account_id"
-    t.index ["board_id", "board_step_id"], name: "index_kanban_tasks_on_board_id_and_board_step_id"
-    t.index ["board_id", "priority"], name: "index_kanban_tasks_on_board_id_and_priority"
-    t.index ["board_id"], name: "index_kanban_tasks_on_board_id"
-    t.index ["board_step_id", "created_at"], name: "index_kanban_tasks_on_step_and_created_at"
-    t.index ["board_step_id", "priority"], name: "index_kanban_tasks_on_board_step_id_and_priority"
-    t.index ["board_step_id", "value"], name: "index_kanban_tasks_on_board_step_id_and_value"
-    t.index ["board_step_id"], name: "index_kanban_tasks_on_board_step_id"
-    t.index ["created_by_id"], name: "index_kanban_tasks_on_created_by_id"
-    t.index ["due_date"], name: "index_kanban_tasks_on_due_date"
-    t.index ["priority"], name: "index_kanban_tasks_on_priority"
   end
 
   create_table "labels", force: :cascade do |t|
@@ -1714,7 +1567,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "conversations", "kanban_tasks"
   add_foreign_key "group_members", "contacts"
   add_foreign_key "group_members", "contacts", column: "group_contact_id"
   add_foreign_key "inboxes", "portals"
@@ -1737,27 +1589,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
   add_foreign_key "internal_chat_polls", "internal_chat_messages"
   add_foreign_key "internal_chat_reactions", "internal_chat_messages"
   add_foreign_key "internal_chat_reactions", "users", on_delete: :cascade
-  add_foreign_key "kanban_account_user_preferences", "account_users"
-  add_foreign_key "kanban_audit_events", "accounts"
-  add_foreign_key "kanban_audit_events", "kanban_tasks", column: "task_id"
-  add_foreign_key "kanban_audit_events", "users", column: "performed_by_id"
-  add_foreign_key "kanban_board_agents", "kanban_boards", column: "board_id"
-  add_foreign_key "kanban_board_agents", "users", column: "agent_id"
-  add_foreign_key "kanban_board_inboxes", "inboxes"
-  add_foreign_key "kanban_board_inboxes", "kanban_boards", column: "board_id"
-  add_foreign_key "kanban_board_steps", "kanban_boards", column: "board_id"
-  add_foreign_key "kanban_boards", "accounts"
-  add_foreign_key "kanban_products", "kanban_boards", column: "board_id", on_delete: :cascade
-  add_foreign_key "kanban_task_agents", "kanban_tasks", column: "task_id"
-  add_foreign_key "kanban_task_agents", "users", column: "agent_id"
-  add_foreign_key "kanban_task_contacts", "contacts"
-  add_foreign_key "kanban_task_contacts", "kanban_tasks", column: "task_id"
-  add_foreign_key "kanban_task_products", "kanban_products", column: "product_id"
-  add_foreign_key "kanban_task_products", "kanban_tasks", column: "task_id", on_delete: :cascade
-  add_foreign_key "kanban_tasks", "accounts"
-  add_foreign_key "kanban_tasks", "kanban_board_steps", column: "board_step_id"
-  add_foreign_key "kanban_tasks", "kanban_boards", column: "board_id"
-  add_foreign_key "kanban_tasks", "users", column: "created_by_id", on_delete: :nullify
   add_foreign_key "recurring_scheduled_messages", "accounts"
   add_foreign_key "recurring_scheduled_messages", "conversations"
   add_foreign_key "recurring_scheduled_messages", "inboxes"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -725,6 +725,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
     t.text "cached_label_list"
     t.bigint "assignee_agent_bot_id"
     t.integer "group_type", default: 0, null: false
+    t.bigint "kanban_task_id"
     t.index ["account_id", "display_id"], name: "index_conversations_on_account_id_and_display_id", unique: true
     t.index ["account_id", "group_type"], name: "index_conversations_on_account_id_and_group_type"
     t.index ["account_id", "id"], name: "index_conversations_on_id_and_account_id"
@@ -738,6 +739,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
     t.index ["identifier", "account_id"], name: "index_conversations_on_identifier_and_account_id"
     t.index ["inbox_id", "group_type"], name: "index_conversations_on_inbox_id_and_group_type"
     t.index ["inbox_id"], name: "index_conversations_on_inbox_id"
+    t.index ["kanban_task_id"], name: "index_conversations_on_kanban_task_id"
     t.index ["priority"], name: "index_conversations_on_priority"
     t.index ["status", "account_id"], name: "index_conversations_on_status_and_account_id"
     t.index ["status", "priority"], name: "index_conversations_on_status_and_priority"
@@ -1128,6 +1130,152 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
     t.index ["internal_chat_message_id", "user_id", "emoji"], name: "idx_ic_reactions_message_user_emoji", unique: true
     t.index ["internal_chat_message_id"], name: "idx_ic_reactions_message"
     t.index ["user_id"], name: "index_internal_chat_reactions_on_user_id"
+  end
+
+  create_table "kanban_account_user_preferences", force: :cascade do |t|
+    t.bigint "account_user_id", null: false
+    t.jsonb "preferences", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_user_id"], name: "index_kanban_account_user_preferences_on_account_user_id", unique: true
+  end
+
+  create_table "kanban_audit_events", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "task_id", null: false
+    t.bigint "performed_by_id"
+    t.string "action", null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "created_at"], name: "index_kanban_audit_events_on_account_id_and_created_at"
+    t.index ["account_id"], name: "index_kanban_audit_events_on_account_id"
+    t.index ["performed_by_id"], name: "index_kanban_audit_events_on_performed_by_id"
+    t.index ["task_id"], name: "index_kanban_audit_events_on_task_id"
+  end
+
+  create_table "kanban_board_agents", force: :cascade do |t|
+    t.bigint "board_id", null: false
+    t.bigint "agent_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["agent_id"], name: "index_kanban_board_agents_on_agent_id"
+    t.index ["board_id", "agent_id"], name: "index_kanban_board_agents_on_board_id_and_agent_id", unique: true
+    t.index ["board_id"], name: "index_kanban_board_agents_on_board_id"
+  end
+
+  create_table "kanban_board_inboxes", force: :cascade do |t|
+    t.bigint "board_id", null: false
+    t.bigint "inbox_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["board_id", "inbox_id"], name: "index_kanban_board_inboxes_on_board_id_and_inbox_id", unique: true
+    t.index ["board_id"], name: "index_kanban_board_inboxes_on_board_id"
+    t.index ["inbox_id"], name: "index_kanban_board_inboxes_on_inbox_id"
+  end
+
+  create_table "kanban_board_steps", force: :cascade do |t|
+    t.bigint "board_id", null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "color", default: "#475569", null: false
+    t.integer "tasks_count", default: 0, null: false
+    t.boolean "cancelled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.decimal "probability", precision: 5, scale: 2, default: "100.0", null: false
+    t.index ["board_id"], name: "index_kanban_board_steps_on_board_id"
+  end
+
+  create_table "kanban_boards", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.string "name", null: false
+    t.text "description"
+    t.jsonb "settings", default: {}, null: false
+    t.integer "steps_order", default: [], array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "currency", limit: 3, default: "USD", null: false
+    t.index ["account_id", "created_at"], name: "index_kanban_boards_on_account_id_and_created_at"
+    t.index ["account_id", "name"], name: "index_kanban_boards_on_account_id_and_name", unique: true
+    t.index ["account_id", "updated_at"], name: "index_kanban_boards_on_account_id_and_updated_at"
+    t.index ["account_id"], name: "index_kanban_boards_on_account_id"
+  end
+
+  create_table "kanban_products", force: :cascade do |t|
+    t.bigint "board_id", null: false
+    t.string "name", limit: 255, null: false
+    t.text "description"
+    t.decimal "unit_price", precision: 15, scale: 2, default: "0.0", null: false
+    t.boolean "archived", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["board_id", "archived"], name: "index_kanban_products_on_board_id_and_archived"
+    t.index ["board_id", "name"], name: "index_kanban_products_on_board_id_and_name"
+    t.index ["board_id"], name: "index_kanban_products_on_board_id"
+  end
+
+  create_table "kanban_task_agents", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "agent_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["agent_id"], name: "index_kanban_task_agents_on_agent_id"
+    t.index ["task_id", "agent_id"], name: "index_kanban_task_agents_on_task_id_and_agent_id", unique: true
+    t.index ["task_id"], name: "index_kanban_task_agents_on_task_id"
+  end
+
+  create_table "kanban_task_contacts", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "contact_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contact_id"], name: "index_kanban_task_contacts_on_contact_id"
+    t.index ["task_id", "contact_id"], name: "index_kanban_task_contacts_on_task_id_and_contact_id", unique: true
+    t.index ["task_id"], name: "index_kanban_task_contacts_on_task_id"
+  end
+
+  create_table "kanban_task_products", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "product_id", null: false
+    t.decimal "quantity", precision: 12, scale: 4, default: "1.0", null: false
+    t.decimal "unit_price", precision: 15, scale: 2, null: false
+    t.decimal "discount_percentage", precision: 5, scale: 2, default: "0.0", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_kanban_task_products_on_product_id"
+    t.index ["task_id"], name: "index_kanban_task_products_on_task_id"
+  end
+
+  create_table "kanban_tasks", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "board_id", null: false
+    t.bigint "board_step_id", null: false
+    t.bigint "created_by_id"
+    t.string "title", null: false
+    t.text "description"
+    t.string "priority"
+    t.datetime "start_date"
+    t.datetime "due_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "cached_label_list"
+    t.datetime "step_changed_at"
+    t.datetime "overdue_notified_at"
+    t.decimal "value", precision: 15, scale: 2
+    t.jsonb "custom_attributes", default: {}, null: false
+    t.index ["account_id", "created_at"], name: "index_kanban_tasks_on_account_id_and_created_at"
+    t.index ["account_id"], name: "index_kanban_tasks_on_account_id"
+    t.index ["board_id", "board_step_id"], name: "index_kanban_tasks_on_board_id_and_board_step_id"
+    t.index ["board_id", "priority"], name: "index_kanban_tasks_on_board_id_and_priority"
+    t.index ["board_id"], name: "index_kanban_tasks_on_board_id"
+    t.index ["board_step_id", "created_at"], name: "index_kanban_tasks_on_step_and_created_at"
+    t.index ["board_step_id", "priority"], name: "index_kanban_tasks_on_board_step_id_and_priority"
+    t.index ["board_step_id", "value"], name: "index_kanban_tasks_on_board_step_id_and_value"
+    t.index ["board_step_id"], name: "index_kanban_tasks_on_board_step_id"
+    t.index ["created_by_id"], name: "index_kanban_tasks_on_created_by_id"
+    t.index ["due_date"], name: "index_kanban_tasks_on_due_date"
+    t.index ["priority"], name: "index_kanban_tasks_on_priority"
   end
 
   create_table "labels", force: :cascade do |t|
@@ -1566,6 +1714,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "conversations", "kanban_tasks"
   add_foreign_key "group_members", "contacts"
   add_foreign_key "group_members", "contacts", column: "group_contact_id"
   add_foreign_key "inboxes", "portals"
@@ -1588,6 +1737,27 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
   add_foreign_key "internal_chat_polls", "internal_chat_messages"
   add_foreign_key "internal_chat_reactions", "internal_chat_messages"
   add_foreign_key "internal_chat_reactions", "users", on_delete: :cascade
+  add_foreign_key "kanban_account_user_preferences", "account_users"
+  add_foreign_key "kanban_audit_events", "accounts"
+  add_foreign_key "kanban_audit_events", "kanban_tasks", column: "task_id"
+  add_foreign_key "kanban_audit_events", "users", column: "performed_by_id"
+  add_foreign_key "kanban_board_agents", "kanban_boards", column: "board_id"
+  add_foreign_key "kanban_board_agents", "users", column: "agent_id"
+  add_foreign_key "kanban_board_inboxes", "inboxes"
+  add_foreign_key "kanban_board_inboxes", "kanban_boards", column: "board_id"
+  add_foreign_key "kanban_board_steps", "kanban_boards", column: "board_id"
+  add_foreign_key "kanban_boards", "accounts"
+  add_foreign_key "kanban_products", "kanban_boards", column: "board_id", on_delete: :cascade
+  add_foreign_key "kanban_task_agents", "kanban_tasks", column: "task_id"
+  add_foreign_key "kanban_task_agents", "users", column: "agent_id"
+  add_foreign_key "kanban_task_contacts", "contacts"
+  add_foreign_key "kanban_task_contacts", "kanban_tasks", column: "task_id"
+  add_foreign_key "kanban_task_products", "kanban_products", column: "product_id"
+  add_foreign_key "kanban_task_products", "kanban_tasks", column: "task_id", on_delete: :cascade
+  add_foreign_key "kanban_tasks", "accounts"
+  add_foreign_key "kanban_tasks", "kanban_board_steps", column: "board_step_id"
+  add_foreign_key "kanban_tasks", "kanban_boards", column: "board_id"
+  add_foreign_key "kanban_tasks", "users", column: "created_by_id", on_delete: :nullify
   add_foreign_key "recurring_scheduled_messages", "accounts"
   add_foreign_key "recurring_scheduled_messages", "conversations"
   add_foreign_key "recurring_scheduled_messages", "inboxes"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_06_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_10_160215) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -815,6 +815,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_06_120000) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "visibility", default: 0, null: false
     t.index ["account_id"], name: "index_custom_filters_on_account_id"
     t.index ["user_id"], name: "index_custom_filters_on_user_id"
   end

--- a/spec/controllers/api/v1/accounts/custom_filters_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/custom_filters_controller_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe 'Custom Filters API', type: :request do
       end
     end
 
-    context 'when it is an authenticated admin user' do
+    context 'when it is an authenticated user' do
       it 'deletes custom filter if it is attached to the current user and account' do
         delete "/api/v1/accounts/#{account.id}/custom_filters/#{custom_filter.id}",
                headers: user.create_new_auth_token,

--- a/spec/controllers/api/v1/accounts/custom_filters_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/custom_filters_controller_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe 'Custom Filters API', type: :request do
 
         expect(response).to have_http_status(:unauthorized)
       end
+
+      it 'forbids administrators from fetching a personal filter owned by another user' do
+        get "/api/v1/accounts/#{account.id}/custom_filters/#{custom_filter.id}",
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 

--- a/spec/controllers/api/v1/accounts/custom_filters_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/custom_filters_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Custom Filters API', type: :request do
   let(:account) { create(:account) }
   let(:user) { create(:user, account: account, role: :agent) }
+  let(:admin) { create(:user, account: account, role: :administrator) }
   let!(:custom_filter) { create(:custom_filter, user: user, account: account) }
 
   before do
@@ -41,6 +42,19 @@ RSpec.describe 'Custom Filters API', type: :request do
         expect(response_body.first['name']).to eq(custom_filter.name)
         expect(response_body.first['query']).to eq(custom_filter.query)
       end
+
+      it 'includes global filters created by other users in the same account' do
+        global_filter = create(:custom_filter, user: admin, account: account, visibility: :global, name: 'shared folder')
+        create(:custom_filter, user: admin, account: account, visibility: :personal, name: 'private to admin')
+
+        get "/api/v1/accounts/#{account.id}/custom_filters",
+            headers: user.create_new_auth_token,
+            as: :json
+
+        names = response.parsed_body.pluck('name')
+        expect(names).to include(custom_filter.name, global_filter.name)
+        expect(names).not_to include('private to admin')
+      end
     end
   end
 
@@ -61,6 +75,16 @@ RSpec.describe 'Custom Filters API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(response.body).to include(custom_filter.name)
+      end
+
+      it 'forbids fetching a personal filter owned by another user' do
+        other_filter = create(:custom_filter, user: admin, account: account, visibility: :personal)
+
+        get "/api/v1/accounts/#{account.id}/custom_filters/#{other_filter.id}",
+            headers: user.create_new_auth_token,
+            as: :json
+
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
@@ -91,6 +115,23 @@ RSpec.describe 'Custom Filters API', type: :request do
         expect(response).to have_http_status(:success)
         json_response = response.parsed_body
         expect(json_response['name']).to eq 'vip-customers'
+        expect(json_response['visibility']).to eq 'personal'
+      end
+
+      it 'forces agent-created filters to personal even when visibility=global is sent' do
+        post "/api/v1/accounts/#{account.id}/custom_filters", headers: user.create_new_auth_token,
+                                                              params: { custom_filter: payload[:custom_filter].merge(visibility: 'global') }
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['visibility']).to eq 'personal'
+      end
+
+      it 'allows administrators to create global filters' do
+        post "/api/v1/accounts/#{account.id}/custom_filters", headers: admin.create_new_auth_token,
+                                                              params: { custom_filter: payload[:custom_filter].merge(visibility: 'global') }
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['visibility']).to eq 'global'
       end
 
       it 'gives the error for 1001st record' do
@@ -157,6 +198,42 @@ RSpec.describe 'Custom Filters API', type: :request do
 
         expect(response).to have_http_status(:not_found)
       end
+
+      it 'forbids agents from updating a global filter authored by an admin' do
+        global_filter = create(:custom_filter, user: admin, account: account, visibility: :global)
+
+        patch "/api/v1/accounts/#{account.id}/custom_filters/#{global_filter.id}",
+              headers: user.create_new_auth_token,
+              params: payload,
+              as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'allows administrators to flip a personal filter to global' do
+        admin_filter = create(:custom_filter, user: admin, account: account, visibility: :personal)
+
+        patch "/api/v1/accounts/#{account.id}/custom_filters/#{admin_filter.id}",
+              headers: admin.create_new_auth_token,
+              params: { custom_filter: { visibility: 'global' } },
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(admin_filter.reload.visibility).to eq('global')
+      end
+
+      it 'allows administrators to edit a global filter authored by another admin' do
+        other_admin = create(:user, account: account, role: :administrator)
+        global_filter = create(:custom_filter, user: other_admin, account: account, visibility: :global)
+
+        patch "/api/v1/accounts/#{account.id}/custom_filters/#{global_filter.id}",
+              headers: admin.create_new_auth_token,
+              params: { custom_filter: { name: 'renamed by other admin' } },
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(global_filter.reload.name).to eq('renamed by other admin')
+      end
     end
   end
 
@@ -175,6 +252,28 @@ RSpec.describe 'Custom Filters API', type: :request do
                as: :json
         expect(response).to have_http_status(:no_content)
         expect(user.custom_filters.count).to be 0
+      end
+
+      it 'forbids an agent from deleting a global filter owned by an admin' do
+        global_filter = create(:custom_filter, user: admin, account: account, visibility: :global)
+
+        delete "/api/v1/accounts/#{account.id}/custom_filters/#{global_filter.id}",
+               headers: user.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(CustomFilter.exists?(global_filter.id)).to be true
+      end
+
+      it 'allows admin to delete a global filter authored by another admin' do
+        other_admin = create(:user, account: account, role: :administrator)
+        global_filter = create(:custom_filter, user: other_admin, account: account, visibility: :global)
+
+        delete "/api/v1/accounts/#{account.id}/custom_filters/#{global_filter.id}",
+               headers: admin.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:no_content)
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/custom_filters_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/custom_filters_controller_spec.rb
@@ -230,6 +230,18 @@ RSpec.describe 'Custom Filters API', type: :request do
         expect(admin_filter.reload.visibility).to eq('global')
       end
 
+      it 'keeps agent-owned filters personal when agent sends visibility=global on update' do
+        agent_filter = create(:custom_filter, user: user, account: account, visibility: :personal)
+
+        patch "/api/v1/accounts/#{account.id}/custom_filters/#{agent_filter.id}",
+              headers: user.create_new_auth_token,
+              params: { custom_filter: { visibility: 'global' } },
+              as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(agent_filter.reload.visibility).to eq('personal')
+      end
+
       it 'allows administrators to edit a global filter authored by another admin' do
         other_admin = create(:user, account: account, role: :administrator)
         global_filter = create(:custom_filter, user: other_admin, account: account, visibility: :global)

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe CustomFilter do
+  let(:account) { create(:account) }
+  let(:admin) { create(:user, account: account, role: :administrator) }
+  let(:agent) { create(:user, account: account, role: :agent) }
+
+  after do
+    Current.user = nil
+    Current.account = nil
+  end
+
+  describe '#set_visibility' do
+    let(:custom_filter) { create(:custom_filter, account: account, user: admin) }
+
+    context 'when user is administrator' do
+      it 'sets visibility from params' do
+        Current.account = account
+
+        expect(custom_filter.visibility).to eq('personal')
+
+        custom_filter.set_visibility(admin, { visibility: :global })
+        expect(custom_filter.visibility).to eq('global')
+
+        custom_filter.set_visibility(admin, { visibility: :personal })
+        expect(custom_filter.visibility).to eq('personal')
+      end
+    end
+
+    context 'when user is agent' do
+      it 'forces visibility to personal regardless of params' do
+        Current.account = account
+
+        custom_filter.set_visibility(agent, { visibility: :global })
+        expect(custom_filter.visibility).to eq('personal')
+      end
+    end
+
+    context 'when params do not include visibility' do
+      it 'keeps existing visibility for administrators' do
+        Current.account = account
+        custom_filter.update!(visibility: :global)
+
+        custom_filter.set_visibility(admin, {})
+        expect(custom_filter.visibility).to eq('global')
+      end
+    end
+  end
+
+  describe '.with_visibility' do
+    let(:agent_two) { create(:user, account: account, role: :agent) }
+
+    before do
+      Current.account = account
+      create(:custom_filter, account: account, user: admin, filter_type: 0, visibility: :global, name: 'admin global')
+      create(:custom_filter, account: account, user: admin, filter_type: 0, visibility: :personal, name: 'admin personal')
+      create(:custom_filter, account: account, user: agent, filter_type: 0, visibility: :personal, name: 'agent personal')
+      create(:custom_filter, account: account, user: agent_two, filter_type: 0, visibility: :personal, name: 'agent_two personal')
+      create(:custom_filter, account: account, user: admin, filter_type: 1, visibility: :global, name: 'admin contact global')
+    end
+
+    it 'returns globals plus the requesting user personal filters scoped by filter_type' do
+      filters = described_class.with_visibility(agent, { filter_type: 'conversation' })
+      names = filters.pluck(:name)
+
+      expect(names).to include('admin global', 'agent personal')
+      expect(names).not_to include('admin personal', 'agent_two personal', 'admin contact global')
+    end
+
+    it 'defaults to conversation when filter_type is missing' do
+      filters = described_class.with_visibility(admin, {})
+
+      expect(filters.pluck(:filter_type).uniq).to eq(['conversation'])
+    end
+
+    it 'isolates by filter_type for contacts' do
+      filters = described_class.with_visibility(agent, { filter_type: 'contact' })
+
+      expect(filters.pluck(:name)).to eq(['admin contact global'])
+    end
+  end
+end

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe CustomFilter do
       expect(filters.pluck(:filter_type).uniq).to eq(['conversation'])
     end
 
+    it 'defaults to conversation when filter_type is invalid' do
+      filters = described_class.with_visibility(admin, { filter_type: 'bogus' })
+
+      expect(filters.pluck(:filter_type).uniq).to eq(['conversation'])
+    end
+
     it 'isolates by filter_type for contacts' do
       filters = described_class.with_visibility(agent, { filter_type: 'contact' })
 

--- a/spec/policies/custom_filter_policy_spec.rb
+++ b/spec/policies/custom_filter_policy_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe CustomFilterPolicy, type: :policy do
         expect(custom_filter_policy.new(agent_context, global_filter).update?).to be false
         expect(custom_filter_policy.new(agent_context, global_filter).destroy?).to be false
       end
+
+      it 'denies destructive actions to a non-admin author of a global filter' do
+        agent_authored = create(:custom_filter, account: account, user: agent, visibility: :global)
+        expect(custom_filter_policy.new(agent_context, agent_authored).update?).to be false
+        expect(custom_filter_policy.new(agent_context, agent_authored).destroy?).to be false
+      end
     end
 
     context 'when record is personal' do

--- a/spec/policies/custom_filter_policy_spec.rb
+++ b/spec/policies/custom_filter_policy_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CustomFilterPolicy, type: :policy do
+  subject(:custom_filter_policy) { described_class }
+
+  let(:account) { create(:account) }
+  let(:administrator) { create(:user, :administrator, account: account) }
+  let(:agent) { create(:user, account: account) }
+  let(:other_agent) { create(:user, account: account) }
+
+  let(:administrator_context) do
+    { user: administrator, account: account, account_user: administrator.account_users.find_by(account: account) }
+  end
+  let(:agent_context) do
+    { user: agent, account: account, account_user: agent.account_users.find_by(account: account) }
+  end
+  let(:other_agent_context) do
+    { user: other_agent, account: account, account_user: other_agent.account_users.find_by(account: account) }
+  end
+
+  permissions :index?, :create? do
+    it { expect(custom_filter_policy).to permit(administrator_context, build(:custom_filter)) }
+    it { expect(custom_filter_policy).to permit(agent_context, build(:custom_filter)) }
+  end
+
+  permissions :show?, :update?, :destroy? do
+    context 'when record is global' do
+      let(:global_filter) { create(:custom_filter, account: account, user: administrator, visibility: :global) }
+
+      it 'permits the author admin' do
+        expect(custom_filter_policy).to permit(administrator_context, global_filter)
+      end
+
+      it 'permits another admin (handled via update? branch for non-author)' do
+        another_admin = create(:user, :administrator, account: account)
+        another_admin_context = { user: another_admin, account: account,
+                                  account_user: another_admin.account_users.find_by(account: account) }
+        expect(custom_filter_policy).to permit(another_admin_context, global_filter)
+      end
+
+      it 'permits show for agents but not destructive actions' do
+        expect(custom_filter_policy.new(agent_context, global_filter).show?).to be true
+        expect(custom_filter_policy.new(agent_context, global_filter).update?).to be false
+        expect(custom_filter_policy.new(agent_context, global_filter).destroy?).to be false
+      end
+    end
+
+    context 'when record is personal' do
+      let(:personal_filter) { create(:custom_filter, account: account, user: agent, visibility: :personal) }
+
+      it 'permits the author' do
+        expect(custom_filter_policy).to permit(agent_context, personal_filter)
+      end
+
+      it 'denies non-authors, including admins' do
+        expect(custom_filter_policy.new(other_agent_context, personal_filter).show?).to be false
+        expect(custom_filter_policy.new(administrator_context, personal_filter).update?).to be false
+        expect(custom_filter_policy.new(administrator_context, personal_filter).destroy?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adiciona ao recurso de pastas (folders) e segmentos (segments) o mesmo esquema de visibilidade usado em Macros: cada filtro salvo pode ser **Privado** (visível só pelo autor, default) ou **Público** (visível para todos os agentes da conta). Apenas administradores podem marcar um filtro como público; agents continuam só vendo/gerenciando os próprios. Para agents, as pastas públicas aparecem na sidebar como read-only, sem botões de editar/excluir.

Closes #N/A

## How to test

1. Logar como administrador, abrir o filtro de conversas, salvar uma pasta marcada como **Pública**.
2. Logar como agente da mesma conta: a pasta deve aparecer na sidebar de Conversations; ao abri-la, em vez de lápis/lixeira aparece um ícone `i` com tooltip explicando que só admin pode editar.
3. Logar de novo como admin: abrir a pasta, clicar no lápis, no modal de edição alternar para **Privada** e salvar → pasta some para os agentes.
4. Repetir o roteiro em Contacts → Segments.
5. Validar que o agente, ao salvar um novo filtro, **não** vê o seletor Pública/Privada (sempre cai em Privada).

## What changed

- Backend: nova coluna `visibility` em `custom_filters`, enum `personal`/`global`, scopes/policy espelhando `Macro`.
- Frontend: novo `VisibilitySelector.vue` reutilizado por `SaveCustomView`, `CreateSegmentDialog`, `ConversationFilter` e `ContactsFilter`.
- `ChatListHeader` e `ContactHeader` ganham um modo read-only quando o usuário não pode gerenciar a pasta/segment ativo.
- Bug fix: `DeleteCustomViews.vue` exibia mensagem de sucesso quando o delete falhava (precedência incorreta do `||` no `catch`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/287)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visibility modes (Public vs Private) for saved filters/views and a Visibility selector component.

* **UI**
  * Visibility control added across create/edit dialogs, headers and filter modals; management actions show read-only indicators when not permitted.

* **Localization**
  * English and pt_BR translations for visibility labels, descriptions and read-only tooltips.

* **Data & API**
  * Visibility persisted, returned in API responses, and included in create/update/list payloads.

* **Security/Permissions**
  * Authorization updated to enforce visibility and author-based access.

* **Tests & Chores**
  * DB migration and expanded specs covering visibility behavior and policies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/287)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->