### PR TITLE
fix(whatsapp): keep Baileys message processing fast under WhatsApp instability

### DIFF
--- a/app/jobs/channels/whatsapp/baileys_update_contact_avatar_job.rb
+++ b/app/jobs/channels/whatsapp/baileys_update_contact_avatar_job.rb
@@ -1,0 +1,16 @@
+class Channels::Whatsapp::BaileysUpdateContactAvatarJob < ApplicationJob
+  queue_as :low
+
+  def perform(contact, inbox, phone)
+    return if contact.avatar.attached?
+
+    provider = inbox.channel.provider_service
+    return if provider.blank?
+
+    response = provider.get_profile_pic("#{phone}@s.whatsapp.net")
+    profile_pic_url = response&.dig('data', 'profilePictureUrl')
+    Avatar::AvatarFromUrlJob.perform_later(contact, profile_pic_url) if profile_pic_url
+  rescue StandardError => e
+    Rails.logger.error "Failed to fetch profile picture for contact #{contact.id}: #{e.message}"
+  end
+end

--- a/app/jobs/channels/whatsapp/baileys_update_group_avatar_job.rb
+++ b/app/jobs/channels/whatsapp/baileys_update_group_avatar_job.rb
@@ -1,0 +1,10 @@
+class Channels::Whatsapp::BaileysUpdateGroupAvatarJob < ApplicationJob
+  queue_as :low
+
+  def perform(group_contact, force: false)
+    provider = group_contact.group_channel&.provider_service
+    return if provider.blank?
+
+    provider.try_update_group_avatar(group_contact, force: force)
+  end
+end

--- a/app/services/whatsapp/baileys_handlers/concerns/group_stub_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/group_stub_message_handler.rb
@@ -89,12 +89,7 @@ module Whatsapp::BaileysHandlers::Concerns::GroupStubMessageHandler # rubocop:di
   end
 
   def update_group_avatar(group_contact)
-    provider = group_contact.group_channel&.provider_service
-    return if provider.blank?
-
-    provider.try_update_group_avatar(group_contact, force: true)
-  rescue StandardError => e
-    Rails.logger.error "[GROUP_ICON] Failed to update avatar for #{group_contact.identifier}: #{e.message}"
+    Channels::Whatsapp::BaileysUpdateGroupAvatarJob.perform_later(group_contact, force: true)
   end
 
   def parse_membership_request_action(stub_params)

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -179,23 +179,15 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     message_type == 'reaction' && message_content.blank?
   end
 
-  def fetch_profile_picture_url(phone_number)
-    jid = "#{phone_number}@s.whatsapp.net"
-    response = inbox.channel.provider_service.get_profile_pic(jid)
-    response&.dig('data', 'profilePictureUrl')
-  rescue StandardError => e
-    Rails.logger.error "Failed to fetch profile picture for #{phone_number}: #{e.message}"
-    nil
-  end
-
   def try_update_contact_avatar(contact = nil)
     # TODO: Current logic will never update the contact avatar if their profile picture changes on WhatsApp.
     target_contact = contact || @contact
     return if target_contact.avatar.attached?
 
     phone = contact ? target_contact.phone_number&.delete('+') : extract_from_jid(type: 'pn')
-    profile_pic_url = fetch_profile_picture_url(phone) if phone
-    ::Avatar::AvatarFromUrlJob.perform_later(target_contact, profile_pic_url) if profile_pic_url
+    return if phone.blank?
+
+    Channels::Whatsapp::BaileysUpdateContactAvatarJob.perform_later(target_contact, inbox, phone)
   end
 
   def message_under_process?

--- a/app/services/whatsapp/baileys_handlers/presence_update.rb
+++ b/app/services/whatsapp/baileys_handlers/presence_update.rb
@@ -4,9 +4,19 @@ module Whatsapp::BaileysHandlers::PresenceUpdate
   private
 
   def process_presence_update
