### PR TITLE
fix(whatsapp): correct embedded signup flow for inbox conversion and reauth

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/InboxConvert.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/InboxConvert.vue
@@ -55,7 +55,11 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="w-full h-full overflow-auto">
-    <Whatsapp v-if="inbox?.id" mode="convert" :inbox="inbox" />
+  <div class="mx-auto flex flex-col gap-6 mb-8 max-w-7xl w-full !px-6">
+    <div
+      class="grid grid-cols-6 rounded-xl border border-n-weak h-full min-h-[50dvh]"
+    >
+      <Whatsapp v-if="inbox?.id" mode="convert" :inbox="inbox" />
+    </div>
   </div>
 </template>

--- a/app/services/whatsapp/embedded_signup_service.rb
+++ b/app/services/whatsapp/embedded_signup_service.rb
@@ -54,7 +54,7 @@ class Whatsapp::EmbeddedSignupService
           account: @account,
           inbox_id: @inbox_id,
           phone_number_id: @phone_number_id,
-          business_id: @business_id
+          waba_id: @waba_id
         ).perform(access_token, phone_info)
       else
         convert_channel_to_cloud(channel, access_token)
@@ -71,7 +71,7 @@ class Whatsapp::EmbeddedSignupService
       new_provider_config: {
         'api_key' => access_token,
         'phone_number_id' => @phone_number_id,
-        'business_account_id' => @business_id,
+        'business_account_id' => @waba_id,
         'source' => 'embedded_signup'
       }
     )

--- a/app/services/whatsapp/reauthorization_service.rb
+++ b/app/services/whatsapp/reauthorization_service.rb
@@ -1,9 +1,9 @@
 class Whatsapp::ReauthorizationService
-  def initialize(account:, inbox_id:, phone_number_id:, business_id:)
+  def initialize(account:, inbox_id:, phone_number_id:, waba_id:)
     @account = account
     @inbox_id = inbox_id
     @phone_number_id = phone_number_id
-    @business_id = business_id
+    @waba_id = waba_id
   end
 
   def perform(access_token, phone_info)
@@ -30,7 +30,7 @@ class Whatsapp::ReauthorizationService
     channel.provider_config = current_config.merge(
       'api_key' => access_token,
       'phone_number_id' => @phone_number_id,
-      'business_account_id' => @business_id,
+      'business_account_id' => @waba_id,
       'source' => 'embedded_signup'
     )
     channel.save!

--- a/spec/services/whatsapp/embedded_signup_service_spec.rb
+++ b/spec/services/whatsapp/embedded_signup_service_spec.rb
@@ -180,7 +180,7 @@ describe Whatsapp::EmbeddedSignupService do
           new_provider_config: {
             'api_key' => access_token,
             'phone_number_id' => params[:phone_number_id],
-            'business_account_id' => params[:business_id],
+            'business_account_id' => params[:waba_id],
             'source' => 'embedded_signup'
           }
         ).and_return(baileys_channel)
@@ -189,6 +189,19 @@ describe Whatsapp::EmbeddedSignupService do
 
         result = service_with_inbox.perform
         expect(result).to eq(baileys_channel)
+      end
+
+      it 'stores the waba_id (not the meta business_id) in business_account_id' do
+        captured_config = nil
+        allow(baileys_channel).to receive(:convert_provider!) do |args|
+          captured_config = args[:new_provider_config]
+          baileys_channel
+        end
+
+        service_with_inbox.perform
+
+        expect(captured_config['business_account_id']).to eq(params[:waba_id])
+        expect(captured_config['business_account_id']).not_to eq(params[:business_id])
       end
 
       it 'skips ReauthorizationService when current provider is not whatsapp_cloud' do
@@ -223,7 +236,7 @@ describe Whatsapp::EmbeddedSignupService do
           account: account,
           inbox_id: inbox_id,
           phone_number_id: params[:phone_number_id],
-          business_id: params[:business_id]
+          waba_id: params[:waba_id]
         ).and_return(reauth_service)
         allow(reauth_service).to receive(:perform).with(access_token, phone_info).and_return(channel)
 
