### PR TITLE
fix(contacts): respect filters when contact is created or received via realtime

### DIFF
--- a/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue
@@ -44,6 +44,7 @@ const emit = defineEmits([
   'search',
   'applyFilter',
   'clearFilters',
+  'contactCreated',
 ]);
 
 const { t } = useI18n();
@@ -98,6 +99,7 @@ const onCreate = async contact => {
     useAlert(
       t('CONTACTS_LAYOUT.HEADER.ACTIONS.CONTACT_CREATION.SUCCESS_MESSAGE')
     );
+    emit('contactCreated');
   } catch (error) {
     const i18nPrefix = 'CONTACTS_LAYOUT.HEADER.ACTIONS.CONTACT_CREATION';
     if (error instanceof DuplicateContactException) {

--- a/app/javascript/dashboard/components-next/Contacts/ContactsListLayout.vue
+++ b/app/javascript/dashboard/components-next/Contacts/ContactsListLayout.vue
@@ -32,6 +32,7 @@ const emit = defineEmits([
   'applyFilter',
   'clearFilters',
   'loadMore',
+  'contactCreated',
 ]);
 
 const route = useRoute();
@@ -97,6 +98,7 @@ const showPagination = computed(() => {
         @search="emit('search', $event)"
         @apply-filter="emit('applyFilter', $event)"
         @clear-filters="emit('clearFilters')"
+        @contact-created="emit('contactCreated')"
       />
       <main class="flex-1 overflow-y-auto px-6">
         <div class="w-full mx-auto max-w-5xl">

--- a/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactsIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/contacts/pages/ContactsIndex.vue
@@ -404,7 +404,13 @@ const handleSort = async ({ sort, order }) => {
 
 const createContact = async contact => {
   await store.dispatch('contacts/create', contact);
+  await fetchContactsBasedOnContext(pageNumber.value, {
+    clearSelection: false,
+  });
 };
+
+const onContactCreated = () =>
+  fetchContactsBasedOnContext(pageNumber.value, { clearSelection: false });
 
 watch(hasSelection, value => {
   if (!value) {
@@ -497,6 +503,7 @@ onMounted(async () => {
       @apply-filter="fetchSavedOrAppliedFilteredContact"
       @clear-filters="fetchContacts"
       @load-more="loadMoreSearchResults"
+      @contact-created="onContactCreated"
     >
       <div
         v-if="isFetchingList && !(isSearchView && hasContacts)"

--- a/app/javascript/dashboard/store/modules/contacts/mutations.js
+++ b/app/javascript/dashboard/store/modules/contacts/mutations.js
@@ -51,10 +51,6 @@ export const mutations = {
       ...($state.records[data.id] || {}),
       ...data,
     };
-
-    if (!$state.sortOrder.includes(data.id)) {
-      $state.sortOrder.push(data.id);
-    }
   },
 
   [types.EDIT_CONTACT]: ($state, data) => {

--- a/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/contacts/mutations.spec.js
@@ -27,7 +27,7 @@ describe('#mutations', () => {
   });
 
   describe('#SET_CONTACT_ITEM', () => {
-    it('push contact data to the store', () => {
+    it('upserts contact data into records without touching sortOrder', () => {
       const state = {
         records: {
           1: { id: 1, name: 'contact1', email: 'contact1@chatwoot.com' },
@@ -43,7 +43,27 @@ describe('#mutations', () => {
         1: { id: 1, name: 'contact1', email: 'contact1@chatwoot.com' },
         2: { id: 2, name: 'contact2', email: 'contact2@chatwoot.com' },
       });
-      expect(state.sortOrder).toEqual([1, 2]);
+      expect(state.sortOrder).toEqual([1]);
+    });
+
+    it('merges into an existing record without changing sortOrder position', () => {
+      const state = {
+        records: {
+          1: { id: 1, name: 'contact1', email: 'contact1@chatwoot.com' },
+          2: { id: 2, name: 'contact2', email: 'contact2@chatwoot.com' },
+        },
+        sortOrder: [2, 1],
+      };
+      mutations[types.SET_CONTACT_ITEM](state, {
+        id: 1,
+        name: 'contact1-updated',
+      });
+      expect(state.records[1]).toEqual({
+        id: 1,
+        name: 'contact1-updated',
+        email: 'contact1@chatwoot.com',
+      });
+      expect(state.sortOrder).toEqual([2, 1]);
     });
   });
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -3,9 +3,16 @@ require 'rails_helper'
 describe Whatsapp::Providers::WhatsappBaileysService do
   subject(:service) { described_class.new(whatsapp_channel: whatsapp_channel) }
 
+  # `cache_classes = false` in the test env lets Zeitwerk reload constants
+  # between specs (controller specs commonly trigger this). After a reload,
+  # the `described_class` captured when this file was loaded points at a
+  # stale copy whose `::ProviderUnavailableError` constant no longer matches
+  # the one raised by the real (currently-loaded) class, breaking
+  # `raise_error(ProviderUnavailableError, ...)` matchers. Re-resolving the
+  # constant on every example keeps the reference fresh.
+  let(:described_class) { Whatsapp::Providers::WhatsappBaileysService } # rubocop:disable RSpec/DescribedClass
   let(:whatsapp_channel) { create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false) }
   let(:message) { create(:message, inbox: whatsapp_channel.inbox, source_id: 'msg_123', content_attributes: { external_created_at: 123 }) }
-
   let(:test_send_phone_number) { '551187654321' }
   let(:test_send_jid) { '551187654321@s.whatsapp.net' }
 


### PR DESCRIPTION
Quando um filtro estava ativo na tela de contatos (filtro custom, segmento, label, busca ou view 'active') e um novo contato era criado, ele aparecia na lista mesmo sem atender ao filtro. A causa era a mutation \`SET_CONTACT_ITEM\` empurrar o id para \`sortOrder\` em qualquer fluxo que tocasse num contato (criação manual, broadcast \`conversation.created\`, abertura de detalhe, merge, etc.) sem checar contexto.

A correção isola \`SET_CONTACT_ITEM\` em uma operação de cache (\`records\`); a lista visível (\`sortOrder\`) passa a ser controlada apenas pelas mutations alimentadas por fetch. Para preservar a UX de "criei e quero ver", a criação manual agora dispara um refetch no contexto atual.

Closes ticklish-thimble.

## How to test

1. Aplica um filtro custom em \`/contacts\` (ex.: \`email contém @abc.com\`).
2. Abre o dialog \"Novo contato\" e cria um contato com email que NÃO bate (ex.: \`@xyz.com\`). Confirma que ele não aparece na lista.
3. Cria outro contato cujo email bate com o filtro. Confirma que ele aparece.
4. Repete em segmento, label (\`/contacts/labels/<slug>\`), busca e view \`active\`.
5. Caso realtime: aplica um filtro, então em outro terminal:
   \`\`\`bash
   bundle exec rails runner '
     account = Account.first
     inbox   = account.inboxes.first
     email   = \"teste-rt-#{Time.now.to_i}@nao-bate.com\"
     contact = Contact.create!(account: account, name: \"Teste RT\", email: email)
     ci      = ContactInbox.create!(contact: contact, inbox: inbox, source_id: SecureRandom.uuid)
     Conversation.create!(account_id: account.id, inbox_id: inbox.id, contact_id: contact.id, contact_inbox_id: ci.id)
   '
   \`\`\`
   Confirma que o novo contato NÃO aparece automaticamente na lista filtrada (antes do fix, aparecia).
6. Em \`/contacts\` sem filtro: criar contato pelo header faz ele aparecer (via refetch). Conversa nova via realtime passa a só aparecer com reload (intencional, evita 16º item brotando no fim de uma página de 15 com ordenação errada).

## What changed

- \`store/modules/contacts/mutations.js\`: \`SET_CONTACT_ITEM\` virou puro upsert em \`records\`.
- \`store/modules/specs/contacts/mutations.spec.js\`: spec atualizada + caso de merge.
- \`components-next/Contacts/ContactsHeader/ContactListHeaderWrapper.vue\`: emite \`contactCreated\` após sucesso.
- \`components-next/Contacts/ContactsListLayout.vue\`: propaga o evento.
- \`routes/dashboard/contacts/pages/ContactsIndex.vue\`: refetch no contexto atual ao receber \`contact-created\` ou via \`createContact\` (empty state).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/288)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a contact creation event that propagates through the contacts interface

* **Improvements**
  * Contacts list now automatically refreshes when a new contact is created without clearing current selection
  * Fixed contact sorting order preservation during record updates

* **Tests**
  * Added tests to verify contact record upsert behavior and sort order handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/288)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->