+    return unless presence_subscribe_enabled?
+
     data = processed_params[:data]
     return if data[:id].blank? || data[:id].include?('@g.us')
 
+    dispatch_presence_events(data)
+  end
+
+  def presence_subscribe_enabled?
+    inbox.channel.provider_config&.dig('presence_subscribe')
+  end
+
+  def dispatch_presence_events(data)
     lid, phone = extract_presence_identifiers(data)
     consolidate_presence_contact(lid, phone) if lid && phone
 

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -47,8 +47,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         webhookVerifyToken: whatsapp_channel.provider_config['webhook_verify_token'],
         # TODO: Remove on Baileys v2, default will be false
         includeMedia: false,
-        groupsEnabled: self.class.groups_enabled?,
-        autoPresenceSubscribe: whatsapp_channel.provider_config['presence_subscribe'] || false
+        groupsEnabled: self.class.groups_enabled?
       }.compact.to_json
     )
 

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -264,7 +264,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     persist_group_settings(group_contact, metadata)
     persist_invite_code(group_contact) unless soft
     persist_pending_join_requests(group_contact, inbox) unless soft
-    try_update_group_avatar(group_contact) unless soft
+    Channels::Whatsapp::BaileysUpdateGroupAvatarJob.perform_later(group_contact) unless soft
 
     participant_contacts = build_participant_contacts(metadata[:participants], inbox, skip_avatars: soft)
     sync_group_members(group_contact, participant_contacts)
@@ -405,7 +405,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/profile-picture-url",
       headers: api_headers,
       query: { jid: jid },
-      format: :json
+      format: :json,
+      timeout: 10
     )
 
     return nil unless process_response(response)

