### PR TITLE
feat(mailer): port v4.14.0 invite email redesign with pt-BR i18n

### DIFF
--- a/app/views/devise/mailer/_confirmation_body.html.erb
+++ b/app/views/devise/mailer/_confirmation_body.html.erb
@@ -12,7 +12,7 @@
 </tr>
 <tr>
   <td style="padding: 0 0 8px;">
-    <p style="margin: 0; font-size: 14px; line-height: 21px; color: #334155;">Hi <%= recipient_name %>,</p>
+    <p style="margin: 0; font-size: 14px; line-height: 21px; color: #334155;"><%= t('mailer.common.hi', name: recipient_name) %>,</p>
   </td>
 </tr>
 <tr>
@@ -62,12 +62,14 @@
   <tr>
     <td style="padding: 0 0 20px;">
       <p style="margin: 0; font-size: 14px; line-height: 21px; color: #64748B;">
-        If the button does not work, open
-        <%= link_to(
-          'this secure link',
-          action_url,
-          style: 'color:#2781F6; text-decoration:none; font-weight:600;'
-        ) %>.
+        <%= t(
+          'mailer.devise.confirmation_instructions.button_fallback_html',
+          link: link_to(
+            t('mailer.devise.confirmation_instructions.secure_link'),
+            action_url,
+            style: 'color:#2781F6; text-decoration:none; font-weight:600;'
+          )
+        ) %>
       </p>
     </td>
   </tr>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,30 +1,67 @@
-<p><%= t('mailer.common.hi', name: @resource.name) %>,</p>
+<%
+  brand_name = global_config['BRAND_NAME'] || 'Chatwoot'
+  recipient_name = @resource.name.presence || @resource.email
+  account_user = @resource&.account_users&.first
+  inviter = account_user&.inviter
+  account_name = account_user&.account&.name
+  invited_user = inviter.present? && @resource.unconfirmed_email.blank?
 
-<% account_user = @resource&.account_users&.first %>
-<% brand_name = global_config['BRAND_NAME'] || 'Chatwoot' %>
+  i18n_scope = 'mailer.devise.confirmation_instructions'
+  eyebrow = t("#{i18n_scope}.welcome.eyebrow")
+  heading = t("#{i18n_scope}.welcome.heading")
+  intro_text = t("#{i18n_scope}.welcome.intro_html", brand_name: brand_name)
+  supporting_text = t("#{i18n_scope}.welcome.supporting_text")
+  action_text = t("#{i18n_scope}.welcome.action_text")
+  action_url = frontend_url('auth/confirmation', confirmation_token: @token)
+  info_title = nil
+  info_text = nil
+  detail_rows = []
 
-<% if account_user&.inviter.present? && @resource.unconfirmed_email.blank? %>
-  <p><%= t('mailer.devise.confirmation_instructions.invited_html', inviter_name: account_user.inviter.name, account_name: account_user.account.name, brand_name: brand_name) %></p>
-<% end %>
+  if @resource.unconfirmed_email.present?
+    eyebrow = t("#{i18n_scope}.email_update.eyebrow")
+    heading = t("#{i18n_scope}.email_update.heading")
+    intro_text = t("#{i18n_scope}.email_update.intro_html", brand_name: brand_name)
+    supporting_text = t("#{i18n_scope}.email_update.supporting_text")
+    action_text = t("#{i18n_scope}.email_update.action_text")
+    detail_rows << [t("#{i18n_scope}.labels.new_email"), @resource.unconfirmed_email]
+  elsif @resource.confirmed?
+    eyebrow = t("#{i18n_scope}.account_ready.eyebrow")
+    heading = t("#{i18n_scope}.account_ready.heading")
+    intro_text = t("#{i18n_scope}.account_ready.intro_html", brand_name: brand_name)
+    supporting_text = t("#{i18n_scope}.account_ready.supporting_text")
+    action_text = t("#{i18n_scope}.account_ready.action_text")
+    action_url = frontend_url('auth/sign_in')
+  elsif invited_user
+    eyebrow = t("#{i18n_scope}.invitation.eyebrow")
+    heading = if account_name.present?
+                t("#{i18n_scope}.invitation.heading_with_account", account_name: account_name)
+              else
+                t("#{i18n_scope}.invitation.heading_default", brand_name: brand_name)
+              end
+    intro_text = if account_name.present?
+                   t("#{i18n_scope}.invitation.intro_with_account_html",
+                     inviter_name: inviter.name, account_name: account_name, brand_name: brand_name)
+                 else
+                   t("#{i18n_scope}.invitation.intro_default_html",
+                     inviter_name: inviter.name, brand_name: brand_name)
+                 end
+    supporting_text = t("#{i18n_scope}.invitation.supporting_text")
+    action_text = t("#{i18n_scope}.invitation.action_text")
+    action_url = frontend_url('auth/password/edit', reset_password_token: @resource.send(:set_reset_password_token))
+    detail_rows = [[t("#{i18n_scope}.labels.invited_by"), inviter.name]]
+    detail_rows << [t("#{i18n_scope}.labels.workspace"), account_name] if account_name.present?
+  end
+%>
 
