### PR TITLE
feat(whatsapp): capture click-to-WhatsApp ad referral on inbound messages

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Base.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Base.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 
 import MessageMeta from '../MessageMeta.vue';
+import ReferralCard from './ReferralCard.vue';
 
 import { emitter } from 'shared/helpers/mitt';
 import { useMessageContext } from '../provider.js';
@@ -21,8 +22,12 @@ const {
   inReplyTo,
   shouldGroupWithNext,
   additionalAttributes,
+  contentAttributes,
 } = useMessageContext();
 const { t } = useI18n();
+
+// Click-to-WhatsApp ad metadata attached to the first message after an ad click.
+const referral = computed(() => contentAttributes.value?.referral);
 
 const varaintBaseMap = {
   [MESSAGE_VARIANTS.AGENT]: 'bg-n-solid-blue text-n-slate-12',
@@ -122,6 +127,7 @@ const replyToPreview = computed(() => {
       },
     ]"
   >
+    <ReferralCard v-if="referral" :referral="referral" />
     <div
       v-if="inReplyTo"
       class="p-2 -mx-1 mb-2 rounded-lg cursor-pointer bg-n-alpha-black1"

--- a/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
@@ -18,16 +18,28 @@ const hasImageError = ref(false);
 const showImage = computed(
   () => Boolean(props.referral.thumbnailUrl) && !hasImageError.value
 );
+
+// Only treat the ad source as a link when it's a well-formed http(s) URL, so a
+// malicious referral can't smuggle an unsafe scheme (e.g. javascript:) into href.
+const adUrl = computed(() => {
+  const url = props.referral.sourceUrl;
+  if (!url) return null;
+  try {
+    return ['http:', 'https:'].includes(new URL(url).protocol) ? url : null;
+  } catch {
+    return null;
+  }
+});
 </script>
 
 <template>
   <component
-    :is="referral.sourceUrl ? 'a' : 'div'"
-    :href="referral.sourceUrl || undefined"
-    :target="referral.sourceUrl ? '_blank' : undefined"
+    :is="adUrl ? 'a' : 'div'"
+    :href="adUrl || undefined"
+    :target="adUrl ? '_blank' : undefined"
     rel="noopener noreferrer"
     class="flex flex-col gap-2 p-2 -mx-1 mb-2 overflow-hidden no-underline rounded-lg bg-n-alpha-black1"
-    :class="referral.sourceUrl ? 'cursor-pointer hover:bg-n-alpha-black2' : ''"
+    :class="adUrl ? 'cursor-pointer hover:bg-n-alpha-black2' : ''"
   >
     <div class="flex items-center gap-1 text-xs text-n-slate-11">
       <Icon icon="i-lucide-megaphone" class="size-3" />
@@ -48,7 +60,7 @@ const showImage = computed(
       </p>
     </div>
     <div
-      v-if="referral.sourceUrl"
+      v-if="adUrl"
       class="flex items-center gap-1 text-xs font-medium text-n-slate-12"
     >
       <Icon icon="i-lucide-external-link" class="size-3 shrink-0" />

--- a/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
@@ -7,6 +7,14 @@ const props = defineProps({
   referral: {
     type: Object,
     required: true,
+    // Webhook-derived payload — guard the string fields the template renders so a
+    // malformed referral warns in dev instead of silently rendering a broken card.
+    validator: value =>
+      value != null &&
+      typeof value === 'object' &&
+      ['title', 'body', 'sourceUrl', 'thumbnailUrl'].every(
+        key => value[key] == null || typeof value[key] === 'string'
+      ),
   },
 });
 

--- a/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
@@ -1,0 +1,58 @@
+<script setup>
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Icon from 'next/icon/Icon.vue';
+
+const props = defineProps({
+  referral: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { t } = useI18n();
+
+// content_attributes keys are deep-camelized by MessageList (useCamelCase),
+// so the referral payload arrives as sourceUrl/thumbnailUrl/etc.
+const hasImageError = ref(false);
+const showImage = computed(
+  () => Boolean(props.referral.thumbnailUrl) && !hasImageError.value
+);
+</script>
+
+<template>
+  <component
+    :is="referral.sourceUrl ? 'a' : 'div'"
+    :href="referral.sourceUrl || undefined"
+    :target="referral.sourceUrl ? '_blank' : undefined"
+    rel="noopener noreferrer"
+    class="flex flex-col gap-2 p-2 -mx-1 mb-2 overflow-hidden no-underline rounded-lg bg-n-alpha-black1"
+    :class="referral.sourceUrl ? 'cursor-pointer hover:bg-n-alpha-black2' : ''"
+  >
+    <div class="flex items-center gap-1 text-xs text-n-slate-11">
+      <Icon icon="i-lucide-megaphone" class="size-3" />
+      <span>{{ t('COMPONENTS.REFERRAL_CARD.AD_LABEL') }}</span>
+    </div>
+    <img
+      v-if="showImage"
+      :src="referral.thumbnailUrl"
+      class="object-cover w-full rounded max-h-44 skip-context-menu"
+      @error="hasImageError = true"
+    />
+    <div class="min-w-0">
+      <p v-if="referral.title" class="mb-0 text-sm font-medium line-clamp-2">
+        {{ referral.title }}
+      </p>
+      <p v-if="referral.body" class="mb-0 text-xs text-n-slate-11 line-clamp-2">
+        {{ referral.body }}
+      </p>
+    </div>
+    <div
+      v-if="referral.sourceUrl"
+      class="flex items-center gap-1 text-xs font-medium text-n-slate-12"
+    >
+      <Icon icon="i-lucide-external-link" class="size-3 shrink-0" />
+      <span>{{ t('COMPONENTS.REFERRAL_CARD.VIEW_AD') }}</span>
+    </div>
+  </component>
+</template>

--- a/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
@@ -48,6 +48,7 @@ const adUrl = computed(() => {
     <img
       v-if="showImage"
       :src="referral.thumbnailUrl"
+      :alt="referral.title || ''"
       class="object-cover w-full rounded max-h-44 skip-context-menu"
       @error="hasImageError = true"
     />

--- a/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/ReferralCard.vue
@@ -22,22 +22,27 @@ const { t } = useI18n();
 
 // content_attributes keys are deep-camelized by MessageList (useCamelCase),
 // so the referral payload arrives as sourceUrl/thumbnailUrl/etc.
-const hasImageError = ref(false);
-const showImage = computed(
-  () => Boolean(props.referral.thumbnailUrl) && !hasImageError.value
-);
 
-// Only treat the ad source as a link when it's a well-formed http(s) URL, so a
-// malicious referral can't smuggle an unsafe scheme (e.g. javascript:) into href.
-const adUrl = computed(() => {
-  const url = props.referral.sourceUrl;
+// Both the ad link (href) and the thumbnail (img src) come from the webhook, so
+// only accept well-formed http(s) URLs: this keeps an unsafe scheme (e.g.
+// javascript:) out of the link and stops an arbitrary URL from triggering a
+// request from the agent's browser through the image.
+const toHttpUrl = url => {
   if (!url) return null;
   try {
     return ['http:', 'https:'].includes(new URL(url).protocol) ? url : null;
   } catch {
     return null;
   }
-});
+};
+
+const adUrl = computed(() => toHttpUrl(props.referral.sourceUrl));
+const imageUrl = computed(() => toHttpUrl(props.referral.thumbnailUrl));
+
+const hasImageError = ref(false);
+const showImage = computed(
+  () => Boolean(imageUrl.value) && !hasImageError.value
+);
 </script>
 
 <template>
@@ -55,7 +60,7 @@ const adUrl = computed(() => {
     </div>
     <img
       v-if="showImage"
-      :src="referral.thumbnailUrl"
+      :src="imageUrl || undefined"
       :alt="referral.title || ''"
       class="object-cover w-full rounded max-h-44 skip-context-menu"
       @error="hasImageError = true"

--- a/app/javascript/dashboard/components-next/message/provider.js
+++ b/app/javascript/dashboard/components-next/message/provider.js
@@ -66,6 +66,15 @@ const MessageControl = Symbol('MessageControl');
  * @property {EmailContent} [email] - Email content and metadata
  * @property {string|null} [ccEmail] - CC email addresses
  * @property {string|null} [bccEmail] - BCC email addresses
+ * @property {Object} [referral] - Click-to-WhatsApp ad metadata on the first message after an ad click (keys camelized by MessageList)
+ * @property {string} [referral.sourceType] - Ad source type (e.g. 'ad', 'post')
+ * @property {string} [referral.sourceId] - Source ad identifier
+ * @property {string} [referral.sourceUrl] - URL of the ad/post
+ * @property {string} [referral.ctwaClid] - Click-to-WhatsApp click ID
+ * @property {string} [referral.title] - Ad headline/title
+ * @property {string} [referral.body] - Ad body text
+ * @property {string} [referral.mediaType] - Ad media type ('image'|'video'|'none')
+ * @property {string} [referral.thumbnailUrl] - Ad thumbnail URL
  */
 
 /**

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -304,6 +304,10 @@
       "INSTAGRAM_STORY_UNAVAILABLE": "This story is no longer available.",
       "INSTAGRAM_STORY_REPLY": "Replied to your story:"
     },
+    "REFERRAL_CARD": {
+      "AD_LABEL": "From an ad",
+      "VIEW_AD": "View ad"
+    },
     "LOCATION_BUBBLE": {
       "SEE_ON_MAP": "See on map"
     },

--- a/app/javascript/dashboard/i18n/locale/pt_BR/settings.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/settings.json
@@ -304,6 +304,10 @@
       "INSTAGRAM_STORY_UNAVAILABLE": "Este story não está mais disponível.",
       "INSTAGRAM_STORY_REPLY": "Respondido ao seu story:"
     },
+    "REFERRAL_CARD": {
+      "AD_LABEL": "Veio de um anúncio",
+      "VIEW_AD": "Ver anúncio"
+    },
     "LOCATION_BUBBLE": {
       "SEE_ON_MAP": "Ver Localização"
     },

--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -6,6 +6,7 @@ class Webhooks::WhatsappEventsJob < MutexApplicationJob
   retry_on LockAcquisitionError, wait: 2.seconds, attempts: 20
 
   def perform(params = {})
+    dump_raw_payload(params)
     channel = find_channel_from_whatsapp_business_payload(params)
 
     if channel_is_inactive?(channel)
@@ -90,6 +91,16 @@ class Webhooks::WhatsappEventsJob < MutexApplicationJob
   end
 
   private
+
+  # Debug aid: set WHATSAPP_WEBHOOK_DEBUG=true to log the raw inbound webhook
+  # payload (Baileys or Cloud) so you can capture a real Click-to-WhatsApp ad
+  # referral / externalAdReply and replay it later. Off by default since it
+  # logs full message content.
+  def dump_raw_payload(params)
+    return unless ActiveModel::Type::Boolean.new.cast(ENV.fetch('WHATSAPP_WEBHOOK_DEBUG', false))
+
+    Rails.logger.info("[WhatsappWebhookDebug] #{params.to_json}")
+  end
 
   # Echo payloads reverse the fields — `from` is the business number and `to` is the contact.
   # Returns nil for status-only webhooks so they bypass the lock.

--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -92,11 +92,12 @@ class Webhooks::WhatsappEventsJob < MutexApplicationJob
 
   private
 
-  # Debug aid: set WHATSAPP_WEBHOOK_DEBUG=true to log the raw inbound webhook
-  # payload (Baileys or Cloud) so you can capture a real Click-to-WhatsApp ad
-  # referral / externalAdReply and replay it later. Off by default since it
-  # logs full message content.
+  # Debug aid for non-production only: set WHATSAPP_WEBHOOK_DEBUG=true to log the
+  # raw inbound webhook payload (Baileys or Cloud) so you can capture a real
+  # Click-to-WhatsApp ad referral / externalAdReply and replay it later. Logs
+  # full message content, so it never runs in production and is off by default.
   def dump_raw_payload(params)
+    return if Rails.env.production?
     return unless ActiveModel::Type::Boolean.new.cast(ENV.fetch('WHATSAPP_WEBHOOK_DEBUG', false))
 
     Rails.logger.info("[WhatsappWebhookDebug] #{params.to_json}")

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -115,11 +115,12 @@ class Message < ApplicationRecord
   # [:is_reaction] : Used to denote if the message is a reaction and differentiate it from a simple reply message
   # [:is_edited, :previous_content] : Used to indicated edited message and previous content (before edit)
   # [:zapi_args] : Used to pass additional arguments specific to Z-API WhatsApp provider
+  # [:referral] : Click-to-WhatsApp ad metadata (source ad, headline, ctwa_clid, ...) attached to the first message after an ad click
 
   store :content_attributes, accessors: [:submitted_email, :items, :submitted_values, :email, :in_reply_to, :deleted,
                                          :external_created_at, :story_sender, :story_id, :external_error,
                                          :translations, :in_reply_to_external_id, :is_unsupported, :data,
-                                         :is_reaction, :is_edited, :previous_content, :zapi_args], coder: JSON
+                                         :is_reaction, :is_edited, :previous_content, :zapi_args, :referral], coder: JSON
 
   store :external_source_ids, accessors: [:slack], coder: JSON, prefix: :external_source_id
 

--- a/app/services/whatsapp/baileys_handlers/concerns/individual_contact_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/individual_contact_message_handler.rb
@@ -33,12 +33,21 @@ module Whatsapp::BaileysHandlers::Concerns::IndividualContactMessageHandler
       # set_conversation so a blank webhook can't open/create a stray thread.
       next mark_existing_reaction_as_removed(sender: @contact) if reaction_removal?
 
+      set_first_touch_attribution
       set_conversation
       handle_create_message
       dispatch_incoming_typing_off
     end
   ensure
     clear_message_source_id_from_redis if @lock_acquired
+  end
+
+  # First-touch attribution: set before set_conversation so conversation_params
+  # can persist it on the conversation created from this originating message.
+  def set_first_touch_attribution
+    context_info = message_context_info
+    @referral = normalize_baileys_referral(context_info)
+    @entry_point = normalize_baileys_entry_point(context_info)
   end
 
   def dispatch_incoming_typing_off

--- a/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
@@ -97,6 +97,9 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler
       content_attributes[:is_unsupported] = true
     end
 
+    referral = normalize_baileys_referral(message_context_info)
+    content_attributes[:referral] = referral if referral.present?
+
     content_attributes
   end
 

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -41,7 +41,11 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
 
   def message_type # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength,Metrics/AbcSize
     msg = unwrap_ephemeral_message(@raw_message[:message])
-    if msg.key?(:conversation) || msg.dig(:extendedTextMessage, :text).present?
+    # A Click-to-WhatsApp ad-click can arrive as an extendedTextMessage carrying
+    # only the ad context (no text). Classify it as text so it renders with the
+    # ad headline/body as fallback content instead of being dropped/unsupported.
+    if msg.key?(:conversation) || msg.dig(:extendedTextMessage, :text).present? ||
+       msg.dig(:extendedTextMessage, :contextInfo, :externalAdReply).present?
       'text'
     elsif msg.key?(:imageMessage)
       'image'
@@ -69,12 +73,13 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     end
   end
 
-  def message_content # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength
+  def message_content # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength,Metrics/AbcSize
     msg = unwrap_ephemeral_message(@raw_message[:message])
     case message_type
     when 'text'
       text = msg[:conversation] || msg.dig(:extendedTextMessage, :text)
       context_info = msg.dig(:extendedTextMessage, :contextInfo)
+      text = baileys_referral_fallback_content(context_info) if text.blank?
       convert_incoming_mentions(text, context_info)
     when 'image'
       msg.dig(:imageMessage, :caption)
@@ -114,6 +119,29 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
                   end
 
     msg.dig(message_key, :contextInfo, :stanzaId) if message_key
+  end
+
+  # Returns the `contextInfo` for the current message type, where the
+  # Click-to-WhatsApp ad metadata (`externalAdReply`) lives.
+  def message_context_info # rubocop:disable Metrics/CyclomaticComplexity
+    msg = unwrap_ephemeral_message(@raw_message[:message])
+    case message_type
+    when 'text' then msg.dig(:extendedTextMessage, :contextInfo)
+    when 'image' then msg.dig(:imageMessage, :contextInfo)
+    when 'video' then msg.dig(:videoMessage, :contextInfo)
+    when 'audio' then msg.dig(:audioMessage, :contextInfo)
+    when 'sticker' then msg.dig(:stickerMessage, :contextInfo)
+    when 'file'
+      msg.dig(:documentMessage, :contextInfo).presence ||
+        msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :contextInfo)
+    end
+  end
+
+  def baileys_referral_fallback_content(context_info)
+    ad = context_info&.dig(:externalAdReply)
+    return if ad.blank?
+
+    ad[:title].presence || ad[:body].presence
   end
 
   def file_content_type

--- a/app/services/whatsapp/baileys_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_upsert.rb
@@ -14,6 +14,8 @@ module Whatsapp::BaileysHandlers::MessagesUpsert
       @message = nil
       @contact_inbox = nil
       @contact = nil
+      @referral = nil
+      @entry_point = nil
       @raw_message = message
 
       next handle_message if incoming?

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -262,10 +262,11 @@ class Whatsapp::IncomingMessageBaseService # rubocop:disable Metrics/ClassLength
   # only the keys still missing so a genuine first touch is never overwritten.
   def backfill_first_touch_attribution
     attribution = { 'referral' => @referral, 'entry_point' => @entry_point }.compact
-    missing = attribution.reject { |key, _| @conversation.additional_attributes.key?(key) }
+    existing_attributes = @conversation.additional_attributes || {}
+    missing = attribution.reject { |key, _| existing_attributes.key?(key) }
     return if missing.blank?
 
-    @conversation.update!(additional_attributes: @conversation.additional_attributes.merge(missing))
+    @conversation.update!(additional_attributes: existing_attributes.merge(missing))
   end
 
   def conversation_for_reaction

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -252,9 +252,20 @@ class Whatsapp::IncomingMessageBaseService # rubocop:disable Metrics/ClassLength
     # Mirrors the inbox-scoped lookup used by the reaction-removal flow; falls back
     # to the normal logic when the target isn't stored locally.
     @conversation = conversation_for_reaction || conversation_by_inbox_config
-    return if @conversation
+    return backfill_first_touch_attribution if @conversation
 
     @conversation = ::Conversation.create!(conversation_params)
+  end
+
+  # When the inbound message reuses an existing thread (active/reopened), the
+  # attribution conversation_params would have set on create never lands. Backfill
+  # only the keys still missing so a genuine first touch is never overwritten.
+  def backfill_first_touch_attribution
+    attribution = { 'referral' => @referral, 'entry_point' => @entry_point }.compact
+    missing = attribution.reject { |key, _| @conversation.additional_attributes.key?(key) }
+    return if missing.blank?
+
+    @conversation.update!(additional_attributes: @conversation.additional_attributes.merge(missing))
   end
 
   def conversation_for_reaction

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -52,6 +52,7 @@ class Whatsapp::IncomingMessageBaseService # rubocop:disable Metrics/ClassLength
       # just to no-op. The match is sender-agnostic on purpose; the precise
       # filter happens inside `mark_existing_reaction_as_removed`.
       process_in_reply_to(messages_data.first)
+      @referral = normalize_cloud_referral(messages_data.first)
       next if reaction_removal? && !existing_reaction_row?
 
       set_contact
@@ -78,6 +79,11 @@ class Whatsapp::IncomingMessageBaseService # rubocop:disable Metrics/ClassLength
   end
 
   def skip_message?
+    # Don't drop a Click-to-WhatsApp ad-click webhook even when its type would
+    # otherwise be unprocessable (e.g. request_welcome): the ad referral is the
+    # whole point of the message and must be persisted.
+    return false if normalize_cloud_referral(messages_data.first).present?
+
     unprocessable_message_type?(message_type)
   end
 
@@ -277,7 +283,7 @@ class Whatsapp::IncomingMessageBaseService # rubocop:disable Metrics/ClassLength
   end
 
   def attach_files
-    return if %w[text button interactive location contacts reaction].include?(message_type)
+    return if %w[text button interactive location contacts reaction request_welcome unsupported].include?(message_type)
 
     attachment_payload = messages_data.first[message_type.to_sym]
     @message.content ||= attachment_payload[:caption]
@@ -329,6 +335,8 @@ class Whatsapp::IncomingMessageBaseService # rubocop:disable Metrics/ClassLength
     content_attrs[:in_reply_to_external_id] = @in_reply_to_external_id if @in_reply_to_external_id.present?
     content_attrs[:external_created_at] = message[:timestamp].to_i
     content_attrs[:is_reaction] = true if message_type == 'reaction'
+    referral = normalize_cloud_referral(message)
+    content_attrs[:referral] = referral if referral.present?
     content_attrs
   end
 

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -1,15 +1,21 @@
-module Whatsapp::IncomingMessageServiceHelpers
+module Whatsapp::IncomingMessageServiceHelpers # rubocop:disable Metrics/ModuleLength
   def download_attachment_file(attachment_payload)
     Down.download(inbox.channel.media_url(attachment_payload[:id]), headers: inbox.channel.api_headers)
   end
 
   def conversation_params
-    {
+    params = {
       account_id: @inbox.account_id,
       inbox_id: @inbox.id,
       contact_id: @contact.id,
       contact_inbox_id: @contact_inbox.id
     }
+    # First-touch attribution persisted only when the conversation is created from
+    # the originating message: the rich ad/post referral (externalAdReply) and/or
+    # the WhatsApp entry point (e.g. click_to_chat_link from a profile/bio link).
+    attribution = { referral: @referral, entry_point: @entry_point }.compact
+    params[:additional_attributes] = attribution if attribution.present?
+    params
   end
 
   def processed_params
@@ -31,7 +37,73 @@ module Whatsapp::IncomingMessageServiceHelpers
       message.dig(:interactive, :button_reply, :title) ||
       message.dig(:interactive, :list_reply, :title) ||
       message.dig(:name, :formatted_name) ||
-      message.dig(:reaction, :emoji)
+      message.dig(:reaction, :emoji) ||
+      referral_fallback_content(message)
+  end
+
+  # Ad-click webhooks can arrive with no textual body (e.g. request_welcome), so
+  # fall back to the ad headline/body to keep the message renderable.
+  def referral_fallback_content(message)
+    ref = message[:referral]
+    return if ref.blank?
+
+    ref[:headline].presence || ref[:body].presence
+  end
+
+  # Normalizes the WhatsApp Cloud API `referral` object (sent on the first
+  # message after a Click-to-WhatsApp ad click) to a provider-agnostic hash.
+  def normalize_cloud_referral(message)
+    ref = message[:referral]
+    return if ref.blank?
+
+    {
+      source_type: ref[:source_type],
+      source_id: ref[:source_id],
+      source_url: ref[:source_url],
+      ctwa_clid: ref[:ctwa_clid],
+      title: ref[:headline],
+      body: ref[:body],
+      media_type: ref[:media_type]&.to_s&.downcase,
+      thumbnail_url: ref[:image_url] || ref[:thumbnail_url] || ref[:video_url]
+    }.compact.presence
+  end
+
+  # Normalizes the Baileys `contextInfo.externalAdReply` to the same shape as
+  # `normalize_cloud_referral` so the frontend reads a single referral payload.
+  def normalize_baileys_referral(context_info)
+    ad = context_info&.dig(:externalAdReply)
+    return if ad.blank?
+
+    {
+      source_type: ad[:sourceType],
+      source_id: ad[:sourceId],
+      source_url: ad[:sourceUrl],
+      ctwa_clid: ad[:ctwaClid],
+      title: ad[:title],
+      body: ad[:body],
+      media_type: baileys_media_type(ad[:mediaType]),
+      thumbnail_url: ad[:thumbnailUrl]
+    }.compact.presence
+  end
+
+  # Baileys serializes the externalAdReply MediaType proto enum as a number
+  # (0=none, 1=image, 2=video), but some layers emit the string name instead.
+  # Handle both so the frontend always gets a lowercase string.
+  def baileys_media_type(value)
+    return if value.nil?
+    return { 0 => 'none', 1 => 'image', 2 => 'video' }[value] if value.is_a?(Integer)
+
+    value.to_s.downcase.presence
+  end
+
+  # Lightweight WhatsApp entry-point attribution from Baileys `contextInfo`.
+  # Present on first-contact messages even without an ad (e.g. a profile/bio
+  # click-to-chat link reports `click_to_chat_link`). Does NOT render the ad card.
+  def normalize_baileys_entry_point(context_info)
+    source = context_info&.dig(:entryPointConversionSource)
+    return if source.blank?
+
+    { source: source, app: context_info[:entryPointConversionApp].presence }.compact.presence
   end
 
   def file_content_type(file_type)

--- a/lib/tasks/whatsapp_replay.rake
+++ b/lib/tasks/whatsapp_replay.rake
@@ -18,10 +18,16 @@ namespace :whatsapp do
     phone = args[:phone_number].presence || payload[:phone_number]
     payload[:phone_number] = phone if phone.present?
 
+    # Cloud payloads embed the channel in their metadata; Baileys payloads resolve
+    # the channel from the phone. Fail fast on a Baileys replay with no phone
+    # available instead of silently no-opping inside the events job.
+    cloud_payload = payload[:object] == 'whatsapp_business_account'
+    abort 'Baileys replays require a phone_number argument or payload[:phone_number]' if !cloud_payload && phone.blank?
+
     channel = Channel::Whatsapp.find_by(phone_number: phone) if phone.present?
 
-    # Fail fast on a Baileys-style payload (a phone was given) that resolves to no
-    # channel, instead of silently no-opping inside the events job.
+    # A Baileys-style payload (a phone was given) that resolves to no channel is
+    # also a dead end — abort instead of no-opping inside the events job.
     abort "No WhatsApp channel found for phone #{phone.inspect}" if phone.present? && channel.nil?
 
     # Baileys verifies webhookVerifyToken inside the service, so inject the

--- a/lib/tasks/whatsapp_replay.rake
+++ b/lib/tasks/whatsapp_replay.rake
@@ -24,7 +24,10 @@ namespace :whatsapp do
     cloud_payload = payload[:object] == 'whatsapp_business_account'
     abort 'Baileys replays require a phone_number argument or payload[:phone_number]' if !cloud_payload && phone.blank?
 
-    channel = Channel::Whatsapp.find_by(phone_number: phone) if phone.present?
+    # Only resolve a channel for non-cloud (Baileys) replays: cloud payloads route
+    # from embedded metadata, so an optional/stale phone must not pull in a channel
+    # here (which could misprint the destination or inject a Baileys token).
+    channel = Channel::Whatsapp.find_by(phone_number: phone) if phone.present? && !cloud_payload
 
     # A non-cloud payload (a phone was given) that resolves to no channel is a
     # dead end — abort instead of no-opping inside the events job. Cloud replays

--- a/lib/tasks/whatsapp_replay.rake
+++ b/lib/tasks/whatsapp_replay.rake
@@ -37,7 +37,8 @@ namespace :whatsapp do
     end
 
     Rails.logger.info("[whatsapp:replay_webhook] replaying #{args[:path]} (phone=#{phone.inspect})")
-    puts "Replaying #{args[:path]}#{" -> #{channel.name} (#{channel.provider})" if channel}"
+    destination = " -> #{channel.name} (#{channel.provider})" if channel
+    puts "Replaying #{args[:path]}#{destination}"
     Webhooks::WhatsappEventsJob.perform_now(payload)
     puts 'Done. Check the conversation / last message in the inbox.'
   end

--- a/lib/tasks/whatsapp_replay.rake
+++ b/lib/tasks/whatsapp_replay.rake
@@ -20,6 +20,10 @@ namespace :whatsapp do
 
     channel = Channel::Whatsapp.find_by(phone_number: phone) if phone.present?
 
+    # Fail fast on a Baileys-style payload (a phone was given) that resolves to no
+    # channel, instead of silently no-opping inside the events job.
+    abort "No WhatsApp channel found for phone #{phone.inspect}" if phone.present? && channel.nil?
+
     # Baileys verifies webhookVerifyToken inside the service, so inject the
     # channel's token (captured payloads usually omit/filter it).
     if channel&.provider == 'baileys' && payload[:webhookVerifyToken].blank?

--- a/lib/tasks/whatsapp_replay.rake
+++ b/lib/tasks/whatsapp_replay.rake
@@ -30,6 +30,10 @@ namespace :whatsapp do
     # also a dead end — abort instead of no-opping inside the events job.
     abort "No WhatsApp channel found for phone #{phone.inspect}" if phone.present? && channel.nil?
 
+    # A non-cloud payload must run through the Baileys parser; if the phone maps to
+    # a Cloud/Z-API channel the events job would misroute it, so fail fast.
+    abort "Baileys replays must target a Baileys channel, got #{channel.provider.inspect}" if !cloud_payload && channel.provider != 'baileys'
+
     # Baileys verifies webhookVerifyToken inside the service, so inject the
     # channel's token (captured payloads usually omit/filter it).
     if channel&.provider == 'baileys' && payload[:webhookVerifyToken].blank?

--- a/lib/tasks/whatsapp_replay.rake
+++ b/lib/tasks/whatsapp_replay.rake
@@ -1,0 +1,34 @@
+namespace :whatsapp do
+  # Replays a captured WhatsApp webhook payload (Baileys or Cloud) through the
+  # real ingestion pipeline (Webhooks::WhatsappEventsJob), bypassing the HTTP
+  # controller so you don't need the Meta signature (Cloud) or a live request.
+  #
+  # Usage:
+  #   bundle exec rails "whatsapp:replay_webhook[tmp/payload.json]"
+  #   bundle exec rails "whatsapp:replay_webhook[tmp/payload.json,+5511936199421]"
+  #
+  # The phone_number arg is required for Baileys payloads (used to find the
+  # channel and inject its webhook_verify_token). Cloud payloads resolve the
+  # channel from the embedded metadata, so the arg is optional there.
+  desc 'Replay a captured WhatsApp webhook payload (Baileys/Cloud) through the parser'
+  task :replay_webhook, %i[path phone_number] => :environment do |_task, args|
+    raise 'usage: rake "whatsapp:replay_webhook[path/to/payload.json,+55...]"' if args[:path].blank?
+
+    payload = JSON.parse(File.read(args[:path])).with_indifferent_access
+    phone = args[:phone_number].presence || payload[:phone_number]
+    payload[:phone_number] = phone if phone.present?
+
+    channel = Channel::Whatsapp.find_by(phone_number: phone) if phone.present?
+
+    # Baileys verifies webhookVerifyToken inside the service, so inject the
+    # channel's token (captured payloads usually omit/filter it).
+    if channel&.provider == 'baileys' && payload[:webhookVerifyToken].blank?
+      payload[:webhookVerifyToken] = channel.provider_config['webhook_verify_token']
+    end
+
+    Rails.logger.info("[whatsapp:replay_webhook] replaying #{args[:path]} (phone=#{phone.inspect})")
+    puts "Replaying #{args[:path]}#{" -> #{channel.name} (#{channel.provider})" if channel}"
+    Webhooks::WhatsappEventsJob.perform_now(payload)
+    puts 'Done. Check the conversation / last message in the inbox.'
+  end
+end

--- a/lib/tasks/whatsapp_replay.rake
+++ b/lib/tasks/whatsapp_replay.rake
@@ -12,7 +12,7 @@ namespace :whatsapp do
   # channel from the embedded metadata, so the arg is optional there.
   desc 'Replay a captured WhatsApp webhook payload (Baileys/Cloud) through the parser'
   task :replay_webhook, %i[path phone_number] => :environment do |_task, args|
-    raise 'usage: rake "whatsapp:replay_webhook[path/to/payload.json,+55...]"' if args[:path].blank?
+    abort 'usage: rake "whatsapp:replay_webhook[path/to/payload.json,+55...]"' if args[:path].blank?
 
     payload = JSON.parse(File.read(args[:path])).with_indifferent_access
     phone = args[:phone_number].presence || payload[:phone_number]
@@ -26,9 +26,10 @@ namespace :whatsapp do
 
     channel = Channel::Whatsapp.find_by(phone_number: phone) if phone.present?
 
-    # A Baileys-style payload (a phone was given) that resolves to no channel is
-    # also a dead end — abort instead of no-opping inside the events job.
-    abort "No WhatsApp channel found for phone #{phone.inspect}" if phone.present? && channel.nil?
+    # A non-cloud payload (a phone was given) that resolves to no channel is a
+    # dead end — abort instead of no-opping inside the events job. Cloud replays
+    # resolve the channel from embedded metadata, so a stale phone must not fail them.
+    abort "No WhatsApp channel found for phone #{phone.inspect}" if phone.present? && channel.nil? && !cloud_payload
 
     # A non-cloud payload must run through the Baileys parser; if the phone maps to
     # a Cloud/Z-API channel the events job would misroute it, so fail fast.

--- a/spec/fixtures/files/whatsapp/baileys_ctwa_ad.json
+++ b/spec/fixtures/files/whatsapp/baileys_ctwa_ad.json
@@ -1,0 +1,45 @@
+{
+  "event": "messages.upsert",
+  "data": {
+    "type": "notify",
+    "messages": [
+      {
+        "key": {
+          "remoteJid": "44778899@lid",
+          "remoteJidAlt": "5511922221111@s.whatsapp.net",
+          "fromMe": false,
+          "id": "BAILEYS_CTWA_AD_FIXTURE",
+          "addressingMode": "lid"
+        },
+        "messageTimestamp": 1764178999,
+        "pushName": "Lead Video Ad",
+        "message": {
+          "extendedTextMessage": {
+            "text": "Quero agendar minha avaliacao",
+            "previewType": 0,
+            "contextInfo": {
+              "conversionSource": "FB_Ads",
+              "entryPointConversionSource": "ctwa_ad",
+              "entryPointConversionApp": "facebook",
+              "ctwaSignals": "all,all",
+              "externalAdReply": {
+                "title": "Agende ja sua Avaliacao",
+                "body": "LEGENDA Y PRODUTO X",
+                "mediaType": 2,
+                "thumbnailUrl": "https://scontent.xx.fbcdn.net/v/thumb.jpg",
+                "mediaUrl": "https://www.facebook.com/criativox/videos/123456789",
+                "sourceType": "ad",
+                "sourceId": "1120214541917380261",
+                "sourceUrl": "https://fb.me/criativox",
+                "containsAutoReply": false,
+                "renderLargerThumbnail": true,
+                "showAdAttribution": true,
+                "ctwaClid": "AaRDg86i-z5_xrIOfs9Adr1example"
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/files/whatsapp/cloud_ctwa_referral.json
+++ b/spec/fixtures/files/whatsapp/cloud_ctwa_referral.json
@@ -1,0 +1,38 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "WHATSAPP_BUSINESS_ACCOUNT_ID",
+      "changes": [
+        {
+          "field": "messages",
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": { "display_phone_number": "15550001111", "phone_number_id": "111222333" },
+            "contacts": [{ "profile": { "name": "Lead Cloud Ad" }, "wa_id": "5511955551111" }],
+            "messages": [
+              {
+                "from": "5511955551111",
+                "id": "wamid.CLOUD_CTWA_FIXTURE",
+                "timestamp": "1764178999",
+                "type": "text",
+                "text": { "body": "Vim pelo anuncio, quero saber mais" },
+                "referral": {
+                  "source_url": "https://fb.me/criativox",
+                  "source_id": "1120214541917380261",
+                  "source_type": "ad",
+                  "headline": "Agende ja sua Avaliacao",
+                  "body": "LEGENDA Y PRODUTO X",
+                  "media_type": "video",
+                  "image_url": "https://scontent.xx.fbcdn.net/v/thumb.jpg",
+                  "video_url": "https://video.example/ad.mp4",
+                  "ctwa_clid": "AaRDg86i-z5_xrIOfs9Adr1example"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -949,5 +949,37 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
         expect(message.conversation.additional_attributes['entry_point']).to eq('source' => 'click_to_chat_link')
       end
     end
+
+    context 'when a later message reuses the conversation' do
+      it 'preserves the original ad attribution (first touch wins)' do
+        first = ad_params(
+          { extendedTextMessage: { text: 'Oi, vi o anúncio', contextInfo: { externalAdReply: external_ad_reply } } },
+          id: 'ad_msg_first_touch_1'
+        )
+        follow_up = ad_params({ extendedTextMessage: { text: 'seguindo a conversa' } }, id: 'ad_msg_first_touch_2')
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: first).perform
+        conversation = inbox.messages.last.conversation
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: follow_up).perform
+
+        expect(conversation.reload.additional_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
+      end
+
+      it 'backfills attribution when the reused conversation had none' do
+        plain = ad_params({ extendedTextMessage: { text: 'oi, tudo bem?' } }, id: 'ad_msg_backfill_1')
+        ad = ad_params(
+          { extendedTextMessage: { text: 'agora vi o anúncio', contextInfo: { externalAdReply: external_ad_reply } } },
+          id: 'ad_msg_backfill_2'
+        )
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: plain).perform
+        conversation = inbox.messages.last.conversation
+        expect(conversation.additional_attributes['referral']).to be_nil
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: ad).perform
+
+        expect(conversation.reload.additional_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
+      end
+    end
   end
 end

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -862,9 +862,11 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       }
     end
 
-    def ad_params(message)
+    # Each example needs a distinct id so the MESSAGE_SOURCE_KEY dedupe doesn't
+    # short-circuit later examples based on execution order.
+    def ad_params(message, id:)
       raw_message = {
-        key: { id: 'ad_msg_1', remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false, addressingMode: 'pn' },
+        key: { id: id, remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false, addressingMode: 'pn' },
         pushName: 'Lead Anúncio',
         messageTimestamp: timestamp,
         message: message
@@ -874,7 +876,10 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
 
     context 'when a text message carries an externalAdReply' do
       it 'persists the referral on the message and the conversation' do
-        params = ad_params(extendedTextMessage: { text: 'Oi, vi o anúncio', contextInfo: { externalAdReply: external_ad_reply } })
+        params = ad_params(
+          { extendedTextMessage: { text: 'Oi, vi o anúncio', contextInfo: { externalAdReply: external_ad_reply } } },
+          id: 'ad_msg_text_1'
+        )
 
         expect do
           Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
@@ -893,7 +898,10 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
 
     context 'when an ad-click message has no text body' do
       it 'still creates a renderable message using the ad headline as content' do
-        params = ad_params(extendedTextMessage: { contextInfo: { externalAdReply: external_ad_reply } })
+        params = ad_params(
+          { extendedTextMessage: { contextInfo: { externalAdReply: external_ad_reply } } },
+          id: 'ad_msg_headline_fallback_1'
+        )
 
         expect do
           Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
@@ -909,7 +917,10 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
     context 'when externalAdReply mediaType is the numeric proto enum' do
       it 'maps the enum number to the string media type' do
         ad = external_ad_reply.merge(mediaType: 2)
-        params = ad_params(extendedTextMessage: { text: 'oi', contextInfo: { externalAdReply: ad } })
+        params = ad_params(
+          { extendedTextMessage: { text: 'oi', contextInfo: { externalAdReply: ad } } },
+          id: 'ad_msg_numeric_media_1'
+        )
 
         Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
 
@@ -919,10 +930,13 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
 
     context 'when the message comes from a click-to-chat link (no ad)' do
       it 'records the entry point on the conversation without a referral or card' do
-        params = ad_params(extendedTextMessage: {
-                             text: 'oi',
-                             contextInfo: { entryPointConversionSource: 'click_to_chat_link', entryPointConversionApp: '' }
-                           })
+        params = ad_params(
+          { extendedTextMessage: {
+            text: 'oi',
+            contextInfo: { entryPointConversionSource: 'click_to_chat_link', entryPointConversionApp: '' }
+          } },
+          id: 'ad_msg_entry_point_1'
+        )
 
         expect do
           Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -848,7 +848,6 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
 
   describe 'click-to-WhatsApp ad referral and entry-point handling' do
     let(:phone) { '5511912345678' }
-    let(:lid) { '12345678' }
     let(:external_ad_reply) do
       {
         title: 'Promo de Inverno',
@@ -860,6 +859,13 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
         sourceUrl: 'https://fb.me/abc123',
         ctwaClid: 'ARAaCtwaClid123'
       }
+    end
+    let(:lid) { '12345678' }
+
+    # Scope the dedupe cleanup to this inbox so it can't wipe keys other specs
+    # are using against the same Redis DB.
+    after do
+      Redis::Alfred.scan_each(match: "MESSAGE_SOURCE_KEY::#{inbox.id}_*") { |key| Redis::Alfred.delete(key) }
     end
 
     # Each example needs a distinct id so the MESSAGE_SOURCE_KEY dedupe doesn't

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -845,4 +845,95 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
         .not_to raise_error
     end
   end
+
+  describe 'click-to-WhatsApp ad referral and entry-point handling' do
+    let(:phone) { '5511912345678' }
+    let(:lid) { '12345678' }
+    let(:external_ad_reply) do
+      {
+        title: 'Promo de Inverno',
+        body: '50% OFF em tudo',
+        mediaType: 'IMAGE',
+        thumbnailUrl: 'https://example.com/ad-thumb.jpg',
+        sourceType: 'ad',
+        sourceId: '120210000000000',
+        sourceUrl: 'https://fb.me/abc123',
+        ctwaClid: 'ARAaCtwaClid123'
+      }
+    end
+
+    def ad_params(message)
+      raw_message = {
+        key: { id: 'ad_msg_1', remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false, addressingMode: 'pn' },
+        pushName: 'Lead Anúncio',
+        messageTimestamp: timestamp,
+        message: message
+      }
+      { webhookVerifyToken: webhook_verify_token, event: 'messages.upsert', data: { type: 'notify', messages: [raw_message] } }
+    end
+
+    context 'when a text message carries an externalAdReply' do
+      it 'persists the referral on the message and the conversation' do
+        params = ad_params(extendedTextMessage: { text: 'Oi, vi o anúncio', contextInfo: { externalAdReply: external_ad_reply } })
+
+        expect do
+          Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+        end.to change(inbox.messages, :count).by(1)
+
+        message = inbox.messages.last
+        expect(message.content).to eq('Oi, vi o anúncio')
+        expect(message.content_attributes['referral']).to include(
+          'source_type' => 'ad', 'source_id' => '120210000000000', 'source_url' => 'https://fb.me/abc123',
+          'ctwa_clid' => 'ARAaCtwaClid123', 'title' => 'Promo de Inverno', 'body' => '50% OFF em tudo',
+          'media_type' => 'image', 'thumbnail_url' => 'https://example.com/ad-thumb.jpg'
+        )
+        expect(message.conversation.additional_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
+      end
+    end
+
+    context 'when an ad-click message has no text body' do
+      it 'still creates a renderable message using the ad headline as content' do
+        params = ad_params(extendedTextMessage: { contextInfo: { externalAdReply: external_ad_reply } })
+
+        expect do
+          Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+        end.to change(inbox.messages, :count).by(1)
+
+        message = inbox.messages.last
+        expect(message.is_unsupported).to be_falsey
+        expect(message.content).to eq('Promo de Inverno')
+        expect(message.content_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
+      end
+    end
+
+    context 'when externalAdReply mediaType is the numeric proto enum' do
+      it 'maps the enum number to the string media type' do
+        ad = external_ad_reply.merge(mediaType: 2)
+        params = ad_params(extendedTextMessage: { text: 'oi', contextInfo: { externalAdReply: ad } })
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+        expect(inbox.messages.last.content_attributes.dig('referral', 'media_type')).to eq('video')
+      end
+    end
+
+    context 'when the message comes from a click-to-chat link (no ad)' do
+      it 'records the entry point on the conversation without a referral or card' do
+        params = ad_params(extendedTextMessage: {
+                             text: 'oi',
+                             contextInfo: { entryPointConversionSource: 'click_to_chat_link', entryPointConversionApp: '' }
+                           })
+
+        expect do
+          Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+        end.to change(inbox.messages, :count).by(1)
+
+        message = inbox.messages.last
+        expect(message.content).to eq('oi')
+        expect(message.content_attributes['referral']).to be_nil
+        expect(message.conversation.additional_attributes['referral']).to be_nil
+        expect(message.conversation.additional_attributes['entry_point']).to eq('source' => 'click_to_chat_link')
+      end
+    end
+  end
 end

--- a/spec/services/whatsapp/ctwa_referral_real_payload_spec.rb
+++ b/spec/services/whatsapp/ctwa_referral_real_payload_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+# Contract specs backed by real Click-to-WhatsApp ad payload shapes captured from
+# the wild, so a provider serialization change is caught instead of trusting the
+# hand-built hashes elsewhere:
+# - Baileys externalAdReply field names per the WAProto + EvolutionAPI #1252;
+#   mediaType is the numeric proto enum (2 = VIDEO) because our baileys-api
+#   forwards the raw Baileys object via JSON.stringify (no enum->string mapping).
+#   Other wrappers (EvolutionAPI) emit the string "VIDEO"; both are handled.
+# - Cloud referral object per Meta's webhook docs (media_type is a lowercase string).
+describe 'WhatsApp Click-to-WhatsApp referral (real payload shapes)' do # rubocop:disable RSpec/DescribeClass
+  def load_fixture(name)
+    JSON.parse(Rails.root.join('spec/fixtures/files/whatsapp', name).read).with_indifferent_access
+  end
+
+  describe 'Baileys externalAdReply (numeric mediaType)' do
+    let(:webhook_verify_token) { 'valid_token' }
+    let!(:channel) do
+      create(:channel_whatsapp, provider: 'baileys', provider_config: { webhook_verify_token: webhook_verify_token },
+                                validate_provider_config: false, received_messages: false)
+    end
+
+    before do
+      stub_request(:get, /profile-picture-url/).to_return(status: 200, body: { data: { profilePictureUrl: nil } }.to_json)
+    end
+
+    it 'normalizes the real ad payload into referral (message) and entry_point (conversation)' do
+      params = load_fixture('baileys_ctwa_ad.json').merge(webhookVerifyToken: webhook_verify_token)
+
+      Whatsapp::IncomingMessageBaileysService.new(inbox: channel.inbox, params: params).perform
+
+      message = channel.inbox.messages.last
+      expect(message.content_attributes['referral']).to include(
+        'source_type' => 'ad',
+        'source_id' => '1120214541917380261',
+        'source_url' => 'https://fb.me/criativox',
+        'ctwa_clid' => 'AaRDg86i-z5_xrIOfs9Adr1example',
+        'title' => 'Agende ja sua Avaliacao',
+        'media_type' => 'video',
+        'thumbnail_url' => 'https://scontent.xx.fbcdn.net/v/thumb.jpg'
+      )
+      expect(message.conversation.additional_attributes['entry_point']).to eq('source' => 'ctwa_ad', 'app' => 'facebook')
+    end
+  end
+
+  describe 'Cloud referral object' do
+    let!(:channel) { create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false) }
+
+    it 'normalizes the real referral object into the message and conversation' do
+      params = load_fixture('cloud_ctwa_referral.json')
+
+      Whatsapp::IncomingMessageWhatsappCloudService.new(inbox: channel.inbox, params: params).perform
+
+      message = channel.inbox.messages.last
+      expect(message.content_attributes['referral']).to include(
+        'source_type' => 'ad',
+        'source_id' => '1120214541917380261',
+        'ctwa_clid' => 'AaRDg86i-z5_xrIOfs9Adr1example',
+        'title' => 'Agende ja sua Avaliacao',
+        'media_type' => 'video',
+        'thumbnail_url' => 'https://scontent.xx.fbcdn.net/v/thumb.jpg'
+      )
+      expect(message.conversation.additional_attributes['referral']).to include('ctwa_clid' => 'AaRDg86i-z5_xrIOfs9Adr1example')
+    end
+  end
+end

--- a/spec/services/whatsapp/ctwa_referral_real_payload_spec.rb
+++ b/spec/services/whatsapp/ctwa_referral_real_payload_spec.rb
@@ -13,6 +13,10 @@ describe 'WhatsApp Click-to-WhatsApp referral (real payload shapes)' do # ruboco
     JSON.parse(Rails.root.join('spec/fixtures/files/whatsapp', name).read).with_indifferent_access
   end
 
+  after do
+    Redis::Alfred.scan_each(match: 'MESSAGE_SOURCE_KEY::*') { |key| Redis::Alfred.delete(key) }
+  end
+
   describe 'Baileys externalAdReply (numeric mediaType)' do
     let(:webhook_verify_token) { 'valid_token' }
     let!(:channel) do

--- a/spec/services/whatsapp/ctwa_referral_real_payload_spec.rb
+++ b/spec/services/whatsapp/ctwa_referral_real_payload_spec.rb
@@ -13,10 +13,6 @@ describe 'WhatsApp Click-to-WhatsApp referral (real payload shapes)' do # ruboco
     JSON.parse(Rails.root.join('spec/fixtures/files/whatsapp', name).read).with_indifferent_access
   end
 
-  after do
-    Redis::Alfred.scan_each(match: 'MESSAGE_SOURCE_KEY::*') { |key| Redis::Alfred.delete(key) }
-  end
-
   describe 'Baileys externalAdReply (numeric mediaType)' do
     let(:webhook_verify_token) { 'valid_token' }
     let!(:channel) do
@@ -26,6 +22,12 @@ describe 'WhatsApp Click-to-WhatsApp referral (real payload shapes)' do # ruboco
 
     before do
       stub_request(:get, /profile-picture-url/).to_return(status: 200, body: { data: { profilePictureUrl: nil } }.to_json)
+    end
+
+    # Scope the dedupe cleanup to this inbox so it can't wipe keys other specs
+    # are using against the same Redis DB.
+    after do
+      Redis::Alfred.scan_each(match: "MESSAGE_SOURCE_KEY::#{channel.inbox.id}_*") { |key| Redis::Alfred.delete(key) }
     end
 
     it 'normalizes the real ad payload into referral (message) and entry_point (conversation)' do
@@ -49,6 +51,10 @@ describe 'WhatsApp Click-to-WhatsApp referral (real payload shapes)' do # ruboco
 
   describe 'Cloud referral object' do
     let!(:channel) { create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false) }
+
+    after do
+      Redis::Alfred.scan_each(match: "MESSAGE_SOURCE_KEY::#{channel.inbox.id}_*") { |key| Redis::Alfred.delete(key) }
+    end
 
     it 'normalizes the real referral object into the message and conversation' do
       params = load_fixture('cloud_ctwa_referral.json')

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -433,6 +433,7 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         created = whatsapp_channel.inbox.messages.last
         expect(created.content).to eq('Promo de Inverno')
         expect(created.content_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
+        expect(created.conversation.additional_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
       end
     end
   end

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -380,8 +380,11 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
   end
 
   describe '#perform with a click-to-WhatsApp ad referral' do
+    # The service clears its own dedupe key in an ensure; this is a safety net for
+    # any path that bails before the lock, scoped to this inbox so it can't wipe
+    # keys other specs are using against the same Redis DB.
     after do
-      Redis::Alfred.scan_each(match: 'MESSAGE_SOURCE_KEY::*') { |key| Redis::Alfred.delete(key) }
+      Redis::Alfred.scan_each(match: "MESSAGE_SOURCE_KEY::#{whatsapp_channel.inbox.id}_*") { |key| Redis::Alfred.delete(key) }
     end
 
     let!(:whatsapp_channel) { create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false) }
@@ -434,6 +437,21 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         expect(created.content).to eq('Promo de Inverno')
         expect(created.content_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
         expect(created.conversation.additional_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
+      end
+    end
+
+    context 'when a referral arrives on an existing conversation' do
+      it 'backfills the first-touch attribution without overwriting it' do
+        plain = { from: '2423423243', id: 'wamid.plain1', timestamp: '1664799904', type: 'text', text: { body: 'oi' } }
+        described_class.new(inbox: whatsapp_channel.inbox, params: referral_params(plain)).perform
+        conversation = whatsapp_channel.inbox.messages.last.conversation
+        expect(conversation.additional_attributes['referral']).to be_nil
+
+        ad = { from: '2423423243', id: 'wamid.ad2', timestamp: '1664799999', type: 'text',
+               text: { body: 'agora vi o anúncio' }, referral: referral }
+        described_class.new(inbox: whatsapp_channel.inbox, params: referral_params(ad)).perform
+
+        expect(conversation.reload.additional_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
       end
     end
   end

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -441,7 +441,7 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
     end
 
     context 'when a referral arrives on an existing conversation' do
-      it 'backfills the first-touch attribution without overwriting it' do
+      it 'backfills missing attribution and preserves the first touch thereafter' do
         plain = { from: '2423423243', id: 'wamid.plain1', timestamp: '1664799904', type: 'text', text: { body: 'oi' } }
         described_class.new(inbox: whatsapp_channel.inbox, params: referral_params(plain)).perform
         conversation = whatsapp_channel.inbox.messages.last.conversation
@@ -452,6 +452,13 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         described_class.new(inbox: whatsapp_channel.inbox, params: referral_params(ad)).perform
 
         expect(conversation.reload.additional_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
+
+        later_referral = referral.merge(ctwa_clid: 'DIFFERENT_CLID', source_id: '999999999999999')
+        later_ad = { from: '2423423243', id: 'wamid.ad3', timestamp: '1664800000', type: 'text',
+                     text: { body: 'outro anúncio' }, referral: later_referral }
+        described_class.new(inbox: whatsapp_channel.inbox, params: referral_params(later_ad)).perform
+
+        expect(conversation.reload.additional_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123', 'source_id' => '120210000000000')
       end
     end
   end

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -379,6 +379,64 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
     end
   end
 
+  describe '#perform with a click-to-WhatsApp ad referral' do
+    after do
+      Redis::Alfred.scan_each(match: 'MESSAGE_SOURCE_KEY::*') { |key| Redis::Alfred.delete(key) }
+    end
+
+    let!(:whatsapp_channel) { create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false) }
+    let(:referral) do
+      {
+        source_url: 'https://fb.me/abc123', source_id: '120210000000000', source_type: 'ad',
+        headline: 'Promo de Inverno', body: '50% OFF em tudo', media_type: 'image',
+        image_url: 'https://example.com/ad-thumb.jpg', ctwa_clid: 'ARAaCtwaClid123'
+      }
+    end
+
+    def referral_params(message)
+      {
+        phone_number: whatsapp_channel.phone_number,
+        object: 'whatsapp_business_account',
+        entry: [{ changes: [{ value: {
+          contacts: [{ profile: { name: 'Lead Anúncio' }, wa_id: '2423423243' }],
+          messages: [message]
+        } }] }]
+      }.with_indifferent_access
+    end
+
+    context 'when a text message carries a referral object' do
+      it 'persists the referral on the message and the conversation' do
+        message = { from: '2423423243', id: 'wamid.ad1', timestamp: '1664799904', type: 'text',
+                    text: { body: 'Oi, vi o anúncio' }, referral: referral }
+
+        described_class.new(inbox: whatsapp_channel.inbox, params: referral_params(message)).perform
+
+        created = whatsapp_channel.inbox.messages.last
+        expect(created.content).to eq('Oi, vi o anúncio')
+        expect(created.content_attributes['referral']).to include(
+          'source_type' => 'ad', 'source_id' => '120210000000000', 'source_url' => 'https://fb.me/abc123',
+          'ctwa_clid' => 'ARAaCtwaClid123', 'title' => 'Promo de Inverno', 'body' => '50% OFF em tudo',
+          'media_type' => 'image', 'thumbnail_url' => 'https://example.com/ad-thumb.jpg'
+        )
+        expect(created.conversation.additional_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
+      end
+    end
+
+    context 'when a request_welcome message carries a referral object' do
+      it 'is not skipped and creates a renderable message from the ad headline' do
+        message = { from: '2423423243', id: 'wamid.welcome1', timestamp: '1664799904', type: 'request_welcome', referral: referral }
+
+        expect do
+          described_class.new(inbox: whatsapp_channel.inbox, params: referral_params(message)).perform
+        end.to change(whatsapp_channel.inbox.messages, :count).by(1)
+
+        created = whatsapp_channel.inbox.messages.last
+        expect(created.content).to eq('Promo de Inverno')
+        expect(created.content_attributes['referral']).to include('ctwa_clid' => 'ARAaCtwaClid123')
+      end
+    end
+  end
+
   # Métodos auxiliares para reduzir o tamanho do exemplo
 
   def stub_media_url_request


### PR DESCRIPTION
When a lead arrives by tapping a Click-to-WhatsApp ad (Facebook/Instagram), Chatwoot now preserves and surfaces the campaign data instead of dropping it. The first inbound message shows a "from an ad" card (title, description, image, link) in the bubble, and the attribution (source ad, `ctwa_clid`) is stored on the message and on the conversation.

## What changed
- **Backend**: extracts and normalizes Baileys `externalAdReply` and the Cloud API / Coexistence `referral` object into a single `message.content_attributes[:referral]` shape, and stores first-touch attribution on `conversation.additional_attributes`. Handles both numeric and string `mediaType`.
- **Baileys**: ad-click messages with no text body are no longer dropped (they render using the ad headline); also captures the WhatsApp `entry_point` (e.g. `click_to_chat_link`, `ctwa_ad`).
- **Cloud**: webhooks carrying a `referral` are no longer skipped (covers `request_welcome`).
- **Frontend**: new `ReferralCard.vue` rendered inside the bubble (image + title + body + "View ad"), only when ad data is present.
- **Tooling**: `whatsapp:replay_webhook` rake task to replay captured payloads, and an opt-in raw-payload debug log (`WHATSAPP_WEBHOOK_DEBUG`).

## How to test
1. On a WhatsApp inbox (Baileys or Cloud), trigger a real CTWA ad click — or replay a sample payload:
   `bundle exec rails "whatsapp:replay_webhook[spec/fixtures/files/whatsapp/baileys_ctwa_ad.json,+<channel_phone>]"`
2. Open the conversation: the first message should show the "From an ad" card with image, title, description and a clickable link.
3. Check `Conversation#additional_attributes['referral']` (first-touch attribution) and, on Baileys, `entry_point`.

## Closes
N/A — no tracked issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/314)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message bubbles display a referral card for ad-origin messages (title, optional thumbnail, and "View ad" link); ad headline used as message content when original text is missing.
  * First-touch ad attribution is captured on messages and can be backfilled into existing conversations.

* **Localization**
  * Added referral card labels in English and Portuguese (pt‑BR).

* **Tests**
  * Added specs for referral normalization, attribution, entry‑point handling, and content fallbacks.

* **Chores**
  * Added a rake task to replay captured WhatsApp webhook payloads and conditional webhook debug logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->