--- a/spec/jobs/channels/whatsapp/baileys_update_contact_avatar_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/baileys_update_contact_avatar_job_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Channels::Whatsapp::BaileysUpdateContactAvatarJob do
+  let(:whatsapp_channel) { create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { whatsapp_channel.inbox }
+  let(:contact) { create(:contact, account: whatsapp_channel.account) }
+  let(:phone) { '5511987654321' }
+  let(:provider) { instance_double(Whatsapp::Providers::WhatsappBaileysService) }
+
+  before do
+    allow(inbox.channel).to receive(:provider_service).and_return(provider)
+  end
+
+  it 'enqueues on the low queue' do
+    expect { described_class.perform_later(contact, inbox, phone) }.to have_enqueued_job(described_class).on_queue('low')
+  end
+
+  context 'when the contact already has an avatar attached' do
+    before do
+      allow(contact).to receive(:avatar).and_return(instance_double(ActiveStorage::Attached::One, attached?: true))
+    end
+
+    it 'does not call the provider' do
+      described_class.perform_now(contact, inbox, phone)
+
+      expect(provider).not_to have_received(:get_profile_pic) if provider.respond_to?(:get_profile_pic)
+    end
+  end
+
+  context 'when the provider returns a profile picture url' do
+    before do
+      allow(provider).to receive(:get_profile_pic)
+        .with("#{phone}@s.whatsapp.net")
+        .and_return({ 'data' => { 'profilePictureUrl' => 'https://pps.whatsapp.net/avatar.jpg' } })
+    end
+
+    it 'enqueues the avatar download job' do
+      expect { described_class.perform_now(contact, inbox, phone) }
+        .to have_enqueued_job(Avatar::AvatarFromUrlJob)
+        .with(contact, 'https://pps.whatsapp.net/avatar.jpg')
+    end
+  end
+
+  context 'when the provider returns no url' do
+    before do
+      allow(provider).to receive(:get_profile_pic).and_return({ 'data' => { 'profilePictureUrl' => nil } })
+    end
+
+    it 'does not enqueue the avatar download job' do
+      expect { described_class.perform_now(contact, inbox, phone) }.not_to have_enqueued_job(Avatar::AvatarFromUrlJob)
+    end
+  end
+
+  context 'when the provider raises' do
+    before do
+      allow(provider).to receive(:get_profile_pic).and_raise(StandardError, 'baileys down')
+    end
+
+    it 'rescues and logs without propagating' do
+      expect(Rails.logger).to receive(:error).with(/baileys down/)
+      expect { described_class.perform_now(contact, inbox, phone) }.not_to raise_error
+    end
+  end
+end

--- a/spec/jobs/channels/whatsapp/baileys_update_group_avatar_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/baileys_update_group_avatar_job_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Channels::Whatsapp::BaileysUpdateGroupAvatarJob do
+  let(:whatsapp_channel) { create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false) }
+  let(:group_contact) { create(:contact, account: whatsapp_channel.account, identifier: '123456789@g.us') }
+
+  before do
+    # group_channel relies on contact_inboxes.first&.inbox&.channel
+    create(:contact_inbox, inbox: whatsapp_channel.inbox, contact: group_contact, source_id: '123456789')
+  end
+
+  it 'enqueues on the low queue' do
+    expect { described_class.perform_later(group_contact) }.to have_enqueued_job(described_class).on_queue('low')
+  end
+
+  context 'when the group channel has a provider' do
+    let(:provider) { instance_double(Whatsapp::Providers::WhatsappBaileysService, try_update_group_avatar: nil) }
+
+    before do
+      allow_any_instance_of(Channel::Whatsapp).to receive(:provider_service).and_return(provider) # rubocop:disable RSpec/AnyInstance
+    end
+
+    it 'forwards to try_update_group_avatar with force: false by default' do
+      described_class.perform_now(group_contact)
+
+      expect(provider).to have_received(:try_update_group_avatar).with(group_contact, force: false)
+    end
+
+    it 'forwards force: true when passed' do
+      described_class.perform_now(group_contact, force: true)
+
+      expect(provider).to have_received(:try_update_group_avatar).with(group_contact, force: true)
+    end
+  end
+
+  context 'when the group has no channel' do
+    let(:orphan_contact) { create(:contact, account: whatsapp_channel.account, identifier: '999@g.us') }
+
+    it 'returns without raising' do
+      expect { described_class.perform_now(orphan_contact) }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/whatsapp/baileys_handlers/presence_update_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/presence_update_spec.rb
@@ -5,7 +5,7 @@ describe Whatsapp::BaileysHandlers::PresenceUpdate do
   let!(:whatsapp_channel) do
     create(:channel_whatsapp,
            provider: 'baileys',
-           provider_config: { webhook_verify_token: webhook_verify_token },
+           provider_config: { webhook_verify_token: webhook_verify_token, presence_subscribe: true },
            validate_provider_config: false,
            received_messages: false)
   end
@@ -133,6 +133,36 @@ describe Whatsapp::BaileysHandlers::PresenceUpdate do
       expect(Rails.configuration.dispatcher).not_to receive(:dispatch).with('conversation.typing_on', any_args)
 
       perform(group_data)
+    end
+
+    context 'when presence_subscribe is disabled on the channel' do
+      before do
+        whatsapp_channel.update!(provider_config: whatsapp_channel.provider_config.merge('presence_subscribe' => false))
+      end
+
+      it 'does not dispatch typing events' do
+        jid = "#{lid}@lid"
+
+        expect(Rails.configuration.dispatcher).to receive(:dispatch).with('provider.event_received', any_args)
+        expect(Rails.configuration.dispatcher).not_to receive(:dispatch).with('conversation.typing_on', any_args)
+
+        perform(presence_data_for(jid, 'composing'))
+      end
+    end
+
+    context 'when presence_subscribe key is missing on the channel' do
+      before do
+        whatsapp_channel.update!(provider_config: whatsapp_channel.provider_config.except('presence_subscribe'))
+      end
+
+      it 'does not dispatch typing events' do
+        jid = "#{lid}@lid"
+
+        expect(Rails.configuration.dispatcher).to receive(:dispatch).with('provider.event_received', any_args)
+        expect(Rails.configuration.dispatcher).not_to receive(:dispatch).with('conversation.typing_on', any_args)
+
+        perform(presence_data_for(jid, 'composing'))
+      end
     end
   end
 end

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -199,42 +199,22 @@ describe Whatsapp::IncomingMessageBaileysService do
       end
 
       context 'when updating contact avatar' do