-<% if @resource.confirmed? %>
-  <p><%= t('mailer.devise.confirmation_instructions.login_message_html', brand_name: brand_name) %></p>
-<% else %>
-  <% if account_user&.inviter.blank? %>
-  <p>
-    <%= t('mailer.devise.confirmation_instructions.welcome_html', brand_name: brand_name) %>
-  </p>
-  <% end %>
-  <p><%= t('mailer.devise.confirmation_instructions.activate_html') %></p>
-<% end %>
-
-
-<% if @resource.unconfirmed_email.present? %>
-  <p><%= link_to t('mailer.devise.confirmation_instructions.confirm_account'), frontend_url('auth/confirmation', confirmation_token: @token) %></p>
-<% elsif @resource.confirmed? %>
-  <p><%= link_to t('mailer.devise.confirmation_instructions.login_account'), frontend_url('auth/sign_in') %></p>
-<% elsif account_user&.inviter.present? %>
-  <p><%= link_to t('mailer.devise.confirmation_instructions.confirm_account'), frontend_url('auth/password/edit', reset_password_token: @resource.send(:set_reset_password_token)) %></p>
-<% else %>
-  <p><%= link_to t('mailer.devise.confirmation_instructions.confirm_account'), frontend_url('auth/confirmation', confirmation_token: @token) %></p>
-<% end %>
+<%= render partial: 'devise/mailer/confirmation_body', locals: {
+  action_text: action_text,
+  action_url: action_url,
+  detail_rows: detail_rows,
+  eyebrow: eyebrow,
+  heading: heading,
+  info_text: info_text,
+  info_title: info_title,
+  intro_text: intro_text,
+  recipient_name: recipient_name,
+  supporting_text: supporting_text
+} %>

--- a/app/views/layouts/mailer/base.liquid
+++ b/app/views/layouts/mailer/base.liquid
@@ -7,86 +7,129 @@
     <style type="text/css">
       img {
         max-width: 100%;
+        border: none;
       }
 
       body {
         -webkit-font-smoothing: antialiased;
         -webkit-text-size-adjust: none;
-        height: 100%;
-        line-height: 1.6em;
+        line-height: 21px;
         width: 100% !important;
+        margin: 0;
+        padding: 0;
+        background-color: #F4F7FB;
       }
 
