### PR TITLE
fix(whatsapp): show embedded signup when converting inbox to cloud

### DIFF
--- a/app/controllers/api/v1/accounts/whatsapp/authorizations_controller.rb
+++ b/app/controllers/api/v1/accounts/whatsapp/authorizations_controller.rb
@@ -37,11 +37,11 @@ class Api::V1::Accounts::Whatsapp::AuthorizationsController < Api::V1::Accounts:
     }, status: :unprocessable_entity
   end
 
+  # Accept any WhatsApp inbox here so the embedded signup flow can drive both
+  # reauth/upgrade of an existing whatsapp_cloud inbox AND provider conversion
+  # from a non-cloud WhatsApp inbox (baileys, zapi, 360dialog) to cloud.
   def can_upgrade_to_embedded_signup?
-    channel = @inbox.channel
-    return false unless channel.provider == 'whatsapp_cloud'
-
-    true
+    @inbox.channel.is_a?(Channel::Whatsapp)
   end
 
   def render_success_response(inbox)

--- a/app/javascript/dashboard/api/channel/whatsappChannel.js
+++ b/app/javascript/dashboard/api/channel/whatsappChannel.js
@@ -16,6 +16,13 @@ class WhatsappChannel extends ApiClient {
       inbox_id: inboxId,
     });
   }
+
+  convertViaEmbeddedSignup({ inboxId, ...params }) {
+    return axios.post(`${this.baseUrl()}/whatsapp/authorization`, {
+      ...params,
+      inbox_id: inboxId,
+    });
+  }
 }
 
 export default new WhatsappChannel();

--- a/app/javascript/dashboard/api/channel/whatsappChannel.js
+++ b/app/javascript/dashboard/api/channel/whatsappChannel.js
@@ -10,14 +10,7 @@ class WhatsappChannel extends ApiClient {
     return axios.post(`${this.baseUrl()}/whatsapp/authorization`, params);
   }
 
