### PR TITLE
fix(custom-attributes): keep editor open during click-drag and auto-save on click outside

### DIFF
--- a/app/javascript/dashboard/components-next/CustomAttributes/DateAttribute.vue
+++ b/app/javascript/dashboard/components-next/CustomAttributes/DateAttribute.vue
@@ -4,6 +4,7 @@ import { parseISO } from 'date-fns';
 import { useI18n } from 'vue-i18n';
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
+import { vOnClickOutside } from '@vueuse/components';
 import Input from 'dashboard/components-next/input/Input.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
 
@@ -24,6 +25,7 @@ const { t } = useI18n();
 
 const isEditingValue = ref(false);
 const editedValue = ref(props.attribute.value || '');
+const initialEditValue = ref('');
 
 const rules = {
   editedValue: {
@@ -63,6 +65,9 @@ const toggleEditValue = value => {
     v$.value.$reset();
     editedValue.value = new Date().toISOString();
   }
+  if (isEditingValue.value) {
+    initialEditValue.value = editedValue.value;
+  }
 };
 
 const handleInputUpdate = async () => {
@@ -71,6 +76,14 @@ const handleInputUpdate = async () => {
 
   emit('update', parseISO(editedValue.value));
   isEditingValue.value = false;
+};
+
+const handleClickOutside = () => {
+  if (editedValue.value === initialEditValue.value) {
+    isEditingValue.value = false;
+    return;
+  }
+  handleInputUpdate();
 };
 </script>
 
@@ -119,7 +132,7 @@ const handleInputUpdate = async () => {
 
     <div
       v-if="isEditingValue"
-      v-on-clickaway="() => toggleEditValue(false)"
+      v-on-click-outside="handleClickOutside"
       class="flex items-center w-full"
     >
       <Input

--- a/app/javascript/dashboard/components-next/CustomAttributes/ListAttribute.vue
+++ b/app/javascript/dashboard/components-next/CustomAttributes/ListAttribute.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useToggle } from '@vueuse/core';
+import { vOnClickOutside } from '@vueuse/components';
 import DropdownMenu from 'dashboard/components-next/dropdown-menu/DropdownMenu.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
 
@@ -48,7 +49,7 @@ const handleAttributeAction = async action => {
     }"
   >
     <div
-      v-on-clickaway="() => toggleAttributeListDropdown(false)"
+      v-on-click-outside="() => toggleAttributeListDropdown(false)"
       class="relative flex items-center"
     >
       <span

--- a/app/javascript/dashboard/components-next/CustomAttributes/OtherAttribute.vue
+++ b/app/javascript/dashboard/components-next/CustomAttributes/OtherAttribute.vue
@@ -4,6 +4,7 @@ import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
+import { vOnClickOutside } from '@vueuse/components';
 import { isValidURL } from 'dashboard/helper/URLHelper.js';
 import { getRegexp } from 'shared/helpers/Validators';
 
@@ -26,6 +27,7 @@ const emit = defineEmits(['update', 'delete']);
 const { t } = useI18n();
 const isEditingValue = ref(false);
 const editedValue = ref(props.attribute.value || '');
+const initialEditValue = ref('');
 
 const isAttributeTypeLink = computed(
   () => props.attribute.attributeDisplayType === 'link'
@@ -101,6 +103,7 @@ const toggleEditValue = value => {
   if (isEditingValue.value) {
     v$.value.$reset();
     editedValue.value = props.attribute.value || '';
+    initialEditValue.value = editedValue.value;
   }
 };
 
@@ -110,6 +113,14 @@ const handleInputUpdate = async () => {
 
   emit('update', editedValue.value);
   toggleEditValue(false);
+};
+
+const handleClickOutside = () => {
+  if (editedValue.value === initialEditValue.value) {
+    toggleEditValue(false);
+    return;
+  }
+  handleInputUpdate();
 };
 </script>
 
@@ -175,7 +186,7 @@ const handleInputUpdate = async () => {
 
     <div
       v-if="isEditingValue"
-      v-on-clickaway="() => toggleEditValue(false)"
+      v-on-click-outside="handleClickOutside"
       class="flex items-center w-full"
     >
       <Input

--- a/app/javascript/dashboard/components/CustomAttribute.vue
+++ b/app/javascript/dashboard/components/CustomAttribute.vue
@@ -1,6 +1,7 @@
 <script>
 import { format, parseISO } from 'date-fns';
 import { required, url } from '@vuelidate/validators';
+import { vOnClickOutside } from '@vueuse/components';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import MultiselectDropdown from 'shared/components/ui/MultiselectDropdown.vue';
 import HelperTextPopup from 'dashboard/components/ui/HelperTextPopup.vue';
@@ -18,6 +19,9 @@ export default {
     MultiselectDropdown,
     HelperTextPopup,
     NextButton,
+  },
+  directives: {
+    onClickOutside: vOnClickOutside,
   },
   props: {
     label: { type: String, required: true },
@@ -42,6 +46,7 @@ export default {
     return {
       isEditing: false,
       editedValue: null,
+      initialEditValue: null,
     };
   },
   computed: {
@@ -160,11 +165,16 @@ export default {
       }
     },
     onClickAway() {
-      this.v$.$reset();
-      this.isEditing = false;
+      if (this.editedValue === this.initialEditValue) {
+        this.v$.$reset();
+        this.isEditing = false;
+        return;
+      }
+      this.onUpdate();
     },
     onEdit() {
       this.isEditing = true;
+      this.initialEditValue = this.editedValue;
       this.$nextTick(() => {
         this.focusInput();
       });
@@ -238,7 +248,7 @@ export default {
       </h4>
     </div>
     <div v-if="notAttributeTypeCheckboxAndList">
-      <div v-if="isEditing" v-on-clickaway="onClickAway">
+      <div v-if="isEditing" v-on-click-outside="onClickAway">
         <div class="flex items-center w-full mb-2">
           <input
             ref="inputfield"


### PR DESCRIPTION
Os inputs de atributo customizado (contato, conversa e tarefa do Kanban) ficavam fechando quando o usuário começava a selecionar texto dentro e soltava o mouse fora do campo. Agora o input só fecha se o press do mouse acontecer fora; além disso, clicar fora salva automaticamente o valor digitado, igual ao Enter.

## What changed

- Troca de `v-on-clickaway` (`vue3-click-away`) por `v-on-click-outside` (`@vueuse/components`), que ignora o click quando o `pointerdown` começou dentro do elemento. Resolve o problema de drag-select.
- `OtherAttribute.vue`, `DateAttribute.vue` (componentes novos) e `CustomAttribute.vue` (legacy, usado em conversa e Kanban Task) agora chamam o handler de save no click fora. Se o valor estiver vazio/igual ao original, só fecha; se for inválido, mantém o editor aberto com erro (mesma semântica do Enter).
- `ListAttribute.vue` apenas migra a directive; o dropdown não tem valor pendente para auto-salvar.

## How to test

1. Em um contato, abra a sidebar e edite um custom attribute texto/número/URL/data.
2. Clique dentro do input e arraste para fora soltando: o input deve permanecer aberto.
3. Edite o valor e clique em qualquer lugar fora do input: o valor deve ser salvo (mesmo efeito do Enter).
4. Repita no painel de conversa (custom attributes da conversa).
5. (Pro) Repita no modal de tarefa do Kanban — mesma fix se aplica via `CustomAttribute.vue`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/290)
<!-- Reviewable:end -->