-      body {
-        background-color: #F8FAFC;
+      table {
+        border-collapse: separate;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+
+      a {
+        color: #2781F6;
+      }
+
+      .email-container {
+        width: 100%;
+        max-width: 640px;
+      }
+
+      .main-card {
+        width: 100%;
+        border: 1px solid #DCE7F5;
+        border-radius: 24px;
+        background-color: #FFFFFF;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
+        overflow: hidden;
+      }
+
+      .accent-bar {
+        height: 6px;
+        background-color: #2781F6;
+        font-size: 0;
+        line-height: 0;
+      }
+
+      .content-wrap {
+        padding: 40px 36px 20px;
+      }
+
+      .footer {
+        padding: 20px 8px 0;
+        text-align: center;
+        color: #64748B;
+        font-size: 13px;
+        line-height: 21px;
+      }
+
+      .footer a {
+        color: #2781F6;
+        font-weight: 600;
+        text-decoration: none;
       }
 
       @media only screen and (max-width: 640px) {
-        body {
-          padding: 0 !important;
-        }
         h1 {
-          font-size: 22px !important;
-          font-weight: 800 !important;
-          margin: 20px 0 5px !important;
+          font-size: 28px !important;
+          line-height: 34px !important;
         }
-        h2 {
-          font-size: 18px !important;
-          font-weight: 800 !important;
-          margin: 20px 0 5px !important;
+
+        .page-wrap {
+          padding: 24px 12px 32px !important;
         }
-        h3 {
-          font-size: 16px !important;
-          font-weight: 800 !important;
-          margin: 20px 0 5px !important;
+
+        .main-card {
+          border-radius: 20px !important;
         }
-        h4 {
-          font-weight: 800 !important;
-          margin: 20px 0 5px !important;
-        }
-        .container {
-          padding: 0 !important;
-          width: 100% !important;
-        }
-        .content {
-          padding: 0 !important;
-        }
+
         .content-wrap {
-          padding: 10px !important;
+          padding: 32px 24px 18px !important;
         }
       }
     </style>
   </head>
 
-  <body itemscope itemtype="http://schema.org/EmailMessage" style="font-size: 14px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #F8FAFC; margin: 0;" bgcolor="#F8FAFC">
-    <table class="body-wrap" style="width: 100%; background-color: #F8FAFC; margin: 0;" bgcolor="#F8FAFC">
+  {% assign brand_name = global_config['BRAND_NAME'] %}
+  {% if brand_name == nil %}
+    {% assign brand_name = 'Chatwoot' %}
+  {% endif %}
+  {% assign brand_url = global_config['BRAND_URL'] %}
+
+  <body itemscope itemtype="http://schema.org/EmailMessage" style="font-size: 14px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,Helvetica,Arial,sans-serif; box-sizing: border-box; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; line-height: 21px; background-color: #F4F7FB; margin: 0; padding: 0;" bgcolor="#F4F7FB">
+    <table class="body-wrap" role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; background-color: #F4F7FB; margin: 0;" bgcolor="#F4F7FB">
       <tr style="margin: 0;">
-        <td class="container" width="600" style="display: block !important; max-width: 600px !important; clear: both !important; margin: 0 auto;" valign="top">
-          <div class="content" style="display: block; margin: 0 auto; padding: 20px; text-align:center;">
-            <table class="main" width="100%" cellpadding="0" cellspacing="0" itemprop="action" itemscope itemtype="http://schema.org/ConfirmAction" data-build="ZmF6ZXIuYWk=" style="border-radius: 6px;  background-color: #fff; text-align:left; margin: 0; border: 1px solid #e9e9e9; border-top:3px solid #0080f8;" bgcolor="#fff">
+        <td align="center" class="page-wrap" style="padding: 32px 16px 40px;" valign="top">
+          <table class="email-container" role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 640px; margin: 0 auto;">
+            <tr style="margin: 0;">
+              <td style="margin: 0;">
+                <table class="main-card" role="presentation" width="100%" cellpadding="0" cellspacing="0" itemprop="action" itemscope itemtype="http://schema.org/ConfirmAction" style="width: 100%; border: 1px solid #DCE7F5; border-radius: 24px; background-color: #FFFFFF; box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06); overflow: hidden;" bgcolor="#FFFFFF">
+                  <tr style="margin: 0;">
+                    <td class="accent-bar" style="height: 6px; background-color: #2781F6; font-size: 0; line-height: 0;">&nbsp;</td>
+                  </tr>
+                  <tr style="margin: 0;">
+                    <td class="content-wrap" style="vertical-align: top; margin: 0; padding: 40px 36px 20px; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;" valign="top">
+                      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; margin: 0;">
+                        {{ content_for_layout }}
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            {% if brand_name != '' %}
               <tr style="margin: 0;">
-                <td class="content-wrap" style="vertical-align: top; margin: 0; padding: 20px; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;" valign="top">
-                  <table width="100%" cellpadding="0" cellspacing="0" style="margin: 0;">
-                    {{ content_for_layout }}
-                  </table>
+                <td class="footer" style="padding: 20px 8px 0; text-align: center; color: #64748B; font-size: 13px; line-height: 21px;">
+                  {{ 'mailer.common.sent_by_prefix' | t }}
+                  {% if brand_url != nil and brand_url != '' %}
+                    <a href="{{ brand_url }}" style="color: #2781F6; font-weight: 600; text-decoration: none;">{{ brand_name }}</a>.
+                  {% else %}
+                    <span style="color: #0F172A; font-weight: 600;">{{ brand_name }}</span>.
+                  {% endif %}
                 </td>
               </tr>
-            </table>
-          </div>
-          <div class="footer" style="color: #93AFC8; margin: 0; padding: 0 20px 40px; text-align: center">
-            <table width="100%" style="margin: 0;">
-              <tr style="margin: 0;">
-                {% if global_config['BRAND_NAME'] != '' %}
-                  <td class="content-block" style="font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-                    {{ 'mailer.common.powered_by' | t }}
-                    <a href="{{ global_config['BRAND_URL'] }}" style="vertical-align: top; color: #93AFC8; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">
-                      {{ global_config['BRAND_NAME'] }}
-                    </a>
-                  </td>
-                {% endif %}
-              </tr>
-            </table>
-          </div>
+            {% endif %}
+          </table>
         </td>
       </tr>
     </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -613,6 +613,7 @@ en:
       hello_there: Hello there,
       click_here: "Click <a href=\"%{url}\">here</a>"
       powered_by: Powered by
+      sent_by_prefix: This email was sent by
       you: You
       attachment_click_to_view: "Attachment [<a href=\"%{url}\" target=\"_blank\">Click here to view</a>]"
       click_here_to_get_cracking: "Click <a href=\"%{url}\">here</a> to get cracking."
@@ -756,16 +757,52 @@ en:
         support_message: If you have any questions or need help, feel free to reach out to our support team. We're here to assist you.
     devise:
       confirmation_instructions:
-        invited_html: "%{inviter_name}, with %{account_name}, has invited you to try out %{brand_name}."
-        login_message_html: "You can login to your %{brand_name} account through the link below:"
-        welcome_html: Welcome to %{brand_name}! We have a suite of powerful tools ready for you to explore. Before that we quickly need to verify your email address to know it's really you.
-        activate_html: Please take a moment and click the link below and activate your account.
-        confirm_account: Confirm my account
-        login_account: Login to my account
-        invited_sso_html: "%{inviter_name}, with %{account_name}, has invited you to access %{brand_name} via Single Sign-On (SSO)."
-        sso_no_password_html: Your organization uses SSO for secure authentication. You will not need a password to access your account.
-        sso_login_html: You can now access your account by logging in through your organization's SSO portal.
-        sso_access_html: You can access your account by logging in through your organization's SSO portal.
+        secure_link: this secure link
+        button_fallback_html: "If the button does not work, open %{link}."
+        labels:
+          invited_by: Invited by
+          workspace: Workspace
+          sign_in_method: Sign-in method
+          sign_in_method_value: Single Sign-On (SSO)
+          new_email: New email
+        welcome:
+          eyebrow: Welcome
+          heading: Confirm your email to get started
+          intro_html: "Welcome to %{brand_name}. We just need to verify your email address before you can start using your account."
+          supporting_text: This only takes a moment.
+          action_text: Confirm my account
+        email_update:
+          eyebrow: Email update
+          heading: Confirm your new email address
+          intro_html: "We received a request to update the email address on your %{brand_name} account."
+          supporting_text: Confirm the new address below to finish the change.
+          action_text: Confirm email address
+        account_ready:
+          eyebrow: Account ready
+          heading: Your account is ready
+          intro_html: "Your %{brand_name} account is already active."
+          supporting_text: Use the button below to sign in and continue where you left off.
+          action_text: Open my account
+        invitation:
+          eyebrow: Workspace invitation
+          heading_with_account: "You're invited to join %{account_name}"
+          heading_default: "You're invited to try %{brand_name}"
+          intro_with_account_html: "%{inviter_name} invited you to join the %{account_name} workspace on %{brand_name}."
+          intro_default_html: "%{inviter_name} invited you to try %{brand_name}."
+          supporting_text: Create your account to start collaborating with your team.
+          action_text: Accept invitation
+        sso_access_ready:
+          heading: Your access is ready
+          intro_html: "Your %{brand_name} access is already set up."
+          supporting_html: "Use your organization's Single Sign-On (SSO) portal to access %{brand_name}."
+          info_title: "Sign in with your organization's SSO"
+          info_text_html: "You won't need a separate password for %{brand_name}. Start from your company identity provider portal."
+        sso_invitation:
+          intro_with_account_html: "%{inviter_name} invited you to access the %{account_name} workspace on %{brand_name}."
+          intro_default_html: "%{inviter_name} invited you to access %{brand_name}."
+          supporting_html: "Your organization uses Single Sign-On (SSO), so you won't need to create a separate password."
+          info_title: "Use your organization's SSO portal"
+          info_text_html: "Continue from your company identity provider portal to access %{brand_name}."
       reset_password_instructions:
         greeting_html: Hello %{name}!
         body_html: Someone has requested a link to change your password. You can do this through the link below.

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -595,6 +595,7 @@ pt_BR:
       hello_there: Olá,
       click_here: "Clique <a href=\"%{url}\">aqui</a>"
       powered_by: Desenvolvido por
+      sent_by_prefix: Este e-mail foi enviado por
       you: Você
       attachment_click_to_view: "Anexo [<a href=\"%{url}\" target=\"_blank\">Clique aqui para visualizar</a>]"
       click_here_to_get_cracking: "Clique <a href=\"%{url}\">aqui</a> para acessar."
@@ -738,16 +739,52 @@ pt_BR:
         support_message: Se você tiver alguma dúvida ou precisar de ajuda, entre em contato com nossa equipe de suporte. Estamos aqui para ajudar.
     devise:
       confirmation_instructions:
-        invited_html: "%{inviter_name}, de %{account_name}, convidou você para experimentar o %{brand_name}."
-        login_message_html: "Você pode acessar sua conta %{brand_name} através do link abaixo:"
-        welcome_html: Bem-vindo ao %{brand_name}! Temos um conjunto de ferramentas poderosas prontas para você explorar. Antes disso, precisamos verificar rapidamente seu endereço de e-mail para confirmar que é realmente você.
-        activate_html: Clique no link abaixo para ativar sua conta.
-        confirm_account: Confirmar minha conta
-        login_account: Acessar minha conta
-        invited_sso_html: "%{inviter_name}, de %{account_name}, convidou você para acessar o %{brand_name} via Single Sign-On (SSO)."
-        sso_no_password_html: Sua organização utiliza SSO para autenticação segura. Você não precisará de uma senha para acessar sua conta.
-        sso_login_html: Agora você pode acessar sua conta fazendo login pelo portal SSO da sua organização.
-        sso_access_html: Você pode acessar sua conta fazendo login pelo portal SSO da sua organização.
+        secure_link: este link seguro
+        button_fallback_html: "Se o botão não funcionar, abra %{link}."
+        labels:
+          invited_by: Convidado por
+          workspace: Espaço de trabalho
+          sign_in_method: Método de acesso
+          sign_in_method_value: Single Sign-On (SSO)
+          new_email: Novo e-mail
+        welcome:
+          eyebrow: Boas-vindas
+          heading: Confirme seu e-mail para começar
+          intro_html: "Boas-vindas ao %{brand_name}. Só precisamos verificar seu endereço de e-mail antes que você possa começar a usar sua conta."
+          supporting_text: Leva só um instante.
+          action_text: Confirmar minha conta
+        email_update:
+          eyebrow: Atualização de e-mail
+          heading: Confirme seu novo endereço de e-mail
+          intro_html: "Recebemos um pedido para atualizar o endereço de e-mail da sua conta %{brand_name}."
+          supporting_text: Confirme o novo endereço abaixo para concluir a alteração.
+          action_text: Confirmar endereço de e-mail
+        account_ready:
+          eyebrow: Conta pronta
+          heading: Sua conta está pronta
+          intro_html: "Sua conta %{brand_name} já está ativa."
+          supporting_text: Use o botão abaixo para acessar e continuar de onde parou.
+          action_text: Abrir minha conta
+        invitation:
+          eyebrow: Convite para o espaço de trabalho
+          heading_with_account: "Você foi convidado para entrar em %{account_name}"
+          heading_default: "Você foi convidado para experimentar o %{brand_name}"
+          intro_with_account_html: "%{inviter_name} convidou você para entrar no espaço de trabalho %{account_name} no %{brand_name}."
+          intro_default_html: "%{inviter_name} convidou você para experimentar o %{brand_name}."
+          supporting_text: Crie sua conta para começar a colaborar com sua equipe.
+          action_text: Aceitar convite
+        sso_access_ready:
+          heading: Seu acesso está pronto
+          intro_html: "Seu acesso ao %{brand_name} já está configurado."
+          supporting_html: "Use o portal Single Sign-On (SSO) da sua organização para acessar o %{brand_name}."
+          info_title: "Acesse pelo SSO da sua organização"
+          info_text_html: "Você não precisará de uma senha separada para o %{brand_name}. Comece pelo portal de identidade da sua empresa."
+        sso_invitation:
+          intro_with_account_html: "%{inviter_name} convidou você para acessar o espaço de trabalho %{account_name} no %{brand_name}."
+          intro_default_html: "%{inviter_name} convidou você para acessar o %{brand_name}."
+          supporting_html: "Sua organização usa Single Sign-On (SSO), então você não precisará criar uma senha separada."
+          info_title: "Use o portal SSO da sua organização"
+          info_text_html: "Continue pelo portal de identidade da sua empresa para acessar o %{brand_name}."
       reset_password_instructions:
         greeting_html: Olá %{name}!
         body_html: Alguém solicitou um link para alterar sua senha. Você pode fazer isso através do link abaixo.

--- a/enterprise/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/enterprise/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,46 +1,101 @@
-<p><%= t('mailer.common.hi', name: @resource.name) %>,</p>
+<%
+  brand_name = global_config['BRAND_NAME'] || 'Chatwoot'
+  recipient_name = @resource.name.presence || @resource.email
+  account_user = @resource&.account_users&.first
+  inviter = account_user&.inviter
+  account_name = account_user&.account&.name
+  is_saml_account = account_user&.account&.saml_enabled?
+  invited_user = inviter.present? && @resource.unconfirmed_email.blank?
 
-<% account_user = @resource&.account_users&.first %>
-<% is_saml_account = account_user&.account&.saml_enabled? %>
-<% brand_name = global_config['BRAND_NAME'] || 'Chatwoot' %>
+  i18n_scope = 'mailer.devise.confirmation_instructions'
+  eyebrow = t("#{i18n_scope}.welcome.eyebrow")
+  heading = t("#{i18n_scope}.welcome.heading")
+  intro_text = t("#{i18n_scope}.welcome.intro_html", brand_name: brand_name)
+  supporting_text = t("#{i18n_scope}.welcome.supporting_text")
+  action_text = t("#{i18n_scope}.welcome.action_text")
+  action_url = frontend_url('auth/confirmation', confirmation_token: @token)
+  info_title = nil
+  info_text = nil
+  detail_rows = []
 
-<% if account_user&.inviter.present? && @resource.unconfirmed_email.blank? %>
-  <% if is_saml_account %>
-    <p><%= t('mailer.devise.confirmation_instructions.invited_sso_html', inviter_name: account_user.inviter.name, account_name: account_user.account.name, brand_name: brand_name) %></p>
-    <p><%= t('mailer.devise.confirmation_instructions.sso_no_password_html') %></p>
-  <% else %>
-    <p><%= t('mailer.devise.confirmation_instructions.invited_html', inviter_name: account_user.inviter.name, account_name: account_user.account.name, brand_name: brand_name) %></p>
-  <% end %>
-<% end %>
+  if @resource.unconfirmed_email.present?
+    eyebrow = t("#{i18n_scope}.email_update.eyebrow")
+    heading = t("#{i18n_scope}.email_update.heading")
+    intro_text = t("#{i18n_scope}.email_update.intro_html", brand_name: brand_name)
+    supporting_text = t("#{i18n_scope}.email_update.supporting_text")
+    action_text = t("#{i18n_scope}.email_update.action_text")
+    detail_rows << [t("#{i18n_scope}.labels.new_email"), @resource.unconfirmed_email]
+  elsif @resource.confirmed?
+    if is_saml_account
+      eyebrow = t("#{i18n_scope}.account_ready.eyebrow")
+      heading = t("#{i18n_scope}.sso_access_ready.heading")
+      intro_text = t("#{i18n_scope}.sso_access_ready.intro_html", brand_name: brand_name)
+      supporting_text = t("#{i18n_scope}.sso_access_ready.supporting_html", brand_name: brand_name)
+      action_text = nil
+      action_url = nil
+      info_title = t("#{i18n_scope}.sso_access_ready.info_title")
+      info_text = t("#{i18n_scope}.sso_access_ready.info_text_html", brand_name: brand_name)
+      detail_rows = []
+      detail_rows << [t("#{i18n_scope}.labels.workspace"), account_name] if account_name.present?
+      detail_rows << [t("#{i18n_scope}.labels.sign_in_method"), t("#{i18n_scope}.labels.sign_in_method_value")]
+    else
+      eyebrow = t("#{i18n_scope}.account_ready.eyebrow")
+      heading = t("#{i18n_scope}.account_ready.heading")
+      intro_text = t("#{i18n_scope}.account_ready.intro_html", brand_name: brand_name)
+      supporting_text = t("#{i18n_scope}.account_ready.supporting_text")
+      action_text = t("#{i18n_scope}.account_ready.action_text")
+      action_url = frontend_url('auth/sign_in')
+    end
+  elsif invited_user
+    eyebrow = t("#{i18n_scope}.invitation.eyebrow")
+    heading = if account_name.present?
+                t("#{i18n_scope}.invitation.heading_with_account", account_name: account_name)
+              else
+                t("#{i18n_scope}.invitation.heading_default", brand_name: brand_name)
+              end
 
-<% if @resource.confirmed? %>
-  <p><%= t('mailer.devise.confirmation_instructions.login_message_html', brand_name: brand_name) %></p>
-<% else %>
-  <% if account_user&.inviter.blank? %>
-  <p>
-    <%= t('mailer.devise.confirmation_instructions.welcome_html', brand_name: brand_name) %>
-  </p>
-  <% end %>
-  <% unless is_saml_account %>
-  <p><%= t('mailer.devise.confirmation_instructions.activate_html') %></p>
-  <% end %>
-<% end %>
+    if is_saml_account
+      intro_text = if account_name.present?
+                     t("#{i18n_scope}.sso_invitation.intro_with_account_html",
+                       inviter_name: inviter.name, account_name: account_name, brand_name: brand_name)
+                   else
+                     t("#{i18n_scope}.sso_invitation.intro_default_html",
+                       inviter_name: inviter.name, brand_name: brand_name)
+                   end
+      supporting_text = t("#{i18n_scope}.sso_invitation.supporting_html")
+      action_text = nil
+      action_url = nil
+      info_title = t("#{i18n_scope}.sso_invitation.info_title")
+      info_text = t("#{i18n_scope}.sso_invitation.info_text_html", brand_name: brand_name)
+      detail_rows = [[t("#{i18n_scope}.labels.invited_by"), inviter.name]]
+      detail_rows << [t("#{i18n_scope}.labels.workspace"), account_name] if account_name.present?
+      detail_rows << [t("#{i18n_scope}.labels.sign_in_method"), t("#{i18n_scope}.labels.sign_in_method_value")]
+    else
+      intro_text = if account_name.present?
+                     t("#{i18n_scope}.invitation.intro_with_account_html",
+                       inviter_name: inviter.name, account_name: account_name, brand_name: brand_name)
+                   else
+                     t("#{i18n_scope}.invitation.intro_default_html",
+                       inviter_name: inviter.name, brand_name: brand_name)
+                   end
+      supporting_text = t("#{i18n_scope}.invitation.supporting_text")
+      action_text = t("#{i18n_scope}.invitation.action_text")
+      action_url = frontend_url('auth/password/edit', reset_password_token: @resource.send(:set_reset_password_token))
+      detail_rows = [[t("#{i18n_scope}.labels.invited_by"), inviter.name]]
+      detail_rows << [t("#{i18n_scope}.labels.workspace"), account_name] if account_name.present?
+    end
+  end
+%>
 
-
-<% if @resource.unconfirmed_email.present? %>
-  <p><%= link_to t('mailer.devise.confirmation_instructions.confirm_account'), frontend_url('auth/confirmation', confirmation_token: @token) %></p>
-<% elsif @resource.confirmed? %>
-  <% if is_saml_account %>
-    <p><%= t('mailer.devise.confirmation_instructions.sso_login_html') %></p>
-  <% else %>
-    <p><%= link_to t('mailer.devise.confirmation_instructions.login_account'), frontend_url('auth/sign_in') %></p>
-  <% end %>
-<% elsif account_user&.inviter.present? %>
-  <% if is_saml_account %>
-    <p><%= t('mailer.devise.confirmation_instructions.sso_access_html') %></p>
-  <% else %>
-    <p><%= link_to t('mailer.devise.confirmation_instructions.confirm_account'), frontend_url('auth/password/edit', reset_password_token: @resource.send(:set_reset_password_token)) %></p>
-  <% end %>
-<% else %>
-  <p><%= link_to t('mailer.devise.confirmation_instructions.confirm_account'), frontend_url('auth/confirmation', confirmation_token: @token) %></p>
-<% end %>
+<%= render partial: 'devise/mailer/confirmation_body', locals: {
+  action_text: action_text,
+  action_url: action_url,
+  detail_rows: detail_rows,
+  eyebrow: eyebrow,
+  heading: heading,
+  info_text: info_text,
+  info_title: info_title,
+  intro_text: intro_text,
+  recipient_name: recipient_name,
+  supporting_text: supporting_text
+} %>


### PR DESCRIPTION
Porta o redesign do email de confirmação/convite do upstream (PR chatwoot/chatwoot#14090, commit 4959a1ff1e) preservando o i18n pt-BR que o fork introduziu na PR #255. Empilha em cima de \`chore/merge-upstream-4.14.0\` (#298) e deve ser mergeado depois dele.

Closes #296

## What changed

- **\`app/views/layouts/mailer/base.liquid\`** ganhou o novo layout do upstream: card branco com borda azul, accent bar no topo, footer com "Este e-mail foi enviado por X." e estilos responsivos. O footer agora puxa de \`mailer.common.sent_by_prefix\` em vez de hardcode em inglês, e usa Liquid puro para concatenar o link do brand (o filtro \`t:\` do Liquid escapa HTML, então o link fica fora do \`t:\`).

- **\`app/views/devise/mailer/_confirmation_body.html.erb\`** mantém o markup do partial novo do upstream (pill eyebrow, h1, parágrafo Hi/intro/supporting, tabela de detail rows, CTA azul ou caixa info), mas:
  - \`Hi\` virou \`mailer.common.hi\` (que já existia)
  - "If the button does not work, open this secure link." virou \`mailer.devise.confirmation_instructions.button_fallback_html\` + \`secure_link\`

- **\`app/views/devise/mailer/confirmation_instructions.html.erb\`** (CE) e a versão enterprise foram reescritos para o modelo do upstream (assign de locals + render do partial), mas cada string passa por \`t()\`. As variações cobertas são as mesmas do upstream:
  - **welcome** (default): "Confirm your email to get started" / "Confirm my account"
  - **email_update** (\`unconfirmed_email\` presente): "Confirm your new email address" + detail row "New email"
  - **account_ready** (já confirmado, fluxo CE): "Your account is ready" / "Open my account"
  - **invitation** (com inviter, fluxo CE): "You're invited to join %{account_name}" / "Accept invitation" + detail rows "Invited by", "Workspace"
  - **sso_access_ready** (já confirmado + SAML, EE): "Your access is ready" + info box "Sign in with your organization's SSO" + detail rows "Workspace" e "Sign-in method"
  - **sso_invitation** (com inviter + SAML, EE): "You're invited to join %{account_name}" + info box "Use your organization's SSO portal"

- **\`config/locales/en.yml\`** e **\`config/locales/pt_BR.yml\`** ganharam as chaves novas em \`mailer.devise.confirmation_instructions.{welcome, email_update, account_ready, invitation, sso_access_ready, sso_invitation, labels.*, button_fallback_html, secure_link}\` e \`mailer.common.sent_by_prefix\`. As chaves legadas (\`invited_html\`, \`login_message_html\`, \`welcome_html\`, \`activate_html\`, \`confirm_account\`, \`login_account\`, \`invited_sso_html\`, \`sso_no_password_html\`, \`sso_login_html\`, \`sso_access_html\`) foram removidas em ambos os locales porque os templates não as referenciam mais.

- **Specs** (\`spec/mailers/confirmation_instructions_spec.rb\` e \`spec/enterprise/mailers/devise_mailer_spec.rb\`) não precisaram de mudança: já estavam na versão do upstream (com strings em inglês), e as chaves \`en.yml\` que adicionei batem verbatim com o que o upstream usava, então continuam passando.

### Locale resolution
O \`User#send_devise_notification\` já passa \`Devise::Mailer.with(account: Current.account || accounts.first)\` desde a PR #267, então o locale da conta do usuário chega via \`params[:account]\` no \`before_action\` do \`ApplicationMailer\` e o \`switch_locale\` aplica corretamente. Validado localmente: setando \`account.locale = 'pt_BR'\` e disparando \`Devise::Mailer.with(account: account).confirmation_instructions(user, nil, {}).deliver_now\`, o corpo sai em pt-BR ("Boas-vindas", "Confirme seu e-mail", "Confirmar minha conta", "Este e-mail foi enviado por").

## How to test

Render local em pt-BR via o caminho real:

\`\`\`bash
bundle exec rails runner '
  account = Account.first
  account.update!(locale: "pt_BR")
  user = account.users.first
  user.update!(confirmed_at: nil)
  user.send(:generate_confirmation_token)
  mail = Devise::Mailer.with(account: account).confirmation_instructions(user.reload, nil, {}).deliver_now
  File.write("/tmp/mail-pt.html", CGI.unescapeHTML(mail.body.to_s))
'
\`\`\`

Conferir em \`/tmp/mail-pt.html\` (abrir no navegador): card branco, accent bar azul, pill "BOAS-VINDAS", título "Confirme seu e-mail para começar", "Olá %{name},", parágrafo "Boas-vindas ao Chatwoot. Só precisamos verificar...", botão "Confirmar minha conta", linha "Se o botão não funcionar, abra este link seguro.", footer "Este e-mail foi enviado por Chatwoot.".

Reproduzir cada estado:
- **welcome**: usuário recém-criado sem inviter, com \`confirmed_at: nil\`
- **email_update**: usuário com \`unconfirmed_email\` presente
- **account_ready**: usuário já confirmado (\`user.confirm\`), conta sem SAML
- **invitation**: usuário recém-criado com \`inviter\`
- **sso_access_ready** (EE): usuário confirmado + conta com SAML habilitado
- **sso_invitation** (EE): usuário com inviter + conta com SAML

Para cada estado conferir as duas linguagens (en e pt-BR) e confirmar que o footer e o button fallback batem.

Specs:

\`\`\`bash
bundle exec rspec spec/mailers/confirmation_instructions_spec.rb spec/enterprise/mailers/devise_mailer_spec.rb
\`\`\`

(o CE deve passar 10/10; localmente pode falhar 1 spec de \`reply_to\` se o seu \`.env\` tiver \`MAILER_SENDER_EMAIL=chatwoot@fazer.ai\`, mas isso é independente do redesign).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/300)
<!-- Reviewable:end -->
