### PR TITLE
feat(messages): enable reply and reactions on private notes

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages/reactions_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages/reactions_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Accounts::Conversations::Messages::ReactionsController < Api::V1::Accounts::Conversations::BaseController
-  before_action :ensure_channel_supports_reactions
   before_action :fetch_target_message
+  before_action :ensure_channel_supports_reactions
   before_action :ensure_target_is_reactable
 
   MAX_EMOJI_BYTES = 32 # an emoji with skin tone + ZWJ sequences fits in <=32 bytes
@@ -124,6 +124,10 @@ class Api::V1::Accounts::Conversations::Messages::ReactionsController < Api::V1:
   end
 
   def ensure_channel_supports_reactions
+    # Private notes are agent-only and never leave Chatwoot, so we don't gate
+    # reactions on them by the inbox channel's external capabilities.
+    return if @target_message&.private?
+
     channel = @conversation.inbox.channel
     return if channel.respond_to?(:supports_reactions?) && channel.supports_reactions?
 
@@ -146,14 +150,14 @@ class Api::V1::Accounts::Conversations::Messages::ReactionsController < Api::V1:
   # so a crafted POST cannot persist a reaction (and enqueue a provider send)
   # against a target the UI would never let the user pick.
   def target_unreactable_error # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-    return 'Cannot react to private messages' if @target_message.private?
     return 'Cannot react to a reaction' if @target_message.reaction?
     return 'Cannot react to deleted messages' if @target_message.content_attributes['deleted']
     return 'Cannot react to activity messages' if @target_message.activity?
     return 'Cannot react to template messages' if @target_message.template?
     return 'Cannot react to failed messages' if @target_message.failed?
     return 'Cannot react to unsupported messages' if @target_message.content_attributes['is_unsupported']
-    return 'Target message is not deliverable to WhatsApp' if @target_message.source_id.blank?
+    # Private notes never reach the provider, so the source_id gate doesn't apply.
+    return 'Target message is not deliverable to WhatsApp' if @target_message.source_id.blank? && !@target_message.private?
 
     nil
   end
@@ -204,6 +208,9 @@ class Api::V1::Accounts::Conversations::Messages::ReactionsController < Api::V1:
         message_type: 'outgoing',
         content: emoji,
         echo_id: reaction_params[:echo_id],
