### PR TITLE
fix(automation): widen action dropdown and flip selects upward near viewport edge

### DIFF
--- a/app/javascript/dashboard/components-next/filter/inputs/MultiSelect.vue
+++ b/app/javascript/dashboard/components-next/filter/inputs/MultiSelect.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { defineModel, computed } from 'vue';
+import { defineModel, computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useElementBounding, useWindowSize } from '@vueuse/core';
 import Icon from 'next/icon/Icon.vue';
 import Button from 'next/button/Button.vue';
 import DropdownContainer from 'next/dropdown-menu/base/DropdownContainer.vue';
@@ -27,6 +28,24 @@ const { t } = useI18n();
 const selected = defineModel({
   type: [Array, String],
   required: true,
+});
+
+const triggerRef = ref(null);
+const dropdownRef = ref(null);
+
+const { top } = useElementBounding(triggerRef);
+const { height } = useWindowSize();
+const { height: dropdownHeight } = useElementBounding(dropdownRef);
+
+// Open the menu upward when there isn't enough room below the trigger, so it
+// never overflows past the viewport bottom (e.g. action selects low in a tall modal).
+const dropdownPosition = computed(() => {
+  // Matches the default `dropdownMaxHeight` prop (`max-h-80` = 320px); used as a
+  // fallback before the menu has been measured. 20px keeps a small gap below.
+  const DROPDOWN_MAX_HEIGHT = 320;
+  const menuHeight = (dropdownHeight.value || DROPDOWN_MAX_HEIGHT) + 20;
+  const spaceBelow = height.value - top.value;
+  return spaceBelow < menuHeight ? 'bottom-0' : 'top-0';
 });
 
 const hasItems = computed(() => {
@@ -95,6 +114,7 @@ const toggleOption = option => {
     <template #trigger="{ toggle }">
       <button
         v-if="hasItems"
+        ref="triggerRef"
         class="bg-n-alpha-2 py-2 rounded-lg h-8 flex items-center px-0"
         @click="toggle"
       >
@@ -119,14 +139,19 @@ const toggleOption = option => {
           <Icon icon="i-lucide-plus" />
         </div>
       </button>
-      <Button v-else sm slate faded @click="toggle">
+      <Button v-else ref="triggerRef" sm slate faded @click="toggle">
         <template #icon>
           <Icon icon="i-lucide-plus" class="text-n-slate-11" />
         </template>
         <span class="text-n-slate-11">{{ t('COMBOBOX.PLACEHOLDER') }}</span>
       </Button>
     </template>
-    <DropdownBody class="top-0 min-w-48 z-50" strong>
+    <DropdownBody
+      ref="dropdownRef"
+      class="min-w-48 z-50"
+      :class="dropdownPosition"
+      strong
+    >
       <DropdownSection :height="dropdownMaxHeight">
         <DropdownItem
           v-for="option in options"

--- a/app/javascript/dashboard/components-next/filter/inputs/SingleSelect.vue
+++ b/app/javascript/dashboard/components-next/filter/inputs/SingleSelect.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { defineModel, computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useElementBounding, useWindowSize } from '@vueuse/core';
 import { picoSearch } from '@scmmishra/pico-search';
 import Icon from 'next/icon/Icon.vue';
 import Button from 'next/button/Button.vue';
@@ -59,6 +60,24 @@ const selected = defineModel({
   required: true,
 });
 
+const triggerRef = ref(null);
+const dropdownRef = ref(null);
+
+const { top } = useElementBounding(triggerRef);
+const { height } = useWindowSize();
+const { height: dropdownHeight } = useElementBounding(dropdownRef);
+
+// Open the menu upward when there isn't enough room below the trigger, so it
+// never overflows past the viewport bottom (e.g. action selects low in a tall modal).
+const dropdownPosition = computed(() => {
+  // Matches the default `dropdownMaxHeight` prop (`max-h-80` = 320px); used as a
+  // fallback before the menu has been measured. 20px keeps a small gap below.
+  const DROPDOWN_MAX_HEIGHT = 320;
+  const menuHeight = (dropdownHeight.value || DROPDOWN_MAX_HEIGHT) + 20;
+  const spaceBelow = height.value - top.value;
+  return spaceBelow < menuHeight ? 'bottom-0' : 'top-0';
+});
+
 const searchTerm = ref('');
 const searchResults = computed(() => {
   if (!options) return [];
@@ -101,6 +120,7 @@ const toggleSelected = option => {
     <template #trigger="{ toggle }">
       <Button
         v-if="selectedItem"
+        ref="triggerRef"
         sm
         slate
         faded
@@ -111,6 +131,7 @@ const toggleSelected = option => {
       />
       <Button
         v-else
+        ref="triggerRef"
         sm
         slate
         faded
@@ -126,7 +147,12 @@ const toggleSelected = option => {
         }}</span>
       </Button>
     </template>
-    <DropdownBody class="top-0 min-w-56 z-50" strong>
+    <DropdownBody
+      ref="dropdownRef"
+      class="min-w-56 z-50"
+      :class="dropdownPosition"
+      strong
+    >
       <div v-if="!disableSearch" class="relative">
         <Icon class="absolute size-4 left-2 top-2" icon="i-lucide-search" />
         <input

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleForm.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/AutomationRuleForm.vue
@@ -362,7 +362,7 @@ defineExpose({ open, close });
             :key="i"
             v-model="automation.actions[i]"
             :action-types="automationActionTypes"
-            dropdown-max-height="max-h-[7.5rem]"
+            dropdown-max-height="max-h-72"
             :dropdown-values="getActionDropdownValues(action.action_name)"
             :show-action-input="
               showActionInput(automationActionTypes, action.action_name)


### PR DESCRIPTION
Improves the automation rule action dropdown: it now opens taller (matching the conditions dropdown) so more actions are visible at once, and any select that would overflow past the bottom of the viewport now flips upward instead of being clipped.

## What changed
- `SingleSelect`/`MultiSelect` (shared filter inputs): open the menu upward when there isn't enough room below the trigger, anchored to the rendered menu height.
- Automation rule form: action dropdown height raised from `max-h-[7.5rem]` (~3 items) to `max-h-72`, matching the conditions dropdown.

## How to test
- Settings → Automation → add/edit a rule. Open the action select: the list is taller and, when the action sits low in a tall modal, the menu opens upward instead of overflowing off-screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/317)
<!-- Reviewable:end -->
