### PR TITLE
refactor(frontend): port v4.14.0 ConversationCard and ComposeConversation refactors

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
@@ -3,14 +3,11 @@ import { reactive, ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useStore, useMapGetter } from 'dashboard/composables/store';
 import { useI18n } from 'vue-i18n';
 import { useRouter, useRoute } from 'vue-router';
-import { useWindowSize } from '@vueuse/core';
 import { useUISettings } from 'dashboard/composables/useUISettings';
 import { useInboxSignatures } from 'dashboard/composables/useInboxSignatures';
-import { vOnClickOutside } from '@vueuse/components';
 import { useAlert } from 'dashboard/composables';
 import { ExceptionWithMessage } from 'shared/helpers/CustomErrors';
 import { debounce } from '@chatwoot/utils';
-import { useKeyboardEvents } from 'dashboard/composables/useKeyboardEvents';
 import { emitter } from 'shared/helpers/mitt';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import {
@@ -22,23 +19,19 @@ import {
 } from 'dashboard/components-next/NewConversation/helpers/composeConversationHelper';
 import { frontendURL, conversationUrl } from 'dashboard/helper/URLHelper';
 import { pendingGroupNavigation } from 'dashboard/helper/pendingGroupNavigation';
-import wootConstants from 'dashboard/constants/globals';
 
+import Popover from 'dashboard/components-next/popover/Popover.vue';
 import ComposeNewConversationForm from 'dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue';
 import ComposeNewGroupForm from 'dashboard/components-next/NewConversation/components/ComposeNewGroupForm.vue';
 
 const props = defineProps({
-  alignPosition: {
-    type: String,
-    default: 'left',
-  },
   contactId: {
     type: String,
     default: null,
   },
-  isModal: {
-    type: Boolean,
-    default: false,
+  align: {
+    type: String,
+    default: 'end',
   },
 });
 
@@ -49,23 +42,16 @@ const store = useStore();
 const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
-const { width: windowWidth } = useWindowSize();
 
 const { fetchSignatureFlagFromUISettings } = useUISettings();
 
-const isSmallScreen = computed(
-  () => windowWidth.value < wootConstants.SMALL_SCREEN_BREAKPOINT
-);
-
-const viewInModal = computed(() => props.isModal || isSmallScreen.value);
-
+const popoverRef = ref(null);
 const contacts = ref([]);
 const selectedContact = ref(null);
 const targetInbox = ref(null);
 const isCreatingContact = ref(false);
 const isFetchingInboxes = ref(false);
 const isSearching = ref(false);
-const showComposeNewConversation = ref(false);
 const composeMode = ref('conversation');
 const groupFormRef = ref(null);
 
@@ -106,55 +92,6 @@ const isGroupsDisabled = computed(
 );
 const isSuperAdmin = computed(() => currentUser.value.type === 'SuperAdmin');
 
-const resetContacts = () => {
-  contacts.value = [];
-};
-
-const closeCompose = () => {
-  showComposeNewConversation.value = false;
-  composeMode.value = 'conversation';
-  if (!props.contactId) {
-    selectedContact.value = null;
-  }
-  targetInbox.value = null;
-  resetContacts();
-  groupFormRef.value?.resetForm();
-  emit('close');
-};
-
-const discardCompose = () => {
-  clearFormState();
-  formState.message = '';
-  closeCompose();
-};
-
-const switchMode = mode => {
-  if (composeMode.value === mode) return;
-  composeMode.value = mode;
-  selectedContact.value = null;
-  targetInbox.value = null;
-  clearFormState();
-  formState.message = '';
-  resetContacts();
-  groupFormRef.value?.resetForm();
-};
-
-const createGroup = async ({ inboxId, subject, participants }) => {
-  try {
-    const data = await store.dispatch('groupMembers/createGroup', {
-      inbox_id: inboxId,
-      subject,
-      participants,
-    });
-    pendingGroupNavigation.set(data.group_jid);
-    groupFormRef.value?.resetForm();
-    discardCompose();
-    useAlert(t('GROUP.CREATE.SUCCESS_MESSAGE'));
-  } catch {
-    useAlert(t('GROUP.CREATE.ERROR_MESSAGE'));
-  }
-};
-
 const {
   fetchInboxSignatures,
   getSignatureForInbox,
@@ -183,13 +120,9 @@ const directUploadsEnabled = computed(
 
 const activeContact = computed(() => contactById.value(props.contactId));
 
-const composePopoverClass = computed(() => {
-  if (viewInModal.value) return '';
-
-  return props.alignPosition === 'right'
-    ? 'absolute ltr:left-0 ltr:right-[unset] rtl:right-0 rtl:left-[unset]'
-    : 'absolute rtl:left-0 rtl:right-[unset] ltr:right-0 ltr:left-[unset]';
-});
+const resetContacts = () => {
+  contacts.value = [];
+};
 
 const onContactSearch = debounce(
   async query => {
@@ -255,6 +188,43 @@ const clearSelectedContact = () => {
   clearFormState();
 };
 
+const closeCompose = () => {
+  popoverRef.value?.hide();
+};
+
+const discardCompose = () => {
+  clearFormState();
+  formState.message = '';
+  closeCompose();
+};
+
+const switchMode = mode => {
+  if (composeMode.value === mode) return;
+  composeMode.value = mode;
+  selectedContact.value = null;
+  targetInbox.value = null;
+  clearFormState();
+  formState.message = '';
+  resetContacts();
+  groupFormRef.value?.resetForm();
+};
+
+const createGroup = async ({ inboxId, subject, participants }) => {
+  try {
+    const data = await store.dispatch('groupMembers/createGroup', {
+      inbox_id: inboxId,
+      subject,
+      participants,
+    });
+    pendingGroupNavigation.set(data.group_jid);
+    groupFormRef.value?.resetForm();
+    discardCompose();
+    useAlert(t('GROUP.CREATE.SUCCESS_MESSAGE'));
+  } catch {
+    useAlert(t('GROUP.CREATE.ERROR_MESSAGE'));
+  }
+};
+
 const createConversation = async ({ payload, isFromWhatsApp }) => {
   try {
     const data = await store.dispatch('contactConversations/create', {
@@ -279,8 +249,21 @@ const createConversation = async ({ payload, isFromWhatsApp }) => {
   }
 };
 
-const toggle = () => {
-  showComposeNewConversation.value = !showComposeNewConversation.value;
+const onPopoverShow = () => {
+  // Flag to prevent triggering drag n drop while compose is open
+  emitter.emit(BUS_EVENTS.NEW_CONVERSATION_MODAL, true);
+};
+
+const onPopoverHide = () => {
+  composeMode.value = 'conversation';
+  if (!props.contactId) {
+    selectedContact.value = null;
+  }
+  targetInbox.value = null;
+  resetContacts();
+  groupFormRef.value?.resetForm();
+  emitter.emit(BUS_EVENTS.NEW_CONVERSATION_MODAL, false);
+  emit('close');
 };
 
 watch(
@@ -308,18 +291,6 @@ watch(
   { immediate: true, deep: true }
 );
 
-const handleClickOutside = () => {
-  if (!showComposeNewConversation.value) return;
-
-  showComposeNewConversation.value = false;
-  emit('close');
-};
-
-const onModalBackdropClick = () => {
-  if (!viewInModal.value) return;
-  handleClickOutside();
-};
-
 const navigateToGroup = ({ conversationId }) => {
   const url = frontendURL(
     conversationUrl({
@@ -338,53 +309,21 @@ onMounted(() => {
 onUnmounted(() => {
   emitter.off(BUS_EVENTS.NAVIGATE_TO_GROUP, navigateToGroup);
 });
-
-const keyboardEvents = {
-  Escape: {
-    action: () => {
-      if (showComposeNewConversation.value) {
-        showComposeNewConversation.value = false;
-        emit('close');
-        emitter.emit(BUS_EVENTS.NEW_CONVERSATION_MODAL, false);
-      }
-    },
-  },
-};
-
-useKeyboardEvents(keyboardEvents);
 </script>
 
 <template>
-  <div
-    v-on-click-outside="[
-      handleClickOutside,
-      // Fixed and edge case https://github.com/chatwoot/chatwoot/issues/10785
-      // This will prevent closing the compose conversation modal when the editor Create link popup is open
-      { ignore: ['dialog.ProseMirror-prompt-backdrop'] },
-    ]"
-    class="relative"
-    :class="{
-      'z-50': showComposeNewConversation && !viewInModal,
-    }"
+  <Popover
+    ref="popoverRef"
+    :align="align"
+    :show-content-border="false"
+    @show="onPopoverShow"
+    @hide="onPopoverHide"
   >
-    <slot
-      name="trigger"
-      :is-open="showComposeNewConversation"
-      :toggle="toggle"
-    />
-    <div
-      v-if="showComposeNewConversation"
-      :class="{
-        'fixed z-50 bg-n-alpha-black1 backdrop-blur-[4px] flex items-start pt-[clamp(3rem,15vh,12rem)] justify-center inset-0':
-          viewInModal,
-      }"
-      @click.self="onModalBackdropClick"
-    >
-      <div
-        v-if="!isGroupMode"
-        :class="[{ 'mt-2': !viewInModal }, composePopoverClass]"
-        class="w-[42rem] flex flex-col min-w-0"
-      >
+    <template #default="{ isOpen }">
+      <slot name="trigger" :is-open="isOpen" />
+    </template>
+    <template #content>
+      <div class="w-[42rem] flex flex-col min-w-0">
         <div
           v-if="hasGroupInboxes"
           class="flex gap-1 px-4 pt-3 pb-0 bg-n-alpha-3 border border-b-0 border-n-strong backdrop-blur-[100px] rounded-t-xl"
@@ -413,6 +352,7 @@ useKeyboardEvents(keyboardEvents);
           </button>
         </div>
         <ComposeNewConversationForm
+          v-if="!isGroupMode"
           :form-state="formState"
           :class="{ '!rounded-t-none !border-t-0': hasGroupInboxes }"
           :contacts="contacts"
@@ -437,40 +377,8 @@ useKeyboardEvents(keyboardEvents);
           @create-conversation="createConversation"
           @discard="discardCompose"
         />
-      </div>
-
-      <div
-        v-else
-        :class="[{ 'mt-2': !viewInModal }, composePopoverClass]"
-        class="w-[42rem] flex flex-col min-w-0"
-      >
-        <div
-          class="flex gap-1 px-4 pt-3 pb-0 bg-n-alpha-3 border border-b-0 border-n-strong backdrop-blur-[100px] rounded-t-xl"
-        >
-          <button
-            class="px-3 py-1.5 text-sm font-medium rounded-t-lg border-b-2 transition-colors"
-            :class="
-              !isGroupMode
-                ? 'text-n-brand border-n-brand bg-n-alpha-2'
-                : 'text-n-slate-11 border-transparent hover:text-n-slate-12'
-            "
-            @click="switchMode('conversation')"
-          >
-            {{ t('COMPOSE_NEW_CONVERSATION.TAB_CONVERSATION') }}
-          </button>
-          <button
-            class="px-3 py-1.5 text-sm font-medium rounded-t-lg border-b-2 transition-colors"
-            :class="
-              isGroupMode
-                ? 'text-n-brand border-n-brand bg-n-alpha-2'
-                : 'text-n-slate-11 border-transparent hover:text-n-slate-12'
-            "
-            @click="switchMode('group')"
-          >
-            {{ t('COMPOSE_NEW_CONVERSATION.TAB_GROUP') }}
-          </button>
-        </div>
         <ComposeNewGroupForm
+          v-else
           ref="groupFormRef"
           class="!rounded-t-none !border-t-0"
           :inboxes="groupCreationInboxes"
@@ -481,6 +389,6 @@ useKeyboardEvents(keyboardEvents);
           @discard="discardCompose"
         />
       </div>
-    </div>
-  </div>
+    </template>
+  </Popover>
 </template>

--- a/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
@@ -323,7 +323,7 @@ onUnmounted(() => {
       <slot name="trigger" :is-open="isOpen" />
     </template>
     <template #content>
-      <div class="w-[42rem] flex flex-col min-w-0">
+      <div class="w-full md:w-[42rem] flex flex-col min-w-0">
         <div
           v-if="hasGroupInboxes"
           class="flex gap-1 px-4 pt-3 pb-0 bg-n-alpha-3 border border-b-0 border-n-strong backdrop-blur-[100px] rounded-t-xl"

--- a/app/javascript/dashboard/components/ConversationItem.vue
+++ b/app/javascript/dashboard/components/ConversationItem.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch, inject } from 'vue';
 import { useRouter } from 'vue-router';
 import { useStore, useMapGetter } from 'dashboard/composables/store';
+import { useI18n } from 'vue-i18n';
 import { frontendURL, conversationUrl } from 'dashboard/helper/URLHelper';
 import ConversationCard from './widgets/conversation/ConversationCard.vue';
 import ConversationCardExpanded from 'dashboard/components-next/Conversation/ConversationCard/ConversationCardExpanded.vue';
@@ -51,10 +52,13 @@ watch(
   }
 );
 
+const { t } = useI18n();
+
 const currentChat = useMapGetter('getSelectedChat');
 const inboxesList = useMapGetter('inboxes/getInboxes');
 const activeInbox = useMapGetter('getSelectedInbox');
 const accountId = useMapGetter('getCurrentAccountId');
+const globalConfig = useMapGetter('globalConfig/get');
 
 const chatMetadata = computed(() => props.source.meta || {});
 const assignee = computed(() => chatMetadata.value.assignee || {});
@@ -78,6 +82,32 @@ const isInboxView = computed(() => !!activeInbox.value);
 const showAssigneeForExpandedCard = computed(
   () => props.showExpanded || props.showAssignee
 );
+
+const typingUsersList = computed(() => {
+  const users = store.getters['conversationTypingStatus/getUserList'](
+    props.source.id
+  );
+  return users.filter(u => u.type === 'contact');
+});
+const typingPreviewText = computed(() => {
+  if (typingUsersList.value.length === 0) return '';
+  return typingUsersList.value.some(u => u.recording)
+    ? t('CHAT_LIST.RECORDING')
+    : t('CHAT_LIST.TYPING');
+});
+
+const isGroupsDisabled = computed(
+  () =>
+    props.source.group_type === 'group' &&
+    !globalConfig.value.baileysWhatsappGroupsEnabled
+);
+
+const hasGroupActivity = computed(() => {
+  if (!isGroupsDisabled.value) return false;
+  const lastActivity = props.source.last_activity_at;
+  const agentSeen = props.source.agent_last_seen_at;
+  return lastActivity > 0 && (!agentSeen || lastActivity > agentSeen);
+});
 
 const conversationPath = computed(() =>
   frontendURL(
@@ -208,6 +238,8 @@ const onDeleteConversation = () => {
     :is-active-chat="isActiveChat"
     :show-assignee="showAssignee"
     :show-inbox-name="showInboxName"
+    :typing-preview="typingPreviewText"
+    :has-group-activity="hasGroupActivity"
     @click="onCardClick"
     @contextmenu="openContextMenu"
     @select-conversation="selectConversation"

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue
@@ -1,156 +1,57 @@
 <script setup>
 import { computed, ref, watch } from 'vue';
-import { useRouter } from 'vue-router';
-import { useStore, useMapGetter } from 'dashboard/composables/store';
-import { useI18n } from 'vue-i18n';
 import { getLastMessage } from 'dashboard/helper/conversationHelper';
-import { frontendURL, conversationUrl } from 'dashboard/helper/URLHelper';
 import Avatar from 'next/avatar/Avatar.vue';
 import MessagePreview from './MessagePreview.vue';
 import InboxName from '../InboxName.vue';
-import ConversationContextMenu from './contextMenu/Index.vue';
 import TimeAgo from 'dashboard/components/ui/TimeAgo.vue';
 import CardLabels from './conversationCardComponents/CardLabels.vue';
 import CardPriorityIcon from 'dashboard/components-next/Conversation/ConversationCard/CardPriorityIcon.vue';
+import UnreadBadge from 'dashboard/components-next/Conversation/ConversationCard/UnreadBadge.vue';
 import SLACardLabel from './components/SLACardLabel.vue';
-import ContextMenu from 'dashboard/components/ui/ContextMenu.vue';
 import VoiceCallStatus from './VoiceCallStatus.vue';
+import Checkbox from 'dashboard/components-next/checkbox/Checkbox.vue';
 
 const props = defineProps({
-  activeLabel: { type: String, default: '' },
-  chat: { type: Object, default: () => ({}) },
-  hideInboxName: { type: Boolean, default: false },
-  hideThumbnail: { type: Boolean, default: false },
-  teamId: { type: [String, Number], default: 0 },
-  foldersId: { type: [String, Number], default: 0 },
-  showAssignee: { type: Boolean, default: false },
-  conversationType: { type: String, default: '' },
+  chat: { type: Object, required: true },
+  currentContact: { type: Object, required: true },
+  assignee: { type: Object, default: () => ({}) },
+  inbox: { type: Object, default: () => ({}) },
   selected: { type: Boolean, default: false },
+  isActiveChat: { type: Boolean, default: false },
+  showAssignee: { type: Boolean, default: false },
+  showInboxName: { type: Boolean, default: false },
+  hideThumbnail: { type: Boolean, default: false },
   compact: { type: Boolean, default: false },
-  enableContextMenu: { type: Boolean, default: false },
-  allowedContextMenuOptions: { type: Array, default: () => [] },
+  typingPreview: { type: String, default: '' },
+  hasGroupActivity: { type: Boolean, default: false },
 });
 
 const emit = defineEmits([
-  'contextMenuToggle',
-  'assignAgent',
-  'assignLabel',
-  'removeLabel',
-  'assignTeam',
-  'markAsUnread',
-  'markAsRead',
-  'assignPriority',
-  'updateConversationStatus',
-  'deleteConversation',
+  'click',
+  'contextmenu',
   'selectConversation',
   'deSelectConversation',
 ]);
 
-const router = useRouter();
-const store = useStore();
-
 const hovered = ref(false);
-const showContextMenu = ref(false);
-const contextMenu = ref({ x: null, y: null });
-
-// Reset UI state when conversation changes at same index (no :key, instance reused on reorder)
-// This prevents context menu/hover state from leaking to a different conversation
-// Emit contextMenuToggle(false) to sync parent state if menu was open during recycling
-const resetState = () => {
-  if (showContextMenu.value) {
-    emit('contextMenuToggle', false);
-  }
-  hovered.value = false;
-  showContextMenu.value = false;
-  contextMenu.value = { x: null, y: null };
-};
-
-watch(() => props.chat.id, resetState);
-
-const currentChat = useMapGetter('getSelectedChat');
-const inboxesList = useMapGetter('inboxes/getInboxes');
-const activeInbox = useMapGetter('getSelectedInbox');
-const accountId = useMapGetter('getCurrentAccountId');
-const globalConfig = useMapGetter('globalConfig/get');
-
-const chatMetadata = computed(() => props.chat.meta || {});
-
-const assignee = computed(() => chatMetadata.value.assignee || {});
-
-const senderId = computed(() => chatMetadata.value.sender?.id);
-
-const currentContact = computed(() => {
-  return senderId.value
-    ? store.getters['contacts/getContact'](senderId.value)
-    : {};
-});
-
-const isActiveChat = computed(() => {
-  return currentChat.value.id === props.chat.id;
-});
 
 const unreadCount = computed(() => props.chat.unread_count);
-
-const isGroupsDisabled = computed(() => {
-  return (
-    props.chat.group_type === 'group' &&
-    !globalConfig.value.baileysWhatsappGroupsEnabled
-  );
-});
-
-const hasGroupActivity = computed(() => {
-  if (!isGroupsDisabled.value) return false;
-  const lastActivity = props.chat.last_activity_at;
-  const agentSeen = props.chat.agent_last_seen_at;
-  return lastActivity > 0 && (!agentSeen || lastActivity > agentSeen);
-});
-
 const hasUnread = computed(
-  () => unreadCount.value > 0 || hasGroupActivity.value
+  () => unreadCount.value > 0 || props.hasGroupActivity
 );
-
-const isInboxNameVisible = computed(() => !activeInbox.value);
-
+const isAnyoneTyping = computed(() => !!props.typingPreview);
 const lastMessageInChat = computed(() => getLastMessage(props.chat));
-
-const { t } = useI18n();
-const typingUsersList = computed(() => {
-  const users = store.getters['conversationTypingStatus/getUserList'](
-    props.chat.id
-  );
-  return users.filter(u => u.type === 'contact');
-});
-const isAnyoneTyping = computed(() => typingUsersList.value.length > 0);
-const typingPreviewText = computed(() => {
-  if (!isAnyoneTyping.value) return '';
-  return typingUsersList.value.some(u => u.recording)
-    ? t('CHAT_LIST.RECORDING')
-    : t('CHAT_LIST.TYPING');
-});
 
 const voiceCallData = computed(() => ({
   status: props.chat.additional_attributes?.call_status,
   direction: props.chat.additional_attributes?.call_direction,
 }));
 
-const inboxId = computed(() => props.chat.inbox_id);
-
-const inbox = computed(() => {
-  return inboxId.value ? store.getters['inboxes/getInbox'](inboxId.value) : {};
-});
-
-const showInboxName = computed(() => {
-  return (
-    !props.hideInboxName &&
-    isInboxNameVisible.value &&
-    inboxesList.value.length > 1
-  );
-});
-
 const showMetaSection = computed(() => {
   return (
-    showInboxName.value ||
-    (props.showAssignee && assignee.value.name) ||
+    props.showInboxName ||
+    (props.showAssignee && props.assignee.name) ||
     props.chat.priority
   );
 });
@@ -161,54 +62,15 @@ const showLabelsSection = computed(() => {
   return props.chat.labels?.length > 0 || hasSlaPolicyId.value;
 });
 
-const messagePreviewPaddingClass = computed(() => {
-  return [
-    !props.compact && hasUnread.value ? 'ltr:pr-4 rtl:pl-4' : '',
-    props.compact && hasUnread.value ? 'ltr:pr-6 rtl:pl-6' : '',
-  ];
-});
+const messagePreviewPaddingClass = computed(() => [
+  !props.compact && hasUnread.value ? 'ltr:pr-4 rtl:pl-4' : '',
+  props.compact && hasUnread.value ? 'ltr:pr-6 rtl:pl-6' : '',
+]);
 
-const messagePreviewClass = computed(() => {
-  return [
-    hasUnread.value ? 'font-medium text-n-slate-12' : 'text-n-slate-11',
-    ...messagePreviewPaddingClass.value,
-  ];
-});
-
-const conversationPath = computed(() => {
-  return frontendURL(
-    conversationUrl({
-      accountId: accountId.value,
-      activeInbox: activeInbox.value,
-      id: props.chat.id,
-      label: props.activeLabel,
-      teamId: props.teamId,
-      conversationType: props.conversationType,
-      foldersId: props.foldersId,
-    })
-  );
-});
-
-const onCardClick = e => {
-  const path = conversationPath.value;
-  if (!path) return;
-
-  // Handle Ctrl/Cmd + Click for new tab
-  if (e.metaKey || e.ctrlKey) {
-    e.preventDefault();
-    window.open(
-      `${window.chatwootConfig.hostURL}${path}`,
-      '_blank',
-      'noopener,noreferrer'
-    );
-    return;
-  }
-
-  // Skip if already active
-  if (isActiveChat.value) return;
-
-  router.push({ path });
-};
+const messagePreviewClass = computed(() => [
+  hasUnread.value ? 'font-medium text-n-slate-12' : 'text-n-slate-11',
+  ...messagePreviewPaddingClass.value,
+]);
 
 const onThumbnailHover = () => {
   hovered.value = !props.hideThumbnail;
@@ -220,83 +82,37 @@ const onThumbnailLeave = () => {
 
 const onSelectConversation = checked => {
   if (checked) {
-    emit('selectConversation', props.chat.id, inbox.value.id);
+    emit('selectConversation', props.chat.id, props.inbox.id);
   } else {
-    emit('deSelectConversation', props.chat.id, inbox.value.id);
+    emit('deSelectConversation', props.chat.id, props.inbox.id);
   }
 };
 
-const openContextMenu = e => {
-  if (!props.enableContextMenu) return;
-  e.preventDefault();
-  emit('contextMenuToggle', true);
-  contextMenu.value.x = e.pageX || e.clientX;
-  contextMenu.value.y = e.pageY || e.clientY;
-  showContextMenu.value = true;
-};
+const selectedModel = computed({
+  get: () => props.selected,
+  set: value => onSelectConversation(value),
+});
 
-const closeContextMenu = () => {
-  emit('contextMenuToggle', false);
-  showContextMenu.value = false;
-  contextMenu.value.x = null;
-  contextMenu.value.y = null;
-};
-
-const onUpdateConversation = (status, snoozedUntil) => {
-  closeContextMenu();
-  emit('updateConversationStatus', props.chat.id, status, snoozedUntil);
-};
-
-const onAssignAgent = agent => {
-  emit('assignAgent', agent, [props.chat.id]);
-  closeContextMenu();
-};
-
-const onAssignLabel = label => {
-  emit('assignLabel', [label.title], [props.chat.id]);
-};
-
-const onRemoveLabel = label => {
-  emit('removeLabel', [label.title], [props.chat.id]);
-};
-
-const onAssignTeam = team => {
-  emit('assignTeam', team, props.chat.id);
-  closeContextMenu();
-};
-
-const markAsUnread = () => {
-  emit('markAsUnread', props.chat.id);
-  closeContextMenu();
-};
-
-const markAsRead = () => {
-  emit('markAsRead', props.chat.id);
-  closeContextMenu();
-};
-
-const assignPriority = priority => {
-  emit('assignPriority', priority, props.chat.id);
-  closeContextMenu();
-};
-
-const deleteConversation = () => {
-  emit('deleteConversation', props.chat.id);
-  closeContextMenu();
-};
+watch(
+  () => props.chat.id,
+  () => {
+    hovered.value = false;
+  }
+);
 </script>
 
 <template>
   <div
-    class="relative flex items-start flex-grow-0 flex-shrink-0 w-auto max-w-full py-0 border-t-0 border-b-0 border-l-0 border-r-0 border-transparent border-solid cursor-pointer conversation hover:bg-n-alpha-1 dark:hover:bg-n-alpha-3 group"
+    class="relative flex items-start flex-grow-0 flex-shrink-0 w-auto max-w-full py-0 cursor-pointer conversation border-b border-n-slate-3 hover:border-n-surface-1 hover:bg-n-alpha-1 dark:hover:bg-n-alpha-3 group hover:z-[1] before:content-[none] before:absolute before:-top-px before:inset-x-0 before:h-px before:bg-n-surface-1 before:pointer-events-none hover:before:content-['']"
     :class="{
-      'active animate-card-select bg-n-background border-n-weak': isActiveChat,
-      'bg-n-slate-2': selected,
+      'active animate-card-select bg-n-background !border-n-surface-1':
+        isActiveChat,
+      'selected bg-n-slate-2 !border-n-surface-1': selected,
       'px-0': compact,
       'px-3': !compact,
     }"
-    @click="onCardClick"
-    @contextmenu="openContextMenu($event)"
+    @click="$emit('click', $event)"
+    @contextmenu="$emit('contextmenu', $event)"
   >
     <div
       class="relative"
@@ -311,7 +127,6 @@ const deleteConversation = () => {
         :status="currentContact.availability_status"
         :class="!showInboxName ? 'mt-4' : 'mt-8'"
         hide-offline-status
-        rounded-full
       >
         <template #overlay="{ size }">
           <label
@@ -320,20 +135,12 @@ const deleteConversation = () => {
             :style="{ width: `${size}px`, height: `${size}px` }"
             @click.stop
           >
-            <input
-              :value="selected"
-              :checked="selected"
-              class="!m-0 cursor-pointer"
-              type="checkbox"
-              @change="onSelectConversation($event.target.checked)"
-            />
+            <Checkbox v-model="selectedModel" />
           </label>
         </template>
       </Avatar>
     </div>
-    <div
-      class="px-0 py-3 border-b group-hover:border-transparent flex-1 border-n-slate-3 min-w-0"
-    >
+    <div class="px-0 py-3 flex-1 min-w-0 border-line">
       <div
         v-if="showMetaSection"
         class="flex items-center min-w-0 gap-1"
@@ -381,7 +188,7 @@ const deleteConversation = () => {
         class="text-green-500 text-sm font-medium my-0 mx-2 leading-6 h-6 flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap"
         :class="messagePreviewPaddingClass"
       >
-        {{ typingPreviewText }}
+        {{ typingPreview }}
       </p>
       <MessagePreview
         v-else-if="lastMessageInChat"
@@ -416,14 +223,13 @@ const deleteConversation = () => {
             :conversation-id="chat.id"
           />
         </span>
+        <UnreadBadge
+          v-if="unreadCount > 0"
+          :count="unreadCount"
+          class="ltr:ml-auto rtl:mr-auto mt-1"
+        />
         <span
-          v-if="hasUnread && unreadCount > 0"
-          class="shadow-lg rounded-full text-xxs font-semibold h-4 leading-4 ltr:ml-auto rtl:mr-auto mt-1 min-w-[1rem] px-1 py-0 text-center text-white bg-n-teal-9"
-        >
-          {{ unreadCount > 9 ? '9+' : unreadCount }}
-        </span>
-        <span
-          v-else-if="hasUnread"
+          v-else-if="hasGroupActivity"
           class="shadow-lg rounded-full ltr:ml-auto rtl:mr-auto mt-1 size-2 bg-n-teal-9"
         />
       </div>
@@ -437,32 +243,5 @@ const deleteConversation = () => {
         </template>
       </CardLabels>
     </div>
-    <ContextMenu
-      v-if="showContextMenu"
-      :x="contextMenu.x"
-      :y="contextMenu.y"
-      @close="closeContextMenu"
-    >
-      <ConversationContextMenu
-        :status="chat.status"
-        :inbox-id="inbox.id"
-        :priority="chat.priority"
-        :chat-id="chat.id"
-        :has-unread-messages="hasUnread"
-        :conversation-labels="chat.labels"
-        :conversation-url="conversationPath"
-        :allowed-options="allowedContextMenuOptions"
-        @update-conversation="onUpdateConversation"
-        @assign-agent="onAssignAgent"
-        @assign-label="onAssignLabel"
-        @remove-label="onRemoveLabel"
-        @assign-team="onAssignTeam"
-        @mark-as-unread="markAsUnread"
-        @mark-as-read="markAsRead"
-        @assign-priority="assignPriority"
-        @delete-conversation="deleteConversation"
-        @close="closeContextMenu"
-      />
-    </ContextMenu>
   </div>
 </template>

--- a/enterprise/app/services/twilio/voice_teardown_service.rb
+++ b/enterprise/app/services/twilio/voice_teardown_service.rb
@@ -22,7 +22,7 @@ class Twilio::VoiceTeardownService
 
     channel.client
            .incoming_phone_numbers(numbers.first.sid)
-           .update(voice_url: '', status_callback: '')
+           .update(voice_url: '', status_callback: '') # rubocop:disable Rails/SaveBang
   rescue StandardError => e
     Rails.logger.error("TWILIO_VOICE_TEARDOWN_WEBHOOK_ERROR: #{e.class} #{e.message} phone=#{channel.phone_number} account=#{channel.account_id}")
   end

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe 'Accounts API', type: :request do
       end
 
       it 'clears onboarding step when current value is account_details' do
-        account.update(custom_attributes: { onboarding_step: 'account_details' })
+        account.update!(custom_attributes: { onboarding_step: 'account_details' })
         patch "/api/v1/accounts/#{account.id}",
               params: params,
               headers: admin.create_new_auth_token,


### PR DESCRIPTION
Porta os refactors do upstream em `ConversationCard.vue` e `ComposeConversation.vue` que tinham sido rejeitados como KC durante o merge do v4.14.0 (PR #298), preservando todas as features do fork. Empilha em cima de `chore/merge-upstream-4.14.0` (PR #298) e deve ser mergeado depois dele.

Closes #297

## What changed

- **`app/javascript/dashboard/components/widgets/conversation/ConversationCard.vue`** virou um componente burro: recebe `chat`, `currentContact`, `assignee`, `inbox`, `isActiveChat`, `showInboxName` como props em vez de buscar tudo na store. Adotou `UnreadBadge` e `Checkbox` do `components-next`. As features do fork ficaram atrás de dois novos props no pai (`ConversationItem`):
  - `typingPreview`: string com `TYPING`/`RECORDING` para o indicador de digitação/gravação via Baileys presence
  - `hasGroupActivity`: bool que liga o dot verde de atividade em grupos quando `unread_count == 0`
  - `voiceCallData` continua sendo derivado de `chat.additional_attributes.call_status/call_direction` (jeito do fork), não do `lastMessage.content_type` (jeito upstream)

- **`app/javascript/dashboard/components/ConversationItem.vue`** passou a calcular `typingPreviewText`, `isGroupsDisabled` e `hasGroupActivity` a partir da store e a propagar tudo para o card.

- **`app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue`** adotou o `Popover` de `components-next` no lugar do modal custom + `vOnClickOutside` + `useKeyboardEvents` manuais. O Popover já encapsula backdrop, ignore para o `ProseMirror-prompt-backdrop`, Escape e o modo modal abaixo do breakpoint md. Continuou tendo: abas Conversation/Group, `ComposeNewGroupForm`, `useInboxSignatures` (resolve assinatura por inbox), `pendingGroupNavigation` e `BUS_EVENTS.NAVIGATE_TO_GROUP`. Prop `alignPosition` (left/right) substituído por `align` (start/end); `isModal` removido (o Popover muda para layout modal automaticamente).

- **`ComposeNewConversationForm.vue`** não precisou de mudança. O `effectiveChannelType` que o upstream usa é consumido apenas por handlers editor-side de `appendSignature`/`removeSignature` que o fork removeu via PR #79 (assinatura aplicada em send-time, no `prepareNewMessagePayload`). O `getEffectiveChannelType` continua sendo chamado onde importa de fato, dentro de `handleInboxAction` para `stripMessageFormatting`.

Também inclui um commit prévio (`chore(rubocop)`) que silencia duas offences Rails/SaveBang restantes do merge anterior (`voice_teardown_service.rb` e `accounts_controller_spec.rb`) que o pre-commit hook reabriu.

## How to test

- Lista de conversas (`ChatList`):
  - Card normal renderiza igual: avatar, nome do contato, prévia da última mensagem, badge de não lidas, timestamp, prioridade, labels, SLA
  - Conversa selecionada destaca em background e o checkbox aparece ao hover
  - Conversa ativa fica com background `bg-n-background` e borda `n-surface-1`
  - Contato digitando em conversa Baileys: aparece "digitando..." em verde no lugar da prévia
  - Contato gravando áudio em conversa Baileys: aparece "gravando..." em verde
  - Conversa Baileys de grupo com `BAILEYS_WHATSAPP_GROUPS_ENABLED=false` e atividade nova: dot verde aparece no canto direito sem número
  - Chamada de voice (Twilio): `VoiceCallStatus` renderiza no lugar da prévia
  - Menu de contexto (botão direito): abre, executa actions (atribuir agente/time/label/prioridade, mark as unread/read, status, deletar) e fecha

- Nova conversa pelo botão pen do Sidebar (`align="start"`, popover abre para a direita):
  - Clica no botão: popover abre com o form de nova conversa
  - Esc fecha
  - Clica fora fecha (incluindo se um popup de link do editor estiver aberto: nesse caso continua aberto)
  - Buscar contato, selecionar inbox, enviar mensagem com assinatura habilitada (não duplica)
  - Em uma conta com inbox Baileys que tem `allow_group_creation`: aparecem abas Conversation/Group; clicar em Group troca para `ComposeNewGroupForm`; criar grupo navega para a conversa via `BUS_EVENTS.NAVIGATE_TO_GROUP`

- Botão "Nova mensagem" no `ContactInfo` (drawer da conversa), no `ContactsHeader` da listagem de contatos e no `ContactsDetailsLayout` do detalhe do contato: abre o popover já com o `contactId` pré-preenchido; envia uma mensagem com sucesso

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/299)
<!-- Reviewable:end -->
