### PR TITLE
test: stub Vite tag helpers to avoid on-demand build in request specs

### DIFF
--- a/spec/support/vite_test_stub.rb
+++ b/spec/support/vite_test_stub.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Specs never need the real Vite bundle. Rendering a view that calls the Vite
+# tag helpers (e.g. the super_admin/Administrate layout) would otherwise trigger
+# an on-demand `vite build` whenever no manifest exists (as in CI), which is
+# slow enough to time out the request and surface as a 500. Stub the helpers so
+# request specs render those layouts without building any assets.
+ViteRails::TagHelpers.module_eval do
+  def vite_client_tag(*_args, **_options) = ''
+  def vite_javascript_tag(*_names, **_options) = ''
+  def vite_typescript_tag(*_names, **_options) = ''
+  def vite_stylesheet_tag(*_names, **_options) = ''
+  def vite_react_refresh_tag(*_args, **_options) = ''
+end


### PR DESCRIPTION
Fixes flaky `backend-tests` failures where super_admin (Administrate) request specs intermittently returned 500.

## Root cause
The super_admin layout renders Vite tag helpers (`vite_client_tag`, `vite_javascript_tag 'superadmin'`). In CI there is no pre-built Vite manifest, so the first super_admin request triggers an on-demand `vite build` (`autoBuild: true` in the test env). That build can take minutes and time out the request, surfacing as a 500. It passes or fails depending on build/cache timing, which is why it was intermittent.

## Fix
Stub the Vite tag helpers in the test environment so request specs render those layouts without building any assets. No spec asserts on real Vite output, and there are no JS-driven system/feature specs, so this is safe.

## How to reproduce
On a clean checkout with no `public/vite-test` manifest, run a super_admin request spec (e.g. `spec/controllers/super_admin/access_tokens_controller_spec.rb`) together with its CI shard — the request hangs building Vite and eventually 500s. With the stub it passes in ~1s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/318)
<!-- Reviewable:end -->
