### PR TITLE
feat(whatsapp): normalize Baileys contact phone via on_whatsapp

### DIFF
--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -20,8 +20,9 @@ class ContactInboxBuilder
   # the exact number registered there. For Brazilian mobile numbers the leading
   # "9" may or may not be present in the user-typed value; sending to the wrong
   # variant fails silently. Use on_whatsapp to resolve the canonical number and
-  # align the contact (and source_id) with what Baileys expects. Any provider
-  # error is swallowed so the original flow continues unchanged.
+  # align the contact (and source_id) with what Baileys expects. Provider
+  # lookup errors are swallowed; write/merge errors must surface so the caller
+  # sees inconsistent state.
   def normalize_phone_for_baileys!
     return if @contact.phone_number.blank?
 
@@ -33,8 +34,6 @@ class ContactInboxBuilder
     apply_canonical_phone(canonical_phone)
 
     @source_id = canonical_phone.delete('+') if @source_id == old_source_id_candidate
-  rescue StandardError => e
-    Rails.logger.warn("[WHATSAPP][BAILEYS] phone normalization via on_whatsapp failed (ignored): #{e.class.name}: #{e.message}")
   end
 
   def fetch_canonical_baileys_phone
@@ -45,6 +44,9 @@ class ContactInboxBuilder
     return if jid_digits.blank?
 
     "+#{jid_digits}"
+  rescue StandardError => e
+    Rails.logger.warn("[WHATSAPP][BAILEYS] phone normalization via on_whatsapp failed (ignored): #{e.class.name}: #{e.message}")
+    nil
   end
 
   def apply_canonical_phone(canonical_phone)

--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -2,14 +2,60 @@
 # For Specific Channels like whatsapp, email etc . it smartly generated appropriate the source id when none is provided.
 
 class ContactInboxBuilder
-  pattr_initialize [:contact, :inbox, :source_id, { hmac_verified: false }]
+  pattr_initialize [:contact, :inbox, :source_id, { hmac_verified: false, validate_baileys_phone: false }]
 
   def perform
+    normalize_phone_for_baileys! if validate_baileys_phone && baileys_whatsapp_inbox?
     @source_id ||= generate_source_id
     create_contact_inbox if source_id.present?
   end
 
   private
+
+  def baileys_whatsapp_inbox?
+    @inbox.channel_type == 'Channel::Whatsapp' && @inbox.channel.provider == 'baileys'
+  end
+
+  # WhatsApp matches the canonical phone for an account, but Baileys requires
+  # the exact number registered there. For Brazilian mobile numbers the leading
+  # "9" may or may not be present in the user-typed value; sending to the wrong
+  # variant fails silently. Use on_whatsapp to resolve the canonical number and
+  # align the contact (and source_id) with what Baileys expects. Any provider
+  # error is swallowed so the original flow continues unchanged.
+  def normalize_phone_for_baileys!
+    return if @contact.phone_number.blank?
+
+    old_source_id_candidate = @contact.phone_number.delete('+')
+
+    canonical_phone = fetch_canonical_baileys_phone
+    return if canonical_phone.blank? || canonical_phone == @contact.phone_number
+
+    apply_canonical_phone(canonical_phone)
+
+    @source_id = canonical_phone.delete('+') if @source_id == old_source_id_candidate
+  rescue StandardError => e
+    Rails.logger.warn("[WHATSAPP][BAILEYS] phone normalization via on_whatsapp failed (ignored): #{e.class.name}: #{e.message}")
+  end
+
+  def fetch_canonical_baileys_phone
+    response = @inbox.channel.on_whatsapp(@contact.phone_number)
+    return unless response.is_a?(Hash) && response['exists']
+
+    jid_digits = response['jid'].to_s.split('@').first
+    return if jid_digits.blank?
+
+    "+#{jid_digits}"
+  end
+
+  def apply_canonical_phone(canonical_phone)
+    existing = @inbox.account.contacts.where.not(id: @contact.id).find_by(phone_number: canonical_phone)
+
+    if existing
+      @contact = ContactMergeAction.new(account: @inbox.account, base_contact: existing, mergee_contact: @contact).perform
+    else
+      @contact.update!(phone_number: canonical_phone)
+    end
+  end
 
   def generate_source_id
     case @inbox.channel_type