@@ -281,7 +294,7 @@ describe Whatsapp::EmbeddedSignupService do
             account: account,
             inbox_id: inbox.id,
             phone_number_id: params[:phone_number_id],
-            business_id: params[:business_id]
+            waba_id: params[:waba_id]
           ).and_return(reauth_service)
 
           allow(reauth_service).to receive(:perform) do

--- a/spec/services/whatsapp/reauthorization_service_spec.rb
+++ b/spec/services/whatsapp/reauthorization_service_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe Whatsapp::ReauthorizationService do
+  let(:account) { create(:account) }
+  let(:initial_provider_config) do
+    {
+      'api_key' => 'old_token',
+      'phone_number_id' => 'old_phone_number_id',
+      'business_account_id' => 'old_waba_id',
+      'webhook_verify_token' => 'verify_token'
+    }
+  end
+  let(:channel) do
+    create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud', phone_number: '+1234567890',
+                              provider_config: initial_provider_config, validate_provider_config: false, sync_templates: false)
+  end
+  let(:inbox) { channel.inbox }
+
+  let(:access_token) { 'new_access_token' }
+  let(:phone_info) do
+    {
+      phone_number_id: 'new_phone_number_id',
+      phone_number: '+1234567890',
+      verified: true,
+      business_name: 'New Business Name'
+    }
+  end
+
+  let(:service) do
+    described_class.new(
+      account: account,
+      inbox_id: inbox.id,
+      phone_number_id: 'new_phone_number_id',
+      waba_id: 'new_waba_id'
+    )
+  end
+
+  before do
+    # Stub the Meta Graph call that backs `validate_provider_config?` so the
+    # save inside ReauthorizationService doesn't reach out to the network and
+    # doesn't fail validation with a network error.
+    stub_request(:get, %r{https://graph.facebook.com/.*/message_templates}).to_return(status: 200, body: { data: [] }.to_json)
+  end
+
+  describe '#perform' do
+    it 'stores the waba_id in business_account_id' do
+      service.perform(access_token, phone_info)
+      expect(channel.reload.provider_config['business_account_id']).to eq('new_waba_id')
+    end
+
+    it 'updates api_key and phone_number_id' do
+      service.perform(access_token, phone_info)
+      reloaded_config = channel.reload.provider_config
+      expect(reloaded_config['api_key']).to eq('new_access_token')
+      expect(reloaded_config['phone_number_id']).to eq('new_phone_number_id')
+    end
+
+    it 'preserves the existing webhook_verify_token' do
+      service.perform(access_token, phone_info)
+      expect(channel.reload.provider_config['webhook_verify_token']).to eq('verify_token')
+    end
+
+    it 'updates the inbox name when business_name is provided' do
+      service.perform(access_token, phone_info)
+      expect(inbox.reload.name).to eq('New Business Name')
+    end
+
+    it 'raises when the phone number does not match' do
+      mismatched_phone_info = phone_info.merge(phone_number: '+0987654321')
+      expect { service.perform(access_token, mismatched_phone_info) }
+        .to raise_error(StandardError, /Phone number mismatch/)
+    end
+  end
+end

--- a/spec/services/whatsapp/reauthorization_service_spec.rb
+++ b/spec/services/whatsapp/reauthorization_service_spec.rb
@@ -68,7 +68,10 @@ describe Whatsapp::ReauthorizationService do
     it 'raises when the phone number does not match' do
       mismatched_phone_info = phone_info.merge(phone_number: '+0987654321')
       expect { service.perform(access_token, mismatched_phone_info) }
-        .to raise_error(StandardError, /Phone number mismatch/)
+        .to raise_error do |error|
+          expect(error.class.name).to eq('StandardError')
+          expect(error.message).to match(/Phone number mismatch/)
+        end
     end
   end
 end


### PR DESCRIPTION
Fixes the WhatsApp embedded signup flow for two operations that were failing with `Validation failed: Provider config Invalid Credentials`:

- Converting a non-Cloud WhatsApp inbox (Baileys, 360Dialog, Zapi) to Cloud via the embedded signup popup.
- Re-authorizing an existing Cloud inbox by going through the full embedded signup popup (rather than the fast path that reuses stored config).

Also constrains the width of the inbox conversion form so the layout matches the create flow instead of stretching across the full viewport.

## How to reproduce (before the fix)

1. Have a WhatsApp inbox on Baileys, 360Dialog, or Zapi.
2. Click **Convert provider** → **WhatsApp Cloud (embedded signup)** and complete the Facebook popup.
3. The request to `/api/v1/accounts/:id/whatsapp/authorization` fails with 422 and `[WHATSAPP] Embedded signup failed: Validation failed: Provider config Invalid Credentials`. Inbox stays on its previous provider.

## Root cause

The embedded signup popup returns two distinct identifiers from Meta:

- `business_id` → Meta Business Manager ID (the parent organizational object).
- `waba_id` → WhatsApp Business Account ID (the actual WABA the Cloud API talks to).

The Cloud API provider config requires the WABA ID under `business_account_id`, since `Channel::Whatsapp#validate_provider_config?` queries `GET /<business_account_id>/message_templates` on Meta Graph to confirm the credentials.

Two code paths were writing `@business_id` (Business Manager) instead of `@waba_id` (WABA) into `provider_config['business_account_id']`:

- `Whatsapp::EmbeddedSignupService#convert_channel_to_cloud`
- `Whatsapp::ReauthorizationService#update_channel_config`

The first path is exercised whenever a Baileys/Zapi/360Dialog inbox is upgraded to Cloud. The second runs on full embedded-signup reauthorization. In both, the validation `GET` hits `/<business_id>/message_templates` and Meta replies `(#100) Tried accessing nonexisting field (message_templates)` because a Business Manager object has no `message_templates` sub-resource. The validation then fails with the generic `Invalid Credentials` message and the change is rolled back.

`ChannelCreationService` (new-inbox flow) was already correct: it stores `@waba_info[:waba_id]`, which is why creating a brand new Cloud inbox via embedded signup worked.

## Why this bug had not surfaced in the reauth path before

`ReauthorizationService` has had the wrong field since #11940 (Aug 2025), but no one hit it in practice because:

- `Reauthorize.vue`'s fast path sends `business_id == waba_id == provider_config.business_account_id` (the same already-correct value for both fields), masking the swap.
- The popup path that would send the two distinct values is rarely taken because Cloud API System User tokens do not expire (`expires_at: 0`), so explicit reauth via popup is uncommon.

## What changed

### Backend

- `app/services/whatsapp/embedded_signup_service.rb`: pass `waba_id: @waba_id` to `ReauthorizationService` and store `@waba_id` in `convert_channel_to_cloud`'s `business_account_id`.
- `app/services/whatsapp/reauthorization_service.rb`: rename initializer keyword from `business_id:` to `waba_id:` and update the `provider_config.merge` accordingly.

### Specs

- `spec/services/whatsapp/embedded_signup_service_spec.rb`: update existing mocks to expect `waba_id:` on `ReauthorizationService.new` and add an explicit regression case asserting `business_account_id` equals `params[:waba_id]` (and not `params[:business_id]`) on `convert_provider!`.
- `spec/services/whatsapp/reauthorization_service_spec.rb` (new): covers `business_account_id` receiving `waba_id`, api_key/phone_number_id rotation, preservation of `webhook_verify_token`, inbox-name update, and phone-number-mismatch error path.

### Frontend (layout fix surfaced during reproduction)

- `app/javascript/dashboard/routes/dashboard/settings/inbox/InboxConvert.vue`: wrap the conversion form in `mx-auto max-w-7xl !px-6` and a `grid-cols-6` container so the inner `col-span-6` applies, matching the create flow's visual constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/294)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated inbox conversion page layout with centered, constrained-width grid, improved spacing and rounded container styling

* **Bug Fixes**
  * Fixed WhatsApp conversion and reauthorization flows to source the correct account identifier for provider updates

* **Tests**
  * Added and updated specs to cover WhatsApp conversion and reauthorization behaviors and validations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/294)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->