-  reauthorizeWhatsApp({ inboxId, ...params }) {
-    return axios.post(`${this.baseUrl()}/whatsapp/authorization`, {
-      ...params,
-      inbox_id: inboxId,
-    });
-  }
-
-  convertViaEmbeddedSignup({ inboxId, ...params }) {
+  postEmbeddedSignupAuthorization({ inboxId, ...params }) {
     return axios.post(`${this.baseUrl()}/whatsapp/authorization`, {
       ...params,
       inbox_id: inboxId,

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -39,10 +39,14 @@ const PROVIDER_TYPES = {
   ZAPI: 'zapi',
 };
 
-const hasWhatsappAppId = computed(() => {
+const hasEmbeddedSignupConfig = computed(() => {
+  const { whatsappAppId, whatsappConfigurationId } =
+    window.chatwootConfig ?? {};
   return (
-    window.chatwootConfig?.whatsappAppId &&
-    window.chatwootConfig.whatsappAppId !== 'none'
+    whatsappAppId &&
+    whatsappAppId !== 'none' &&
+    whatsappConfigurationId &&
+    whatsappConfigurationId !== 'none'
   );
 });
 
@@ -153,7 +157,7 @@ const selectProvider = providerValue => {
 const shouldShowCloudWhatsapp = provider => {
   return (
     provider === PROVIDER_TYPES.WHATSAPP_MANUAL ||
-    (provider === PROVIDER_TYPES.WHATSAPP && !hasWhatsappAppId.value)
+    (provider === PROVIDER_TYPES.WHATSAPP && !hasEmbeddedSignupConfig.value)
   );
 };
 
@@ -202,7 +206,8 @@ const handleManualLinkClick = () => {
         <!-- Show embedded signup if app ID is configured -->
         <div
           v-if="
-            hasWhatsappAppId && selectedProvider === PROVIDER_TYPES.WHATSAPP
+            hasEmbeddedSignupConfig &&
+            selectedProvider === PROVIDER_TYPES.WHATSAPP
           "
         >
           <WhatsappEmbeddedSignup :mode="mode" :inbox="inbox" />

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -153,8 +153,7 @@ const selectProvider = providerValue => {
 const shouldShowCloudWhatsapp = provider => {
   return (
     provider === PROVIDER_TYPES.WHATSAPP_MANUAL ||
-    (provider === PROVIDER_TYPES.WHATSAPP &&
-      (!hasWhatsappAppId.value || isConvertMode.value))
+    (provider === PROVIDER_TYPES.WHATSAPP && !hasWhatsappAppId.value)
   );
 };
 
@@ -203,12 +202,10 @@ const handleManualLinkClick = () => {
         <!-- Show embedded signup if app ID is configured -->
         <div
           v-if="
-            !isConvertMode &&
-            hasWhatsappAppId &&
-            selectedProvider === PROVIDER_TYPES.WHATSAPP
+            hasWhatsappAppId && selectedProvider === PROVIDER_TYPES.WHATSAPP
           "
         >
-          <WhatsappEmbeddedSignup />
+          <WhatsappEmbeddedSignup :mode="mode" :inbox="inbox" />
 
           <!-- Manual setup fallback option -->
           <div class="pt-6 mt-6 border-t border-n-weak">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/WhatsappEmbeddedSignup.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/WhatsappEmbeddedSignup.vue
@@ -16,6 +16,20 @@ import {
   isValidBusinessData,
 } from './whatsapp/utils';
 
+const props = defineProps({
+  mode: {
+    type: String,
+    default: 'create',
+    validator: value => ['create', 'convert'].includes(value),
+  },
+  inbox: {
+    type: Object,
+    default: null,
+  },
+});
+
+const isConvertMode = computed(() => props.mode === 'convert');
+
 const store = useStore();
 const router = useRouter();
 const { t } = useI18n();
@@ -69,6 +83,15 @@ const handleSignupSuccess = inboxData => {
   isProcessing.value = false;
   isAuthenticating.value = false;
 
+  if (isConvertMode.value && props.inbox?.id) {
+    useAlert(t('INBOX_MGMT.CONVERT.API.SUCCESS_MESSAGE'));
+    router.replace({
+      name: 'settings_inbox_show',
+      params: { inboxId: props.inbox.id },
+    });
+    return;
+  }
+
   if (inboxData && inboxData.id) {
     useAlert(t('INBOX_MGMT.FINISH.MESSAGE'));
     router.replace({
@@ -108,10 +131,16 @@ const completeSignupFlow = async businessDataParam => {
       phone_number_id: businessDataParam?.phone_number_id || '',
     };
 
-    const responseData = await store.dispatch(
-      'inboxes/createWhatsAppEmbeddedSignup',
-      params
-    );
+    const action =
+      isConvertMode.value && props.inbox?.id
+        ? 'inboxes/convertWhatsAppEmbeddedSignup'
+        : 'inboxes/createWhatsAppEmbeddedSignup';
+    const dispatchParams =
+      isConvertMode.value && props.inbox?.id
+        ? { ...params, inboxId: props.inbox.id }
+        : params;
+
+    const responseData = await store.dispatch(action, dispatchParams);
 
     authCode.value = null;
     handleSignupSuccess(responseData);

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/WhatsappEmbeddedSignup.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/WhatsappEmbeddedSignup.vue
@@ -83,7 +83,7 @@ const handleSignupSuccess = inboxData => {
   isProcessing.value = false;
   isAuthenticating.value = false;
 
-  if (isConvertMode.value && props.inbox?.id) {
+  if (isConvertMode.value) {
     useAlert(t('INBOX_MGMT.CONVERT.API.SUCCESS_MESSAGE'));
     router.replace({
       name: 'settings_inbox_show',
@@ -111,6 +111,13 @@ const handleSignupSuccess = inboxData => {
 
 // Signup flow
 const completeSignupFlow = async businessDataParam => {
+  if (isConvertMode.value && !props.inbox?.id) {
+    handleSignupError({
+      error: t('INBOX_MGMT.ADD.WHATSAPP.API.ERROR_MESSAGE'),
+    });
+    return;
+  }
+
   if (!authCodeReceived.value || !authCode.value) {
     handleSignupError({
       error: t('INBOX_MGMT.ADD.WHATSAPP.EMBEDDED_SIGNUP.AUTH_NOT_COMPLETED'),
@@ -131,14 +138,12 @@ const completeSignupFlow = async businessDataParam => {
       phone_number_id: businessDataParam?.phone_number_id || '',
     };
 
-    const action =
-      isConvertMode.value && props.inbox?.id
-        ? 'inboxes/convertWhatsAppEmbeddedSignup'
-        : 'inboxes/createWhatsAppEmbeddedSignup';
-    const dispatchParams =
-      isConvertMode.value && props.inbox?.id
-        ? { ...params, inboxId: props.inbox.id }
-        : params;
+    const action = isConvertMode.value
+      ? 'inboxes/convertWhatsAppEmbeddedSignup'
+      : 'inboxes/createWhatsAppEmbeddedSignup';
+    const dispatchParams = isConvertMode.value
+      ? { ...params, inboxId: props.inbox.id }
+      : params;
 
     const responseData = await store.dispatch(action, dispatchParams);
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/whatsapp/Reauthorize.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/whatsapp/Reauthorize.vue
@@ -50,7 +50,7 @@ const reauthorizeWhatsApp = async params => {
   isRequestingAuthorization.value = true;
 
   try {
-    const response = await whatsappChannel.reauthorizeWhatsApp({
+    const response = await whatsappChannel.postEmbeddedSignupAuthorization({
       inboxId: props.inbox.id,
       ...params,
     });

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -276,6 +276,18 @@ export const actions = {
       throw error;
     }
   },
+  convertWhatsAppEmbeddedSignup: async ({ commit, dispatch }, params) => {
+    commit(types.default.SET_INBOXES_UI_FLAG, { isUpdating: true });
+    try {
+      const response = await WhatsappChannel.convertViaEmbeddedSignup(params);
+      await dispatch('get');
+      commit(types.default.SET_INBOXES_UI_FLAG, { isUpdating: false });
+      return response.data;
+    } catch (error) {
+      commit(types.default.SET_INBOXES_UI_FLAG, { isUpdating: false });
+      throw error;
+    }
+  },
   ...channelActions,
   // TODO: Extract other create channel methods to separate files to reduce file size
   // - createChannel

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -279,7 +279,8 @@ export const actions = {
   convertWhatsAppEmbeddedSignup: async ({ commit, dispatch }, params) => {
     commit(types.default.SET_INBOXES_UI_FLAG, { isUpdating: true });
     try {
-      const response = await WhatsappChannel.convertViaEmbeddedSignup(params);
+      const response =
+        await WhatsappChannel.postEmbeddedSignupAuthorization(params);
       await dispatch('get');
       commit(types.default.SET_INBOXES_UI_FLAG, { isUpdating: false });
       return response.data;

--- a/app/services/whatsapp/embedded_signup_service.rb
+++ b/app/services/whatsapp/embedded_signup_service.rb
@@ -48,16 +48,34 @@ class Whatsapp::EmbeddedSignupService
 
   def create_or_reauthorize_channel(access_token, phone_info)
     if @inbox_id.present?
-      Whatsapp::ReauthorizationService.new(
-        account: @account,
-        inbox_id: @inbox_id,
-        phone_number_id: @phone_number_id,
-        business_id: @business_id
-      ).perform(access_token, phone_info)
+      channel = @account.inboxes.find(@inbox_id).channel
+      if channel.provider == 'whatsapp_cloud'
+        Whatsapp::ReauthorizationService.new(
+          account: @account,
+          inbox_id: @inbox_id,
+          phone_number_id: @phone_number_id,
+          business_id: @business_id
+        ).perform(access_token, phone_info)
+      else
+        convert_channel_to_cloud(channel, access_token)
+      end
     else
       waba_info = { waba_id: @waba_id, business_name: phone_info[:business_name] }
       Whatsapp::ChannelCreationService.new(@account, waba_info, phone_info, access_token).perform
     end
+  end
+
+  def convert_channel_to_cloud(channel, access_token)
+    channel.convert_provider!(
+      new_provider: 'whatsapp_cloud',
+      new_provider_config: {
+        'api_key' => access_token,
+        'phone_number_id' => @phone_number_id,
+        'business_account_id' => @business_id,
+        'source' => 'embedded_signup'
+      }
+    )
+    channel
   end
 
   def check_channel_health_and_prompt_reauth(channel)

--- a/spec/controllers/api/v1/accounts/whatsapp/authorizations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/whatsapp/authorizations_controller_spec.rb
@@ -423,6 +423,49 @@ RSpec.describe 'WhatsApp Authorization API', type: :request do
         end
       end
 
+      context 'when converting a non-cloud WhatsApp channel' do
+        let(:baileys_channel) do
+          create(:channel_whatsapp, account: account, provider: 'baileys', phone_number: '+15551234567',
+                                    validate_provider_config: false, sync_templates: false)
+        end
+        let(:baileys_inbox) { baileys_channel.inbox }
+        let(:convert_params) do
+          {
+            code: 'auth_code_xyz',
+            business_id: 'business_xyz',
+            waba_id: 'waba_xyz',
+            phone_number_id: 'phone_xyz',
+            inbox_id: baileys_inbox.id
+          }
+        end
+
+        it 'allows the embedded signup flow to drive the conversion' do
+          embedded_signup_service = instance_double(Whatsapp::EmbeddedSignupService)
+          expect(Whatsapp::EmbeddedSignupService).to receive(:new).with(
+            account: account,
+            params: {
+              code: 'auth_code_xyz',
+              business_id: 'business_xyz',
+              waba_id: 'waba_xyz',
+              phone_number_id: 'phone_xyz'
+            },
+            inbox_id: baileys_inbox.id
+          ).and_return(embedded_signup_service)
+          allow(embedded_signup_service).to receive(:perform).and_return(baileys_channel)
+          allow(baileys_channel).to receive(:inbox).and_return(baileys_inbox)
+
+          post "/api/v1/accounts/#{account.id}/whatsapp/authorization",
+               params: convert_params,
+               headers: administrator.create_new_auth_token,
+               as: :json
+
+          expect(response).to have_http_status(:success)
+          json_response = response.parsed_body
+          expect(json_response['success']).to be true
+          expect(json_response['id']).to eq(baileys_inbox.id)
+        end
+      end
+
       context 'when channel is not WhatsApp' do
         let(:facebook_channel) do
           stub_request(:post, 'https://graph.facebook.com/v3.2/me/subscribed_apps')

--- a/spec/services/whatsapp/embedded_signup_service_spec.rb
+++ b/spec/services/whatsapp/embedded_signup_service_spec.rb
@@ -151,14 +151,74 @@ describe Whatsapp::EmbeddedSignupService do
       end
     end
 
+    context 'with provider conversion flow' do
+      let(:baileys_channel) do
+        create(:channel_whatsapp, account: account, provider: 'baileys', phone_number: '+1234567890',
+                                  validate_provider_config: false, sync_templates: false)
+      end
+      let(:baileys_inbox) { baileys_channel.inbox }
+      let(:service_with_inbox) do
+        described_class.new(account: account, params: params, inbox_id: baileys_inbox.id)
+      end
+
+      before do
+        # The service does `@account.inboxes.find(id).channel`; force the chain
+        # to return the same Ruby instances the test sets expectations on so
+        # the message expectations actually match.
+        inbox_relation = instance_double(ActiveRecord::Relation)
+        allow(account).to receive(:inboxes).and_return(inbox_relation)
+        allow(inbox_relation).to receive(:find).with(baileys_inbox.id).and_return(baileys_inbox)
+        allow(baileys_inbox).to receive(:channel).and_return(baileys_channel)
+
+        allow(baileys_channel).to receive(:convert_provider!).and_return(baileys_channel)
+        allow(baileys_channel).to receive(:setup_webhooks)
+      end
+
+      it 'routes to convert_provider! with embedded signup credentials' do
+        expect(baileys_channel).to receive(:convert_provider!).with(
+          new_provider: 'whatsapp_cloud',
+          new_provider_config: {
+            'api_key' => access_token,
+            'phone_number_id' => params[:phone_number_id],
+            'business_account_id' => params[:business_id],
+            'source' => 'embedded_signup'
+          }
+        ).and_return(baileys_channel)
+
+        expect(baileys_channel).to receive(:setup_webhooks)
+
+        result = service_with_inbox.perform
+        expect(result).to eq(baileys_channel)
+      end
+
+      it 'skips ReauthorizationService when current provider is not whatsapp_cloud' do
+        expect(Whatsapp::ReauthorizationService).not_to receive(:new)
+        service_with_inbox.perform
+      end
+
+      it 'does not run channel health check on conversion' do
+        expect(Whatsapp::HealthService).not_to receive(:new)
+        service_with_inbox.perform
+      end
+    end
+
     context 'with reauthorization flow' do
       let(:inbox_id) { 123 }
+      let(:cloud_inbox) { instance_double(Inbox) }
+      let(:cloud_channel) { instance_double(Channel::Whatsapp, provider: 'whatsapp_cloud') }
       let(:reauth_service) { instance_double(Whatsapp::ReauthorizationService) }
       let(:service_with_inbox) do
         described_class.new(account: account, params: params, inbox_id: inbox_id)
       end
 
       before do
+        # The service looks up the channel before routing; stub the lookup chain
+        # so it returns a whatsapp_cloud channel and routes to ReauthorizationService.
+        inbox_relation = instance_double(ActiveRecord::Relation)
+        allow(account).to receive(:inboxes).and_return(inbox_relation)
+        allow(inbox_relation).to receive(:find).with(inbox_id).and_return(cloud_inbox)
+        allow(cloud_inbox).to receive(:channel).and_return(cloud_channel)
+
         allow(Whatsapp::ReauthorizationService).to receive(:new).with(
           account: account,
           inbox_id: inbox_id,
@@ -189,12 +249,16 @@ describe Whatsapp::EmbeddedSignupService do
       context 'with real channel requiring reauthorization' do
         let(:inbox) { create(:inbox, account: account) }
         let(:whatsapp_channel) do
-          create(:channel_whatsapp, account: account, phone_number: '+1234567890',
+          create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud', phone_number: '+1234567890',
                                     validate_provider_config: false, sync_templates: false)
         end
         let(:service_with_real_inbox) { described_class.new(account: account, params: params, inbox_id: inbox.id) }
 
         before do
+          # Reset the outer context's account.inboxes stub so the real lookup runs
+          # against the persisted inbox created here.
+          allow(account).to receive(:inboxes).and_call_original
+
           inbox.update!(channel: whatsapp_channel)
           whatsapp_channel.prompt_reauthorization!
 


### PR DESCRIPTION
Quando um admin convertia uma caixa de entrada WhatsApp (Baileys, Z-API ou 360dialog) para o provedor Cloud, a tela mostrava apenas o formulário manual de API key, mesmo com o Embedded Signup do Meta totalmente configurado. Agora o card do Embedded Signup aparece também na conversão, com link de fallback para o cadastro manual, espelhando o fluxo de nova caixa.

## How to test

1. Garantir que `WHATSAPP_APP_ID`/`WHATSAPP_CONFIGURATION_ID` estão configurados.
2. Em uma conta com caixa WhatsApp Baileys/Z-API/360dialog, abrir Settings → Inbox → Convert.
3. Selecionar "WhatsApp Cloud" como destino.
4. Esperado: card do Embedded Signup com botão "Login with Facebook" + link "Configuração manual" abaixo.
5. Concluir o fluxo do Meta. A caixa deve ser convertida para `whatsapp_cloud` mantendo `inbox.id`, e a UI redireciona para `settings_inbox_show` com mensagem de sucesso.
6. Alternativa: clicar no link "Configuração manual" e cair no formulário antigo (`CloudWhatsapp.vue`).

## What changed

- `Whatsapp.vue`: condição de exibição do Embedded Signup deixa de excluir `convert mode`; props `mode`/`inbox` são propagadas.
- `WhatsappEmbeddedSignup.vue`: aceita `mode`/`inbox`; em `convert` despacha `inboxes/convertWhatsAppEmbeddedSignup` (POST `/whatsapp/authorization` com `inbox_id`) e redireciona para `settings_inbox_show`.
- Store/API: nova action `convertWhatsAppEmbeddedSignup` e método `WhatsappChannel.convertViaEmbeddedSignup`.
- `Whatsapp::EmbeddedSignupService`: quando `inbox_id` está presente, roteia por provider — `whatsapp_cloud` segue para `ReauthorizationService`; outros providers caem em `convert_provider!` com `source: 'embedded_signup'`.
- `AuthorizationsController#can_upgrade_to_embedded_signup?`: relaxado para aceitar qualquer `Channel::Whatsapp` (cobrindo tanto reauth quanto conversão).
- Specs novos para o caminho de conversão (service + controller); spec existente de reauth atualizado para criar canal `whatsapp_cloud` explicitamente.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/292)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded WhatsApp signup can convert legacy WhatsApp channels to WhatsApp Cloud and supports both create and convert modes; UI shows embedded signup when app config is present and updates post-signup navigation.

* **Bug Fixes**
  * Reauthorization/upgrade now applies to all WhatsApp channels, not just a single provider.

* **Tests**
  * Added request and service tests covering conversion and reauthorization flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/292)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->