--- a/app/controllers/api/v1/accounts/contacts/contact_inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/contact_inboxes_controller.rb
@@ -7,7 +7,8 @@ class Api::V1::Accounts::Contacts::ContactInboxesController < Api::V1::Accounts:
       contact: @contact,
       inbox: @inbox,
       source_id: params[:source_id],
-      hmac_verified: hmac_verified?
+      hmac_verified: hmac_verified?,
+      validate_baileys_phone: true
     ).perform
   end
 

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
+class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController # rubocop:disable Metrics/ClassLength
   include Sift
   sort_on :email, type: :string
   sort_on :name, internal_name: :order_on_name, type: :scope, scope_params: [:direction]
@@ -96,6 +96,9 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
       @contact = Current.account.contacts.new(permitted_params.except(:avatar_url))
       @contact.save!
       @contact_inbox = build_contact_inbox
+      # Baileys phone normalization in the builder may merge @contact into an
+      # existing contact with the canonical phone; switch to the surviving record.
+      @contact = @contact_inbox.contact if @contact_inbox&.contact.present?
       process_avatar_from_url
     end
   end
@@ -175,7 +178,8 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController
     ContactInboxBuilder.new(
       contact: @contact,
       inbox: inbox,
-      source_id: params[:source_id]
+      source_id: params[:source_id],
+      validate_baileys_phone: true
     ).perform
   end
 

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -247,7 +247,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
       contact: @contact,
       inbox: @inbox,
       source_id: params[:source_id],
-      hmac_verified: hmac_verified?
+      hmac_verified: hmac_verified?,
+      validate_baileys_phone: true
     ).perform
   end
 

--- a/app/services/whatsapp/baileys_handlers/concerns/group_contact_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/group_contact_message_handler.rb
@@ -94,7 +94,7 @@ module Whatsapp::BaileysHandlers::Concerns::GroupContactMessageHandler # rubocop
     update_params = {
       phone_number: ("+#{phone}" if should_update_contact_phone?(contact, phone)),
       identifier: (identifier if should_update_contact_identifier?(contact, identifier)),
-      name: (name if should_update_contact_name?(contact, name))
+      name: (name if should_update_contact_name?(contact, phone, identifier, name))
     }.compact
 
     contact.update!(update_params) if update_params.present?
@@ -109,8 +109,8 @@ module Whatsapp::BaileysHandlers::Concerns::GroupContactMessageHandler # rubocop
     identifier && contact.identifier.blank?
   end
 
-  def should_update_contact_name?(contact, name)
-    name && (contact.name.blank? || contact.name.match?(/^\d+/))
+  def should_update_contact_name?(contact, phone, identifier, name)
+    name && placeholder_contact_name?(contact.name, phone: phone, identifier: identifier)
   end
 
   def extract_lid_from_participant(participant)

--- a/app/services/whatsapp/baileys_handlers/concerns/individual_contact_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/individual_contact_message_handler.rb
@@ -75,14 +75,14 @@ module Whatsapp::BaileysHandlers::Concerns::IndividualContactMessageHandler
     @contact_inbox = contact_inbox
     @contact = contact_inbox.contact
 
-    update_contact_info(phone, source_id, identifier)
+    update_contact_info(phone, identifier)
   end
 
-  def update_contact_info(phone, source_id, identifier)
+  def update_contact_info(phone, identifier)
     update_params = {
       phone_number: ("+#{phone}" if phone),
       identifier: (identifier if @contact.identifier != identifier),
-      name: (contact_name if @contact.name.in?([phone, source_id, identifier]))
+      name: (contact_name if placeholder_contact_name?(@contact.name, phone: phone, identifier: identifier))
     }.compact
 
     @contact.update!(update_params) if update_params.present?

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -171,6 +171,38 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     Whatsapp::PhoneNormalizers::BrazilPhoneNormalizer.new.normalize(phone_number)
   end
 
