### PR TITLE
feat(whatsapp): render Baileys rich messages (template, interactive, list, poll, location, contact)

### DIFF
--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -503,6 +503,7 @@ const shouldRenderMessage = computed(() => {
     props.contentType === CONTENT_TYPES.INTEGRATIONS;
   const isFailedMessage = props.status === MESSAGE_STATUS.FAILED;
   const hasExternalError = !!props.contentAttributes?.externalError;
+  const hasRichContent = !!props.contentAttributes?.rich;
 
   return (
     hasAttachments ||
@@ -511,7 +512,8 @@ const shouldRenderMessage = computed(() => {
     isUnsupported ||
     isAnIntegrationMessage ||
     isFailedMessage ||
-    hasExternalError
+    hasExternalError ||
+    hasRichContent
   );
 });
 

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -34,6 +34,7 @@ import EmbedBubble from './bubbles/Embed.vue';
 import InstagramStoryBubble from './bubbles/InstagramStory.vue';
 import EmailBubble from './bubbles/Email/Index.vue';
 import UnsupportedBubble from './bubbles/Unsupported.vue';
+import RichMessageBubble from './bubbles/RichMessage.vue';
 import ContactBubble from './bubbles/Contact.vue';
 import DyteBubble from './bubbles/Dyte.vue';
 import LocationBubble from './bubbles/Location.vue';
@@ -371,6 +372,10 @@ const componentToRender = computed(() => {
     }
     // Attachment content is the name of the contact
     if (fileType === ATTACHMENT_TYPES.CONTACT) return ContactBubble;
+  }
+
+  if (props.contentAttributes?.rich) {
+    return RichMessageBubble;
   }
 
   return TextBubble;

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -407,6 +407,7 @@ const payloadForContextMenu = computed(() => {
 const contextMenuEnabledOptions = computed(() => {
   const hasText = !!props.content;
   const hasAttachments = !!(props.attachments && props.attachments.length > 0);
+  const hasRichContent = !!props.contentAttributes?.rich;
 
   const isOutgoing = props.messageType === MESSAGE_TYPES.OUTGOING;
   const isFailedOrProcessing =
@@ -416,7 +417,7 @@ const contextMenuEnabledOptions = computed(() => {
   return {
     copy: hasText,
     delete:
-      (hasText || hasAttachments) &&
+      (hasText || hasAttachments || hasRichContent) &&
       !isFailedOrProcessing &&
       !isMessageDeleted.value,
     cannedResponse: isOutgoing && hasText && !isMessageDeleted.value,

--- a/app/javascript/dashboard/components-next/message/bubbles/RichMessage.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/RichMessage.vue
@@ -27,28 +27,31 @@ const toHttpUrl = url => {
   }
 };
 
-const buttons = computed(() =>
-  (rich.value.buttons ?? []).map(button => {
-    const url = toHttpUrl(button.url);
-    if (url) {
-      return {
-        text: button.text,
-        href: url,
-        isLink: true,
-        icon: 'i-lucide-external-link',
-      };
-    }
-    if (button.phone) {
-      return {
-        text: button.text,
-        href: `tel:${button.phone}`,
-        isLink: false,
-        icon: 'i-lucide-phone',
-      };
-    }
-    return { text: button.text, href: null, isLink: false, icon: null };
-  })
-);
+const buttons = computed(() => {
+  const list = Array.isArray(rich.value.buttons) ? rich.value.buttons : [];
+  return list
+    .filter(button => button && typeof button === 'object')
+    .map(button => {
+      const url = toHttpUrl(button.url);
+      if (url) {
+        return {
+          text: button.text,
+          href: url,
+          isLink: true,
+          icon: 'i-lucide-external-link',
+        };
+      }
+      if (typeof button.phone === 'string' && button.phone) {
+        return {
+          text: button.text,
+          href: `tel:${button.phone}`,
+          isLink: false,
+          icon: 'i-lucide-phone',
+        };
+      }
+      return { text: button.text, href: null, isLink: false, icon: null };
+    });
+});
 </script>
 
 <template>

--- a/app/javascript/dashboard/components-next/message/bubbles/RichMessage.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/RichMessage.vue
@@ -75,7 +75,7 @@ const buttons = computed(() =>
           :key="`${button.text}-${index}`"
           :href="button.href || undefined"
           :target="button.isLink ? '_blank' : undefined"
-          rel="noopener noreferrer"
+          :rel="button.isLink ? 'noopener noreferrer' : undefined"
           class="flex items-center justify-center gap-1 px-3 py-1.5 text-sm font-medium text-center no-underline rounded-lg bg-n-alpha-black1"
           :class="
             button.href

--- a/app/javascript/dashboard/components-next/message/bubbles/RichMessage.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/RichMessage.vue
@@ -1,0 +1,90 @@
+<script setup>
+import { computed } from 'vue';
+import BaseBubble from './Base.vue';
+import Icon from 'next/icon/Icon.vue';
+import MessageFormatter from 'shared/helpers/MessageFormatter.js';
+import { useMessageContext } from '../provider.js';
+
+const { contentAttributes } = useMessageContext();
+
+// content_attributes keys are deep-camelized by MessageList (useCamelCase), so the
+// rich payload arrives as { type, title, body, footer, buttons: [{ text, url, phone }] }.
+const rich = computed(() => contentAttributes.value?.rich ?? {});
+
+const formattedBody = computed(() =>
+  rich.value.body ? new MessageFormatter(rich.value.body).formattedMessage : ''
+);
+
+// Webhook-derived URLs: only accept well-formed http(s) so an unsafe scheme
+// (e.g. javascript:) never reaches the link. Mirrors ReferralCard.
+const toHttpUrl = url => {
+  if (!url) return null;
+  try {
+    return ['http:', 'https:'].includes(new URL(url).protocol) ? url : null;
+  } catch {
+    return null;
+  }
+};
+
+const buttons = computed(() =>
+  (rich.value.buttons ?? []).map(button => {
+    const url = toHttpUrl(button.url);
+    if (url) {
+      return {
+        text: button.text,
+        href: url,
+        isLink: true,
+        icon: 'i-lucide-external-link',
+      };
+    }
+    if (button.phone) {
+      return {
+        text: button.text,
+        href: `tel:${button.phone}`,
+        isLink: false,
+        icon: 'i-lucide-phone',
+      };
+    }
+    return { text: button.text, href: null, isLink: false, icon: null };
+  })
+);
+</script>
+
+<template>
+  <BaseBubble class="px-4 py-3 text-sm" data-bubble-name="rich">
+    <div class="flex flex-col gap-2">
+      <p v-if="rich.title" class="mb-0 font-medium">{{ rich.title }}</p>
+      <div
+        v-if="formattedBody"
+        v-dompurify-html="formattedBody"
+        class="prose prose-bubble"
+      />
+      <p v-if="rich.footer" class="mb-0 text-xs text-n-slate-11">
+        {{ rich.footer }}
+      </p>
+      <div v-if="buttons.length" class="flex flex-col gap-1 pt-1">
+        <component
+          :is="button.href ? 'a' : 'div'"
+          v-for="(button, index) in buttons"
+          :key="`${button.text}-${index}`"
+          :href="button.href || undefined"
+          :target="button.isLink ? '_blank' : undefined"
+          rel="noopener noreferrer"
+          class="flex items-center justify-center gap-1 px-3 py-1.5 text-sm font-medium text-center no-underline rounded-lg bg-n-alpha-black1"
+          :class="
+            button.href
+              ? 'cursor-pointer hover:bg-n-alpha-black2 text-n-slate-12'
+              : 'text-n-slate-11'
+          "
+        >
+          <Icon
+            v-if="button.icon"
+            :icon="button.icon"
+            class="size-3 shrink-0"
+          />
+          <span>{{ button.text }}</span>
+        </component>
+      </div>
+    </div>
+  </BaseBubble>
+</template>

--- a/app/javascript/dashboard/components-next/message/bubbles/RichMessage.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/RichMessage.vue
@@ -2,10 +2,11 @@
 import { computed } from 'vue';
 import BaseBubble from './Base.vue';
 import Icon from 'next/icon/Icon.vue';
+import AttachmentChips from '../chips/AttachmentChips.vue';
 import MessageFormatter from 'shared/helpers/MessageFormatter.js';
 import { useMessageContext } from '../provider.js';
 
-const { contentAttributes } = useMessageContext();
+const { contentAttributes, attachments } = useMessageContext();
 
 // content_attributes keys are deep-camelized by MessageList (useCamelCase), so the
 // rich payload arrives as { type, title, body, footer, buttons: [{ text, url, phone }] }.
@@ -53,6 +54,11 @@ const buttons = computed(() =>
 <template>
   <BaseBubble class="px-4 py-3 text-sm" data-bubble-name="rich">
     <div class="flex flex-col gap-2">
+      <AttachmentChips
+        v-if="attachments?.length"
+        :attachments="attachments"
+        class="gap-2"
+      />
       <p v-if="rich.title" class="mb-0 font-medium">{{ rich.title }}</p>
       <div
         v-if="formattedBody"

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -116,11 +116,12 @@ class Message < ApplicationRecord
   # [:is_edited, :previous_content] : Used to indicated edited message and previous content (before edit)
   # [:zapi_args] : Used to pass additional arguments specific to Z-API WhatsApp provider
   # [:referral] : Click-to-WhatsApp ad metadata (source ad, headline, ctwa_clid, ...) attached to the first message after an ad click
+  # [:rich] : Structured WhatsApp "rich" message (template/interactive/buttons/list) with title/body/footer/buttons rendered as a card
 
   store :content_attributes, accessors: [:submitted_email, :items, :submitted_values, :email, :in_reply_to, :deleted,
                                          :external_created_at, :story_sender, :story_id, :external_error,
                                          :translations, :in_reply_to_external_id, :is_unsupported, :data,
-                                         :is_reaction, :is_edited, :previous_content, :zapi_args, :referral], coder: JSON
+                                         :is_reaction, :is_edited, :previous_content, :zapi_args, :referral, :rich], coder: JSON
 
   store :external_source_ids, accessors: [:slack], coder: JSON, prefix: :external_source_id
 

--- a/app/services/whatsapp/baileys/rich_message_parser.rb
+++ b/app/services/whatsapp/baileys/rich_message_parser.rb
@@ -13,13 +13,18 @@ class Whatsapp::Baileys::RichMessageParser
   RICH_KEYS = %i[
     interactiveMessage templateMessage buttonsMessage listMessage
     buttonsResponseMessage listResponseMessage templateButtonReplyMessage interactiveResponseMessage
+    pollCreationMessage pollCreationMessageV2 pollCreationMessageV3
   ].freeze
 
   # Tried in order; mirrors Baileys' extractMessageContent. First non-nil wins.
   PARSERS = %i[
     parse_interactive parse_template parse_buttons parse_list
     parse_buttons_response parse_list_response parse_template_reply parse_interactive_response
+    parse_poll
   ].freeze
+
+  # Media that can sit in a rich header, mapped to Chatwoot attachment kinds.
+  MEDIA_HEADER_KINDS = { imageMessage: 'image', videoMessage: 'video', documentMessage: 'file' }.freeze
 
   class << self
     def rich?(msg)
@@ -62,11 +67,33 @@ class Whatsapp::Baileys::RichMessageParser
       @msg.dig(:interactiveResponseMessage, :contextInfo)
   end
 
+  # Media nested in a rich header (template/interactive/buttons), e.g. an invoice
+  # PDF in a template header. Returns { kind: 'image'|'video'|'file', node: } or nil.
+  def media_header
+    source = template_header || interactive_payload&.dig(:header) || @msg[:buttonsMessage]
+    return if source.blank?
+
+    MEDIA_HEADER_KINDS.each do |key, kind|
+      node = source[key]
+      return { kind: kind, node: node } if node.present?
+    end
+    nil
+  end
+
   private
 
+  def template_header
+    @msg.dig(:templateMessage, :hydratedFourRowTemplate) || @msg.dig(:templateMessage, :hydratedTemplate)
+  end
+
+  # WABA "interactive" templates arrive as an InteractiveMessage nested under
+  # templateMessage.interactiveMessageTemplate instead of at the top level.
+  def interactive_payload
+    @msg[:interactiveMessage] || @msg.dig(:templateMessage, :interactiveMessageTemplate)
+  end
+
   def parse_template
-    tpl = @msg.dig(:templateMessage, :hydratedFourRowTemplate) ||
-          @msg.dig(:templateMessage, :hydratedTemplate)
+    tpl = template_header
     return if tpl.blank?
 
     buttons = Array(tpl[:hydratedButtons]).filter_map { |button| template_button(button) }
@@ -84,24 +111,25 @@ class Whatsapp::Baileys::RichMessageParser
     end
   end
 
-  # UNVERIFIED: no real interactiveMessage payload captured yet.
   def parse_interactive
-    interactive = @msg[:interactiveMessage]
+    interactive = interactive_payload
     return if interactive.blank?
 
-    buttons = Array(interactive.dig(:nativeFlowMessage, :buttons)).filter_map { |button| native_flow_button(button) }
+    buttons = Array(interactive.dig(:nativeFlowMessage, :buttons)).flat_map { |button| native_flow_buttons(button) }
     build('interactive', title: interactive.dig(:header, :title), body: interactive.dig(:body, :text),
                          footer: interactive.dig(:footer, :text), buttons: buttons)
   end
 
-  # buttonParamsJson is a snake_case JSON string; parse defensively.
-  def native_flow_button(button)
+  # buttonParamsJson is a snake_case JSON string; parse defensively. Returns an
+  # array because single_select expands into one entry per row.
+  def native_flow_buttons(button) # rubocop:disable Metrics/CyclomaticComplexity
     params = parse_json(button[:buttonParamsJson])
     case button[:name]
-    when 'cta_url' then { text: params['display_text'], url: params['url'] }
-    when 'cta_call' then { text: params['display_text'], phone: params['phone_number'] }
-    when 'single_select' then { text: params['title'] }
-    else { text: params['display_text'] || params['title'] } # quick_reply, cta_copy, ...
+    when 'cta_url' then [{ text: params['display_text'], url: params['url'] }]
+    when 'cta_call' then [{ text: params['display_text'], phone: params['phone_number'] }]
+    when 'open_webview' then [{ text: params['title'] || params['display_text'], url: params.dig('link', 'url') }]
+    when 'single_select' then Array(params['sections']).flat_map { |s| Array(s['rows']) }.map { |r| { text: r['title'] } }
+    else [{ text: params['display_text'] || params['title'] || params['flow_cta'] }] # quick_reply, cta_copy, flow, ...
     end
   end
 
@@ -144,6 +172,14 @@ class Whatsapp::Baileys::RichMessageParser
 
   def parse_interactive_response
     build('interactive_response', body: @msg.dig(:interactiveResponseMessage, :body, :text))
+  end
+
+  def parse_poll
+    poll = @msg[:pollCreationMessage] || @msg[:pollCreationMessageV2] || @msg[:pollCreationMessageV3]
+    return if poll.blank?
+
+    options = Array(poll[:options]).filter_map { |option| { text: option[:optionName] } if option[:optionName].present? }
+    build('poll', title: poll[:name], buttons: options)
   end
 
   # Returns the normalized hash only when there is something renderable, else nil

--- a/app/services/whatsapp/baileys/rich_message_parser.rb
+++ b/app/services/whatsapp/baileys/rich_message_parser.rb
@@ -195,7 +195,7 @@ class Whatsapp::Baileys::RichMessageParser
     return {} if str.blank?
 
     JSON.parse(str)
-  rescue JSON::ParserError
+  rescue JSON::ParserError, TypeError
     {}
   end
 end

--- a/app/services/whatsapp/baileys/rich_message_parser.rb
+++ b/app/services/whatsapp/baileys/rich_message_parser.rb
@@ -194,7 +194,8 @@ class Whatsapp::Baileys::RichMessageParser
   def parse_json(str)
     return {} if str.blank?
 
-    JSON.parse(str)
+    parsed = JSON.parse(str)
+    parsed.is_a?(Hash) ? parsed : {}
   rescue JSON::ParserError, TypeError
     {}
   end

--- a/app/services/whatsapp/baileys/rich_message_parser.rb
+++ b/app/services/whatsapp/baileys/rich_message_parser.rb
@@ -61,7 +61,7 @@ class Whatsapp::Baileys::RichMessageParser
   # contextInfo of the current rich subtype, where externalAdReply (CTWA) lives.
   def context_info
     @msg.dig(:templateMessage, :contextInfo) ||
-      @msg.dig(:interactiveMessage, :contextInfo) ||
+      interactive_payload&.dig(:contextInfo) ||
       @msg.dig(:buttonsMessage, :contextInfo) ||
       @msg.dig(:listMessage, :contextInfo) ||
       @msg.dig(:interactiveResponseMessage, :contextInfo)

--- a/app/services/whatsapp/baileys/rich_message_parser.rb
+++ b/app/services/whatsapp/baileys/rich_message_parser.rb
@@ -1,0 +1,165 @@
+# Parses Baileys "rich" message proto shapes (template / interactive / buttons /
+# list and their response variants) into a normalized hash the dashboard renders
+# as a structured card, plus a flat text rendering used for `content`/previews.
+#
+# The Baileys bridge forwards the raw proto via JSON.stringify (camelCase keys,
+# enums as number OR string). We only read string fields here, so the enum
+# number-vs-string ambiguity does not affect this parser. The one risky shape is
+# interactiveMessage's nativeFlow `buttonParamsJson` (a snake_case JSON string),
+# parsed defensively so a malformed/unexpected payload degrades to is_unsupported
+# instead of raising. Branches not yet exercised by a real captured payload are
+# tagged `# UNVERIFIED`.
+class Whatsapp::Baileys::RichMessageParser
+  RICH_KEYS = %i[
+    interactiveMessage templateMessage buttonsMessage listMessage
+    buttonsResponseMessage listResponseMessage templateButtonReplyMessage interactiveResponseMessage
+  ].freeze
+
+  # Tried in order; mirrors Baileys' extractMessageContent. First non-nil wins.
+  PARSERS = %i[
+    parse_interactive parse_template parse_buttons parse_list
+    parse_buttons_response parse_list_response parse_template_reply parse_interactive_response
+  ].freeze
+
+  class << self
+    def rich?(msg)
+      RICH_KEYS.any? { |key| msg.key?(key) }
+    end
+
+    # Renders the normalized hash into the plain-text body stored as `content`.
+    def to_text(parsed)
+      return if parsed.blank?
+
+      lines = [parsed[:title], parsed[:body], parsed[:footer], *button_lines(parsed[:buttons])]
+      lines.compact_blank.join("\n\n").presence
+    end
+
+    private
+
+    def button_lines(buttons)
+      Array(buttons).map do |button|
+        suffix = button[:url].presence || button[:phone].presence
+        suffix ? "▸ #{button[:text]}: #{suffix}" : "▸ #{button[:text]}"
+      end
+    end
+  end
+
+  def initialize(msg)
+    @msg = msg
+  end
+
+  # Normalized hash ({ type:, title:, body:, footer:, buttons: [...] }) or nil.
+  def parse
+    PARSERS.lazy.filter_map { |parser| send(parser) }.first
+  end
+
+  # contextInfo of the current rich subtype, where externalAdReply (CTWA) lives.
+  def context_info
+    @msg.dig(:templateMessage, :contextInfo) ||
+      @msg.dig(:interactiveMessage, :contextInfo) ||
+      @msg.dig(:buttonsMessage, :contextInfo) ||
+      @msg.dig(:listMessage, :contextInfo) ||
+      @msg.dig(:interactiveResponseMessage, :contextInfo)
+  end
+
+  private
+
+  def parse_template
+    tpl = @msg.dig(:templateMessage, :hydratedFourRowTemplate) ||
+          @msg.dig(:templateMessage, :hydratedTemplate)
+    return if tpl.blank?
+
+    buttons = Array(tpl[:hydratedButtons]).filter_map { |button| template_button(button) }
+    build('template', title: tpl[:hydratedTitleText], body: tpl[:hydratedContentText],
+                      footer: tpl[:hydratedFooterText], buttons: buttons)
+  end
+
+  def template_button(button)
+    if (quick = button[:quickReplyButton])
+      { text: quick[:displayText] }
+    elsif (url = button[:urlButton])
+      { text: url[:displayText], url: url[:url] }
+    elsif (call = button[:callButton])
+      { text: call[:displayText], phone: call[:phoneNumber] }
+    end
+  end
+
+  # UNVERIFIED: no real interactiveMessage payload captured yet.
+  def parse_interactive
+    interactive = @msg[:interactiveMessage]
+    return if interactive.blank?
+
+    buttons = Array(interactive.dig(:nativeFlowMessage, :buttons)).filter_map { |button| native_flow_button(button) }
+    build('interactive', title: interactive.dig(:header, :title), body: interactive.dig(:body, :text),
+                         footer: interactive.dig(:footer, :text), buttons: buttons)
+  end
+
+  # buttonParamsJson is a snake_case JSON string; parse defensively.
+  def native_flow_button(button)
+    params = parse_json(button[:buttonParamsJson])
+    case button[:name]
+    when 'cta_url' then { text: params['display_text'], url: params['url'] }
+    when 'cta_call' then { text: params['display_text'], phone: params['phone_number'] }
+    when 'single_select' then { text: params['title'] }
+    else { text: params['display_text'] || params['title'] } # quick_reply, cta_copy, ...
+    end
+  end
+
+  # UNVERIFIED: no real buttonsMessage payload captured yet.
+  def parse_buttons
+    buttons_msg = @msg[:buttonsMessage]
+    return if buttons_msg.blank?
+
+    buttons = Array(buttons_msg[:buttons]).filter_map do |button|
+      text = button.dig(:buttonText, :displayText)
+      { text: text } if text.present?
+    end
+    build('buttons', title: buttons_msg[:text], body: buttons_msg[:contentText],
+                     footer: buttons_msg[:footerText], buttons: buttons)
+  end
+
+  # UNVERIFIED: no real listMessage payload captured yet.
+  def parse_list
+    list_msg = @msg[:listMessage]
+    return if list_msg.blank?
+
+    rows = Array(list_msg[:sections]).flat_map { |section| Array(section[:rows]) }
+                                     .filter_map { |row| { text: row[:title] } if row[:title].present? }
+    build('list', title: list_msg[:title], body: list_msg[:description],
+                  footer: list_msg[:footerText], buttons: rows)
+  end
+
+  # UNVERIFIED: no real *ResponseMessage payload captured yet.
+  def parse_buttons_response
+    build('buttons_response', body: @msg.dig(:buttonsResponseMessage, :selectedDisplayText))
+  end
+
+  def parse_list_response
+    build('list_response', body: @msg.dig(:listResponseMessage, :title))
+  end
+
+  def parse_template_reply
+    build('template_reply', body: @msg.dig(:templateButtonReplyMessage, :selectedDisplayText))
+  end
+
+  def parse_interactive_response
+    build('interactive_response', body: @msg.dig(:interactiveResponseMessage, :body, :text))
+  end
+
+  # Returns the normalized hash only when there is something renderable, else nil
+  # (the caller marks the message as unsupported).
+  def build(type, title: nil, body: nil, footer: nil, buttons: [])
+    cleaned = buttons.map(&:compact).reject { |button| button[:text].blank? }
+    return if title.blank? && body.blank? && footer.blank? && cleaned.empty?
+
+    { type: type, title: title.presence, body: body.presence, footer: footer.presence, buttons: cleaned.presence }.compact
+  end
+
+  def parse_json(str)
+    return {} if str.blank?
+
+    JSON.parse(str)
+  rescue JSON::ParserError
+    {}
+  end
+end

--- a/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
@@ -1,9 +1,11 @@
-module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler
+module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:disable Metrics/ModuleLength
   extend ActiveSupport::Concern
 
   private
 
   def build_and_save_message(conversation:, sender:, attach_media: false)
+    return build_and_save_contact_messages(conversation: conversation, sender: sender) if message_type == 'contact'
+
     @message = conversation.messages.build(
       content: message_content,
       account_id: inbox.account_id,
@@ -15,12 +17,43 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler
     )
 
     attach_media_to_message if attach_media
+    attach_location_to_message if message_type == 'location'
 
     @message.save!
 
     inbox.channel.received_messages([@message], conversation) if incoming?
 
     @message
+  end
+
+  # Mirrors the Cloud provider (create_contact_messages): one message per shared
+  # contact, each with a native contact attachment, so the dashboard renders them
+  # in the contact bubble instead of as plain text.
+  def build_and_save_contact_messages(conversation:, sender:)
+    messages = baileys_contacts.filter_map { |contact| build_contact_message(conversation, sender, contact) }
+    inbox.channel.received_messages(messages, conversation) if incoming? && messages.any?
+    @message = messages.last
+  end
+
+  def build_contact_message(conversation, sender, contact)
+    fields = baileys_contact_fields(contact)
+    return if fields[:phone].blank? && fields[:name].blank?
+
+    message = conversation.messages.build(
+      content: baileys_contact_line(contact), account_id: inbox.account_id, inbox_id: inbox.id,
+      source_id: raw_message_id, sender: incoming? ? sender : nil,
+      message_type: incoming? ? :incoming : :outgoing, content_attributes: build_message_content_attributes
+    )
+    attach_contact_card(message, fields)
+    message.save!
+    message
+  end
+
+  def attach_contact_card(message, fields)
+    message.attachments.build(
+      account_id: inbox.account_id, file_type: :contact,
+      fallback_title: fields[:phone].presence || fields[:name], meta: { firstName: fields[:name] }.compact
+    )
   end
 
   # WhatsApp delivers a reaction removal as a fresh message with empty text.
@@ -105,11 +138,14 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler
     content_attributes
   end
 
-  # Persists the structured card payload; an unparseable rich shape falls back to
-  # unsupported (the previous empty-bubble behavior) and is logged to capture real shapes.
+  # Persists the structured card payload. A rich shape with neither text/buttons
+  # nor a media header falls back to unsupported (the previous empty-bubble
+  # behavior) and is logged to capture real shapes. A media-only header still
+  # renders via the attached media, so it is not flagged unsupported.
   def add_rich_content_attributes(content_attributes, msg)
     rich = Whatsapp::Baileys::RichMessageParser.new(msg).parse
-    return content_attributes[:rich] = rich if rich.present?
+    content_attributes[:rich] = rich if rich.present?
+    return if rich.present? || should_attach_media?
 
     content_attributes[:is_unsupported] = true
     Rails.logger.info("[Baileys] rich message fell back to unsupported: keys=#{msg.keys}")
@@ -139,14 +175,34 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler
 
   def build_attachment_filename
     msg = unwrap_ephemeral_message(@raw_message[:message])
-    filename = msg.dig(:documentMessage, :fileName) || msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :fileName)
+    filename = msg.dig(:documentMessage, :fileName) ||
+               msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :fileName) ||
+               rich_media_header&.dig(:node, :fileName)
     return filename if filename.present?
 
     ext = ".#{message_mimetype.split(';').first.split('/').last}" if message_mimetype.present?
     "#{file_content_type}_#{raw_message_id}_#{Time.current.strftime('%Y%m%d')}#{ext}"
   end
 
+  # Location carries no downloadable bytes; persist coordinates as a native
+  # location attachment so the dashboard renders it in the map bubble.
+  def attach_location_to_message
+    loc = unwrap_ephemeral_message(@raw_message[:message])
+    loc = loc[:locationMessage] || loc[:liveLocationMessage]
+    return if loc.blank?
+
+    name = [loc[:name], loc[:address]].compact_blank.join(', ')
+    @message.attachments.build(
+      account_id: @message.account_id,
+      file_type: :location,
+      coordinates_lat: loc[:degreesLatitude],
+      coordinates_long: loc[:degreesLongitude],
+      fallback_title: name.presence,
+      external_url: loc[:url]
+    )
+  end
+
   def should_attach_media?
-    %w[image file video audio sticker].include?(message_type)
+    %w[image file video audio sticker].include?(message_type) || rich_media_header.present?
   end
 end

--- a/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
@@ -97,10 +97,22 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler
       content_attributes[:is_unsupported] = true
     end
 
+    add_rich_content_attributes(content_attributes, msg) if type == 'rich'
+
     referral = normalize_baileys_referral(message_context_info)
     content_attributes[:referral] = referral if referral.present?
 
     content_attributes
+  end
+
+  # Persists the structured card payload; an unparseable rich shape falls back to
+  # unsupported (the previous empty-bubble behavior) and is logged to capture real shapes.
+  def add_rich_content_attributes(content_attributes, msg)
+    rich = Whatsapp::Baileys::RichMessageParser.new(msg).parse
+    return content_attributes[:rich] = rich if rich.present?
+
+    content_attributes[:is_unsupported] = true
+    Rails.logger.info("[Baileys] rich message fell back to unsupported: keys=#{msg.keys}")
   end
 
   def attach_media_to_message

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -64,6 +64,8 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     elsif msg.key?(:contactMessage)
       match_phone_number = msg.dig(:contactMessage, :vcard)&.match(/waid=(\d+)/)
       match_phone_number ? 'contact' : 'unsupported'
+    elsif msg.key?(:templateMessage)
+      'template'
     elsif msg.key?(:protocolMessage)
       'protocol'
     elsif msg.key?(:messageContextInfo) && msg.keys.count == 1
@@ -88,6 +90,15 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     when 'file'
       msg.dig(:documentMessage, :caption).presence ||
         msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :caption)
+    when 'template'
+      tpl = msg.dig(:templateMessage, :hydratedTemplate) ||
+            msg.dig(:templateMessage, :hydratedFourRowTemplate) || {}
+      parts = [tpl[:hydratedTitleText], tpl[:hydratedContentText], tpl[:hydratedFooterText]].select(&:present?)
+      buttons = (tpl[:hydratedButtons] || []).map do |b|
+        b.dig(:quickReplyButton, :displayText) || b.dig(:urlButton, :displayText) || b.dig(:callButton, :displayText)
+      end.compact
+      parts << buttons.map { |t| "[#{t}]" }.join(" ") if buttons.any?
+      parts.join("\n\n").presence
     when 'reaction'
       msg.dig(:reactionMessage, :text)
     when 'contact'

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -64,12 +64,12 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     elsif msg.key?(:contactMessage)
       match_phone_number = msg.dig(:contactMessage, :vcard)&.match(/waid=(\d+)/)
       match_phone_number ? 'contact' : 'unsupported'
-    elsif msg.key?(:templateMessage)
-      'template'
     elsif msg.key?(:protocolMessage)
       'protocol'
     elsif msg.key?(:messageContextInfo) && msg.keys.count == 1
       'context'
+    elsif Whatsapp::Baileys::RichMessageParser.rich?(msg)
+      'rich'
     else
       'unsupported'
     end
@@ -90,15 +90,8 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     when 'file'
       msg.dig(:documentMessage, :caption).presence ||
         msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :caption)
-    when 'template'
-      tpl = msg.dig(:templateMessage, :hydratedTemplate) ||
-            msg.dig(:templateMessage, :hydratedFourRowTemplate) || {}
-      parts = [tpl[:hydratedTitleText], tpl[:hydratedContentText], tpl[:hydratedFooterText]].select(&:present?)
-      buttons = (tpl[:hydratedButtons] || []).map do |b|
-        b.dig(:quickReplyButton, :displayText) || b.dig(:urlButton, :displayText) || b.dig(:callButton, :displayText)
-      end.compact
-      parts << buttons.map { |t| "[#{t}]" }.join(" ") if buttons.any?
-      parts.join("\n\n").presence
+    when 'rich'
+      Whatsapp::Baileys::RichMessageParser.to_text(Whatsapp::Baileys::RichMessageParser.new(msg).parse)
     when 'reaction'
       msg.dig(:reactionMessage, :text)
     when 'contact'
@@ -145,6 +138,7 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     when 'file'
       msg.dig(:documentMessage, :contextInfo).presence ||
         msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :contextInfo)
+    when 'rich' then Whatsapp::Baileys::RichMessageParser.new(msg).context_info
     end
   end
 

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -64,6 +64,10 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     elsif msg.key?(:contactMessage)
       match_phone_number = msg.dig(:contactMessage, :vcard)&.match(/waid=(\d+)/)
       match_phone_number ? 'contact' : 'unsupported'
+    elsif msg.key?(:contactsArrayMessage)
+      'contact'
+    elsif msg.key?(:locationMessage) || msg.key?(:liveLocationMessage)
+      'location'
     elsif msg.key?(:protocolMessage)
       'protocol'
     elsif msg.key?(:messageContextInfo) && msg.keys.count == 1
@@ -75,7 +79,7 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     end
   end
 
-  def message_content # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength,Metrics/AbcSize
+  def message_content # rubocop:disable Metrics/CyclomaticComplexity
     msg = unwrap_ephemeral_message(@raw_message[:message])
     case message_type
     when 'text'
@@ -94,17 +98,33 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
       Whatsapp::Baileys::RichMessageParser.to_text(Whatsapp::Baileys::RichMessageParser.new(msg).parse)
     when 'reaction'
       msg.dig(:reactionMessage, :text)
-    when 'contact'
-      # FIXME: Missing specs
-      display_name = msg.dig(:contactMessage, :displayName)
-      vcard = msg.dig(:contactMessage, :vcard)
-      match_phone_number = vcard&.match(/waid=(\d+)/)
-
-      return display_name unless match_phone_number
-      return match_phone_number[1] if display_name&.start_with?('+')
-
-      "#{display_name} - #{match_phone_number[1]}" if match_phone_number
     end
+  end
+
+  # The shared contacts of the current message: the entries of a
+  # contactsArrayMessage, or the single contactMessage wrapped in an array.
+  def baileys_contacts
+    msg = unwrap_ephemeral_message(@raw_message[:message])
+    msg.dig(:contactsArrayMessage, :contacts).presence || [msg[:contactMessage]].compact
+  end
+
+  # Extracts { phone, name } from a Baileys contact hash. The vcard TEL line is
+  # `...;waid=<digits>:<formatted phone>`, so prefer the formatted phone and fall
+  # back to the waid digits.
+  def baileys_contact_fields(contact)
+    vcard = contact&.dig(:vcard).to_s
+    phone = vcard[/waid=\d+:\s*([^\r\n]+)/, 1]&.strip
+    phone = vcard[/waid=(\d+)/, 1] if phone.blank?
+    { phone: phone, name: contact&.dig(:displayName) }
+  end
+
+  # Short "Name - phone" line used as the message content (chat-list preview).
+  def baileys_contact_line(contact)
+    fields = baileys_contact_fields(contact)
+    return fields[:name] if fields[:phone].blank?
+    return fields[:phone] if fields[:name].blank? || fields[:name].start_with?('+')
+
+    "#{fields[:name]} - #{fields[:phone]}"
   end
 
   def reply_to_message_id # rubocop:disable Metrics/CyclomaticComplexity
@@ -149,15 +169,23 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     ad[:title].presence || ad[:body].presence
   end
 
+  # Media nested in a rich header (e.g. a PDF/image in a template header), or nil.
+  def rich_media_header
+    return unless message_type == 'rich'
+
+    Whatsapp::Baileys::RichMessageParser.new(unwrap_ephemeral_message(@raw_message[:message])).media_header
+  end
+
   def file_content_type
     return :image if message_type.in?(%w[image sticker])
     return :video if message_type.in?(%w[video video_note])
     return :audio if message_type == 'audio'
+    return rich_media_header[:kind].to_sym if rich_media_header
 
     :file
   end
 
-  def message_mimetype
+  def message_mimetype # rubocop:disable Metrics/CyclomaticComplexity
     msg = unwrap_ephemeral_message(@raw_message[:message])
     case message_type
     when 'image'
@@ -171,6 +199,8 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     when 'file'
       msg.dig(:documentMessage, :mimetype).presence ||
         msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :mimetype)
+    when 'rich'
+      rich_media_header&.dig(:node, :mimetype)
     end
   end
 

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -127,22 +127,11 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     "#{fields[:name]} - #{fields[:phone]}"
   end
 
-  def reply_to_message_id # rubocop:disable Metrics/CyclomaticComplexity
-    msg = unwrap_ephemeral_message(@raw_message[:message])
-    message_key = case message_type
-                  when 'text' then :extendedTextMessage
-                  when 'image' then :imageMessage
-                  when 'sticker' then :stickerMessage
-                  when 'audio' then :audioMessage
-                  when 'video' then :videoMessage
-                  when 'contact' then :contactMessage
-                  when 'file'
-                    context_info = msg.dig(:documentMessage, :contextInfo).presence ||
-                                   msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :contextInfo)
-                    return context_info&.dig(:stanzaId)
-                  end
-
-    msg.dig(message_key, :contextInfo, :stanzaId) if message_key
+  # The provider id of the quoted message (stanzaId), read from the same per-type
+  # contextInfo used for ad attribution, so every supported type (incl. rich,
+  # location and contact) resolves replies through a single lookup.
+  def reply_to_message_id
+    message_context_info&.dig(:stanzaId)
   end
 
   # Returns the `contextInfo` for the current message type, where the
@@ -158,6 +147,10 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     when 'file'
       msg.dig(:documentMessage, :contextInfo).presence ||
         msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :contextInfo)
+    when 'contact'
+      msg.dig(:contactMessage, :contextInfo) || msg.dig(:contactsArrayMessage, :contextInfo)
+    when 'location'
+      msg.dig(:locationMessage, :contextInfo) || msg.dig(:liveLocationMessage, :contextInfo)
     when 'rich' then Whatsapp::Baileys::RichMessageParser.new(msg).context_info
     end
   end

--- a/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
+++ b/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
@@ -111,6 +111,15 @@ describe Whatsapp::Baileys::RichMessageParser do
       expect(text_for(msg)).to eq('Pick')
     end
 
+    it 'degrades to the body when buttonParamsJson is a non-string (TypeError)' do
+      msg = { interactiveMessage: {
+        body: { text: 'Pick' },
+        nativeFlowMessage: { buttons: [{ name: 'cta_url', buttonParamsJson: { display_text: 'Buy' } }] }
+      } }
+
+      expect(parse(msg)).to eq(type: 'interactive', body: 'Pick')
+    end
+
     # Real WABA shape: an InteractiveMessage nested under templateMessage.
     it 'parses an interactive template (templateMessage.interactiveMessageTemplate)' do
       msg = { templateMessage: { interactiveMessageTemplate: {

--- a/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
+++ b/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
@@ -120,6 +120,15 @@ describe Whatsapp::Baileys::RichMessageParser do
       expect(parse(msg)).to eq(type: 'interactive', body: 'Pick')
     end
 
+    it 'degrades to the body when buttonParamsJson is valid JSON but not an object' do
+      msg = { interactiveMessage: {
+        body: { text: 'Pick' },
+        nativeFlowMessage: { buttons: [{ name: 'cta_url', buttonParamsJson: '[1,2,3]' }] }
+      } }
+
+      expect(parse(msg)).to eq(type: 'interactive', body: 'Pick')
+    end
+
     # Real WABA shape: an InteractiveMessage nested under templateMessage.
     it 'parses an interactive template (templateMessage.interactiveMessageTemplate)' do
       msg = { templateMessage: { interactiveMessageTemplate: {

--- a/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
+++ b/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
@@ -78,6 +78,29 @@ describe Whatsapp::Baileys::RichMessageParser do
       expect(parse(msg)[:buttons]).to eq([{ text: 'Call', phone: '+551130000000' }])
     end
 
+    it 'expands a single_select into one button per row' do
+      params = { title: 'Ver opções', sections: [{ title: 'Bebidas', rows: [{ title: 'Coca' }, { title: 'Água' }] }] }
+      msg = { interactiveMessage: {
+        body: { text: 'Escolha' },
+        nativeFlowMessage: { buttons: [{ name: 'single_select', buttonParamsJson: params.to_json }] }
+      } }
+
+      expect(parse(msg)[:buttons]).to eq([{ text: 'Coca' }, { text: 'Água' }])
+    end
+
+    it 'reads the url of an open_webview button from link.url' do
+      params = { title: 'Abrir', link: { url: 'https://w.io', in_app_webview: true } }
+      msg = { interactiveMessage: { nativeFlowMessage: { buttons: [{ name: 'open_webview', buttonParamsJson: params.to_json }] } } }
+
+      expect(parse(msg)[:buttons]).to eq([{ text: 'Abrir', url: 'https://w.io' }])
+    end
+
+    it 'falls back to flow_cta for a flow button label' do
+      msg = { interactiveMessage: { nativeFlowMessage: { buttons: [{ name: 'flow', buttonParamsJson: '{"flow_cta":"Agendar"}' }] } } }
+
+      expect(parse(msg)[:buttons]).to eq([{ text: 'Agendar' }])
+    end
+
     it 'degrades to the body when buttonParamsJson is malformed' do
       msg = { interactiveMessage: {
         body: { text: 'Pick' },
@@ -86,6 +109,22 @@ describe Whatsapp::Baileys::RichMessageParser do
 
       expect(parse(msg)).to eq(type: 'interactive', body: 'Pick')
       expect(text_for(msg)).to eq('Pick')
+    end
+
+    # Real WABA shape: an InteractiveMessage nested under templateMessage.
+    it 'parses an interactive template (templateMessage.interactiveMessageTemplate)' do
+      msg = { templateMessage: { interactiveMessageTemplate: {
+        body: { text: 'Baixe o app!' },
+        nativeFlowMessage: { buttons: [
+          { name: 'cta_url', buttonParamsJson: '{"display_text":"Baixar no iOS","url":"https://apps.apple.com/x"}' },
+          { name: 'cta_url', buttonParamsJson: '{"display_text":"Baixar no Android","url":"https://play.google.com/x"}' }
+        ] }
+      } } }
+
+      expect(parse(msg)).to eq(type: 'interactive', body: 'Baixe o app!', buttons: [
+                                 { text: 'Baixar no iOS', url: 'https://apps.apple.com/x' },
+                                 { text: 'Baixar no Android', url: 'https://play.google.com/x' }
+                               ])
     end
   end
 
@@ -112,6 +151,21 @@ describe Whatsapp::Baileys::RichMessageParser do
     end
   end
 
+  describe 'pollCreationMessage' do
+    it 'renders the question and options (real shape)' do
+      msg = { pollCreationMessage: { name: 'Pergunta?', options: [{ optionName: 'Opção 1' }, { optionName: 'Opção 2' }],
+                                     selectableOptionsCount: 0 } }
+
+      expect(parse(msg)).to eq(type: 'poll', title: 'Pergunta?', buttons: [{ text: 'Opção 1' }, { text: 'Opção 2' }])
+      expect(text_for(msg)).to eq("Pergunta?\n\n▸ Opção 1\n\n▸ Opção 2")
+    end
+
+    it 'handles the V2/V3 keys' do
+      msg = { pollCreationMessageV3: { name: 'Q', options: [{ optionName: 'A' }] } }
+      expect(parse(msg)[:type]).to eq('poll')
+    end
+  end
+
   describe 'response variants' do
     it 'reads the selected text of each response shape' do
       expect(text_for({ buttonsResponseMessage: { selectedDisplayText: 'Yes' } })).to eq('Yes')
@@ -134,6 +188,47 @@ describe Whatsapp::Baileys::RichMessageParser do
       ctx = { externalAdReply: { title: 'Ad' } }
       expect(described_class.new({ templateMessage: { contextInfo: ctx } }).context_info).to eq(ctx)
       expect(described_class.new({ interactiveMessage: { contextInfo: ctx } }).context_info).to eq(ctx)
+    end
+  end
+
+  describe '#media_header' do
+    def header_for(msg)
+      described_class.new(msg).media_header
+    end
+
+    it 'finds a document in a template header (and maps it to :file)' do
+      node = { url: 'https://x/inv.pdf', mimetype: 'application/pdf', fileName: 'inv.pdf' }
+      expect(header_for({ templateMessage: { hydratedTemplate: { documentMessage: node } } }))
+        .to eq(kind: 'file', node: node)
+    end
+
+    it 'finds an image in a hydratedFourRowTemplate header' do
+      node = { url: 'https://x/i.jpg', mimetype: 'image/jpeg' }
+      expect(header_for({ templateMessage: { hydratedFourRowTemplate: { imageMessage: node } } }))
+        .to eq(kind: 'image', node: node)
+    end
+
+    it 'finds a video in an interactive header and an image in a buttons header' do
+      vid = { url: 'https://x/v.mp4', mimetype: 'video/mp4' }
+      img = { url: 'https://x/i.jpg', mimetype: 'image/jpeg' }
+      expect(header_for({ interactiveMessage: { header: { videoMessage: vid } } })).to eq(kind: 'video', node: vid)
+      expect(header_for({ buttonsMessage: { imageMessage: img } })).to eq(kind: 'image', node: img)
+    end
+
+    it 'finds the video header nested in an interactiveMessageTemplate (real WABA shape)' do
+      vid = { url: 'https://x/v.enc', mimetype: 'video/mp4' }
+      msg = { templateMessage: { interactiveMessageTemplate: { header: { hasMediaAttachment: true, videoMessage: vid } } } }
+      expect(header_for(msg)).to eq(kind: 'video', node: vid)
+    end
+
+    it 'is nil when there is no header media' do
+      expect(header_for({ templateMessage: { hydratedTemplate: { hydratedContentText: 'hi' } } })).to be_nil
+    end
+
+    it 'is exposed even for a media-only template whose #parse is nil' do
+      msg = { templateMessage: { hydratedTemplate: { documentMessage: { mimetype: 'application/pdf' } } } }
+      expect(parse(msg)).to be_nil
+      expect(header_for(msg)).to include(kind: 'file')
     end
   end
 end

--- a/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
+++ b/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
@@ -198,6 +198,11 @@ describe Whatsapp::Baileys::RichMessageParser do
       expect(described_class.new({ templateMessage: { contextInfo: ctx } }).context_info).to eq(ctx)
       expect(described_class.new({ interactiveMessage: { contextInfo: ctx } }).context_info).to eq(ctx)
     end
+
+    it 'reads the contextInfo nested in an interactiveMessageTemplate (real WABA shape)' do
+      ctx = { externalAdReply: { title: 'Ad' }, stanzaId: 'QUOTED_1' }
+      expect(described_class.new({ templateMessage: { interactiveMessageTemplate: { contextInfo: ctx } } }).context_info).to eq(ctx)
+    end
   end
 
   describe '#media_header' do

--- a/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
+++ b/spec/services/whatsapp/baileys/rich_message_parser_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+describe Whatsapp::Baileys::RichMessageParser do
+  def parse(msg)
+    described_class.new(msg).parse
+  end
+
+  def text_for(msg)
+    described_class.to_text(described_class.new(msg).parse)
+  end
+
+  describe '.rich?' do
+    it 'detects every rich/response key' do
+      %i[interactiveMessage templateMessage buttonsMessage listMessage
+         buttonsResponseMessage listResponseMessage templateButtonReplyMessage interactiveResponseMessage].each do |key|
+        expect(described_class.rich?({ key => {} })).to be(true)
+      end
+    end
+
+    it 'is false for a plain text message' do
+      expect(described_class.rich?({ conversation: 'hi' })).to be(false)
+    end
+  end
+
+  describe 'templateMessage' do
+    it 'renders the body only (real hydratedTemplate shape)' do
+      msg = { templateMessage: { hydratedTemplate: { hydratedTitleText: '', hydratedContentText: 'Your plan expires soon' } } }
+
+      expect(parse(msg)).to eq(type: 'template', body: 'Your plan expires soon')
+      expect(text_for(msg)).to eq('Your plan expires soon')
+    end
+
+    it 'renders body + footer + quick-reply button (real shape)' do
+      msg = { templateMessage: { hydratedTemplate: {
+        hydratedContentText: 'Renew?', hydratedFooterText: 'Acme',
+        hydratedButtons: [{ quickReplyButton: { displayText: 'Renew now!', id: 'renew' }, index: 0 }]
+      } } }
+
+      expect(text_for(msg)).to eq("Renew?\n\nAcme\n\n▸ Renew now!")
+    end
+
+    it 'includes the url and phone of url/call buttons (hydratedFourRowTemplate)' do
+      msg = { templateMessage: { hydratedFourRowTemplate: {
+        hydratedContentText: 'Invoice',
+        hydratedButtons: [
+          { urlButton: { displayText: 'Pay now', url: 'https://acme.io/pay' } },
+          { callButton: { displayText: 'Call us', phoneNumber: '+5511999999999' } }
+        ]
+      } } }
+
+      expect(parse(msg)[:buttons]).to eq(
+        [{ text: 'Pay now', url: 'https://acme.io/pay' }, { text: 'Call us', phone: '+5511999999999' }]
+      )
+      expect(text_for(msg)).to eq("Invoice\n\n▸ Pay now: https://acme.io/pay\n\n▸ Call us: +5511999999999")
+    end
+
+    it 'returns nil for an empty template (only media header / no text)' do
+      expect(parse({ templateMessage: { hydratedTemplate: { templateId: '1' } } })).to be_nil
+    end
+  end
+
+  describe 'interactiveMessage (nativeFlow)' do
+    it 'parses a cta_url button from the snake_case JSON string' do
+      msg = { interactiveMessage: {
+        body: { text: 'Pick one' },
+        nativeFlowMessage: { buttons: [{ name: 'cta_url', buttonParamsJson: '{"display_text":"Buy","url":"https://b.io"}' }] }
+      } }
+
+      expect(parse(msg)).to eq(type: 'interactive', body: 'Pick one', buttons: [{ text: 'Buy', url: 'https://b.io' }])
+      expect(text_for(msg)).to eq("Pick one\n\n▸ Buy: https://b.io")
+    end
+
+    it 'parses a cta_call button phone number' do
+      msg = { interactiveMessage: {
+        nativeFlowMessage: { buttons: [{ name: 'cta_call', buttonParamsJson: '{"display_text":"Call","phone_number":"+551130000000"}' }] }
+      } }
+
+      expect(parse(msg)[:buttons]).to eq([{ text: 'Call', phone: '+551130000000' }])
+    end
+
+    it 'degrades to the body when buttonParamsJson is malformed' do
+      msg = { interactiveMessage: {
+        body: { text: 'Pick' },
+        nativeFlowMessage: { buttons: [{ name: 'cta_url', buttonParamsJson: 'not-json' }] }
+      } }
+
+      expect(parse(msg)).to eq(type: 'interactive', body: 'Pick')
+      expect(text_for(msg)).to eq('Pick')
+    end
+  end
+
+  describe 'buttonsMessage' do
+    it 'renders content + button labels' do
+      msg = { buttonsMessage: {
+        contentText: 'Choose', footerText: 'footer',
+        buttons: [{ buttonText: { displayText: 'Yes' } }, { buttonText: { displayText: 'No' } }]
+      } }
+
+      expect(text_for(msg)).to eq("Choose\n\nfooter\n\n▸ Yes\n\n▸ No")
+    end
+  end
+
+  describe 'listMessage' do
+    it 'renders title/description + section rows' do
+      msg = { listMessage: {
+        title: 'Menu', description: 'Pick one', buttonText: 'Open',
+        sections: [{ title: 'Drinks', rows: [{ title: 'Coke', rowId: 'c' }, { title: 'Water', rowId: 'w' }] }]
+      } }
+
+      expect(parse(msg)[:buttons]).to eq([{ text: 'Coke' }, { text: 'Water' }])
+      expect(text_for(msg)).to eq("Menu\n\nPick one\n\n▸ Coke\n\n▸ Water")
+    end
+  end
+
+  describe 'response variants' do
+    it 'reads the selected text of each response shape' do
+      expect(text_for({ buttonsResponseMessage: { selectedDisplayText: 'Yes' } })).to eq('Yes')
+      expect(text_for({ listResponseMessage: { title: 'Coke', singleSelectReply: { selectedRowId: 'c' } } })).to eq('Coke')
+      expect(text_for({ templateButtonReplyMessage: { selectedDisplayText: 'Pay now' } })).to eq('Pay now')
+      expect(text_for({ interactiveResponseMessage: { body: { text: 'Done' } } })).to eq('Done')
+    end
+  end
+
+  describe 'unknown / empty rich shapes' do
+    it 'returns nil so the caller marks the message unsupported' do
+      expect(parse({ interactiveMessage: {} })).to be_nil
+      expect(parse({ buttonsResponseMessage: {} })).to be_nil
+      expect(described_class.to_text(nil)).to be_nil
+    end
+  end
+
+  describe '#context_info' do
+    it 'returns the contextInfo of the rich subtype (for externalAdReply)' do
+      ctx = { externalAdReply: { title: 'Ad' } }
+      expect(described_class.new({ templateMessage: { contextInfo: ctx } }).context_info).to eq(ctx)
+      expect(described_class.new({ interactiveMessage: { contextInfo: ctx } }).context_info).to eq(ctx)
+    end
+  end
+end

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -988,4 +988,94 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       end
     end
   end
+
+  describe 'rich message handling' do
+    let(:phone) { '5511912345678' }
+    let(:lid) { '12345678' }
+
+    after do
+      Redis::Alfred.scan_each(match: "MESSAGE_SOURCE_KEY::#{inbox.id}_*") { |key| Redis::Alfred.delete(key) }
+    end
+
+    def rich_params(message, id:)
+      raw_message = {
+        key: { id: id, remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false, addressingMode: 'pn' },
+        pushName: 'Acme Payments',
+        messageTimestamp: timestamp,
+        message: message
+      }
+      { webhookVerifyToken: webhook_verify_token, event: 'messages.upsert', data: { type: 'notify', messages: [raw_message] } }
+    end
+
+    context 'when receiving a hydrated template message' do
+      it 'stores the text content and the structured rich payload, not unsupported' do
+        params = rich_params(
+          { templateMessage: { hydratedTemplate: {
+            hydratedContentText: 'Your invoice is ready.', hydratedFooterText: 'Reply STOP to opt out.',
+            hydratedButtons: [{ urlButton: { displayText: 'Pay now', url: 'https://acme.io/pay' } }]
+          } }, messageContextInfo: { deviceListMetadataVersion: 2 } },
+          id: 'rich_tpl_1'
+        )
+
+        expect do
+          Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+        end.to change(inbox.messages, :count).by(1)
+
+        message = inbox.messages.last
+        expect(message.is_unsupported).to be_falsey
+        expect(message.content).to eq("Your invoice is ready.\n\nReply STOP to opt out.\n\n▸ Pay now: https://acme.io/pay")
+        expect(message.content_attributes['rich']).to include(
+          'type' => 'template', 'body' => 'Your invoice is ready.', 'footer' => 'Reply STOP to opt out.',
+          'buttons' => [{ 'text' => 'Pay now', 'url' => 'https://acme.io/pay' }]
+        )
+      end
+    end
+
+    context 'when a template carries an externalAdReply (CTWA)' do
+      it 'captures the referral with the numeric proto media type mapped' do
+        params = rich_params(
+          { templateMessage: { hydratedTemplate: { hydratedContentText: 'Promo' },
+                               contextInfo: { externalAdReply: { title: 'Ad', mediaType: 2, ctwaClid: 'CLID1' } } } },
+          id: 'rich_tpl_ad_1'
+        )
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+        message = inbox.messages.last
+        expect(message.content_attributes['rich']).to include('type' => 'template', 'body' => 'Promo')
+        expect(message.content_attributes['referral']).to include('ctwa_clid' => 'CLID1', 'media_type' => 'video')
+      end
+    end
+
+    context 'when receiving an interactive nativeFlow message' do
+      it 'parses the cta_url button from the snake_case params json' do
+        params = rich_params(
+          { interactiveMessage: { body: { text: 'Pick one' },
+                                  nativeFlowMessage: { buttons: [
+                                    { name: 'cta_url', buttonParamsJson: '{"display_text":"Buy","url":"https://b.io"}' }
+                                  ] } } },
+          id: 'rich_interactive_1'
+        )
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+        message = inbox.messages.last
+        expect(message.is_unsupported).to be_falsey
+        expect(message.content).to eq("Pick one\n\n▸ Buy: https://b.io")
+        expect(message.content_attributes.dig('rich', 'buttons')).to eq([{ 'text' => 'Buy', 'url' => 'https://b.io' }])
+      end
+    end
+
+    context 'when the rich message has no renderable content' do
+      it 'marks the message as unsupported' do
+        params = rich_params({ interactiveMessage: {} }, id: 'rich_empty_1')
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+        message = inbox.messages.last
+        expect(message.is_unsupported).to be(true)
+        expect(message.content).to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -1077,5 +1077,154 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
         expect(message.content).to be_nil
       end
     end
+
+    context 'when a template has a media header alongside text' do
+      it 'attaches the header media and keeps the rich card' do
+        params = rich_params(
+          { templateMessage: { hydratedTemplate: {
+            hydratedContentText: 'Segue a fatura em anexo.',
+            documentMessage: { mimetype: 'application/pdf', fileName: 'fatura.pdf' }
+          } } },
+          id: 'rich_tpl_media_1'
+        )
+        stub_request(:get, whatsapp_channel.media_url('rich_tpl_media_1')).to_return(status: 200, body: 'fake pdf')
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+        message = inbox.messages.last
+        expect(message.is_unsupported).to be_falsey
+        expect(message.content_attributes['rich']).to include('body' => 'Segue a fatura em anexo.')
+        expect(message.attachments.count).to eq(1)
+        expect(message.attachments.first.file_type).to eq('file')
+        expect(message.attachments.first.file.filename.to_s).to eq('fatura.pdf')
+      end
+    end
+
+    context 'when a template is only a media header (no text/buttons)' do
+      it 'attaches the media and does not mark the message unsupported' do
+        params = rich_params(
+          { templateMessage: { hydratedTemplate: { imageMessage: { mimetype: 'image/jpeg' } } } },
+          id: 'rich_tpl_media_only_1'
+        )
+        stub_request(:get, whatsapp_channel.media_url('rich_tpl_media_only_1')).to_return(status: 200, body: 'fake image')
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+        message = inbox.messages.last
+        expect(message.is_unsupported).to be_falsey
+        expect(message.content).to be_nil
+        expect(message.content_attributes['rich']).to be_nil
+        expect(message.attachments.count).to eq(1)
+        expect(message.attachments.first.file_type).to eq('image')
+      end
+    end
+
+    context 'when receiving a poll' do
+      it 'renders the question and options as a rich card' do
+        params = rich_params(
+          { pollCreationMessage: { name: 'Qual horário?', options: [{ optionName: 'Manhã' }, { optionName: 'Tarde' }] } },
+          id: 'rich_poll_1'
+        )
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+        message = inbox.messages.last
+        expect(message.is_unsupported).to be_falsey
+        expect(message.content).to eq("Qual horário?\n\n▸ Manhã\n\n▸ Tarde")
+        expect(message.content_attributes['rich']).to include('type' => 'poll', 'title' => 'Qual horário?')
+      end
+    end
+  end
+
+  describe 'location message handling' do
+    let(:phone) { '5511912345678' }
+    let(:lid) { '12345678' }
+
+    after do
+      Redis::Alfred.scan_each(match: "MESSAGE_SOURCE_KEY::#{inbox.id}_*") { |key| Redis::Alfred.delete(key) }
+    end
+
+    def loc_params(message, id:)
+      raw = { key: { id: id, remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false, addressingMode: 'pn' },
+              pushName: 'Lead', messageTimestamp: timestamp, message: message }
+      { webhookVerifyToken: webhook_verify_token, event: 'messages.upsert', data: { type: 'notify', messages: [raw] } }
+    end
+
+    it 'persists a native location attachment (real shape: coordinates only)' do
+      params = loc_params({ locationMessage: { degreesLatitude: -18.9202171, degreesLongitude: -48.2694733 } }, id: 'loc_1')
+
+      Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+      message = inbox.messages.last
+      expect(message.is_unsupported).to be_falsey
+      attachment = message.attachments.first
+      expect(attachment.file_type).to eq('location')
+      expect(attachment.coordinates_lat).to eq(-18.9202171)
+      expect(attachment.coordinates_long).to eq(-48.2694733)
+    end
+
+    it 'uses name/address as the fallback title and keeps the place url' do
+      params = loc_params(
+        { locationMessage: { degreesLatitude: -23.5, degreesLongitude: -46.6, name: 'Padaria', address: 'Rua X, 1',
+                             url: 'https://maps.example/p' } },
+        id: 'loc_2'
+      )
+
+      Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+      attachment = inbox.messages.last.attachments.first
+      expect(attachment.fallback_title).to eq('Padaria, Rua X, 1')
+      expect(attachment.external_url).to eq('https://maps.example/p')
+    end
+  end
+
+  describe 'contact message handling' do
+    let(:phone) { '5511912345678' }
+    let(:lid) { '12345678' }
+    let(:vcard) { "BEGIN:VCARD\nVERSION:3.0\nFN:Algar\nTEL;type=Mobile;waid=553498840123:+55 34 9884-0123\nEND:VCARD" }
+
+    after do
+      Redis::Alfred.scan_each(match: "MESSAGE_SOURCE_KEY::#{inbox.id}_*") { |key| Redis::Alfred.delete(key) }
+    end
+
+    def contact_params(message, id:)
+      raw = { key: { id: id, remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false, addressingMode: 'pn' },
+              pushName: 'Lead', messageTimestamp: timestamp, message: message }
+      { webhookVerifyToken: webhook_verify_token, event: 'messages.upsert', data: { type: 'notify', messages: [raw] } }
+    end
+
+    it 'persists a single contact as a native contact attachment' do
+      params = contact_params({ contactMessage: { displayName: 'Algar', vcard: vcard } }, id: 'contact_1')
+
+      expect do
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+      end.to change(inbox.messages, :count).by(1)
+
+      message = inbox.messages.last
+      expect(message.is_unsupported).to be_falsey
+      expect(message.content).to eq('Algar - +55 34 9884-0123')
+      attachment = message.attachments.first
+      expect(attachment.file_type).to eq('contact')
+      expect(attachment.fallback_title).to eq('+55 34 9884-0123')
+      expect(attachment.meta).to eq('firstName' => 'Algar')
+    end
+
+    it 'creates one message per contact for a contactsArrayMessage (real shape)' do
+      other = "BEGIN:VCARD\nVERSION:3.0\nFN:+551140037752\nTEL;type=Mobile;waid=551140037752:+55 11 4003-7752\nEND:VCARD"
+      params = contact_params(
+        { contactsArrayMessage: { displayName: '2 contacts', contacts: [
+          { displayName: '+551140037752', vcard: other }, { displayName: 'Algar', vcard: vcard }
+        ] } },
+        id: 'contacts_array_1'
+      )
+
+      expect do
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+      end.to change(inbox.messages, :count).by(2)
+
+      messages = inbox.messages.last(2)
+      expect(messages.map { |m| m.attachments.first&.file_type }).to eq(%w[contact contact])
+      expect(messages.map(&:content)).to contain_exactly('+55 11 4003-7752', 'Algar - +55 34 9884-0123')
+    end
   end
 end

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -1047,6 +1047,27 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       end
     end
 
+    context 'when the rich message quotes another message' do
+      it 'anchors the reply to the quoted message' do
+        contact = create(:contact, account: inbox.account, phone_number: "+#{phone}", identifier: "#{lid}@lid")
+        contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: lid)
+        conversation = create(:conversation, inbox: inbox, contact_inbox: contact_inbox)
+        original = create(:message, inbox: inbox, conversation: conversation, source_id: 'QUOTED_RICH_1')
+
+        params = rich_params(
+          { templateMessage: { hydratedTemplate: { hydratedContentText: 'Re: your order' },
+                               contextInfo: { stanzaId: 'QUOTED_RICH_1' } } },
+          id: 'rich_reply_1'
+        )
+
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+        reply = conversation.messages.last
+        expect(reply.in_reply_to).to eq(original.id)
+        expect(reply.in_reply_to_external_id).to eq('QUOTED_RICH_1')
+      end
+    end
+
     context 'when receiving an interactive nativeFlow message' do
       it 'parses the cta_url button from the snake_case params json' do
         params = rich_params(
@@ -1175,6 +1196,24 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       attachment = inbox.messages.last.attachments.first
       expect(attachment.fallback_title).to eq('Padaria, Rua X, 1')
       expect(attachment.external_url).to eq('https://maps.example/p')
+    end
+
+    it 'anchors the reply when the location quotes another message' do
+      contact = create(:contact, account: inbox.account, phone_number: "+#{phone}", identifier: "#{lid}@lid")
+      contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: lid)
+      conversation = create(:conversation, inbox: inbox, contact_inbox: contact_inbox)
+      original = create(:message, inbox: inbox, conversation: conversation, source_id: 'QUOTED_LOC_1')
+
+      params = loc_params(
+        { locationMessage: { degreesLatitude: -23.5, degreesLongitude: -46.6, contextInfo: { stanzaId: 'QUOTED_LOC_1' } } },
+        id: 'loc_reply_1'
+      )
+
+      Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+      reply = conversation.messages.last
+      expect(reply.in_reply_to).to eq(original.id)
+      expect(reply.in_reply_to_external_id).to eq('QUOTED_LOC_1')
     end
   end
 


### PR DESCRIPTION
WhatsApp messages that carry structured content (marketing/utility templates, interactive button menus, list menus, polls, shared locations and shared contacts) used to arrive through the Baileys bridge as an empty "unsupported" bubble, even though Baileys had already decoded the body, buttons and links. Agents now see the full message: the text, a structured card with clickable buttons (links open in a new tab, phone numbers dial), any media that came in the header (e.g. an invoice PDF or banner image), and native bubbles for locations (map) and shared contacts.

This builds directly on @otimizzeai's template work in #313, which is preserved in the history and credited via co-authorship.

## Closes

- Closes #274
- Builds on / supersedes #313 (credit to @otimizzeai)

## How to test

1. Point a Baileys-backed WhatsApp inbox at a number that receives structured messages.
2. From a WABA/Cloud-API sender, send to that inbox:
   - a utility/marketing **template** with body + footer + a URL button and a call button;
   - a template with **media in the header** (image or an invoice PDF);
   - an **interactive** message (button menu / app-download CTA / list menu);
   - a **poll**;
   - a shared **location** and one or more shared **contacts**.
3. In the dashboard, confirm each renders as a readable card (no "unsupported" badge): the URL button opens in a new tab, the call button dials, header media shows inline, the location opens the map bubble, and each shared contact shows in its own contact bubble.

> Header media for templates also requires the matching `baileys-api` bridge change (separate PR) so the bridge extracts and exposes the header attachment.

## What changed

- New `Whatsapp::Baileys::RichMessageParser` PORO normalizes every rich shape (template / interactive nativeFlow / buttons / list / their response variants / poll) into `{ type, title, body, footer, buttons:[{text,url,phone}] }`, plus a flat text rendering for `content`/previews. Defensive JSON parsing means an unexpected payload degrades to `is_unsupported` (the old behavior) and is logged, instead of raising.
- Handles the real WABA "interactive template" shape nested under `templateMessage.interactiveMessageTemplate`.
- Surfaces media in a rich header as a native attachment (image/video/file).
- Locations and shared contacts are stored as native `location`/`contact` attachments (one message per contact), mirroring the Cloud provider.
- New `RichMessage.vue` bubble renders the card; URLs are http(s)-validated like `ReferralCard`.
- CTWA `externalAdReply` carried on rich messages flows into `referral` via the existing helper, so first-touch attribution keeps working.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/315)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich message rendering: card-style messages with title, formatted HTML body, attachment chips, and actionable buttons/links (safe URL handling).
  * Contact messages: native contact cards created per contact.
  * Location messages: native location attachments with coordinates and place info.

* **Tests**
  * Added comprehensive specs covering rich parsing, rendering, contact and location message handling, and edge cases (media headers, malformed params, reply anchoring).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->