### PR TITLE
fix(whatsapp): anchor reactions to the target message conversation

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -384,6 +384,13 @@ class Message < ApplicationRecord
   end
 
   def set_waiting_since_on_incoming_message
+    # Reactions are annotations, not a new turn awaiting a reply; treating an
+    # incoming reaction as one would push an already-attended conversation back
+    # into the unattended queue (and leave it stuck there, since removals don't
+    # create a Message that could clear it). Mirrors the reaction guard on the
+    # outgoing side (`human_response?`).
+    return if reaction?
+
     # Set waiting_since when customer sends a message (if currently blank)
     conversation.update!(waiting_since: created_at) if incoming? && conversation.waiting_since.blank?
   end

--- a/app/services/whatsapp/baileys_handlers/concerns/group_contact_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/group_contact_message_handler.rb
@@ -49,7 +49,10 @@ module Whatsapp::BaileysHandlers::Concerns::GroupContactMessageHandler # rubocop
       return mark_existing_reaction_as_removed(sender: @sender_contact)
     end
 
-    @conversation = find_or_create_group_conversation(@group_contact_inbox)
+    # A reaction must land in the conversation holding the target message, not
+    # follow the reopen policy: reacting to a message in a resolved group thread
+    # would otherwise spawn a stray blank group conversation.
+    @conversation = conversation_for_reaction || find_or_create_group_conversation(@group_contact_inbox)
     add_group_member(@group_contact, @sender_contact) if @sender_contact
 
     build_and_save_message(

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -211,6 +211,13 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     message_type == 'reaction' && message_content.blank?
   end
 
+  # Baileys doesn't set @in_reply_to_external_id before set_conversation (it's
+  # written later in build_message_content_attributes), so read the target id
+  # straight from the raw reaction webhook here.
+  def reaction_target_external_id
+    unwrap_ephemeral_message(@raw_message[:message]).dig(:reactionMessage, :key, :id)
+  end
+
   def try_update_contact_avatar(contact = nil)
     # TODO: Current logic will never update the contact avatar if their profile picture changes on WhatsApp.
     target_contact = contact || @contact

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -239,16 +239,41 @@ class Whatsapp::IncomingMessageBaseService # rubocop:disable Metrics/ClassLength
   end
 
   def set_conversation
-    # if lock to single conversation is disabled, we will create a new conversation if previous conversation is resolved
-    @conversation = if @inbox.lock_to_single_conversation
-                      @inbox.conversations.where(contact_id: @contact_inbox.contact_id).last
-                    else
-                      @contact_inbox.conversations
-                                    .where.not(status: :resolved).last
-                    end
+    # A reaction annotates an existing message, so it must land in that message's
+    # conversation, not follow the inbox reopen policy. Without this, reacting to a
+    # message in a resolved thread (with lock_to_single_conversation off) would open
+    # a stray blank conversation, or attach the reaction to the wrong active one.
+    # Mirrors the inbox-scoped lookup used by the reaction-removal flow; falls back
+    # to the normal logic when the target isn't stored locally.
+    @conversation = conversation_for_reaction || conversation_by_inbox_config
     return if @conversation
 
     @conversation = ::Conversation.create!(conversation_params)
+  end
+
+  def conversation_for_reaction
+    return unless message_type == 'reaction'
+
+    external_id = reaction_target_external_id
+    return if external_id.blank?
+
+    inbox.messages.find_by(source_id: external_id)&.conversation
+  end
+
+  # Cloud/Z-API set @in_reply_to_external_id before set_conversation; the Baileys
+  # handler overrides this to read it straight from the raw webhook.
+  def reaction_target_external_id
+    @in_reply_to_external_id
+  end
+
+  def conversation_by_inbox_config
+    # if lock to single conversation is disabled, we will create a new conversation if previous conversation is resolved
+    if @inbox.lock_to_single_conversation
+      @inbox.conversations.where(contact_id: @contact_inbox.contact_id).last
+    else
+      @contact_inbox.conversations
+                    .where.not(status: :resolved).last
+    end
   end
 
   def attach_files

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1002,5 +1002,15 @@ RSpec.describe Message do
              content_attributes: { is_reaction: true, in_reply_to: 1 })
       expect(conversation.reload.first_reply_created_at).to be_nil
     end
+
+    it 'does not push an attended conversation back into the unattended queue' do
+      conversation.update!(first_reply_created_at: Time.current, waiting_since: nil)
+      create(:message,
+             conversation: conversation,
+             message_type: :incoming,
+             content: '👍',
+             content_attributes: { is_reaction: true, in_reply_to_external_id: 'EXT' })
+      expect(conversation.reload.waiting_since).to be_nil
+    end
   end
 end

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -638,6 +638,34 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       expect(message.attachments.count).to eq(1)
       expect(message.sender).not_to eq(message.conversation.contact)
     end