-        it 'enqueues avatar job when profile picture is available' do
-          stub_profile_pic_fetch('https://example.com/avatar.jpg')
-
+        it 'enqueues the contact avatar update job for new contacts' do
           described_class.new(inbox: inbox, params: params).perform
 
           conversation = inbox.conversations.last
           contact = conversation.contact
 
-          expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(contact, 'https://example.com/avatar.jpg')
+          expect(Channels::Whatsapp::BaileysUpdateContactAvatarJob).to have_been_enqueued.with(contact, inbox, '5511912345678')
         end
 
-        it 'does not enqueue avatar job when contact already has avatar attached' do
-          stub_profile_pic_fetch('https://example.com/avatar.jpg')
+        it 'does not enqueue the contact avatar update job when contact already has avatar attached' do
           contact = create(:contact, account: inbox.account, name: 'John Doe', phone_number: '+5511912345678')
           contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
 
           described_class.new(inbox: inbox, params: params).perform
 
-          expect(Avatar::AvatarFromUrlJob).not_to have_been_enqueued
-        end
-
-        it 'does not enqueue avatar job when profile picture is not available' do
-          described_class.new(inbox: inbox, params: params).perform
-
-          expect(Avatar::AvatarFromUrlJob).not_to have_been_enqueued
-        end
-
-        it 'logs error and does not enqueue avatar job when profile picture request fails' do
-          allow(Rails.logger).to receive(:error)
-          stub_request(:get, /profile-picture-url/)
-            .to_raise(StandardError.new('Profile picture request failed'))
-
-          described_class.new(inbox: inbox, params: params).perform
-
-          expect(Avatar::AvatarFromUrlJob).not_to have_been_enqueued
-          expect(Rails.logger).to have_received(:error).with('Failed to fetch profile picture for 5511912345678: Profile picture request failed')
+          expect(Channels::Whatsapp::BaileysUpdateContactAvatarJob).not_to have_been_enqueued
         end
       end
 

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -108,8 +108,7 @@ describe Whatsapp::Providers::WhatsappBaileysService do
               webhookUrl: whatsapp_channel.inbox.callback_webhook_url,
               webhookVerifyToken: whatsapp_channel.provider_config['webhook_verify_token'],
               includeMedia: false,
-              groupsEnabled: described_class.groups_enabled?,
-              autoPresenceSubscribe: whatsapp_channel.provider_config['presence_subscribe'] || false
+              groupsEnabled: described_class.groups_enabled?
             }.to_json
           )
           .to_return(status: 200)
@@ -130,8 +129,7 @@ describe Whatsapp::Providers::WhatsappBaileysService do
               webhookUrl: whatsapp_channel.inbox.callback_webhook_url,
               webhookVerifyToken: whatsapp_channel.provider_config['webhook_verify_token'],
               includeMedia: false,
-              groupsEnabled: described_class.groups_enabled?,
-              autoPresenceSubscribe: whatsapp_channel.provider_config['presence_subscribe'] || false
+              groupsEnabled: described_class.groups_enabled?
             }.to_json
           )
           .to_return(
@@ -1387,8 +1385,7 @@ describe Whatsapp::Providers::WhatsappBaileysService do
               webhookUrl: whatsapp_channel.inbox.callback_webhook_url,
               webhookVerifyToken: whatsapp_channel.provider_config['webhook_verify_token'],
               includeMedia: false,
-              groupsEnabled: described_class.groups_enabled?,
-              autoPresenceSubscribe: whatsapp_channel.provider_config['presence_subscribe'] || false
+              groupsEnabled: described_class.groups_enabled?
             }.to_json
           )
           .to_return(status: 200)
