### PR TITLE
feat: discard stale baileys connection.update events by lease epoch

### DIFF
--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -6,17 +6,45 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
   def process_connection_update
     data = processed_params[:data]
 
-    # NOTE: `connection` values
-    #   - `close`: Never opened, or closed and no longer able to send/receive messages
-    #   - `connecting`: In the process of connecting, expecting QR code to be read
-    #   - `reconnecting`: Connection has been established, but not open (i.e. device is being linked for the first time, or Baileys server restart)
-    #   - `open`: Open and ready to send/receive messages
-    inbox.channel.update_provider_connection!({
-      connection: data[:connection] || inbox.channel.provider_connection['connection'],
-      qr_data_url: data[:qrDataUrl] || nil,
-      error: data[:error] ? I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}") : nil
-    }.compact)
+    if stale_connection_event?(data)
+      Rails.logger.warn(
+        "Baileys stale connection.update discarded: epoch #{data[:epoch]} < #{inbox.channel.provider_connection['epoch']}"
+      )
+      return
+    end
+
+    inbox.channel.update_provider_connection!(provider_connection_payload(data))
 
     Rails.logger.error "Baileys connection error: #{data[:error]}" if data[:error].present?
+  end
+
+  # NOTE: `connection` values
+  #   - `close`: Never opened, or closed and no longer able to send/receive messages
+  #   - `connecting`: In the process of connecting, expecting QR code to be read
+  #   - `reconnecting`: Connection has been established, but not open (i.e. device is being linked for the first time, or Baileys server restart)
+  #   - `open`: Open and ready to send/receive messages
+  def provider_connection_payload(data)
+    {
+      connection: data[:connection] || inbox.channel.provider_connection['connection'],
+      qr_data_url: data[:qrDataUrl] || nil,
+      error: data[:error] ? I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}") : nil,
+      epoch: data[:epoch]
+    }.compact
+  end
+
+  # In a multi-instance baileys-api deployment, ownership of a phone number
+  # moves between instances (failover, rebalance, rolling deploys). Each
+  # connection.update carries the lease epoch of its sender; events from a
+  # previous owner can arrive late (webhook retries) and must not overwrite
+  # the current owner's state — last-writer-wins here would leave the inbox
+  # stuck on a stale "reconnecting" while the connection is actually open.
+  # Events without an epoch (older baileys-api versions) are always accepted.
+  def stale_connection_event?(data)
+    return false if data[:epoch].blank?
+
+    last_epoch = inbox.channel.provider_connection['epoch']
+    return false if last_epoch.blank?
+
+    data[:epoch].to_i < last_epoch.to_i
   end
 end

--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -6,16 +6,17 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
   def process_connection_update
     data = processed_params[:data]
 
-    if stale_connection_event?(data)
-      Rails.logger.warn(
-        "Baileys stale connection.update discarded: epoch #{data[:epoch]} < #{inbox.channel.provider_connection['epoch']}"
-      )
-      return
+    inbox.channel.with_lock do
+      if stale_connection_event?(data)
+        Rails.logger.warn(
+          "Baileys stale connection.update discarded: epoch #{data[:epoch]} < #{inbox.channel.provider_connection['epoch']}"
+        )
+        next
+      end
+
+      inbox.channel.update_provider_connection!(provider_connection_payload(data))
+      Rails.logger.error "Baileys connection error: #{data[:error]}" if data[:error].present?
     end
-
-    inbox.channel.update_provider_connection!(provider_connection_payload(data))
-
-    Rails.logger.error "Baileys connection error: #{data[:error]}" if data[:error].present?
   end
 
   # NOTE: `connection` values

--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -28,7 +28,7 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
     {
       connection: data[:connection] || inbox.channel.provider_connection['connection'],
       qr_data_url: data[:qrDataUrl] || nil,
-      error: data[:error] ? I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}") : nil,
+      error: data[:error] ? I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}", default: data[:error].to_s.humanize) : nil,
       epoch: data[:epoch]
     }.compact
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,7 @@ en:
       channel:
         provider_connection:
           wrong_phone_number: The phone number you are trying to link is not the same as the one you have configured. Please make sure the phone number is correct before scanning the QR code.
+          reconnect_loop_detected: The connection could not be re-established after several attempts. Please try reconnecting the inbox.
     custom_filters:
       number_of_records: Limit reached. The maximum number of allowed custom filters for a user per account is 1000.
       invalid_attribute: Invalid attribute key - [%{key}]. The key should be one of [%{allowed_keys}] or a custom attribute defined in the account.

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -135,6 +135,7 @@ pt_BR:
       channel:
         provider_connection:
           wrong_phone_number: O número de telefone que você está tentando conectar não é o mesmo que o configurado. Certifique-se de que o número está correto antes de escanear o QR code.
