### PR TITLE
fix(conversation): keep messageId scroll a one-shot on conversation view

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/conversation/ConversationView.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ConversationView.vue
@@ -67,6 +67,11 @@ export default {
   data() {
     return {
       showSearchModal: false,
+      // Tracks the messageId we've already scrolled to. `setActiveChat` re-runs
+      // whenever the conversation list length or route state changes (incoming
+      // cables, filters), so this keeps the query-driven scroll a one-shot and
+      // stops it from yanking the viewport back on every list update.
+      scrolledToMessageId: null,
     };
   },
   computed: {
@@ -100,6 +105,9 @@ export default {
   },
   watch: {
     conversationId() {
+      // Switching conversations clears the consumed marker so a fresh
+      // messageId on the next conversation is honored.
+      this.scrolledToMessageId = null;
       this.fetchConversationIfUnavailable();
     },
   },
@@ -171,16 +179,23 @@ export default {
         }
 
         const { messageId } = this.$route.query;
+        // The query messageId is a one-shot "jump to this message" instruction.
+        // Treat it as actionable only the first time we see it; re-runs of this
+        // method (list-length/route watchers) must not re-scroll to it.
+        const shouldScrollToMessage =
+          messageId && messageId !== this.scrolledToMessageId;
 
         // Same conversation but new messageId — fetch around that message
         if (selectedConversation.id === this.currentChat.id) {
-          if (messageId) {
+          if (shouldScrollToMessage) {
+            this.scrolledToMessageId = messageId;
             this.scrollToMessageById(messageId);
           }
           return;
         }
 
-        if (messageId) {
+        if (shouldScrollToMessage) {
+          this.scrolledToMessageId = messageId;
           const dismissSearch = usePendingAlert(
             this.$t('SCHEDULED_MESSAGES.ITEM.SEARCHING_MESSAGE')
           );


### PR DESCRIPTION
Ao abrir uma conversa a partir de um resultado de busca ou de uma mensagem agendada, a URL ganha `?messageId=<id>` e a tela rola até essa mensagem, destacando-a. Esse salto deveria acontecer só uma vez. Na prática, ele era re-disparado sozinho sempre que a lista de conversas mudava de tamanho (uma conversa nova chegando via WhatsApp, por exemplo), arrastando o usuário de volta para a mensagem enquanto ele lia outra parte do histórico.

## How to reproduce
1. Abra uma conversa por um resultado de busca ou pelo "ir até a mensagem" de uma mensagem agendada (a URL fica com `?messageId=X`).
2. Role manualmente para outro ponto da conversa.
3. Faça chegar uma conversa nova na lista (ex.: mensagem de outro contato).
4. Antes: o viewport pulava de volta para a mensagem linkada. Depois: permanece onde o usuário deixou.

## What changed
`setActiveChat` em `ConversationView.vue` re-executa a cada mudança de `chatList.length` e de `$store.state.route` (cables de entrada, filtros). Como o `messageId` permanecia na query, cada re-execução relia o valor e re-disparava o scroll.

- Passa a rastrear o `messageId` já consumido (`scrolledToMessageId`) e só age sobre ele quando muda.
- Reseta o marcador ao trocar de conversa, para que um novo `messageId` na conversa seguinte continue sendo honrado.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/311)
<!-- Reviewable:end -->
