### PR TITLE
fix(spec): align send_reply_job_spec with string-based CHANNEL_SERVICES

### DIFF
--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe SendReplyJob do
 
     def expect_mapped_service_to_perform(message, service_class_name)
       channel_name = message.conversation.inbox.channel.class.name
-      service_class = described_class::CHANNEL_SERVICES.fetch(channel_name)
+      mapped_class_name = described_class::CHANNEL_SERVICES.fetch(channel_name)
 
-      expect(service_class.name).to eq(service_class_name)
-      expect(service_class).to receive(:new).with(message: message).and_return(process_service)
+      expect(mapped_class_name).to eq("::#{service_class_name}")
+      expect(mapped_class_name.constantize).to receive(:new).with(message: message).and_return(process_service)
       expect(process_service).to receive(:perform)
 
       described_class.perform_now(message.id)


### PR DESCRIPTION
Conserta o helper \`expect_mapped_service_to_perform\` em \`spec/jobs/send_reply_job_spec.rb\`, que ficou fora de sincronia com o fix \`b0e7688aa\` ("fix(jobs): resolve channel service class by name in SendReplyJob"). Esse fix trocou os valores de \`CHANNEL_SERVICES\` de Class para String + \`constantize\` por chamada (Zeitwerk autoload-safe). O spec continuava chamando \`.name\` no valor mapeado, o que agora retorna \`NoMethodError\` porque o valor é String.

Empilha em cima de \`chore/merge-upstream-4.14.0\` (#298) e deve ser mergeado depois dele.

## Por que só apareceu agora

O CI foi disparado em shards de 16 contra a branch do merge \`v4.14.0\`. Quando o shard 7 (que pega \`send_reply_job_spec\` junto com request specs / \`V2::ReportBuilder\` / \`Captain::Preferences\`) rodou, o Zeitwerk recarregou os constants entre specs, e o helper começou a quebrar com 11 failures consecutivas.

## How to test

\`\`\`bash
bundle exec rspec spec/jobs/send_reply_job_spec.rb
\`\`\`

Deve mostrar \`14 examples, 0 failures\`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/301)
<!-- Reviewable:end -->
