### PR TITLE
fix(scheduled-messages): relocate conflicting table on cross-version migrate

### DIFF
--- a/db/migrate/20260121190545_create_scheduled_messages.rb
+++ b/db/migrate/20260121190545_create_scheduled_messages.rb
@@ -1,5 +1,17 @@
 class CreateScheduledMessages < ActiveRecord::Migration[7.1]
-  def change
+  # Columns the fazer-ai fork table has had since creation. They act as a
+  # signature to tell our table apart from a scheduled_messages coming from
+  # another Chatwoot version/fork, whose schema we don't know up front.
+  FORK_SIGNATURE_COLUMNS = %w[
+    id content template_params scheduled_at status
+    account_id conversation_id inbox_id
+    author_type author_id message_id
+    created_at updated_at
+  ].freeze
+
+  def up
+    relocate_conflicting_table if table_exists?(:scheduled_messages)
+
     create_table :scheduled_messages do |t|
       t.text :content
       t.jsonb :template_params, default: {}
@@ -19,7 +31,38 @@ class CreateScheduledMessages < ActiveRecord::Migration[7.1]
     add_scheduled_messages_indexes
   end
 
+  def down
+    drop_table :scheduled_messages, if_exists: true
+  end
+
   private
+
+  def relocate_conflicting_table
+    if fork_table?
+      raise <<~MSG.squish
+        scheduled_messages already exists with the fazer-ai fork schema, but migration
+        20260121190545 is missing from schema_migrations. This is an inconsistent
+        database (partial restore / out-of-sync schema_migrations), not a migration
+        from another Chatwoot version. Register the version manually
+        (INSERT INTO schema_migrations (version) VALUES ('20260121190545');) and review
+        the rest of the scheduled_messages migration family before re-running.
+      MSG
+    end
+
+    # Unknown schema from another version: move the whole table (with indexes,
+    # sequences and constraints) out of `public`, preserving the data and freeing
+    # the name plus every associated object name.
+    target = "scheduled_messages_#{Time.now.utc.to_i}"
+    execute('CREATE SCHEMA IF NOT EXISTS chatwoot_legacy')
+    execute('ALTER TABLE scheduled_messages SET SCHEMA chatwoot_legacy')
+    execute("ALTER TABLE chatwoot_legacy.scheduled_messages RENAME TO #{target}")
+    say "scheduled_messages from another version preserved at chatwoot_legacy.#{target}"
+  end
+
+  def fork_table?
+    existing = connection.columns(:scheduled_messages).map(&:name)
+    (FORK_SIGNATURE_COLUMNS - existing).empty?
+  end
 
   def add_scheduled_messages_indexes
     add_index :scheduled_messages, [:account_id, :status]

--- a/db/migrate/20260121190545_create_scheduled_messages.rb
+++ b/db/migrate/20260121190545_create_scheduled_messages.rb
@@ -44,14 +44,17 @@ class CreateScheduledMessages < ActiveRecord::Migration[7.1]
   end
 
   def down
-    drop_table :scheduled_messages, if_exists: true
+    raise ActiveRecord::IrreversibleMigration,
+          'CreateScheduledMessages cannot be rolled back: up may relocate an imported ' \
+          'scheduled_messages table or be stamped manually, so dropping the table here ' \
+          'could destroy pre-existing data.'
   end
 
   private
 
   def relocate_conflicting_table
     if fork_table?
-      raise <<~MSG.squish
+      raise ActiveRecord::MigrationError, <<~MSG.squish
         scheduled_messages already exists with the fazer-ai fork schema, but migration
         20260121190545 is missing from schema_migrations. This is an inconsistent
         database (partial restore / out-of-sync schema_migrations), not a migration

--- a/db/migrate/20260121190545_create_scheduled_messages.rb
+++ b/db/migrate/20260121190545_create_scheduled_messages.rb
@@ -1,13 +1,25 @@
 class CreateScheduledMessages < ActiveRecord::Migration[7.1]
-  # Columns the fazer-ai fork table has had since creation. They act as a
-  # signature to tell our table apart from a scheduled_messages coming from
-  # another Chatwoot version/fork, whose schema we don't know up front.
-  FORK_SIGNATURE_COLUMNS = %w[
-    id content template_params scheduled_at status
-    account_id conversation_id inbox_id
-    author_type author_id message_id
-    created_at updated_at
-  ].freeze
+  # Columns (name => cast type) the fazer-ai fork table has had since creation.
+  # They act as a fingerprint to tell our table apart from a scheduled_messages
+  # coming from another Chatwoot version/fork, whose schema we don't know up
+  # front. Nullability is intentionally not matched: 20260201162122 relaxes
+  # author_id/author_type to nullable, so it varies across fork schema stages.
+  # The PostgreSQL adapter reports bigint columns as :integer.
+  FORK_SIGNATURE_COLUMNS = {
+    'id' => :integer,
+    'content' => :text,
+    'template_params' => :jsonb,
+    'scheduled_at' => :datetime,
+    'status' => :integer,
+    'account_id' => :integer,
+    'conversation_id' => :integer,
+    'inbox_id' => :integer,
+    'author_type' => :string,
+    'author_id' => :integer,
+    'message_id' => :integer,
+    'created_at' => :datetime,
+    'updated_at' => :datetime
+  }.freeze
 
   def up
     relocate_conflicting_table if table_exists?(:scheduled_messages)
@@ -60,8 +72,11 @@ class CreateScheduledMessages < ActiveRecord::Migration[7.1]
   end
 
   def fork_table?
-    existing = connection.columns(:scheduled_messages).map(&:name)
-    (FORK_SIGNATURE_COLUMNS - existing).empty?
+    columns = connection.columns(:scheduled_messages).index_by(&:name)
+    FORK_SIGNATURE_COLUMNS.all? do |name, type|
+      column = columns[name]
+      column && column.type == type
+    end
   end
 
   def add_scheduled_messages_indexes


### PR DESCRIPTION
Migrating an existing Chatwoot database into our fork could abort with `PG::DuplicateTable: relation "scheduled_messages" already exists` when the source database already had a `scheduled_messages` table from another Chatwoot version or fork. This makes the `scheduled_messages` migration handle that case so the upgrade goes through without manual intervention.

## How to reproduce

1. Take a database from another Chatwoot version/fork that already has a `scheduled_messages` table (any schema).
2. Run `bundle exec rails db:migrate` on our fork.
3. Before this change: the `CreateScheduledMessages` migration aborts with `PG::DuplicateTable`.

## What changed

`db/migrate/20260121190545_create_scheduled_messages.rb` now checks for a pre-existing `scheduled_messages` table before creating ours:

- **Table matches the fazer-ai fork schema** → raises a clear, actionable error. This is an inconsistent `schema_migrations` (e.g. partial restore), not a version switch, so failing loud is correct.
- **Table has an unknown/foreign schema** → moves the whole table into a `chatwoot_legacy` schema. Relocating via `ALTER TABLE ... SET SCHEMA` carries the indexes, sequences and constraints along, preserving the data and freeing the `public` name (and every associated object name) so ours can be created cleanly.
- **No pre-existing table** → behaves exactly as before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/308)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Safer database migration for scheduled messages: detects conflicting or forked legacy tables and either isolates them into a legacy schema with a timestamped rename (preserving indexes/constraints) or halts for manual registration. Creates the new table without overwriting data. Migration rollback is now explicitly irreversible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->