### PR TITLE
fix(whatsapp): make Baileys disconnect_channel_provider fail-open

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n, I18nT } from 'vue-i18n';
 import Twilio from './Twilio.vue';
@@ -27,6 +27,16 @@ const isConvertMode = computed(() => props.mode === 'convert');
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
+
+// Latched by the child once it triggers the post-success router.replace.
+// Suppresses rendering during the navigation tail so the parent doesn't
+// briefly re-render against the new route's query params (which would clear
+// `route.query.provider` and flash the provider picker between the success
+// toast and the unmount).
+const isLeaving = ref(false);
+const handleEmbeddedSignupLeaving = () => {
+  isLeaving.value = true;
+};
 
 const PROVIDER_TYPES = {
   WHATSAPP: 'whatsapp',
@@ -143,8 +153,12 @@ const isValidSelectedProvider = computed(() => {
   );
 });
 
-const showProviderSelection = computed(() => !isValidSelectedProvider.value);
-const showConfiguration = computed(() => isValidSelectedProvider.value);
+const showProviderSelection = computed(
+  () => !isLeaving.value && !isValidSelectedProvider.value
+);
+const showConfiguration = computed(
+  () => !isLeaving.value && isValidSelectedProvider.value
+);
 
 const selectProvider = providerValue => {
   router.push({
@@ -210,7 +224,11 @@ const handleManualLinkClick = () => {
             selectedProvider === PROVIDER_TYPES.WHATSAPP
           "
         >
-          <WhatsappEmbeddedSignup :mode="mode" :inbox="inbox" />
+          <WhatsappEmbeddedSignup
+            :mode="mode"
+            :inbox="inbox"
+            @leaving="handleEmbeddedSignupLeaving"
+          />
 
           <!-- Manual setup fallback option -->
           <div class="pt-6 mt-6 border-t border-n-weak">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/WhatsappEmbeddedSignup.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/WhatsappEmbeddedSignup.vue
@@ -28,6 +28,8 @@ const props = defineProps({
   },
 });
 
+const emit = defineEmits(['leaving']);
+
 const isConvertMode = computed(() => props.mode === 'convert');
 
 const store = useStore();
@@ -82,6 +84,12 @@ const handleSignupCancellation = () => {
 const handleSignupSuccess = inboxData => {
   isProcessing.value = false;
   isAuthenticating.value = false;
+  // Tell the parent we are about to navigate away. The router.replace below
+  // is reactive against the route — without an explicit signal, the parent
+  // Whatsapp.vue would re-render against the new route's query params while
+  // still mounted, briefly flashing the provider picker between the toast
+  // and the unmount.
+  emit('leaving');
 
   if (isConvertMode.value) {
     useAlert(t('INBOX_MGMT.CONVERT.API.SUCCESS_MESSAGE'));

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/specs/Whatsapp.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/specs/Whatsapp.spec.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { defineComponent, h, nextTick, reactive } from 'vue';
+import { mount } from '@vue/test-utils';
+import Whatsapp from '../Whatsapp.vue';
+
+// Mutable reactive route — tests drive route.query / route.name through it
+// to exercise how the parent reacts to navigation events.
+let mockRoute;
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual('vue-router');
+  return {
+    ...actual,
+    useRoute: () => mockRoute,
+    useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  };
+});
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual('vue-i18n');
+  return {
+    ...actual,
+    useI18n: () => ({ t: key => key }),
+    I18nT: defineComponent({
+      name: 'I18nT',
+      props: { keypath: { type: String, required: true }, tag: String },
+      setup(props, { slots }) {
+        return () =>
+          h(
+            props.tag || 'span',
+            {},
+            slots.default ? slots.default() : props.keypath
+          );
+      },
+    }),
+  };
+});
+
+// We don't care about feature_flags / branding here — render simple stubs.
+const stubComponent = name =>
+  defineComponent({
+    name,
+    template: `<div class="${name}-stub" />`,
+  });
+
+const WhatsappEmbeddedSignupStub = defineComponent({
+  name: 'WhatsappEmbeddedSignup',
+  // eslint-disable-next-line vue/no-unused-emit-declarations
+  emits: ['leaving'],
+  template: '<div class="WhatsappEmbeddedSignup-stub" />',
+});
+
+const mountWhatsapp = (overrides = {}) => {
+  // window.chatwootConfig is read in setup() to decide whether to render the
+  // embedded signup component. Force "configured" by default so a provider
+  // selection of "whatsapp" routes to the embedded signup branch.
+  window.chatwootConfig = {
+    whatsappAppId: 'appid',
+    whatsappConfigurationId: 'configid',
+  };
+
+  return mount(Whatsapp, {
+    props: {
+      mode: 'convert',
+      inbox: { id: 30, provider: 'baileys', name: 'Inbox 30' },
+      ...overrides,
+    },
+    global: {
+      stubs: {
+        WhatsappEmbeddedSignup: WhatsappEmbeddedSignupStub,
+        Twilio: stubComponent('Twilio'),
+        ThreeSixtyDialogWhatsapp: stubComponent('ThreeSixtyDialogWhatsapp'),
+        CloudWhatsapp: stubComponent('CloudWhatsapp'),
+        ChannelSelector: stubComponent('ChannelSelector'),
+        BaileysWhatsapp: stubComponent('BaileysWhatsapp'),
+        ZapiWhatsapp: stubComponent('ZapiWhatsapp'),
+      },
+    },
+  });
+};
+
+const setRouteProvider = value => {
+  if (value === undefined) {
+    mockRoute.query = {};
+  } else {
+    mockRoute.query = { provider: value };
+  }
+};
+
+describe('Whatsapp.vue (convert mode)', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockReplace.mockReset();
+    mockRoute = reactive({
+      name: 'settings_inbox_convert',
+      params: { inboxId: 30 },
+      query: {},
+    });
+  });
+
+  it('shows the provider picker when no provider is selected in the query', () => {
+    const wrapper = mountWhatsapp();
+    expect(wrapper.find('.ChannelSelector-stub').exists()).toBe(true);
+    expect(wrapper.find('.WhatsappEmbeddedSignup-stub').exists()).toBe(false);
+  });
+
+  it('shows the embedded signup configuration when ?provider=whatsapp', async () => {
+    setRouteProvider('whatsapp');
+    const wrapper = mountWhatsapp();
+    await nextTick();
+    expect(wrapper.find('.WhatsappEmbeddedSignup-stub').exists()).toBe(true);
+    expect(wrapper.find('.ChannelSelector-stub').exists()).toBe(false);
+  });
+
+  // Reproduces the "flash" bug: a successful embedded signup runs
+  // router.replace, the route's query.provider is cleared during the
+  // navigation tail, and the still-mounted parent would re-render the
+  // provider picker for a few frames between the success toast and the
+  // unmount.
+  describe('navigation tail after embedded signup success', () => {
+    it('keeps the picker hidden once the child emits "leaving"', async () => {
+      setRouteProvider('whatsapp');
+      const wrapper = mountWhatsapp();
+      await nextTick();
+      expect(wrapper.find('.WhatsappEmbeddedSignup-stub').exists()).toBe(true);
+
+      // Simulate the success path: child signals it is about to navigate,
+      // then the route's query.provider is cleared (as router.replace would).
+      await wrapper
+        .findComponent(WhatsappEmbeddedSignupStub)
+        .vm.$emit('leaving');
+      setRouteProvider(undefined);
+      await nextTick();
+
+      // Neither the picker nor the configuration block should render.
+      expect(wrapper.find('.ChannelSelector-stub').exists()).toBe(false);
+      expect(wrapper.find('.WhatsappEmbeddedSignup-stub').exists()).toBe(false);
+    });
+
+    it('would flash the picker without the "leaving" signal (control)', async () => {
+      setRouteProvider('whatsapp');
+      const wrapper = mountWhatsapp();
+      await nextTick();
+      expect(wrapper.find('.WhatsappEmbeddedSignup-stub').exists()).toBe(true);
+
+      // Simulate the route's query being cleared without the leaving signal.
+      // This is the original buggy behavior: the picker reappears.
+      setRouteProvider(undefined);
+      await nextTick();
+
+      expect(wrapper.find('.ChannelSelector-stub').exists()).toBe(true);
+    });
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/specs/Whatsapp.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/specs/Whatsapp.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { defineComponent, h, nextTick, reactive } from 'vue';
 import { mount } from '@vue/test-utils';
 import Whatsapp from '../Whatsapp.vue';
@@ -8,6 +8,7 @@ import Whatsapp from '../Whatsapp.vue';
 let mockRoute;
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
+let originalChatwootConfig;
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual('vue-router');
@@ -91,6 +92,7 @@ const setRouteProvider = value => {
 
 describe('Whatsapp.vue (convert mode)', () => {
   beforeEach(() => {
+    originalChatwootConfig = window.chatwootConfig;
     mockPush.mockReset();
     mockReplace.mockReset();
     mockRoute = reactive({
@@ -98,6 +100,10 @@ describe('Whatsapp.vue (convert mode)', () => {
       params: { inboxId: 30 },
       query: {},
     });
+  });
+
+  afterEach(() => {
+    window.chatwootConfig = originalChatwootConfig;
   });
 
   it('shows the provider picker when no provider is selected in the query', () => {

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -56,14 +56,20 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     true
   end
 
+  # Best-effort disconnect: we tell the Baileys API to drop the session and
+  # move on regardless of the response. A stale or already-cleared session
+  # (404), a Baileys API hiccup (5xx), or even a network error should not
+  # block a provider conversion or channel teardown — the only point of
+  # calling this is to avoid leaving a dangling session, not to gate the
+  # caller's flow on that cleanup succeeding.
   def disconnect_channel_provider
-    response = HTTParty.delete(
+    HTTParty.delete(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}",
       headers: api_headers
     )
-
-    raise ProviderUnavailableError unless process_response(response)
-
+    true
+  rescue StandardError => e
+    Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider failed (ignored): #{e.message}")
     true
   end
 
@@ -864,7 +870,6 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   end
 
   with_error_handling :setup_channel_provider,
-                      :disconnect_channel_provider,
                       :send_message,
                       :toggle_typing_status,
                       :presence_subscribe,

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -65,7 +65,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   def disconnect_channel_provider
     HTTParty.delete(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}",
-      headers: api_headers
+      headers: api_headers,
+      timeout: 10
     )
     true
   rescue StandardError => e

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -63,11 +63,12 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # calling this is to avoid leaving a dangling session, not to gate the
   # caller's flow on that cleanup succeeding.
   def disconnect_channel_provider
-    HTTParty.delete(
+    response = HTTParty.delete(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}",
       headers: api_headers,
       timeout: 10
     )
+    Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider non-success status=#{response.code}") unless response.success?
     true
   rescue StandardError => e
     Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider failed (ignored): #{e.message}")

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -150,40 +150,55 @@ describe Whatsapp::Providers::WhatsappBaileysService do
   end
 
   describe '#disconnect_channel_provider' do
-    context 'when response is successful' do
-      it 'disconnects the whatsapp connection' do
-        stub_request(:delete, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
+    let(:disconnect_url) { "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}" }
+
+    context 'when the Baileys API responds successfully' do
+      it 'returns true' do
+        stub_request(:delete, disconnect_url)
           .with(headers: stub_headers(whatsapp_channel))
           .to_return(status: 200)
 
-        response = service.disconnect_channel_provider
-
-        expect(response).to be(true)
+        expect(service.disconnect_channel_provider).to be(true)
       end
     end
 
-    context 'when response is unsuccessful' do
-      it 'raises ProviderUnavailableError and logs the error' do
-        # Stub the failing request
-        stub_request(:delete, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
+    # disconnect is best-effort: a missing session (404), a Baileys API error
+    # (5xx), or a transport failure shouldn't propagate. The caller (e.g.
+    # convert_provider!) just needs the cleanup attempt to be made, not to
+    # succeed.
+    context 'when the Baileys API responds with an error status' do
+      [404, 500].each do |status|
+        it "returns true and does not raise for HTTP #{status}" do
+          stub_request(:delete, disconnect_url)
+            .with(headers: stub_headers(whatsapp_channel))
+            .to_return(status: status, body: 'baileys error')
+
+          expect(service.disconnect_channel_provider).to be(true)
+        end
+      end
+    end
+
+    context 'when the request itself fails' do
+      it 'returns true, logs a warning, and does not raise' do
+        stub_request(:delete, disconnect_url)
           .with(headers: stub_headers(whatsapp_channel))
-          .to_return(
-            status: 400,
-            body: 'error message',
-            headers: {}
-          )
+          .to_raise(Net::OpenTimeout)
 
-        # Stub the reconnection attempt
-        stub_request(:post, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
-          .to_return(status: 200)
+        allow(Rails.logger).to receive(:warn)
 
-        allow(Rails.logger).to receive(:error)
+        expect(service.disconnect_channel_provider).to be(true)
+        expect(Rails.logger).to have_received(:warn).with(/disconnect_channel_provider failed/)
+      end
 
-        expect do
-          service.disconnect_channel_provider
-        end.to raise_error(Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError)
+      it 'does not trigger the error recovery flow' do
+        stub_request(:delete, disconnect_url)
+          .with(headers: stub_headers(whatsapp_channel))
+          .to_raise(Net::OpenTimeout)
+        reconnect_request = stub_request(:post, disconnect_url)
 
-        expect(Rails.logger).to have_received(:error).with('error message')
+        service.disconnect_channel_provider
+
+        expect(reconnect_request).not_to have_been_requested
       end
     end
   end

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -168,12 +168,15 @@ describe Whatsapp::Providers::WhatsappBaileysService do
     # succeed.
     context 'when the Baileys API responds with an error status' do
       [404, 500].each do |status|
-        it "returns true and does not raise for HTTP #{status}" do
+        it "returns true, logs a warning, and does not raise for HTTP #{status}" do
           stub_request(:delete, disconnect_url)
             .with(headers: stub_headers(whatsapp_channel))
             .to_return(status: status, body: 'baileys error')
 
+          allow(Rails.logger).to receive(:warn)
+
           expect(service.disconnect_channel_provider).to be(true)
+          expect(Rails.logger).to have_received(:warn).with(/disconnect_channel_provider non-success status=#{status}/)
         end
       end
     end


### PR DESCRIPTION
Fixes a regression where converting a WhatsApp inbox from Baileys to the Cloud provider (or, more generally, tearing down a Baileys channel that doesn't have an active paired session) would fail with `Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError` and roll back.

## How to reproduce (before the fix)

1. Have a WhatsApp inbox on Baileys whose `+phone` has no active session in the Baileys API — for example a freshly created Baileys inbox that was never paired, or one converted from Cloud back to Baileys without re-pairing.
2. Trigger any flow that calls `Channel::Whatsapp#convert_provider!` (e.g. the embedded signup popup with `inbox_id` of the Baileys inbox).
3. The Baileys provider's `disconnect_channel_provider` issues `DELETE /connections/+phone` and gets `404` from the Baileys API. The service raises `ProviderUnavailableError`, `with_error_handling` kicks in and recreates the Baileys session (issuing a new QR), then re-raises — and `convert_provider!` rolls back. Conversion never completes.

## Root cause

`disconnect_channel_provider` was treated as if it could meaningfully fail and require recovery. But it's best-effort cleanup: the caller (`convert_provider!`, channel destroy, etc.) just wants the Baileys session gone if there is one. Whether it was already gone (404), the Baileys API hiccuped (5xx), or the transport itself failed should not block the higher-level operation.

Worse, having `disconnect_channel_provider` go through `with_error_handling` meant any failure also kicked off `handle_channel_error`, which calls `setup_channel_provider_without_error_handling` — spinning up a new Baileys session immediately after we asked for it to be torn down. Exactly the opposite of what a conversion needs.

## What changed

- `app/services/whatsapp/providers/whatsapp_baileys_service.rb`: `disconnect_channel_provider` now ignores the HTTP response status and rescues any `StandardError`, logging a warning and returning `true` in either case. It is also no longer registered with `with_error_handling`, so a transport error can never trigger a recovery reconnect that contradicts the caller's intent.
- `spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb`: covers 200, 404, 500, and transport-error paths, asserting `true` is returned, no exception propagates, and the recovery reconnect endpoint is not hit on failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/295)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * WhatsApp disconnection is now best-effort: uses a short timeout, logs warnings on failures, and always reports success without triggering recovery flows.
  * Embedded-signup flow improved to emit a leaving signal and suppress parent rendering during the post-signup navigation tail to prevent transient flashes.
* **Tests**
  * Specs updated/added to verify best-effort disconnect behavior and the embedded-signup navigation-tail handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/295)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->