+        # Inherits the target's privacy so SendOnChannelService short-circuits
+        # in `message.private?` and the reaction never reaches the provider.
+        private: @target_message.private?,
         content_attributes: {
           is_reaction: true,
           in_reply_to: @target_message.id

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -785,7 +785,7 @@ provideMessageContext({
             :current-user-id="currentUserId"
             :pending-emojis="pendingEmojis"
             :alignment="orientation === ORIENTATION.RIGHT ? 'right' : 'left'"
-            :read-only="!inboxSupportsReactions"
+            :read-only="!inboxSupportsReactions && !props.private"
             :overlap="!isAudioBubble"
             @toggle="handleToggleReaction"
           />

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -418,8 +418,7 @@ const contextMenuEnabledOptions = computed(() => {
     copyLink: !isFailedOrProcessing,
     translate: !isFailedOrProcessing && !isMessageDeleted.value && hasText,
     replyTo:
-      !props.private &&
-      props.inboxSupportsReplyTo.outgoing &&
+      (props.private || props.inboxSupportsReplyTo.outgoing) &&
       !isFailedOrProcessing,
     edit:
       isOutgoing &&
@@ -431,17 +430,19 @@ const contextMenuEnabledOptions = computed(() => {
 });
 
 const canShowReactionToolbar = computed(() => {
-  if (!props.inboxSupportsReactions) return false;
   if (!isBubble.value) return false;
   if (isMessageDeleted.value) return false;
   if (props.contentAttributes?.isUnsupported) return false;
   if (props.status === MESSAGE_STATUS.FAILED) return false;
   if (props.status === MESSAGE_STATUS.PROGRESS) return false;
-  if (props.private) return false;
   if (props.messageType === MESSAGE_TYPES.TEMPLATE) return false;
-  // Mirror ReactionsController#target_unreactable_error: a message without a
-  // provider source_id can't be reacted to on WhatsApp, so the API would 422
-  // if the user clicked. Hide the picker instead of offering a dead action.
+  // Private notes are agent-only and never leave Chatwoot, so reactions on
+  // them don't depend on inbox channel capabilities or a provider source_id.
+  if (props.private) return true;
+  if (!props.inboxSupportsReactions) return false;
+  // Mirror ReactionsController#target_unreactable_error: a non-private message
+  // without a provider source_id can't be reacted to on WhatsApp, so the API
+  // would 422 if the user clicked. Hide the picker instead of a dead action.
   if (!props.sourceId) return false;
   return true;
 });

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -1333,7 +1333,7 @@ export default {
         this.setReplyMode(REPLY_EDITOR_MODES.NOTE);
       }
 
-      this.inReplyTo = target;
+      this.inReplyTo = target ?? {};
     },
     onReplyToMessage() {
       this.fetchAndSetReplyTo();

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -222,12 +222,14 @@ export default {
       );
     },
     shouldShowReplyToMessage() {
+      if (!this.inReplyTo?.id) return false;
+      if (this.copilot.isActive.value) return false;
+      // Private notes are agent-only and don't depend on an external channel
+      // for reply propagation, so the channel feature gates don't apply.
+      if (this.isPrivate) return true;
       return (
-        this.inReplyTo?.id &&
-        !this.isPrivate &&
         this.inboxHasFeature(INBOX_FEATURES.REPLY_TO) &&
-        !this.is360DialogWhatsAppChannel &&
-        !this.copilot.isActive.value
+        !this.is360DialogWhatsAppChannel
       );
     },
     showWhatsappTemplates() {
@@ -1317,12 +1319,21 @@ export default {
         this.conversationId
       );
 
-      this.inReplyTo = this.currentChat?.messages?.find(message => {
+      const target = this.currentChat?.messages?.find(message => {
         if (message.id === replyToMessageId) {
           return true;
         }
         return false;
       });
+
+      // Replying to a private note must keep the composer internal: switching
+      // to NOTE mode prevents leaking the note's id into an outbound reply's
+      // `in_reply_to` and keeps the cited preview visible to agents only.
+      if (target?.private && !this.isOnPrivateNote) {
+        this.setReplyMode(REPLY_EDITOR_MODES.NOTE);
+      }
+
+      this.inReplyTo = target;
     },
     onReplyToMessage() {
       this.fetchAndSetReplyTo();

--- a/spec/controllers/api/v1/accounts/conversations/messages/reactions_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages/reactions_controller_spec.rb
@@ -39,14 +39,40 @@ RSpec.describe 'Conversation Message Reactions API', type: :request do
       end
     end
 
-    context 'when the target message is private' do
-      let(:target_message) { create(:message, account: account, conversation: conversation, content: 'Note', private: true) }
+    context 'when the target message is a private note' do
+      let!(:target_message) { create(:message, account: account, conversation: conversation, content: 'Note', private: true) }
 
-      it 'rejects the request' do
-        post reactions_url, params: { emoji: '👍' }, headers: agent.create_new_auth_token, as: :json
+      it 'allows the reaction and creates a private reaction Message' do
+        expect do
+          post reactions_url, params: { emoji: '👍' }, headers: agent.create_new_auth_token, as: :json
+        end.to change(conversation.messages, :count).by(1)
 
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.parsed_body['error']).to match(/private/i)
+        expect(response).to have_http_status(:ok)
+        created = conversation.messages.last
+        expect(created.private).to be true
+        expect(created.content).to eq('👍')
+        expect(created.content_attributes['is_reaction']).to be true
+        expect(created.content_attributes['in_reply_to']).to eq(target_message.id)
+      end
+
+      context 'when the inbox channel does not support reactions' do
+        let(:channel) { create(:channel_whatsapp, account: account, provider: 'default', validate_provider_config: false, sync_templates: false) }
+
+        it 'still allows reacting to the private note' do
+          post reactions_url, params: { emoji: '👍' }, headers: agent.create_new_auth_token, as: :json
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      it 'does not dispatch the reaction to the external provider' do
+        expect_any_instance_of(Whatsapp::Providers::WhatsappBaileysService).not_to receive(:send_message) # rubocop:disable RSpec/AnyInstance
+
+        perform_enqueued_jobs do
+          post reactions_url, params: { emoji: '👍' }, headers: agent.create_new_auth_token, as: :json
+        end
+
+        expect(response).to have_http_status(:ok)
       end
     end
 


### PR DESCRIPTION
Agentes agora podem citar uma nota privada como reply e reagir com emoji a notas privadas, com mesma UX das reações de WhatsApp. As reações herdam `private: true`, então `SendOnChannelService` faz curto-circuito e nada vaza para o canal externo. Clicar "Responder" numa nota privada troca o composer para modo NOTA automaticamente, mantendo a citação interna ao time.

## Closes

N/A

## How to test

1. Abra uma conversa em qualquer inbox (incluindo uma sem suporte a reações, ex.: email).
2. No composer, alterne para modo **Nota privada** e envie uma nota A.
3. No menu (...) da nota A, clique em **Responder**:
   - O composer mostra preview da nota A citada **e** alterna para modo NOTA (se ainda não estiver).
   - Envie a nota B; a bolha da nota B renderiza a citação da nota A.
4. Faça hover/right-click numa nota privada → o picker de reações aparece. Clique 👍 → chip embaixo da nota.
5. Loge com outro agente da conta e reaja 👍 → o chip mostra count 2.
6. Reaja com 😂 → o chip de 👍 do seu agente é substituído pelo de 😂.
7. Numa inbox Baileys: confirme que a reação numa nota privada **não** dispara chamada ao provider (logs de `SendOnWhatsappService`).
8. Regressão: reagir a uma mensagem WhatsApp normal continua enviando ao provider.

## What changed

- `app/controllers/api/v1/accounts/conversations/messages/reactions_controller.rb`: reordena `before_action`s; `ensure_channel_supports_reactions` ignora o gate de canal quando o target é privado; `target_unreactable_error` deixa de bloquear notas privadas e condiciona o gate de `source_id` a não-privadas; `build_reaction_message!` propaga `private: true` quando o target é privado.
- `app/javascript/dashboard/components-next/message/Message.vue`: `contextMenuEnabledOptions.replyTo` libera para notas privadas independentemente do canal; `canShowReactionToolbar` libera o picker em notas privadas ignorando `inboxSupportsReactions` e `sourceId`.
- `app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue`: `shouldShowReplyToMessage` libera preview em modo nota privada; `fetchAndSetReplyTo` força `setReplyMode(NOTE)` quando a mensagem alvo é privada.
- `spec/controllers/api/v1/accounts/conversations/messages/reactions_controller_spec.rb`: substitui o contexto "rejects private targets" por contextos validando criação da reação herdando `private: true`, suporte mesmo em inboxes sem `supports_reactions?` e não-dispatch ao provider.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/302)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reactions and reply-to now work on private (agent-only) messages; UI enables reaction picker and reply actions for private notes.
  * Replying to a private message auto-opens the private-note editor.

* **Bug Fixes**
  * Private-note reactions remain internal and are not sent to external providers.
  * Private messages bypass external-channel capability blocks and no longer force read-only reaction display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->