### PR TITLE
fix(message): retry load for image-with-caption and video attachments

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Video.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Video.vue
@@ -1,21 +1,15 @@
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import BaseBubble from './Base.vue';
 import Icon from 'next/icon/Icon.vue';
+import { useLoadWithRetry } from 'dashboard/composables/loadWithRetry';
 import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 import { useMessageContext } from '../provider.js';
 import GalleryView from 'dashboard/components/widgets/conversation/components/GalleryView.vue';
 import { ATTACHMENT_TYPES } from '../constants';
 
-const emit = defineEmits(['error']);
-const hasError = ref(false);
 const showGallery = ref(false);
 const { filteredCurrentChatAttachments, attachments } = useMessageContext();
-
-const handleError = () => {
-  hasError.value = true;
-  emit('error');
-};
 
 const attachment = computed(() => {
   return attachments.value[0];
@@ -24,6 +18,20 @@ const attachment = computed(() => {
 const isReel = computed(() => {
   return attachment.value.fileType === ATTACHMENT_TYPES.IG_REEL;
 });
+
+const { isLoaded, hasError, loadWithRetry } = useLoadWithRetry({
+  type: 'video',
+});
+
+onMounted(() => {
+  if (attachment.value?.dataUrl) {
+    loadWithRetry(attachment.value.dataUrl);
+  }
+});
+
+const handleError = () => {
+  hasError.value = true;
+};
 </script>
 
 <template>
@@ -32,7 +40,13 @@ const isReel = computed(() => {
     data-bubble-name="video"
     @click="showGallery = true"
   >
-    <div class="relative group rounded-lg overflow-hidden">
+    <div v-if="hasError" class="flex items-center gap-1 text-center rounded-lg">
+      <Icon icon="i-lucide-circle-off" class="text-n-slate-11" />
+      <p class="mb-0 text-n-slate-11">
+        {{ $t('COMPONENTS.MEDIA.VIDEO_UNAVAILABLE') }}
+      </p>
+    </div>
+    <div v-else-if="isLoaded" class="relative group rounded-lg overflow-hidden">
       <div
         v-if="isReel"
         class="absolute p-2 flex items-start justify-end right-0 pointer-events-none"
@@ -57,7 +71,7 @@ const isReel = computed(() => {
     v-model:show="showGallery"
     :attachment="useSnakeCase(attachment)"
     :all-attachments="filteredCurrentChatAttachments"
-    @error="onError"
+    @error="handleError"
     @close="() => (showGallery = false)"
   />
 </template>

--- a/app/javascript/dashboard/components-next/message/chips/Image.vue
+++ b/app/javascript/dashboard/components-next/message/chips/Image.vue
@@ -1,21 +1,33 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import Icon from 'next/icon/Icon.vue';
+import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
+import { useLoadWithRetry } from 'dashboard/composables/loadWithRetry';
 import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 import { useMessageContext } from '../provider.js';
 
 import GalleryView from 'dashboard/components/widgets/conversation/components/GalleryView.vue';
 
-defineProps({
+const { attachment } = defineProps({
   attachment: {
     type: Object,
     required: true,
   },
 });
-const hasError = ref(false);
+
 const showGallery = ref(false);
 
 const { filteredCurrentChatAttachments } = useMessageContext();
+
+const { isLoaded, hasError, loadWithRetry } = useLoadWithRetry({
+  type: 'image',
+});
+
+onMounted(() => {
+  if (attachment.dataUrl) {
+    loadWithRetry(attachment.dataUrl);
+  }
+});
 
 const handleError = () => {
   hasError.value = true;
@@ -35,11 +47,17 @@ const handleError = () => {
       {{ $t('COMPONENTS.MEDIA.LOADING_FAILED') }}
     </div>
     <img
-      v-else
+      v-else-if="isLoaded"
       class="object-cover w-full h-full skip-context-menu"
       :src="attachment.dataUrl"
       @error="handleError"
     />
+    <div
+      v-else
+      class="flex items-center justify-center rounded-lg size-full bg-n-alpha-1"
+    >
+      <Spinner class="text-n-slate-11" />
+    </div>
   </div>
   <GalleryView
     v-if="showGallery"

--- a/app/javascript/dashboard/components-next/message/chips/Video.vue
+++ b/app/javascript/dashboard/components-next/message/chips/Video.vue
@@ -1,11 +1,13 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import Icon from 'next/icon/Icon.vue';
+import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
+import { useLoadWithRetry } from 'dashboard/composables/loadWithRetry';
 import { useSnakeCase } from 'dashboard/composables/useTransformKeys';
 import { useMessageContext } from '../provider.js';
 import GalleryView from 'dashboard/components/widgets/conversation/components/GalleryView.vue';
 
-defineProps({
+const { attachment } = defineProps({
   attachment: {
     type: Object,
     required: true,
@@ -15,6 +17,20 @@ defineProps({
 const showGallery = ref(false);
 
 const { filteredCurrentChatAttachments } = useMessageContext();
+
+const { isLoaded, hasError, loadWithRetry } = useLoadWithRetry({
+  type: 'video',
+});
+
+onMounted(() => {
+  if (attachment.dataUrl) {
+    loadWithRetry(attachment.dataUrl);
+  }
+});
+
+const handleError = () => {
+  hasError.value = true;
+};
 </script>
 
 <template>
@@ -22,23 +38,39 @@ const { filteredCurrentChatAttachments } = useMessageContext();
     class="size-[72px] overflow-hidden contain-content rounded-xl cursor-pointer relative group"
     @click="showGallery = true"
   >
-    <video
-      :src="attachment.dataUrl"
-      class="w-full h-full object-cover"
-      muted
-      playsInline
-    />
     <div
-      class="absolute w-full h-full inset-0 p-1 flex items-center justify-center"
+      v-if="hasError"
+      class="flex flex-col items-center justify-center gap-1 text-xs text-center rounded-lg size-full bg-n-alpha-1 text-n-slate-11"
     >
+      <Icon icon="i-lucide-circle-off" class="text-n-slate-11" />
+      {{ $t('COMPONENTS.MEDIA.LOADING_FAILED') }}
+    </div>
+    <template v-else-if="isLoaded">
+      <video
+        :src="attachment.dataUrl"
+        class="w-full h-full object-cover"
+        muted
+        playsInline
+        @error="handleError"
+      />
       <div
-        class="size-7 bg-n-slate-1/60 backdrop-blur-sm rounded-full overflow-hidden shadow-[0_5px_15px_rgba(0,0,0,0.4)]"
+        class="absolute w-full h-full inset-0 p-1 flex items-center justify-center"
       >
-        <Icon
-          icon="i-teenyicons-play-small-solid"
-          class="size-7 text-n-slate-12/80 backdrop-blur"
-        />
+        <div
+          class="size-7 bg-n-slate-1/60 backdrop-blur-sm rounded-full overflow-hidden shadow-[0_5px_15px_rgba(0,0,0,0.4)]"
+        >
+          <Icon
+            icon="i-teenyicons-play-small-solid"
+            class="size-7 text-n-slate-12/80 backdrop-blur"
+          />
+        </div>
       </div>
+    </template>
+    <div
+      v-else
+      class="flex items-center justify-center rounded-lg size-full bg-n-alpha-1"
+    >
+      <Spinner class="text-n-slate-11" />
     </div>
   </div>
   <GalleryView
@@ -46,7 +78,7 @@ const { filteredCurrentChatAttachments } = useMessageContext();
     v-model:show="showGallery"
     :attachment="useSnakeCase(attachment)"
     :all-attachments="filteredCurrentChatAttachments"
-    @error="onError"
+    @error="handleError"
     @close="() => (showGallery = false)"
   />
 </template>

--- a/app/javascript/dashboard/composables/loadWithRetry.js
+++ b/app/javascript/dashboard/composables/loadWithRetry.js
@@ -20,6 +20,11 @@ export const useLoadWithRetry = (config = {}) => {
           media = new Audio();
           media.onloadedmetadata = () => resolve();
           media.onerror = () => reject(new Error('Failed to load audio'));
+        } else if (type === 'video') {
+          media = document.createElement('video');
+          media.preload = 'metadata';
+          media.onloadedmetadata = () => resolve();
+          media.onerror = () => reject(new Error('Failed to load video'));
         } else {
           fetch(url)
             .then(res => {

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -317,6 +317,7 @@
     "MEDIA": {
       "IMAGE_UNAVAILABLE": "This image is no longer available.",
       "AUDIO_UNAVAILABLE": "This audio is no longer available.",
+      "VIDEO_UNAVAILABLE": "This video is no longer available.",
       "LOADING_FAILED": "Loading failed"
     }
   },

--- a/app/javascript/dashboard/i18n/locale/pt_BR/settings.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/settings.json
@@ -317,6 +317,7 @@
     "MEDIA": {
       "IMAGE_UNAVAILABLE": "Esta imagem não está mais disponível.",
       "AUDIO_UNAVAILABLE": "Este áudio não está mais disponível.",
+      "VIDEO_UNAVAILABLE": "Este vídeo não está mais disponível.",
       "LOADING_FAILED": "Falha no carregamento"
     }
   },


### PR DESCRIPTION
Imagens e vídeos enviados junto com texto (legenda) agora aplicam o mesmo retry de carregamento que já existe para mídia isolada. Antes, quando o anexo ainda não havia terminado de subir para o object storage, ele aparecia quebrado e só carregava após recarregar a página, mas só quando vinha acompanhado de texto.

### Context

Follow-up da #160, que introduziu o `load-with-retry` mas cobriu apenas a imagem isolada (bubble) e o áudio. Imagens e vídeos com legenda renderizam por outro caminho (`TextBubble → AttachmentChips → chips/*`), que ficou de fora. É a mesma classe de problema da issue upstream chatwoot/chatwoot#11013 (CW-4112), introduzida no upstream pela chatwoot/chatwoot#12873.

### How to reproduce

1. Com object storage (MinIO/S3/R2), enviar/receber uma **imagem com legenda** (ou um **vídeo**) enquanto o anexo ainda está subindo.
2. Sem o fix: o anexo aparece quebrado (404) e só carrega após F5.
3. Com o fix: mostra um spinner e resolve sozinho assim que o upload conclui; após esgotar as tentativas, exibe o estado de indisponível.

### What changed

- `loadWithRetry`: novo tipo `video` (preload de metadata via elemento `<video>` destacado).
- `chips/Image.vue` e `chips/Video.vue`: carregam via `useLoadWithRetry`, com spinner enquanto resolve e estado de falha só após esgotar as tentativas.
- `bubbles/Video.vue`: mesmo tratamento para vídeo isolado.
- Corrige o `@error="onError"` indefinido nos componentes de vídeo (apontava para função inexistente).
- i18n: `VIDEO_UNAVAILABLE` (en + pt_BR).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/323)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media loading reliability with retry behavior for images and videos.
  * Updated video and image rendering to show loading states and only display media after it successfully loads.
  * When loading fails, errors are handled internally and a clear “unavailable” message is shown.

* **Localization**
  * Added new media “video unavailable” translation in English.
  * Added Portuguese (Brazil) translation for the media “video unavailable” message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->