@@ -1407,8 +1404,7 @@ describe Whatsapp::Providers::WhatsappBaileysService do
               webhookUrl: whatsapp_channel.inbox.callback_webhook_url,
               webhookVerifyToken: whatsapp_channel.provider_config['webhook_verify_token'],
               includeMedia: false,
-              groupsEnabled: described_class.groups_enabled?,
-              autoPresenceSubscribe: whatsapp_channel.provider_config['presence_subscribe'] || false
+              groupsEnabled: described_class.groups_enabled?
             }.to_json
           )
           .to_return(status: 200)
@@ -1427,8 +1423,7 @@ describe Whatsapp::Providers::WhatsappBaileysService do
               webhookUrl: whatsapp_channel.inbox.callback_webhook_url,
               webhookVerifyToken: whatsapp_channel.provider_config['webhook_verify_token'],
               includeMedia: false,
-              groupsEnabled: described_class.groups_enabled?,
-              autoPresenceSubscribe: whatsapp_channel.provider_config['presence_subscribe'] || false
+              groupsEnabled: described_class.groups_enabled?
             }.to_json
           )
           .to_return(status: 400, body: 'reconnection failed')


### PR DESCRIPTION
When WhatsApp (via Baileys) gets slow or unstable, incoming messages used to slow down because the message handlers blocked on a synchronous `profile-picture-url` HTTP call for every contact that did not yet have an avatar. This PR moves the avatar fetch off the message processing hot path so messages keep being processed quickly even when WhatsApp is misbehaving.

## What changed

**1. Async contact avatar updates (main fix)**

- New `Channels::Whatsapp::BaileysUpdateContactAvatarJob` (queue `:low`) handles the Baileys profile-picture-url fetch for both individual and group-participant contacts.
- `try_update_contact_avatar` in `Whatsapp::BaileysHandlers::Helpers` now just enqueues the job. The dead `fetch_profile_picture_url` helper was removed.

**2. Async group avatar updates**

- New `Channels::Whatsapp::BaileysUpdateGroupAvatarJob` (queue `:low`) wraps `try_update_group_avatar`.
- `Whatsapp::Providers::WhatsappBaileysService#sync_group` and the group-icon stub handler now enqueue the job instead of calling the avatar update inline.
- `Whatsapp::Providers::WhatsappBaileysService#get_profile_pic` got a 10s HTTParty timeout so the async worker can't hang on a stuck request either.

**3. Presence subscribe opt-in is now client-side**

The `autoPresenceSubscribe` flag we used to forward to Baileys on connection setup was redundant. Drop it and instead gate the `PresenceUpdate` handler on the channel's `provider_config['presence_subscribe']` flag, so inboxes that have not opted in simply ignore incoming presence events.

## How to reproduce / test

Avatar / messages:
1. Trigger a slow or failing response on Baileys' `profile-picture-url` endpoint (e.g., delay/block it).
2. Send incoming WhatsApp messages (DM and group) to a Baileys-backed inbox.
3. Confirm messages keep being processed quickly. Inspect Sidekiq's `low` queue: `Channels::Whatsapp::BaileysUpdateContactAvatarJob` jobs accumulate but do not block message handling.
4. Trigger a group sync or group avatar change event; confirm the sync finishes quickly and the avatar eventually updates via the existing `Avatar::AvatarFromUrlJob`.

Presence:
1. Disable `presence_subscribe` in a Baileys channel's `provider_config` (or leave it unset).
2. Confirm typing indicators no longer appear in the dashboard for that inbox.
3. Re-enable it and confirm typing indicators come back.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/289)
<!-- Reviewable:end -->
