### PR TITLE
fix(internal-chat): escape literal @ in MENTION_BADGE i18n string

### DIFF
--- a/app/javascript/dashboard/i18n/locale/en/internalChat.json
+++ b/app/javascript/dashboard/i18n/locale/en/internalChat.json
@@ -157,7 +157,7 @@
     "SCROLL_TO_BOTTOM": "Scroll to bottom",
     "NEW_MESSAGES": "New messages",
     "LOADING_MESSAGES": "Loading messages...",
-    "MENTION_BADGE": "@",
+    "MENTION_BADGE": "{'@'}",
     "EMPTY_STATE": {
       "TITLE": "Welcome to Internal Chat",
       "SUBTITLE": "Pick a channel or conversation from the sidebar to get started."

--- a/app/javascript/dashboard/i18n/locale/pt_BR/internalChat.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/internalChat.json
@@ -157,7 +157,7 @@
     "SCROLL_TO_BOTTOM": "Ir para o final",
     "NEW_MESSAGES": "Novas mensagens",
     "LOADING_MESSAGES": "Carregando mensagens...",
-    "MENTION_BADGE": "@",
+    "MENTION_BADGE": "{'@'}",
     "EMPTY_STATE": {
       "TITLE": "Bem-vindo ao Chat Interno",
       "SUBTITLE": "Escolha um canal ou conversa na barra lateral para começar."


### PR DESCRIPTION
The Internal Chat sidebar can throw `SyntaxError: Unexpected lexical analysis in token: 'EOF'` from `vue-i18n` for users who have an unread mention in any channel. The bare `@` in the `INTERNAL_CHAT.MENTION_BADGE` translation is interpreted as the start of a linked-message reference (`@:key`, `@.modifier:`); the parser reaches the end of the string before finding a key and aborts. In production builds the thrown error propagates out of `t()` and breaks the badge render.

This change wraps the value in `{'@'}` so the message compiler treats it as a literal, producing the same `@` on screen without entering the linked-message path.

Closes a client report (an admin seeing `SyntaxError` in console when opening Internal Chat with unread mentions).

## How to test

1. Sign in as an account user that has at least one Internal Chat channel with an unread mention pointing to them.
2. Open Internal Chat.
3. The channel should display the red `@<N>` badge and the browser console should be clean (no `Unexpected lexical analysis` or `Message compilation error` from `vue-i18n`).

## What changed

- `app/javascript/dashboard/i18n/locale/en/internalChat.json`: `MENTION_BADGE` → `"{'@'}"`
- `app/javascript/dashboard/i18n/locale/pt_BR/internalChat.json`: `MENTION_BADGE` → `"{'@'}"`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/293)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mention badge character formatting in internal chat localization for English and Portuguese Brazilian languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/293)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->