### PR TITLE
feat(whatsapp): handle Cloud message edits and flag contact-deleted messages

### DIFF
--- a/app/javascript/dashboard/components-next/message/MessageMeta.vue
+++ b/app/javascript/dashboard/components-next/message/MessageMeta.vue
@@ -225,6 +225,10 @@ const isEdited = computed(() => {
 const previousContent = computed(() => {
   return contentAttributes.value?.previousContent || '';
 });
+
+const deletedByContact = computed(() => {
+  return contentAttributes.value?.deletedByContact === true;
+});
 </script>
 
 <template>
@@ -251,6 +255,16 @@ const previousContent = computed(() => {
       class="inline-flex items-center gap-0.5"
     >
       <Icon icon="i-lucide-pencil" class="size-3" />
+    </span>
+    <span
+      v-if="deletedByContact"
+      v-tooltip.top="{
+        content: t('CONVERSATION.MESSAGE_DELETED_BY_CONTACT'),
+        delay: { show: 300, hide: 0 },
+      }"
+      class="inline-flex items-center gap-0.5"
+    >
+      <Icon icon="i-lucide-trash-2" class="size-3" />
     </span>
     <Icon v-if="isPrivate" icon="i-lucide-lock-keyhole" class="size-3" />
     <MessageStatus v-if="showStatusIndicator" :status="statusToShow" />

--- a/app/javascript/dashboard/components-next/message/bubbles/Base.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Base.vue
@@ -29,6 +29,12 @@ const { t } = useI18n();
 // Click-to-WhatsApp ad metadata attached to the first message after an ad click.
 const referral = computed(() => contentAttributes.value?.referral);
 
+// The contact deleted/revoked this message on WhatsApp. We keep the content
+// readable but mute the bubble and add a dashed border to signal the deletion.
+const deletedByContact = computed(
+  () => contentAttributes.value?.deletedByContact === true
+);
+
 const varaintBaseMap = {
   [MESSAGE_VARIANTS.AGENT]: 'bg-n-solid-blue text-n-slate-12',
   [MESSAGE_VARIANTS.PRIVATE]:
@@ -82,6 +88,10 @@ const messageClass = computed(() => {
 
   if (scheduledMessageClass.value) {
     classToApply.push(scheduledMessageClass.value);
+  }
+
+  if (deletedByContact.value) {
+    classToApply.push('border-2 border-dashed border-n-slate-7 opacity-75');
   }
 
   return classToApply;

--- a/app/javascript/dashboard/components-next/message/bubbles/Text/FormattedContent.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Text/FormattedContent.vue
@@ -47,6 +47,14 @@ const shouldShowEditedIndicator = computed(() => {
   return isEdited.value && shouldGroupWithNext.value;
 });
 
+const deletedByContact = computed(() => {
+  return contentAttributes.value?.deletedByContact === true;
+});
+
+const shouldShowDeletedByContactIndicator = computed(() => {
+  return deletedByContact.value && shouldGroupWithNext.value;
+});
+
 // Scheduled message indicator
 const isScheduledMessage = computed(
   () => !!additionalAttributes.value?.scheduledMessageId
@@ -164,6 +172,17 @@ const iconColorClass = computed(() => {
       class="inline-flex items-center ml-1 align-middle"
     >
       <Icon icon="i-lucide-pencil" class="size-3" />
+    </span>
+    <span
+      v-if="shouldShowDeletedByContactIndicator"
+      v-tooltip.top="{
+        content: t('CONVERSATION.MESSAGE_DELETED_BY_CONTACT'),
+        delay: { show: 300, hide: 0 },
+      }"
+      :class="iconColorClass"
+      class="inline-flex items-center ml-1 align-middle"
+    >
+      <Icon icon="i-lucide-trash-2" class="size-3" />
     </span>
   </span>
 </template>

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -277,6 +277,7 @@
     "FILE_SIZE_LIMIT": "File exceeds the {MAXIMUM_SUPPORTED_FILE_UPLOAD_SIZE} MB attachment limit",
     "FILE_TYPE_NOT_SUPPORTED": "This {fileName} file type is not supported in this conversation",
     "MESSAGE_ERROR": "Unable to send this message, please try again later",
+    "MESSAGE_DELETED_BY_CONTACT": "Deleted by the contact",
     "SENT_BY": "Sent by:",
     "BOT": "Bot",
     "NATIVE_APP": "Native app",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/conversation.json
@@ -277,6 +277,7 @@
     "FILE_SIZE_LIMIT": "O arquivo excede os {MAXIMUM_SUPPORTED_FILE_UPLOAD_SIZE} MB do limite para anexos",
     "FILE_TYPE_NOT_SUPPORTED": "O tipo de arquivo {fileName} não é suportado nesta conversa",
     "MESSAGE_ERROR": "Não foi possível enviar esta mensagem, por favor, tente novamente mais tarde",
+    "MESSAGE_DELETED_BY_CONTACT": "Apagada pelo contato",
     "SENT_BY": "Enviado por:",
     "BOT": "Robôs",
     "WHATSAPP": "WhatsApp",

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -117,11 +117,13 @@ class Message < ApplicationRecord
   # [:zapi_args] : Used to pass additional arguments specific to Z-API WhatsApp provider
   # [:referral] : Click-to-WhatsApp ad metadata (source ad, headline, ctwa_clid, ...) attached to the first message after an ad click
   # [:rich] : Structured WhatsApp "rich" message (template/interactive/buttons/list) with title/body/footer/buttons rendered as a card
+  # [:deleted_by_contact] : The contact deleted/revoked the message on WhatsApp; we keep the content visible and only flag it
 
   store :content_attributes, accessors: [:submitted_email, :items, :submitted_values, :email, :in_reply_to, :deleted,
                                          :external_created_at, :story_sender, :story_id, :external_error,
                                          :translations, :in_reply_to_external_id, :is_unsupported, :data,
-                                         :is_reaction, :is_edited, :previous_content, :zapi_args, :referral, :rich], coder: JSON
+                                         :is_reaction, :is_edited, :previous_content, :zapi_args, :referral, :rich,
+                                         :deleted_by_contact], coder: JSON
 
   store :external_source_ids, accessors: [:slack], coder: JSON, prefix: :external_source_id
 

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -263,6 +263,17 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
     message_type.in?(%w[protocol context edited])
   end
 
+  # A protocolMessage of type REVOKE is the contact deleting a message for everyone.
+  # Baileys delivers it as a messages.upsert entry whose protocolMessage.key.id
+  # points at the original message.
+  def protocol_revoke?
+    unwrap_ephemeral_message(@raw_message[:message] || {}).dig(:protocolMessage, :type) == 'REVOKE'
+  end
+
+  def protocol_revoke_target_id
+    unwrap_ephemeral_message(@raw_message[:message] || {}).dig(:protocolMessage, :key, :id)
+  end
+
   def reaction_removal?
     message_type == 'reaction' && message_content.blank?
   end

--- a/app/services/whatsapp/baileys_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_upsert.rb
@@ -45,6 +45,11 @@ module Whatsapp::BaileysHandlers::MessagesUpsert
 
   # The contact deleted a message for everyone. Keep the stored content and only
   # flag it as deleted by the contact so the UI can mark it while staying readable.
+  # NOTE: If the revoke webhook somehow arrives before the original message is
+  # processed, find_message_by_source_id returns nil and the revoke becomes a
+  # no-op; the original is later created without the flag. WhatsApp delivers
+  # webhooks in order so this is rare and accepted; persisting pending revokes
+  # would require updating this flagging logic.
   def handle_revoke
     return unless find_message_by_source_id(protocol_revoke_target_id)
 

--- a/app/services/whatsapp/baileys_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_upsert.rb
@@ -30,12 +30,25 @@ module Whatsapp::BaileysHandlers::MessagesUpsert
     @lock_acquired = false
 
     return handle_message_stub if message_stub?
+    return handle_revoke if protocol_revoke?
 
     return if ignore_message?
     return if find_message_by_source_id(raw_message_id)
 
+    route_contact_message
+  end
+
+  def route_contact_message
     return handle_individual_contact_message if %w[lid user].include?(jid_type)
     return handle_group_contact_message if jid_type == 'group' && Whatsapp::Providers::WhatsappBaileysService.groups_enabled?
+  end
+
+  # The contact deleted a message for everyone. Keep the stored content and only
+  # flag it as deleted by the contact so the UI can mark it while staying readable.
+  def handle_revoke
+    return unless find_message_by_source_id(protocol_revoke_target_id)
+
+    @message.update!(deleted_by_contact: true)
   end
 
   def message_stub?

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -11,6 +11,10 @@ class Whatsapp::IncomingMessageBaseService # rubocop:disable Metrics/ClassLength
 
     if processed_params.try(:[], :statuses).present?
       process_statuses
+    elsif edited_message?
+      process_edited_message
+    elsif revoked_message?
+      process_revoked_message
     elsif messages_data.present?
       process_messages
     end
@@ -113,6 +117,45 @@ class Whatsapp::IncomingMessageBaseService # rubocop:disable Metrics/ClassLength
       message.external_error = "#{error[:code]}: #{error[:title]}"
     end
     message.save!
+  end
+
+  # WhatsApp Cloud delivers an in-place edit as a `type: "edit"` entry under the
+  # `messages` field: the new content is nested in `edit.message` and the edited
+  # message is referenced by `edit.original_message_id`. We update the stored
+  # message in place to mirror the Baileys edit flow (is_edited + previous_content),
+  # which the frontend already renders. Coexistence (embedded signup) inbound edits
+  # arrive through this same `messages` path, so no echo-specific handling is needed.
+  def edited_message?
+    messages_data.present? && message_type == 'edit'
+  end
+
+  def revoked_message?
+    messages_data.present? && message_type == 'revoke'
+  end
+
+  def process_edited_message
+    edit = messages_data.first[:edit]
+    return if edit.blank?
+    return unless find_message_by_source_id(edit[:original_message_id])
+
+    content = edited_message_content(edit[:message])
+    return if content.blank?
+
+    # Keep the earliest known content as previous_content across repeated edits.
+    previous_content = @message.is_edited ? @message.previous_content : @message.content
+    @message.update!(content: content, is_edited: true, previous_content: previous_content)
+  end
+
+  # WhatsApp Cloud delivers a sender-initiated delete as a `type: "revoke"` entry
+  # under the `messages` field, referencing the deleted message via
+  # `revoke.original_message_id`. We keep the original content and only flag the
+  # message as deleted by the contact (the frontend marks it but still shows the text).
+  def process_revoked_message
+    revoke = messages_data.first[:revoke]
+    return if revoke.blank?
+    return unless find_message_by_source_id(revoke[:original_message_id])
+
+    @message.update!(deleted_by_contact: true)
   end
 
   def create_messages

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -41,6 +41,18 @@ module Whatsapp::IncomingMessageServiceHelpers # rubocop:disable Metrics/ModuleL
       referral_fallback_content(message)
   end
 
+  # Edited messages nest the new content under `edit.message`, which carries its own
+  # type. Reuse message_content for text/interactive bodies and fall back to the
+  # media caption for image/video/document edits.
+  def edited_message_content(edited)
+    return if edited.blank?
+
+    message_content(edited) ||
+      edited.dig(:image, :caption) ||
+      edited.dig(:video, :caption) ||
+      edited.dig(:document, :caption)
+  end
+
   # Ad-click webhooks can arrive with no textual body (e.g. request_welcome), so
   # fall back to the ad headline/body to keep the message renderable.
   def referral_fallback_content(message)

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -276,6 +276,37 @@ describe Whatsapp::IncomingMessageBaileysService do
         end
       end
 
+      context 'when message is a revoke (contact deleted for everyone)' do
+        let(:original_message) do
+          contact = create(:contact, account: inbox.account, phone_number: '+5511912345678')
+          contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox, source_id: '5511912345678')
+          conversation = create(:conversation, contact: contact, inbox: inbox, contact_inbox: contact_inbox)
+          create(:message, conversation: conversation, source_id: 'original_msg_id', content: 'secret message')
+        end
+
+        it 'flags the original message as deleted by the contact and keeps the content' do
+          original_message
+          raw_message[:message] = { protocolMessage: { key: { id: 'original_msg_id' }, type: 'REVOKE' } }
+
+          expect do
+            described_class.new(inbox: inbox, params: params).perform
+          end.not_to(change { inbox.messages.count })
+
+          original_message.reload
+          expect(original_message.content).to eq('secret message')
+          expect(original_message.content_attributes['deleted_by_contact']).to be(true)
+        end
+
+        it 'does nothing when the revoked message is unknown' do
+          raw_message[:message] = { protocolMessage: { key: { id: 'unknown_id' }, type: 'REVOKE' } }
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.messages).to be_empty
+          expect(inbox.contact_inboxes).to be_empty
+        end
+      end
+
       context 'when message is not from a user' do
         it 'does not create a conversation' do
           raw_message[:key][:remoteJid] = 'status@broadcast'

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -379,6 +379,158 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
     end
   end
 
+  # WhatsApp Cloud (including coexistence / embedded signup, which the factory
+  # configures by default via provider_config['source'] = 'embedded_signup')
+  # delivers an in-place edit as a `type: "edit"` message under the `messages`
+  # field. Editing flows through the shared base service, so the same coverage
+  # applies to both regular cloud and coexistence inboxes.
+  describe '#perform with an edited message' do
+    after do
+      Redis::Alfred.scan_each(match: 'MESSAGE_SOURCE_KEY::*') { |key| Redis::Alfred.delete(key) }
+    end
+
+    let!(:whatsapp_channel) { create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false) }
+    let(:text_edit_params) { edit_params({ context: { id: 'M0' }, type: 'text', text: { body: 'Edited content' } }) }
+
+    def edit_params(edited_message)
+      message = { from: '2423423243', id: 'wamid.EDIT_EVENT_ID', timestamp: '1664799999', type: 'edit',
+                  edit: { original_message_id: 'wamid.ORIGINAL_MESSAGE_ID', message: edited_message } }
+      value = { contacts: [{ profile: { name: 'Sojan Jose' }, wa_id: '2423423243' }], messages: [message] }
+      {
+        phone_number: whatsapp_channel.phone_number,
+        object: 'whatsapp_business_account',
+        entry: [{ changes: [{ field: 'messages', value: value }] }]
+      }.with_indifferent_access
+    end
+
+    def create_original_message(content:, content_attributes: {})
+      contact = create(:contact, phone_number: '+2423423243', account: whatsapp_channel.account)
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: whatsapp_channel.inbox, source_id: '2423423243')
+      conversation = create(:conversation, contact: contact, inbox: whatsapp_channel.inbox, contact_inbox: contact_inbox)
+      create(:message, conversation: conversation, source_id: 'wamid.ORIGINAL_MESSAGE_ID',
+                       content: content, content_attributes: content_attributes)
+    end
+
+    context 'when the original message exists' do
+      it 'updates the content in place and records the previous content' do
+        original = create_original_message(content: 'Original content')
+
+        expect do
+          described_class.new(inbox: whatsapp_channel.inbox, params: text_edit_params).perform
+        end.not_to(change { whatsapp_channel.inbox.messages.count })
+
+        original.reload
+        expect(original.content).to eq('Edited content')
+        expect(original.content_attributes['is_edited']).to be true
+        expect(original.content_attributes['previous_content']).to eq('Original content')
+      end
+
+      it 'preserves the earliest previous_content across repeated edits' do
+        original = create_original_message(content: 'First edit', content_attributes: { is_edited: true, previous_content: 'Original content' })
+
+        described_class.new(inbox: whatsapp_channel.inbox, params: text_edit_params).perform
+
+        original.reload
+        expect(original.content).to eq('Edited content')
+        expect(original.content_attributes['previous_content']).to eq('Original content')
+      end
+
+      it 'updates a media caption edit' do
+        original = create_original_message(content: 'Old caption')
+        params = edit_params({ type: 'image', image: { id: 'media-id', mime_type: 'image/jpeg', caption: 'New caption' } })
+
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+
+        original.reload
+        expect(original.content).to eq('New caption')
+        expect(original.content_attributes['is_edited']).to be true
+        expect(original.content_attributes['previous_content']).to eq('Old caption')
+      end
+    end
+
+    context 'when the original message does not exist' do
+      it 'does not create a new message or contact' do
+        expect do
+          described_class.new(inbox: whatsapp_channel.inbox, params: text_edit_params).perform
+        end.to not_change(whatsapp_channel.inbox.messages, :count).and not_change(Contact, :count)
+
+        expect(whatsapp_channel.inbox.messages).to be_empty
+      end
+    end
+
+    context 'when the edit carries no usable content' do
+      it 'leaves the original message untouched' do
+        original = create_original_message(content: 'Original content')
+        params = edit_params({ type: 'text', text: {} })
+
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+
+        original.reload
+        expect(original.content).to eq('Original content')
+        expect(original.content_attributes['is_edited']).to be_nil
+      end
+    end
+  end
+
+  # The contact deleting their own message arrives as `type: "revoke"` under the
+  # `messages` field. We keep the content visible and only flag deleted_by_contact.
+  describe '#perform with a revoked (deleted) message' do
+    after do
+      Redis::Alfred.scan_each(match: 'MESSAGE_SOURCE_KEY::*') { |key| Redis::Alfred.delete(key) }
+    end
+
+    let!(:whatsapp_channel) { create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false) }
+    let(:revoke_params) do
+      {
+        phone_number: whatsapp_channel.phone_number,
+        object: 'whatsapp_business_account',
+        entry: [{
+          changes: [{
+            field: 'messages',
+            value: {
+              contacts: [{ profile: { name: 'Sojan Jose' }, wa_id: '2423423243' }],
+              messages: [{
+                from: '2423423243', id: 'wamid.REVOKE_EVENT_ID', timestamp: '1664799999',
+                type: 'revoke', revoke: { original_message_id: 'wamid.ORIGINAL_MESSAGE_ID' }
+              }]
+            }
+          }]
+        }]
+      }.with_indifferent_access
+    end
+
+    def create_original_message(content:)
+      contact = create(:contact, phone_number: '+2423423243', account: whatsapp_channel.account)
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: whatsapp_channel.inbox, source_id: '2423423243')
+      conversation = create(:conversation, contact: contact, inbox: whatsapp_channel.inbox, contact_inbox: contact_inbox)
+      create(:message, conversation: conversation, source_id: 'wamid.ORIGINAL_MESSAGE_ID', content: content)
+    end
+
+    context 'when the original message exists' do
+      it 'flags it as deleted by the contact while keeping the content' do
+        original = create_original_message(content: 'secret message')
+
+        expect do
+          described_class.new(inbox: whatsapp_channel.inbox, params: revoke_params).perform
+        end.not_to(change { whatsapp_channel.inbox.messages.count })
+
+        original.reload
+        expect(original.content).to eq('secret message')
+        expect(original.content_attributes['deleted_by_contact']).to be true
+      end
+    end
+
+    context 'when the original message does not exist' do
+      it 'does not create a new message or contact' do
+        expect do
+          described_class.new(inbox: whatsapp_channel.inbox, params: revoke_params).perform
+        end.to not_change(whatsapp_channel.inbox.messages, :count).and not_change(Contact, :count)
+
+        expect(whatsapp_channel.inbox.messages).to be_empty
+      end
+    end
+  end
+
   describe '#perform with a click-to-WhatsApp ad referral' do
     # The service clears its own dedupe key in an ensure; this is a safety net for
     # any path that bails before the lock, scoped to this inbox so it can't wipe


### PR DESCRIPTION
Brings inbound message edits and deletions to parity across WhatsApp providers. When a customer edits a message on WhatsApp, the conversation now updates in place (previously only Baileys did this; the official Cloud API, including coexistence/embedded signup inboxes, was ignored). When a customer deletes a message for everyone, the bubble stays readable but is visually marked as deleted by the contact, so agents keep the context instead of losing it.

## Closes
- N/A

## How to test
1. On a WhatsApp Cloud (or coexistence) inbox, have the customer send a message, then edit it on their phone. The message in Chatwoot updates to the new text and shows the "edited" indicator; hovering reveals the previous content.
2. Have the customer delete a message for everyone (Cloud or Baileys inbox). The bubble keeps the original text but gets a dashed, muted border and a trash indicator tooltip "Deleted by the contact" / "Apagada pelo contato".

## What changed
- `Whatsapp::IncomingMessageBaseService` now routes `type: "edit"` and `type: "revoke"` Cloud webhooks to in-place updates (`is_edited`/`previous_content` for edits, `deleted_by_contact` flag for deletes).
- Baileys `messages.upsert` handler treats a `protocolMessage` of type `REVOKE` as a contact delete, flagging `deleted_by_contact` while keeping the stored content.
- New `deleted_by_contact` content attribute on `Message`.
- Frontend: dashed/muted bubble + trash indicator (`MessageMeta.vue`, `Base.vue`, `FormattedContent.vue`) with pt-BR/en strings.
- Specs for Cloud edit (text + media caption + repeated edits + unknown/empty edge cases) and revoke, plus Baileys revoke.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/316)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages deleted by contacts now show a muted, dashed-bordered appearance plus a trash icon tooltip while preserving original content
  * Support for WhatsApp in-place message edits with content tracking
  * Automatic handling of message revocations from contacts

* **Localization**
  * Added English and Portuguese (Brazil) translations for the "Deleted by the contact" indicator

* **Tests**
  * Added specs covering revoke and edit handling for both protocols
<!-- end of auto-generated comment: release notes by coderabbit.ai -->