+          reconnect_loop_detected: Não foi possível restabelecer a conexão após várias tentativas. Tente reconectar a caixa de entrada.
     custom_filters:
       number_of_records: Limite atingido. O número máximo de filtros personalizados permitidos para um usuário por conta é de 1000.
       invalid_attribute: Chave de atributo inválido - [%{key}]. A chave deve ser uma das [%{allowed_keys}] ou um atributo personalizado definido na conta.

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -230,6 +230,13 @@ describe Whatsapp::IncomingMessageBaileysService do
 
           expect(inbox.channel.provider_connection).to include('connection' => 'open', 'epoch' => 3)
         end
+
+        it 'acquires a row lock so the epoch check and update are atomic' do
+          params = base_params.merge({ data: { connection: 'open', epoch: 7 } })
+          expect(inbox.channel).to receive(:with_lock).and_call_original
+
+          described_class.new(inbox: inbox, params: params).perform
+        end
       end
     end
 

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -162,6 +162,75 @@ describe Whatsapp::IncomingMessageBaileysService do
 
         expect(inbox.channel.provider_connection['error']).to be_nil
       end
+
+      context 'with lease epochs (multi-instance baileys-api)' do
+        it 'persists the epoch alongside the connection state' do
+          params = base_params.merge(
+            {
+              data: { connection: 'open', epoch: 7 }
+            }
+          )
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection).to include('connection' => 'open', 'epoch' => 7)
+        end
+
+        it 'discards events carrying an epoch older than the last seen' do
+          # A late retry from a previous owner (e.g. "reconnecting") must not
+          # overwrite the current owner's "open".
+          inbox.channel.update_provider_connection!(connection: 'open', epoch: 7)
+          params = base_params.merge(
+            {
+              data: { connection: 'reconnecting', epoch: 6 }
+            }
+          )
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection['connection']).to eq('open')
+          expect(inbox.channel.provider_connection['epoch']).to eq(7)
+        end
+
+        it 'accepts events with the same epoch as the last seen' do
+          inbox.channel.update_provider_connection!(connection: 'reconnecting', epoch: 7)
+          params = base_params.merge(
+            {
+              data: { connection: 'open', epoch: 7 }
+            }
+          )
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection['connection']).to eq('open')
+        end
+
+        it 'accepts events without an epoch (older baileys-api versions)' do
+          inbox.channel.update_provider_connection!(connection: 'reconnecting', epoch: 7)
+          params = base_params.merge(
+            {
+              data: { connection: 'open' }
+            }
+          )
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection['connection']).to eq('open')
+        end
+
+        it 'accepts any epoch when none has been seen yet' do
+          inbox.channel.update_provider_connection!(connection: 'reconnecting')
+          params = base_params.merge(
+            {
+              data: { connection: 'open', epoch: 3 }
+            }
+          )
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection).to include('connection' => 'open', 'epoch' => 3)
+        end
+      end
     end
 
     context 'when processing messages.upsert event' do


### PR DESCRIPTION
## Summary

Companion to fazer-ai/baileys-api#315 (multi-instance baileys-api support).

When ownership of a phone number moves between baileys-api instances (failover, rebalance, rolling deploys), `connection.update` webhooks from the previous owner can arrive late — the baileys-api webhook retry window holds events for up to ~65s. With last-writer-wins handling, a stale `reconnecting` could overwrite the new owner's `open`, leaving the inbox UI stuck on a broken state while the connection is actually healthy.

baileys-api now stamps every `connection.update` with the **lease epoch** of its sender (monotonic per phone across ownership transitions). This PR:

- persists the epoch in `provider_connection` and **discards events whose epoch is strictly older** than the last seen (same epoch is accepted — same owner);
- accepts events without an epoch (older baileys-api versions), so the rollout order between the two services doesn't matter;
- adds the `reconnect_loop_detected` i18n key (en/pt_BR) for the new structured error baileys-api sends when it gives up on a reconnect loop instead of wiping the shared auth state (fazer-ai/baileys-api#330).

## Tests

New specs in `incoming_message_baileys_service_spec.rb`: epoch persistence, stale-epoch discard (late `reconnecting` does not overwrite `open`), same-epoch acceptance, no-epoch backward compatibility, first-epoch acceptance. Rubocop clean. (rspec not run locally — no Postgres available in this session; CI validates.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/320)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp connection stability by ignoring stale/out-of-order connection events and ensuring updates are applied atomically to prevent duplicate or regressive reconnections in multi-instance setups.

* **New Features**
  * Added user-facing reconnection failure message in English and Portuguese for cases where reconnection repeatedly fails.

* **Tests**
  * Added specs covering event ordering, epoch handling, backward compatibility, and atomic update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->