+  # A name equal to the contact's WhatsApp phone (in any normalized "9"-variant),
+  # its LID, or the "<lid>@lid" identifier is an auto-generated placeholder rather
+  # than a human-entered name. Matching normalized phone variants lets the real
+  # pushName replace a number stranded by phone normalization, e.g. when the
+  # Brazilian "9" digit is added/removed and phone_number no longer matches the
+  # digits saved as the name.
+  def placeholder_contact_name?(name, phone:, identifier:)
+    return true if name.blank?
+    return true if name == identifier
+
+    digits = name.delete('+')
+    return false unless digits.match?(/\A\d+\z/)
+
+    lid = identifier&.delete_suffix('@lid')
+    return true if digits.in?([phone, lid].compact)
+
+    phone.present? && same_whatsapp_number?(digits, phone)
+  end
+
+  def same_whatsapp_number?(left, right)
+    normalizer = phone_normalizer_for(left) || phone_normalizer_for(right)
+    return false unless normalizer
+
+    normalizer.normalize(left) == normalizer.normalize(right)
+  end
+
+  def phone_normalizer_for(value)
+    Whatsapp::PhoneNumberNormalizationService::NORMALIZERS
+      .map(&:new)
+      .find { |normalizer| normalizer.handles_country?(value) }
+  end
+
   def ignore_message?
     message_type.in?(%w[protocol context edited])
   end

--- a/spec/builders/contact_inbox_builder_spec.rb
+++ b/spec/builders/contact_inbox_builder_spec.rb
@@ -383,7 +383,7 @@ describe ContactInboxBuilder do
 
         expect(contact_inbox.contact_id).to eq(existing_contact.id)
         expect(existing_contact.reload.phone_number).to eq(canonical_phone)
