### PR TITLE
fix(chat-list): keep assignee tabs visible on mention/participating views

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -61,10 +61,10 @@ import {
   getUserPermissions,
   getUserRole,
   filterItemsByPermission,
+  getVisibleAssigneeTabPermissions,
 } from 'dashboard/helper/permissionsHelper.js';
 import { matchesFilters } from '../store/modules/conversations/helpers/filterHelpers';
 import { CONVERSATION_EVENTS } from '../helper/AnalyticsHelper/events';
-import { ASSIGNEE_TYPE_TAB_PERMISSIONS } from 'dashboard/constants/permissions.js';
 
 const props = defineProps({
   conversationInbox: { type: [String, Number], default: 0 },
@@ -201,23 +201,11 @@ const userPermissions = computed(() => {
 });
 
 const assigneeTabPermissions = computed(() => {
-  if (getUserRole(currentUser.value, currentAccountId.value) !== 'agent') {
-    return ASSIGNEE_TYPE_TAB_PERMISSIONS;
-  }
-
-  const accountSettings =
-    getAccount.value(currentAccountId.value)?.settings || {};
-  const hideUnassigned = Boolean(accountSettings.hide_agent_unassigned_tab);
-  const hideAll = hideUnassigned || Boolean(accountSettings.hide_agent_all_tab);
-
-  if (!hideUnassigned && !hideAll) return ASSIGNEE_TYPE_TAB_PERMISSIONS;
-
-  const { unassigned, all, ...rest } = ASSIGNEE_TYPE_TAB_PERMISSIONS;
-  return {
-    ...rest,
-    ...(hideUnassigned ? {} : { unassigned }),
-    ...(hideAll ? {} : { all }),
-  };
+  return getVisibleAssigneeTabPermissions({
+    conversationType: props.conversationType,
+    userRole: getUserRole(currentUser.value, currentAccountId.value),
+    accountSettings: getAccount.value(currentAccountId.value)?.settings || {},
+  });
 });
 
 const assigneeTabItems = computed(() => {

--- a/app/javascript/dashboard/helper/permissionsHelper.js
+++ b/app/javascript/dashboard/helper/permissionsHelper.js
@@ -1,3 +1,6 @@
+import wootConstants from 'dashboard/constants/globals';
+import { ASSIGNEE_TYPE_TAB_PERMISSIONS } from 'dashboard/constants/permissions';
+
 export const hasPermissions = (
   requiredPermissions = [],
   availablePermissions = []
@@ -52,4 +55,46 @@ export const filterItemsByPermission = (
   return Object.entries(items)
     .filter(([, item]) => hasRequiredPermissions(item)) // Keep only items with required permissions
     .map(([key, item]) => transformItem(key, item)); // Transform each remaining item
+};
+
+/**
+ * Resolves which conversation assignee tabs (Mine/Unassigned/All) a user may
+ * see, applying the account-level hide-tabs toggles for basic agents.
+ *
+ * Mention/Participating views are scoped to conversations the user can already
+ * see, so the toggles must not apply there: hiding Unassigned/All would strand
+ * chats not assigned to the agent under an unreachable tab. Admins and custom
+ * roles are never affected.
+ *
+ * @param {Object} params
+ * @param {String} params.conversationType - Current view type (mention/participating/...).
+ * @param {String} params.userRole - Resolved user role for the account.
+ * @param {Object} [params.accountSettings] - Account settings holding the toggles.
+ * @returns {Object} The visible subset of ASSIGNEE_TYPE_TAB_PERMISSIONS.
+ */
+export const getVisibleAssigneeTabPermissions = ({
+  conversationType,
+  userRole,
+  accountSettings = {},
+} = {}) => {
+  const { MENTION, PARTICIPATING } = wootConstants.CONVERSATION_TYPE;
+  const isPersonalScopeView = [MENTION, PARTICIPATING].includes(
+    conversationType
+  );
+
+  if (isPersonalScopeView || userRole !== 'agent') {
+    return ASSIGNEE_TYPE_TAB_PERMISSIONS;
+  }
+
+  const hideUnassigned = Boolean(accountSettings.hide_agent_unassigned_tab);
+  const hideAll = hideUnassigned || Boolean(accountSettings.hide_agent_all_tab);
+
+  if (!hideUnassigned && !hideAll) return ASSIGNEE_TYPE_TAB_PERMISSIONS;
+
+  const { unassigned, all, ...rest } = ASSIGNEE_TYPE_TAB_PERMISSIONS;
+  return {
+    ...rest,
+    ...(hideUnassigned ? {} : { unassigned }),
+    ...(hideAll ? {} : { all }),
+  };
 };

--- a/app/javascript/dashboard/helper/specs/permissionsHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/permissionsHelper.spec.js
@@ -3,7 +3,9 @@ import {
   getUserPermissions,
   hasPermissions,
   filterItemsByPermission,
+  getVisibleAssigneeTabPermissions,
 } from '../permissionsHelper';
+import { ASSIGNEE_TYPE_TAB_PERMISSIONS } from 'dashboard/constants/permissions';
 
 describe('#getCurrentAccount', () => {
   it('should return the current account', () => {
@@ -149,5 +151,78 @@ describe('filterItemsByPermission', () => {
     expect(result).toContainEqual(
       expect.objectContaining({ key: 'item1', name: 'Item 1' })
     );
+  });
+});
+
+describe('#getVisibleAssigneeTabPermissions', () => {
+  const hideBoth = {
+    hide_agent_unassigned_tab: true,
+    hide_agent_all_tab: true,
+  };
+
+  it('returns all tabs for non-agent roles regardless of settings', () => {
+    expect(
+      getVisibleAssigneeTabPermissions({
+        userRole: 'administrator',
+        accountSettings: hideBoth,
+      })
+    ).toEqual(ASSIGNEE_TYPE_TAB_PERMISSIONS);
+  });
+
+  it('returns all tabs for agents when no toggle is set', () => {
+    expect(
+      getVisibleAssigneeTabPermissions({
+        userRole: 'agent',
+        accountSettings: {},
+      })
+    ).toEqual(ASSIGNEE_TYPE_TAB_PERMISSIONS);
+  });
+
+  it('hides unassigned and all when unassigned toggle is on', () => {
+    const result = getVisibleAssigneeTabPermissions({
+      userRole: 'agent',
+      accountSettings: { hide_agent_unassigned_tab: true },
+    });
+
+    expect(Object.keys(result)).toEqual(['me']);
+  });
+
+  it('hides only all when the all toggle is on by itself', () => {
+    const result = getVisibleAssigneeTabPermissions({
+      userRole: 'agent',
+      accountSettings: { hide_agent_all_tab: true },
+    });
+
+    expect(Object.keys(result)).toEqual(['me', 'unassigned']);
+  });
+
+  it('keeps all tabs on the mention view even with toggles on', () => {
+    expect(
+      getVisibleAssigneeTabPermissions({
+        conversationType: 'mention',
+        userRole: 'agent',
+        accountSettings: hideBoth,
+      })
+    ).toEqual(ASSIGNEE_TYPE_TAB_PERMISSIONS);
+  });
+
+  it('keeps all tabs on the participating view even with toggles on', () => {
+    expect(
+      getVisibleAssigneeTabPermissions({
+        conversationType: 'participating',
+        userRole: 'agent',
+        accountSettings: hideBoth,
+      })
+    ).toEqual(ASSIGNEE_TYPE_TAB_PERMISSIONS);
+  });
+
+  it('still applies toggles on the unattended view', () => {
+    const result = getVisibleAssigneeTabPermissions({
+      conversationType: 'unattended',
+      userRole: 'agent',
+      accountSettings: hideBoth,
+    });
+
+    expect(Object.keys(result)).toEqual(['me']);
   });
 });


### PR DESCRIPTION
Quando um administrador esconde as abas "Não atribuídas" e "Todas" da lista de conversas para agentes básicos, esse esconder estava vazando para as visões **Menções** e **Participando**. Como essas visões só mostram conversas que o agente já pode ver (onde ele foi mencionado ou que está acompanhando), esconder as abas ali deixava conversas legítimas presas numa aba inalcançável: sobrava só "Minhas", e uma conversa mencionada que não estava atribuída ao agente simplesmente sumia.

Agora as abas voltam a aparecer por completo nas visões de Menções e Participando, mantendo o esconder apenas nas visões de fila (Conversas e Não atendidas), onde ele de fato protege o agente de ver a fila geral.

## What changed

- Extraí a regra de visibilidade das abas para um helper puro `getVisibleAssigneeTabPermissions` em `permissionsHelper.js`.
- O helper faz o bypass dos toggles quando `conversationType` é `mention` ou `participating`; nas demais visões a regra continua igual (esconder `unassigned` implica esconder `all`; admins e custom roles não são afetados).
- `ChatList.vue` agora só chama o helper, e o import morto de `ASSIGNEE_TYPE_TAB_PERMISSIONS` foi removido.
- Spec do helper cobrindo os cenários: não-agente, agente sem toggle, esconder unassigned, esconder só all, bypass em mention, bypass em participating e que `unattended` continua aplicando o esconder.

## How to test

1. Como super admin, ligue os toggles "esconder aba Não atribuídas/Todas" para a conta.
2. Entre como um agente básico.
3. Na visão **Conversas**: confirme que só a aba "Minhas" aparece.
4. Vá para **Menções** e **Participando**: as abas "Não atribuídas" e "Todas" devem reaparecer, e uma conversa mencionada/acompanhada não atribuída ao agente deve estar acessível.
5. Em **Não atendidas**: o esconder deve continuar valendo (só "Minhas").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/306)
<!-- Reviewable:end -->