+
+    it 'anchors a group reaction to the target message conversation when it is resolved instead of opening a new one' do
+      Whatsapp::IncomingMessageBaileysService.new(
+        inbox: inbox,
+        params: build_params(build_group_raw_message(id: 'grp_target_001', text: 'Original group message'))
+      ).perform
+
+      conversation = inbox.conversations.last
+      target_message = conversation.messages.last
+      conversation.update!(status: :resolved)
+
+      reaction_raw = {
+        key: { id: 'grp_reaction_001', remoteJid: group_jid, participant: "#{sender_lid}@lid",
+               participantAlt: "#{sender_phone}@s.whatsapp.net", fromMe: false },
+        pushName: 'Sender User',
+        messageTimestamp: timestamp,
+        message: { reactionMessage: { key: { id: target_message.source_id }, text: '👍' } }
+      }
+
+      expect do
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: build_params(reaction_raw)).perform
+      end.not_to change(Conversation, :count)
+
+      reaction = conversation.reload.messages.last
+      expect(reaction.is_reaction).to be(true)
+      expect(reaction.conversation_id).to eq(conversation.id)
+      expect(reaction.in_reply_to_external_id).to eq(target_message.source_id)
+    end
   end
 
   describe 'conversation duplication after deletion or resolution' do

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -555,6 +555,26 @@ describe Whatsapp::IncomingMessageBaileysService do
           expect(reaction.in_reply_to_external_id).to eq(message.source_id)
         end
 
+        it 'anchors the reaction to the target message conversation when it is resolved instead of opening a new one' do
+          message.conversation.update!(status: :resolved)
+          raw_message[:key][:id] = 'reaction_123'
+          raw_message[:message] = {
+            reactionMessage: {
+              key: { remoteJid: '12345678@lid', fromMe: true, id: 'msg_123' },
+              text: '👍'
+            }
+          }
+
+          expect do
+            described_class.new(inbox: inbox, params: params).perform
+          end.not_to change(Conversation, :count)
+
+          reaction = message.conversation.reload.messages.last
+          expect(reaction.is_reaction).to be(true)
+          expect(reaction.conversation_id).to eq(message.conversation.id)
+          expect(reaction.in_reply_to_external_id).to eq(message.source_id)
+        end
+
         it 'does not create the reaction if content is empty' do
           raw_message[:key][:id] = 'reaction_123'
           raw_message[:message] = {


### PR DESCRIPTION
Reacting with an emoji to a WhatsApp message no longer creates an empty conversation or pushes an answered conversation back into the unattended queue. Reactions now always attach to the conversation that holds the message being reacted to, even when that conversation is resolved.

## Closes

- Closes #309

## How to reproduce

1. Set the inbox to **"Create new conversations"** (instead of "Reopen the same conversation").
2. Resolve a conversation with a WhatsApp contact.
3. From WhatsApp, react with an emoji to any message in that resolved conversation.

**Before:** a new empty conversation was created (preview showed "X reacted with :emoji:", but the thread had no history), and the reaction never appeared on the original message. The same happened in WhatsApp groups. Separately, an incoming customer reaction on an already-answered conversation pushed it back into "Unattended" and left it stuck there (removing the reaction did not clear it).

**After:** the reaction is recorded on the original message in the resolved conversation, no stray conversation is created, and a customer reaction no longer flips an attended conversation back to unattended.

## What changed

- `set_conversation` (`incoming_message_base_service.rb`) anchors reactions to the target message's conversation via an inbox-scoped `source_id` lookup, mirroring the existing reaction-removal flow; falls back to the normal reopen logic when the target isn't stored locally. Baileys overrides `reaction_target_external_id` to read the id straight from the raw webhook.
- `group_contact_message_handler` anchors group reactions the same way before `find_or_create_group_conversation`.
- `set_waiting_since_on_incoming_message` (`message.rb`) ignores reactions, mirroring the outgoing `human_response?` guard, so a customer reaction never sets `waiting_since`.
- Regression specs for the individual, group, and unattended scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/310)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reactions now attach to the conversation holding their target message, preventing stray group threads.
  * Incoming reactions no longer push resolved conversations back into the waiting/unattended state.

* **Tests**
  * Added regression and integration specs to verify reaction routing and that reactions don’t reopen resolved conversations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fazer-ai/chatwoot/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->