### PR TITLE
fix(whatsapp): surface Baileys failure reason on failed messages

### DIFF
--- a/app/services/whatsapp/baileys_handlers/messages_update.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_update.rb
@@ -29,7 +29,19 @@ module Whatsapp::BaileysHandlers::MessagesUpdate
   def update_status
     status = status_mapper
     update_last_seen_at if incoming? && status == 'read'
-    @message.update!(status: status) if status.present? && status_transition_allowed?(status)
+    return unless status.present? && status_transition_allowed?(status)
+
+    attrs = { status: status }
+    attrs[:external_error] = extract_external_error if status == 'failed'
+    @message.update!(attrs)
+  end
+
+  def extract_external_error
+    stub = Array(@raw_message.dig(:update, :messageStubParameters))
+    return if stub.empty?
+
+    code, description = stub
+    description.present? ? "#{description} (#{code})" : "WhatsApp error #{code}"
   end
 
   def status_mapper

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -1084,6 +1084,35 @@ describe Whatsapp::IncomingMessageBaileysService do
 
           expect(Rails.logger).to have_received(:warn)
         end
+
+        it 'marks the message as failed and stores the stub description with code' do
+          update_payload[:update][:status] = 0
+          update_payload[:update][:messageStubParameters] = ['463', 'Your account has been restricted']
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.status).to eq('failed')
+          expect(message.external_error).to eq('Your account has been restricted (463)')
+        end
+
+        it 'falls back to a generic message when only the error code is present on failure' do
+          update_payload[:update][:status] = 0
+          update_payload[:update][:messageStubParameters] = ['429']
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.status).to eq('failed')
+          expect(message.external_error).to eq('WhatsApp error 429')
+        end
+
+        it 'leaves external_error blank on failure when stub parameters are absent' do
+          update_payload[:update][:status] = 0
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.status).to eq('failed')
+          expect(message.external_error).to be_blank
+        end
       end
 
       context 'when is a content update' do


### PR DESCRIPTION
## Summary

When a Baileys-sent message is rejected by WhatsApp (e.g. account restricted, error 463), Baileys delivers the cause via the `messages.update` webhook in `messageStubParameters`. The handler in `Whatsapp::BaileysHandlers::MessagesUpdate#update_status` previously only persisted the failed status and dropped the stub parameters on the floor.

That left `content_attributes.external_error` blank on the message, so the `MessageError.vue` component (which gates rendering on `externalError` being present) stayed silent. The bubble showed the red "Failed" styling but no alert triangle, no hover tooltip, and no retry button — agents had no way to know why the send failed.

This change extracts `messageStubParameters` when the status maps to `failed` and writes it to `external_error` in the same `update!` call:
- `["463", "Your account has been restricted"]` → `Your account has been restricted (463)`
- `["429"]` → `WhatsApp error 429`
- empty/missing → `external_error` stays blank

The frontend infra already in place picks this up automatically — no UI changes required.

## Why

Real incident on a client deployment: an agent tried to send a short test message at 12:19 UTC from a connection that WhatsApp had restricted (error 463). Baileys correctly emitted the failure with `messageStubParameters: ["463","Your account has been restricted"]`, but Chatwoot UI only showed a red bubble with no explanation, so the agent couldn't tell whether the issue was on their side, on the customer's side, or on the connection itself.

## Test plan

- [x] `bundle exec rspec spec/services/whatsapp/incoming_message_baileys_service_spec.rb -e "when processing messages.update event"` — 10 examples, 0 failures
- [ ] Manual check on staging: send from a known-restricted Baileys connection and confirm the alert triangle + tooltip render with the WhatsApp reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/304)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed WhatsApp messages by capturing and storing detailed error information from the messaging service, including error codes and descriptions when available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->