-        expect { contact.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { contact.reload }.to(raise_error { |error| expect(error.class.name).to eq('ActiveRecord::RecordNotFound') })
       end
 
       it 'does nothing when on_whatsapp returns the same canonical phone' do

--- a/spec/builders/contact_inbox_builder_spec.rb
+++ b/spec/builders/contact_inbox_builder_spec.rb
@@ -331,6 +331,105 @@ describe ContactInboxBuilder do
       end
     end
 
+    describe 'baileys whatsapp inbox phone normalization' do
+      let(:baileys_channel) do
+        create(:channel_whatsapp, account: account, provider: 'baileys',
+                                  sync_templates: false, validate_provider_config: false)
+      end
+      let(:baileys_inbox) { baileys_channel.inbox }
+      let(:contact) { create(:contact, phone_number: '+5511912345678', account: account) }
+      let(:canonical_phone) { '+551112345678' }
+      let(:canonical_jid) { "#{canonical_phone.delete('+')}@s.whatsapp.net" }
+
+      it 'updates the contact phone when on_whatsapp returns a different canonical jid' do
+        allow_any_instance_of(Channel::Whatsapp).to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
+          .with(contact.phone_number)
+          .and_return({ 'jid' => canonical_jid, 'exists' => true })
+
+        contact_inbox = described_class.new(
+          contact: contact,
+          inbox: baileys_inbox,
+          validate_baileys_phone: true
+        ).perform
+
+        expect(contact.reload.phone_number).to eq(canonical_phone)
+        expect(contact_inbox.source_id).to eq(canonical_phone.delete('+'))
+      end
+
+      it 'rewrites the caller-provided source_id derived from the pre-normalization phone' do
+        allow_any_instance_of(Channel::Whatsapp).to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
+          .and_return({ 'jid' => canonical_jid, 'exists' => true })
+
+        contact_inbox = described_class.new(
+          contact: contact,
+          inbox: baileys_inbox,
+          source_id: '5511912345678',
+          validate_baileys_phone: true
+        ).perform
+
+        expect(contact_inbox.source_id).to eq(canonical_phone.delete('+'))
+      end
+
+      it 'merges into an existing contact when the canonical phone is already taken' do
+        existing_contact = create(:contact, name: 'Existing Maria', phone_number: canonical_phone, account: account)
+        allow_any_instance_of(Channel::Whatsapp).to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
+          .and_return({ 'jid' => canonical_jid, 'exists' => true })
+
+        contact_inbox = described_class.new(
+          contact: contact,
+          inbox: baileys_inbox,
+          validate_baileys_phone: true
+        ).perform
+
+        expect(contact_inbox.contact_id).to eq(existing_contact.id)
+        expect(existing_contact.reload.phone_number).to eq(canonical_phone)
+        expect { contact.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'does nothing when on_whatsapp returns the same canonical phone' do
+        allow_any_instance_of(Channel::Whatsapp).to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
+          .and_return({ 'jid' => "#{contact.phone_number.delete('+')}@s.whatsapp.net", 'exists' => true })
+
+        expect do
+          described_class.new(contact: contact, inbox: baileys_inbox, validate_baileys_phone: true).perform
+        end.not_to(change { contact.reload.phone_number })
+      end
+
+      it 'does nothing when on_whatsapp reports exists=false' do
+        allow_any_instance_of(Channel::Whatsapp).to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
+          .and_return({ 'jid' => canonical_jid, 'exists' => false })
+
+        expect do
+          described_class.new(contact: contact, inbox: baileys_inbox, validate_baileys_phone: true).perform
+        end.not_to(change { contact.reload.phone_number })
+      end
+
+      it 'swallows provider errors and proceeds with the original phone' do
+        allow_any_instance_of(Channel::Whatsapp).to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
+          .and_raise(StandardError, 'baileys boom')
+
+        contact_inbox = nil
+        expect do
+          contact_inbox = described_class.new(contact: contact, inbox: baileys_inbox, validate_baileys_phone: true).perform
+        end.not_to(change { contact.reload.phone_number })
+
+        expect(contact_inbox.source_id).to eq(contact.phone_number.delete('+'))
+      end
+
+      it 'does not call on_whatsapp when validate_baileys_phone is not requested' do
+        expect_any_instance_of(Channel::Whatsapp).not_to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
+
+        described_class.new(contact: contact, inbox: baileys_inbox).perform
+      end
+
+      it 'does not call on_whatsapp for whatsapp inboxes on non-baileys providers' do
+        non_baileys_inbox = create(:channel_whatsapp, account: account, sync_templates: false, validate_provider_config: false).inbox
+        expect_any_instance_of(Channel::Whatsapp).not_to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
+
+        described_class.new(contact: contact, inbox: non_baileys_inbox, validate_baileys_phone: true).perform
+      end
+    end
+
     context 'when there is a race condition' do
       let(:account) { create(:account) }
       let(:contact) { create(:contact, account: account) }

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -406,7 +406,8 @@ RSpec.describe 'Conversations API', type: :request do
         it 'calls contact inbox builder if contact_id and inbox_id is present' do
           builder = double
           allow(Rails.configuration.dispatcher).to receive(:dispatch)
-          allow(ContactInboxBuilder).to receive(:new).with(contact: contact, inbox: inbox, source_id: nil, hmac_verified: false).and_return(builder)
+          allow(ContactInboxBuilder).to receive(:new)
+            .with(contact: contact, inbox: inbox, source_id: nil, hmac_verified: false, validate_baileys_phone: true).and_return(builder)
           allow(builder).to receive(:perform)
           expect(builder).to receive(:perform)
 

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -977,6 +977,26 @@ describe Whatsapp::IncomingMessageBaileysService do
           expect(contact.reload.name).to eq('John Doe')
         end
 
+        it 'updates contact name when stored name is a phone variant missing the Brazilian 9' do
+          # The contact was registered without the "9"; phone normalization later aligned
+          # phone_number to the canonical number, but the name kept the stale digits.
+          contact = create(:contact, account: inbox.account, name: '551112345678', phone_number: '+5511912345678', identifier: '12345678@lid')
+          create(:contact_inbox, inbox: inbox, contact: contact, source_id: '12345678')
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(contact.reload.name).to eq('John Doe')
+        end
+
+        it 'updates contact name when stored name is a phone number with a leading +' do
+          contact = create(:contact, account: inbox.account, name: '+5511912345678', phone_number: '+5511912345678', identifier: '12345678@lid')
+          create(:contact_inbox, inbox: inbox, contact: contact, source_id: '12345678')
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(contact.reload.name).to eq('John Doe')
+        end
+
         it 'updates contact name if it matches LID source_id' do
           contact = create(:contact, account: inbox.account, name: '12345678', phone_number: '+5511912345678', identifier: '12345678@lid')
           create(:contact_inbox, inbox: inbox, contact: contact, source_id: '12345678')
@@ -1002,6 +1022,15 @@ describe Whatsapp::IncomingMessageBaileysService do
           described_class.new(inbox: inbox, params: params).perform
 
           expect(contact.reload.name).to eq('Existing Name')
+        end
+
+        it 'does not overwrite a digit-only name that is not this contact phone or LID' do
+          contact = create(:contact, account: inbox.account, name: '99887766', phone_number: '+5511912345678', identifier: '12345678@lid')
+          create(:contact_inbox, inbox: inbox, contact: contact, source_id: '12345678')
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(contact.reload.name).to eq('99887766')
         end
       end
     end


### PR DESCRIPTION
Caixas de entrada do WhatsApp do provedor Baileys exigem o número exato registrado no WhatsApp para entregar mensagens. Como muitos números brasileiros oscilam entre ter ou não o "9" antes do número, o cadastro feito com a variante errada falhava silenciosamente no envio (diferente do WhatsApp Web, que casa pelo número canônico).

Agora o `ContactInboxBuilder` opt-in (via `validate_baileys_phone: true`) chama `channel.on_whatsapp(contact.phone_number)` no momento do cadastro do ContactInbox em caixas Baileys. Quando o JID canônico difere, o telefone do contato é atualizado; se o número canônico já pertence a outro contato do mesmo account, faz merge automático preservando os dados do contato existente. Erros do provider são engolidos e o fluxo continua normal.

## Closes

- N/A (melhoria interna)

## How to test

1. Crie uma caixa de entrada WhatsApp com provider Baileys.
2. Cadastre um contato com um número brasileiro escrito com a variante "errada" do 9 (ex.: real é `+5511912345678`, cadastre como `+551112345678` ou vice-versa).
3. Abra uma nova conversa nessa caixa pra esse contato e envie uma mensagem.
4. Confirme que (a) o telefone do contato foi reescrito automaticamente para o canônico retornado pelo Baileys e (b) a mensagem foi entregue.
5. Caso o número canônico já exista em outro contato do account, confirme que rolou merge (contato antigo absorvido, ContactInbox vinculado ao contato canônico).
6. Simule erro do provider (ex.: provider offline) e confirme que o cadastro segue sem quebrar, mantendo o número original.

## What changed

- `ContactInboxBuilder`: novo parâmetro `validate_baileys_phone` e método privado `normalize_phone_for_baileys!` que resolve o número canônico via `on_whatsapp`, atualiza/merge o contato, e reescreve `source_id` quando ele veio derivado do telefone antigo.
- `ContactsController#create` agora usa `@contact_inbox.contact` pós-build, pra cobrir o caso em que o builder fez merge e destruiu o contato recém-criado.
- Opt-in em todos os controllers outbound: `ContactInboxesController#create`, `ConversationsController#build_contact_inbox`, `ContactsController#build_contact_inbox`.
- 8 specs novos em `contact_inbox_builder_spec.rb` cobrindo update, merge, no-op (mesmo canônico, exists=false), swallow de erro, opt-out e provider não-Baileys.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/305)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Baileys-backed WhatsApp contacts are now validated and normalized to a canonical phone; contacts with the same canonical number are merged and source IDs updated. Lookup failures fall back gracefully to the original number.
* **Bug Fixes**
  * Controllers now reflect any canonical contact merge created during inbox setup.
* **Tests**
  * Added coverage for normalization, merging, source ID updates, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->