### PR TITLE
feat(whatsapp): reach-out lock & message-cap banners in conversation

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -41,6 +41,13 @@ import { LOCAL_STORAGE_KEYS } from 'dashboard/constants/localStorage';
 import { INBOX_TYPES } from 'dashboard/helper/inbox';
 import WhatsappLinkDeviceModal from '../../../routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue';
 import { isInboxAdminInGroup } from 'dashboard/helper/phoneHelper';
+import {
+  isReachoutRestricted,
+  reachoutRestrictionDeadline,
+  isMessageCapped,
+  isMessageCapReached,
+  messageCapQuota,
+} from 'dashboard/helper/whatsapp';
 
 export default {
   components: {
@@ -346,6 +353,55 @@ export default {
     },
     inboxProviderConnection() {
       return this.currentInbox.provider_connection?.connection;
+    },
+    inboxReachoutLock() {
+      return this.currentInbox.provider_connection?.reachout_time_lock;
+    },
+    showReachoutRestriction() {
+      return isReachoutRestricted(
+        this.inboxReachoutLock,
+        this.inboxProviderConnection
+      );
+    },
+    reachoutRestrictionMessage() {
+      const deadline = reachoutRestrictionDeadline(this.inboxReachoutLock);
+      return deadline
+        ? this.$t(
+            'CONVERSATION.INBOX.WHATSAPP_REACHOUT_RESTRICTION.RESTRICTED_UNTIL',
+            { time: deadline }
+          )
+        : this.$t(
+            'CONVERSATION.INBOX.WHATSAPP_REACHOUT_RESTRICTION.RESTRICTED'
+          );
+    },
+    inboxNewChatCap() {
+      return this.currentInbox.provider_connection?.new_chat_cap;
+    },
+    showMessageCap() {
+      return isMessageCapped(
+        this.inboxNewChatCap,
+        this.inboxProviderConnection
+      );
+    },
+    messageCapBannerScheme() {
+      return isMessageCapReached(this.inboxNewChatCap) ? 'alert' : 'warning';
+    },
+    messageCapMessage() {
+      const quota = messageCapQuota(this.inboxNewChatCap);
+      if (isMessageCapReached(this.inboxNewChatCap)) {
+        return quota
+          ? this.$t(
+              'CONVERSATION.INBOX.WHATSAPP_NEW_CHAT_CAP.CAPPED_WITH_QUOTA',
+              quota
+            )
+          : this.$t('CONVERSATION.INBOX.WHATSAPP_NEW_CHAT_CAP.CAPPED');
+      }
+      return quota
+        ? this.$t(
+            'CONVERSATION.INBOX.WHATSAPP_NEW_CHAT_CAP.WARNING_WITH_QUOTA',
+            quota
+          )
+        : this.$t('CONVERSATION.INBOX.WHATSAPP_NEW_CHAT_CAP.WARNING');
     },
   },
 
@@ -811,6 +867,18 @@ export default {
           @primary-action="
             isAdmin ? onOpenLinkDeviceModal() : onSetupProviderConnection()
           "
+        />
+        <Banner
+          v-if="showReachoutRestriction"
+          color-scheme="alert"
+          class="mt-2 mx-2 rounded-lg overflow-hidden"
+          :banner-message="reachoutRestrictionMessage"
+        />
+        <Banner
+          v-if="showMessageCap"
+          :color-scheme="messageCapBannerScheme"
+          class="mt-2 mx-2 rounded-lg overflow-hidden"
+          :banner-message="messageCapMessage"
         />
       </template>
       <Banner

--- a/app/javascript/dashboard/helper/specs/whatsapp.spec.js
+++ b/app/javascript/dashboard/helper/specs/whatsapp.spec.js
@@ -43,6 +43,11 @@ describe('#isReachoutRestricted', () => {
     };
     expect(isReachoutRestricted(lock, 'open', now)).toBe(false);
   });
+
+  it('keeps the restriction visible when the deadline is malformed (fail safe)', () => {
+    const lock = { is_active: true, time_enforcement_ends: 'not-a-date' };
+    expect(isReachoutRestricted(lock, 'open', now)).toBe(true);
+  });
 });
 
 describe('#reachoutRestrictionDeadline', () => {
@@ -56,6 +61,12 @@ describe('#reachoutRestrictionDeadline', () => {
       time_enforcement_ends: '2026-06-19T21:52:39.000Z',
     });
     expect(formatted).toMatch(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}$/);
+  });
+
+  it('returns an empty string when the deadline is malformed', () => {
+    expect(reachoutRestrictionDeadline({ time_enforcement_ends: 'nope' })).toBe(
+      ''
+    );
   });
 });
 

--- a/app/javascript/dashboard/helper/specs/whatsapp.spec.js
+++ b/app/javascript/dashboard/helper/specs/whatsapp.spec.js
@@ -1,0 +1,115 @@
+import {
+  isReachoutRestricted,
+  reachoutRestrictionDeadline,
+  isMessageCapped,
+  isMessageCapReached,
+  messageCapQuota,
+} from '../whatsapp';
+
+describe('#isReachoutRestricted', () => {
+  const now = new Date('2026-06-16T12:00:00.000Z').getTime();
+
+  it('returns false when there is no lock', () => {
+    expect(isReachoutRestricted(undefined, 'open', now)).toBe(false);
+    expect(isReachoutRestricted(null, 'open', now)).toBe(false);
+  });
+
+  it('returns false when the lock is not active', () => {
+    expect(isReachoutRestricted({ is_active: false }, 'open', now)).toBe(false);
+  });
+
+  it('returns false when the inbox is not connected (offline banner wins)', () => {
+    const lock = { is_active: true };
+    expect(isReachoutRestricted(lock, 'close', now)).toBe(false);
+    expect(isReachoutRestricted(lock, 'connecting', now)).toBe(false);
+  });
+
+  it('returns true when active without a deadline', () => {
+    expect(isReachoutRestricted({ is_active: true }, 'open', now)).toBe(true);
+  });
+
+  it('returns true when active and the deadline is in the future', () => {
+    const lock = {
+      is_active: true,
+      time_enforcement_ends: '2026-06-19T21:52:39.000Z',
+    };
+    expect(isReachoutRestricted(lock, 'open', now)).toBe(true);
+  });
+
+  it('returns false when the deadline has already passed', () => {
+    const lock = {
+      is_active: true,
+      time_enforcement_ends: '2026-06-15T21:52:39.000Z',
+    };
+    expect(isReachoutRestricted(lock, 'open', now)).toBe(false);
+  });
+});
+
+describe('#reachoutRestrictionDeadline', () => {
+  it('returns an empty string when there is no deadline', () => {
+    expect(reachoutRestrictionDeadline(undefined)).toBe('');
+    expect(reachoutRestrictionDeadline({ is_active: true })).toBe('');
+  });
+
+  it('formats the deadline as dd/MM/yyyy HH:mm', () => {
+    const formatted = reachoutRestrictionDeadline({
+      time_enforcement_ends: '2026-06-19T21:52:39.000Z',
+    });
+    expect(formatted).toMatch(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}$/);
+  });
+});
+
+describe('#isMessageCapped', () => {
+  it('returns false when offline regardless of status', () => {
+    expect(isMessageCapped({ capping_status: 'CAPPED' }, 'connecting')).toBe(
+      false
+    );
+  });
+
+  it('returns false for NONE / missing / unknown status', () => {
+    expect(isMessageCapped({ capping_status: 'NONE' }, 'open')).toBe(false);
+    expect(isMessageCapped(undefined, 'open')).toBe(false);
+    expect(isMessageCapped({}, 'open')).toBe(false);
+  });
+
+  it('returns true for warning and capped statuses when open', () => {
+    expect(isMessageCapped({ capping_status: 'FIRST_WARNING' }, 'open')).toBe(
+      true
+    );
+    expect(isMessageCapped({ capping_status: 'SECOND_WARNING' }, 'open')).toBe(
+      true
+    );
+    expect(isMessageCapped({ capping_status: 'CAPPED' }, 'open')).toBe(true);
+  });
+});
+
+describe('#isMessageCapReached', () => {
+  it('is true only for CAPPED', () => {
+    expect(isMessageCapReached({ capping_status: 'CAPPED' })).toBe(true);
+    expect(isMessageCapReached({ capping_status: 'FIRST_WARNING' })).toBe(
+      false
+    );
+    expect(isMessageCapReached(undefined)).toBe(false);
+  });
+});
+
+describe('#messageCapQuota', () => {
+  it('returns null when total_quota is missing or zero (placeholder)', () => {
+    expect(messageCapQuota(undefined)).toBeNull();
+    expect(messageCapQuota({ total_quota: 0, used_quota: 0 })).toBeNull();
+  });
+
+  it('returns used/total when a real quota is present', () => {
+    expect(messageCapQuota({ total_quota: 100, used_quota: 80 })).toEqual({
+      used: 80,
+      total: 100,
+    });
+  });
+
+  it('coerces string numbers and defaults missing used to 0', () => {
+    expect(messageCapQuota({ total_quota: '100' })).toEqual({
+      used: 0,
+      total: 100,
+    });
+  });
+});

--- a/app/javascript/dashboard/helper/whatsapp.js
+++ b/app/javascript/dashboard/helper/whatsapp.js
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, isValid } from 'date-fns';
 
 /**
  * Whether a baileys inbox should surface the WhatsApp reach-out restriction banner.
@@ -16,7 +16,11 @@ export const isReachoutRestricted = (lock, connection, now = Date.now()) => {
   if (!lock?.is_active) return false;
   if (connection !== 'open') return false;
   if (!lock.time_enforcement_ends) return true;
-  return new Date(lock.time_enforcement_ends).getTime() > now;
+  // A malformed deadline must not silently hide an active restriction: keep it
+  // visible (fail safe) rather than letting NaN > now resolve to false.
+  const deadline = new Date(lock.time_enforcement_ends);
+  if (!isValid(deadline)) return true;
+  return deadline.getTime() > now;
 };
 
 /**
@@ -29,7 +33,10 @@ export const isReachoutRestricted = (lock, connection, now = Date.now()) => {
  */
 export const reachoutRestrictionDeadline = lock => {
   if (!lock?.time_enforcement_ends) return '';
-  return format(new Date(lock.time_enforcement_ends), 'dd/MM/yyyy HH:mm');
+  // format() throws RangeError on an Invalid Date; fall back to '' so the banner
+  // renders the generic (deadline-less) copy instead of crashing.
+  const deadline = new Date(lock.time_enforcement_ends);
+  return isValid(deadline) ? format(deadline, 'dd/MM/yyyy HH:mm') : '';
 };
 
 // capping_status values that warrant a banner (NONE / absent => no banner).

--- a/app/javascript/dashboard/helper/whatsapp.js
+++ b/app/javascript/dashboard/helper/whatsapp.js
@@ -1,0 +1,73 @@
+import { format } from 'date-fns';
+
+/**
+ * Whether a baileys inbox should surface the WhatsApp reach-out restriction banner.
+ *
+ * The lock is only meaningful while the connection is open (otherwise the offline banner
+ * takes precedence). With a deadline, the restriction is shown only until it passes — the
+ * provider may lag clearing is_active, so an expired deadline is treated as lifted.
+ *
+ * @param {{is_active?: boolean, time_enforcement_ends?: string}|null|undefined} lock
+ * @param {string|undefined} connection - the provider_connection.connection value
+ * @param {number} [now=Date.now()] - epoch millis, injectable for deterministic tests
+ * @returns {boolean}
+ */
+export const isReachoutRestricted = (lock, connection, now = Date.now()) => {
+  if (!lock?.is_active) return false;
+  if (connection !== 'open') return false;
+  if (!lock.time_enforcement_ends) return true;
+  return new Date(lock.time_enforcement_ends).getTime() > now;
+};
+
+/**
+ * Local-timezone deadline label for the restriction banner, or '' when no deadline is set.
+ * `new Date(isoUtc)` parses the UTC instant and `format` renders it in the browser's
+ * timezone automatically.
+ *
+ * @param {{time_enforcement_ends?: string}|null|undefined} lock
+ * @returns {string}
+ */
+export const reachoutRestrictionDeadline = lock => {
+  if (!lock?.time_enforcement_ends) return '';
+  return format(new Date(lock.time_enforcement_ends), 'dd/MM/yyyy HH:mm');
+};
+
+// capping_status values that warrant a banner (NONE / absent => no banner).
+const CAP_BANNER_STATUSES = ['FIRST_WARNING', 'SECOND_WARNING', 'CAPPED'];
+
+/**
+ * Whether a baileys inbox should surface the new-chat message cap (quota) banner.
+ *
+ * Only meaningful while the connection is open. `capping_status` is the operant signal: an account
+ * that doesn't participate in the cap program reports NONE / NOT_ELIGIBLE, so it never banners.
+ *
+ * @param {{capping_status?: string}|null|undefined} cap
+ * @param {string|undefined} connection - the provider_connection.connection value
+ * @returns {boolean}
+ */
+export const isMessageCapped = (cap, connection) => {
+  if (connection !== 'open') return false;
+  return CAP_BANNER_STATUSES.includes(cap?.capping_status);
+};
+
+/**
+ * Whether the cap is fully reached (CAPPED) vs merely a warning — drives the banner severity.
+ *
+ * @param {{capping_status?: string}|null|undefined} cap
+ * @returns {boolean}
+ */
+export const isMessageCapReached = cap => cap?.capping_status === 'CAPPED';
+
+/**
+ * Usable {used, total} quota numbers, or null when they aren't trustworthy. total_quota:0 is a
+ * placeholder for accounts not enrolled in the cap program, so we never surface a "0 of 0".
+ *
+ * @param {{total_quota?: number|string, used_quota?: number|string}|null|undefined} cap
+ * @returns {{used: number, total: number}|null}
+ */
+export const messageCapQuota = cap => {
+  const total = Number(cap?.total_quota);
+  if (!Number.isFinite(total) || total <= 0) return null;
+  const used = Number(cap?.used_quota) || 0;
+  return { used, total };
+};

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -374,6 +374,16 @@
         "NOT_CONNECTED_CONTACT_ADMIN": "WhatsApp is not connected. Click this button to try to reconnect, or please contact your administrator to link your device again.",
         "LINK_DEVICE": "Link device",
         "RECONNECT_FAILED": "Failed to reconnect. Please contact your administrator to link your device again."
+      },
+      "WHATSAPP_REACHOUT_RESTRICTION": {
+        "RESTRICTED": "WhatsApp has temporarily restricted starting new conversations from this number.",
+        "RESTRICTED_UNTIL": "WhatsApp has temporarily restricted outbound messaging from this number until {time}."
+      },
+      "WHATSAPP_NEW_CHAT_CAP": {
+        "WARNING": "This number is approaching its WhatsApp limit for starting new conversations this cycle.",
+        "WARNING_WITH_QUOTA": "This number has started {used} of {total} new conversations allowed by WhatsApp this cycle.",
+        "CAPPED": "This number has reached its WhatsApp limit for starting new conversations this cycle.",
+        "CAPPED_WITH_QUOTA": "This number has reached its WhatsApp limit ({used} of {total}) for starting new conversations this cycle."
       }
     }
   },

--- a/app/javascript/dashboard/i18n/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/en/conversation.json
@@ -377,7 +377,7 @@
       },
       "WHATSAPP_REACHOUT_RESTRICTION": {
         "RESTRICTED": "WhatsApp has temporarily restricted starting new conversations from this number.",
-        "RESTRICTED_UNTIL": "WhatsApp has temporarily restricted outbound messaging from this number until {time}."
+        "RESTRICTED_UNTIL": "WhatsApp has temporarily restricted starting new conversations from this number until {time}."
       },
       "WHATSAPP_NEW_CHAT_CAP": {
         "WARNING": "This number is approaching its WhatsApp limit for starting new conversations this cycle.",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/conversation.json
@@ -373,6 +373,16 @@
         "NOT_CONNECTED_CONTACT_ADMIN": "O WhatsApp não está conectado. Clique no botão ao lado para tentar reconectar, ou contate o seu administrador para conectar o dispositivo novamente.",
         "LINK_DEVICE": "Conectar dispositivo",
         "RECONNECT_FAILED": "Falha ao reconectar. Por favor, contate o seu administrador para conectar o dispositivo novamente."
+      },
+      "WHATSAPP_REACHOUT_RESTRICTION": {
+        "RESTRICTED": "O WhatsApp restringiu temporariamente o início de novas conversas a partir deste número.",
+        "RESTRICTED_UNTIL": "O WhatsApp restringiu temporariamente o envio de mensagens a partir deste número até {time}."
+      },
+      "WHATSAPP_NEW_CHAT_CAP": {
+        "WARNING": "Este número está se aproximando do limite do WhatsApp para iniciar novas conversas neste ciclo.",
+        "WARNING_WITH_QUOTA": "Este número já iniciou {used} de {total} novas conversas permitidas pelo WhatsApp neste ciclo.",
+        "CAPPED": "Este número atingiu o limite do WhatsApp para iniciar novas conversas neste ciclo.",
+        "CAPPED_WITH_QUOTA": "Este número atingiu o limite do WhatsApp ({used} de {total}) para iniciar novas conversas neste ciclo."
       }
     }
   },

--- a/app/javascript/dashboard/i18n/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/conversation.json
@@ -376,7 +376,7 @@
       },
       "WHATSAPP_REACHOUT_RESTRICTION": {
         "RESTRICTED": "O WhatsApp restringiu temporariamente o início de novas conversas a partir deste número.",
-        "RESTRICTED_UNTIL": "O WhatsApp restringiu temporariamente o envio de mensagens a partir deste número até {time}."
+        "RESTRICTED_UNTIL": "O WhatsApp restringiu temporariamente o início de novas conversas a partir deste número até {time}."
       },
       "WHATSAPP_NEW_CHAT_CAP": {
         "WARNING": "Este número está se aproximando do limite do WhatsApp para iniciar novas conversas neste ciclo.",

--- a/app/jobs/channels/whatsapp/baileys_connection_check_job.rb
+++ b/app/jobs/channels/whatsapp/baileys_connection_check_job.rb
@@ -3,5 +3,28 @@ class Channels::Whatsapp::BaileysConnectionCheckJob < ApplicationJob
 
   def perform(whatsapp_channel)
     whatsapp_channel.setup_channel_provider
+    refresh_reachout_time_lock(whatsapp_channel)
+    refresh_new_chat_cap(whatsapp_channel)
+  end
+
+  private
+
+  # Best-effort: a failed time-lock fetch must not abort the connection check (which also
+  # re-arms the session). nil means "unknown" (404/error) — skip so we never clear a banner
+  # that a webhook push legitimately set; the banner then falls back to push-driven state.
+  def refresh_reachout_time_lock(whatsapp_channel)
+    lock = whatsapp_channel.provider_service.fetch_reachout_timelock
+    whatsapp_channel.update_reachout_time_lock!(lock) unless lock.nil?
+  rescue StandardError => e
+    Rails.logger.warn("[WHATSAPP][BAILEYS] reachout timelock refresh failed for ##{whatsapp_channel.id}: #{e.message}")
+  end
+
+  # Same best-effort contract as refresh_reachout_time_lock: nil (404/error) leaves the last known
+  # cap untouched so a transient blip doesn't clear a legitimately-set banner.
+  def refresh_new_chat_cap(whatsapp_channel)
+    cap = whatsapp_channel.provider_service.fetch_new_chat_cap
+    whatsapp_channel.update_new_chat_cap!(cap) unless cap.nil?
+  rescue StandardError => e
+    Rails.logger.warn("[WHATSAPP][BAILEYS] new-chat cap refresh failed for ##{whatsapp_channel.id}: #{e.message}")
   end
 end

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -52,7 +52,15 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
     admin_tokens = account.administrators.pluck(:pubsub_token)
     agent_tokens = account.agents.pluck(:pubsub_token)
 
-    connection = { connection: provider_connection['connection'] }
+    # reach-out lock and new-chat cap are not credential-sensitive (unlike qr_data_url), so they
+    # ride the base hash shared by both agent and admin broadcasts. Without this, a connection.update
+    # push would broadcast a provider_connection without them and the frontend mutation (wholesale
+    # replace) would drop the restriction/cap banners. .presence + .compact keeps absent keys out.
+    connection = {
+      connection: provider_connection['connection'],
+      reachout_time_lock: provider_connection['reachout_time_lock'].presence,
+      new_chat_cap: provider_connection['new_chat_cap'].presence
+    }.compact
     broadcast(account, agent_tokens, INBOX_PROVIDER_CONNECTION_UPDATED, { inbox_id: inbox.id, provider_connection: connection })
     broadcast(account, admin_tokens, INBOX_PROVIDER_CONNECTION_UPDATED, {
                 inbox_id: inbox.id,

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -31,6 +31,10 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
   # default at the moment is 360dialog lets change later.
   PROVIDERS = %w[default whatsapp_cloud baileys zapi].freeze
   REACTION_SUPPORTED_PROVIDERS = %w[whatsapp_cloud baileys zapi].freeze
+  # UI-relevant subset of the baileys new-chat message cap payload that we persist in
+  # provider_connection. server_sent_timestamp is intentionally dropped (it changes on every
+  # snapshot, so keeping it would make the 5-min poll re-broadcast every cycle for no reason).
+  NEW_CHAT_CAP_KEYS = %w[capping_status ote_status mv_status total_quota used_quota cycle_start_timestamp cycle_end_timestamp].freeze
   before_validation :ensure_webhook_verify_token
 
   validates :provider, inclusion: { in: PROVIDERS }
@@ -144,8 +148,31 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
     broadcast_provider_connection_updated
   end
 
+  # Proactive (REST poll) / push update of just the reach-out lock. Unlike the connection.update
+  # path this carries no lease epoch, so it merges into the existing provider_connection without
+  # touching connection/epoch/qr/error and reuses update_provider_connection!'s no-op guard and
+  # broadcast. The with_lock reloads under SELECT FOR UPDATE so a concurrent connection.update
+  # can't be lost by merging onto a stale snapshot. Callers pass nil (404/fetch error) to skip.
+  def update_reachout_time_lock!(reachout_time_lock)
+    with_lock do
+      update_provider_connection!(provider_connection.merge('reachout_time_lock' => reachout_time_lock.deep_stringify_keys))
+    end
+  end
+
+  # Same contract as update_reachout_time_lock! for the new-chat message cap (quota). We persist
+  # only the UI-relevant keys (dropping the volatile server_sent_timestamp) so the poll doesn't
+  # re-broadcast every cycle when nothing meaningful changed.
+  def update_new_chat_cap!(new_chat_cap)
+    normalized = new_chat_cap.to_h.deep_stringify_keys.slice(*NEW_CHAT_CAP_KEYS)
+    with_lock do
+      update_provider_connection!(provider_connection.merge('new_chat_cap' => normalized))
+    end
+  end
+
   def provider_connection_data
     data = { connection: provider_connection['connection'] }
+    data[:reachout_time_lock] = provider_connection['reachout_time_lock'] if provider_connection['reachout_time_lock'].present?
+    data[:new_chat_cap] = provider_connection['new_chat_cap'] if provider_connection['new_chat_cap'].present?
     if Current.account_user&.administrator?
       data[:qr_data_url] = provider_connection['qr_data_url']
       data[:error] = provider_connection['error']

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -154,6 +154,8 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
   # broadcast. The with_lock reloads under SELECT FOR UPDATE so a concurrent connection.update
   # can't be lost by merging onto a stale snapshot. Callers pass nil (404/fetch error) to skip.
   def update_reachout_time_lock!(reachout_time_lock)
+    return if reachout_time_lock.nil?
+
     with_lock do
       update_provider_connection!(provider_connection.merge('reachout_time_lock' => reachout_time_lock.deep_stringify_keys))
     end
@@ -163,6 +165,8 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
   # only the UI-relevant keys (dropping the volatile server_sent_timestamp) so the poll doesn't
   # re-broadcast every cycle when nothing meaningful changed.
   def update_new_chat_cap!(new_chat_cap)
+    return if new_chat_cap.nil?
+
     normalized = new_chat_cap.to_h.deep_stringify_keys.slice(*NEW_CHAT_CAP_KEYS)
     with_lock do
       update_provider_connection!(provider_connection.merge('new_chat_cap' => normalized))

--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -29,7 +29,25 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
       connection: data[:connection] || inbox.channel.provider_connection['connection'],
       qr_data_url: data[:qrDataUrl] || nil,
       error: data[:error] ? I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}", default: data[:error].to_s.humanize) : nil,
+      reachout_time_lock: reachout_time_lock_payload(data),
       epoch: data[:epoch]
+    }.compact
+  end
+
+  # Reach-out time-lock is NOT echoed on every connection.update (the provider debounces it
+  # ~60s and may push it standalone, without a `connection` value). So, unlike qr_data_url, a
+  # connection-only event must PRESERVE the existing lock rather than reset it. When the
+  # provider DOES send reachoutTimeLock (including isActive:false to lift the restriction), we
+  # persist it verbatim — isActive:false is a real "cleared" state the UI relies on to drop the
+  # banner. Returns nil only when nothing was ever set, so the outer .compact omits the key.
+  def reachout_time_lock_payload(data)
+    raw = data[:reachoutTimeLock]
+    return inbox.channel.provider_connection['reachout_time_lock'] if raw.blank?
+
+    {
+      is_active: raw[:isActive] || false,
+      time_enforcement_ends: raw[:timeEnforcementEnds],
+      enforcement_type: raw[:enforcementType]
     }.compact
   end
 

--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -30,6 +30,11 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
       qr_data_url: data[:qrDataUrl] || nil,
       error: data[:error] ? I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}", default: data[:error].to_s.humanize) : nil,
       reachout_time_lock: reachout_time_lock_payload(data),
+      # new_chat_cap never rides a connection.update (it arrives via message-capping.update / the
+      # poll). update_provider_connection! replaces provider_connection wholesale, so without
+      # carrying it forward here every connection.update would wipe the cap and flicker the banner
+      # off until the next cap push/poll. Preserve the existing value; .compact omits it when unset.
+      new_chat_cap: inbox.channel.provider_connection['new_chat_cap'],
       epoch: data[:epoch]
     }.compact
   end

--- a/app/services/whatsapp/baileys_handlers/message_capping_update.rb
+++ b/app/services/whatsapp/baileys_handlers/message_capping_update.rb
@@ -1,0 +1,11 @@
+module Whatsapp::BaileysHandlers::MessageCappingUpdate
+  private
+
+  # New-chat message cap (quota) snapshot pushed by the provider. Persisted on provider_connection
+  # so the dashboard can warn before the account hits its new-conversation limit, mirroring the
+  # reach-out banner. The payload carries no lease epoch; update_new_chat_cap! merges under a row
+  # lock so it can't clobber a concurrent connection.update.
+  def process_message_capping_update
+    inbox.channel.update_new_chat_cap!(processed_params[:data])
+  end
+end

--- a/app/services/whatsapp/incoming_message_baileys_service.rb
+++ b/app/services/whatsapp/incoming_message_baileys_service.rb
@@ -8,6 +8,7 @@ class Whatsapp::IncomingMessageBaileysService < Whatsapp::IncomingMessageBaseSer
   include Whatsapp::BaileysHandlers::GroupsUpdate
   include Whatsapp::BaileysHandlers::GroupsActivity
   include Whatsapp::BaileysHandlers::PresenceUpdate
+  include Whatsapp::BaileysHandlers::MessageCappingUpdate
 
   class InvalidWebhookVerifyToken < StandardError; end
 

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -487,6 +487,48 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     true
   end
 
+  # Reach-out time-lock state for this connection. Read-only MEX query (safe on a restricted
+  # account; never counts as a "reach out"). 404 = number not connected on the provider, which
+  # is "unknown" and NOT "unrestricted", so we return nil for the caller to leave the banner
+  # state untouched. Deliberately NOT wrapped in with_error_handling: that helper marks the
+  # connection `close` on any error, which would be catastrophic for a diagnostic GET.
+  def fetch_reachout_timelock
+    response = HTTParty.get(
+      "#{provider_url}/connections/#{whatsapp_channel.phone_number}/reachout-timelock",
+      headers: api_headers,
+      format: :json,
+      timeout: 10
+    )
+
+    return nil if response.code == 404
+    return nil unless process_response(response)
+
+    data = response.parsed_response&.deep_symbolize_keys&.dig(:data) || {}
+    {
+      is_active: data[:isActive] || false,
+      time_enforcement_ends: data[:timeEnforcementEnds],
+      enforcement_type: data[:enforcementType]
+    }.compact
+  end
+
+  # New-chat message cap (quota) for this connection. Read-only MEX query with the same 404
+  # semantics as fetch_reachout_timelock (404 = not connected = unknown -> nil, don't clear the
+  # banner). Returns the raw NewChatMessageCapInfo (already snake_case from the provider); the
+  # model slices it to the UI-relevant keys when persisting.
+  def fetch_new_chat_cap
+    response = HTTParty.get(
+      "#{provider_url}/connections/#{whatsapp_channel.phone_number}/new-chat-cap",
+      headers: api_headers,
+      format: :json,
+      timeout: 10
+    )
+
+    return nil if response.code == 404
+    return nil unless process_response(response)
+
+    response.parsed_response&.deep_symbolize_keys&.dig(:data)
+  end
+
   private
 
   def provider_url

--- a/spec/jobs/channels/whatsapp/baileys_connection_check_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/baileys_connection_check_job_spec.rb
@@ -1,7 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Channels::Whatsapp::BaileysConnectionCheckJob do
-  let(:channel_whatsapp) { create(:channel_whatsapp, sync_templates: false, validate_provider_config: false) }
+  let(:channel_whatsapp) { create(:channel_whatsapp, provider: 'baileys', sync_templates: false, validate_provider_config: false) }
+  let(:provider_service) { instance_double(Whatsapp::Providers::WhatsappBaileysService) }
+
+  before do
+    allow(channel_whatsapp).to receive_messages(setup_channel_provider: true, provider_service: provider_service)
+    allow(provider_service).to receive_messages(fetch_reachout_timelock: nil, fetch_new_chat_cap: nil)
+  end
 
   it 'enqueues the job' do
     expect { described_class.perform_later(channel_whatsapp) }.to have_enqueued_job(described_class)
@@ -10,10 +16,45 @@ RSpec.describe Channels::Whatsapp::BaileysConnectionCheckJob do
 
   context 'when called' do
     it 'calls setup_channel_provider' do
-      allow(channel_whatsapp).to receive(:setup_channel_provider).and_return(true)
+      described_class.perform_now(channel_whatsapp)
+
+      expect(channel_whatsapp).to have_received(:setup_channel_provider)
+    end
+
+    it 'persists the fetched reach-out time-lock' do
+      lock = { is_active: true, time_enforcement_ends: '2026-06-19T21:52:39.000Z' }
+      allow(provider_service).to receive(:fetch_reachout_timelock).and_return(lock)
+      allow(channel_whatsapp).to receive(:update_reachout_time_lock!)
 
       described_class.perform_now(channel_whatsapp)
 
+      expect(channel_whatsapp).to have_received(:update_reachout_time_lock!).with(lock)
+    end
+
+    it 'persists the fetched new-chat cap' do
+      cap = { capping_status: 'CAPPED', total_quota: 100, used_quota: 100 }
+      allow(provider_service).to receive(:fetch_new_chat_cap).and_return(cap)
+      allow(channel_whatsapp).to receive(:update_new_chat_cap!)
+
+      described_class.perform_now(channel_whatsapp)
+
+      expect(channel_whatsapp).to have_received(:update_new_chat_cap!).with(cap)
+    end
+
+    it 'skips persistence when a fetch returns nil (unknown / 404)' do
+      allow(channel_whatsapp).to receive(:update_reachout_time_lock!)
+      allow(channel_whatsapp).to receive(:update_new_chat_cap!)
+
+      described_class.perform_now(channel_whatsapp)
+
+      expect(channel_whatsapp).not_to have_received(:update_reachout_time_lock!)
+      expect(channel_whatsapp).not_to have_received(:update_new_chat_cap!)
+    end
+
+    it 'does not let a cap fetch error abort the connection check' do
+      allow(provider_service).to receive(:fetch_new_chat_cap).and_raise(StandardError, 'boom')
+
+      expect { described_class.perform_now(channel_whatsapp) }.not_to raise_error
       expect(channel_whatsapp).to have_received(:setup_channel_provider)
     end
   end

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -303,6 +303,54 @@ describe ActionCableListener do
 
       listener.inbox_provider_connection_updated(event)
     end
+
+    context 'when a reach-out time-lock is present' do
+      let(:provider_connection) do
+        { 'connection' => 'connecting', 'reachout_time_lock' => { 'is_active' => true, 'time_enforcement_ends' => '2026-06-19T21:52:39.000Z' } }
+      end
+
+      it 'includes the lock in the agent broadcast (agents see the banner)' do
+        expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+          [agent.pubsub_token],
+          'inbox.provider_connection_updated',
+          {
+            inbox_id: inbox.id,
+            provider_connection: {
+              connection: 'connecting',
+              reachout_time_lock: { 'is_active' => true, 'time_enforcement_ends' => '2026-06-19T21:52:39.000Z' }
+            },
+            account_id: account.id
+          }
+        )
+        allow(ActionCableBroadcastJob).to receive(:perform_later).with([admin.pubsub_token], anything, anything)
+
+        listener.inbox_provider_connection_updated(event)
+      end
+    end
+
+    context 'when a new-chat cap is present' do
+      let(:provider_connection) do
+        { 'connection' => 'open', 'new_chat_cap' => { 'capping_status' => 'CAPPED', 'total_quota' => 100, 'used_quota' => 100 } }
+      end
+
+      it 'includes the cap in the agent broadcast' do
+        expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+          [agent.pubsub_token],
+          'inbox.provider_connection_updated',
+          {
+            inbox_id: inbox.id,
+            provider_connection: {
+              connection: 'open',
+              new_chat_cap: { 'capping_status' => 'CAPPED', 'total_quota' => 100, 'used_quota' => 100 }
+            },
+            account_id: account.id
+          }
+        )
+        allow(ActionCableBroadcastJob).to receive(:perform_later).with([admin.pubsub_token], anything, anything)
+
+        listener.inbox_provider_connection_updated(event)
+      end
+    end
   end
 
   describe '#conversation_unread_count_changed' do

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -551,6 +551,87 @@ RSpec.describe Channel::Whatsapp do
     end
   end
 
+  describe '#update_reachout_time_lock!' do
+    let(:channel) do
+      create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,
+                                provider_connection: { 'connection' => 'open', 'epoch' => 7 })
+    end
+
+    it 'merges the lock without touching connection or epoch' do
+      channel.update_reachout_time_lock!({ is_active: true, time_enforcement_ends: '2026-06-19T21:52:39.000Z' })
+
+      expect(channel.reload.provider_connection).to eq(
+        'connection' => 'open',
+        'epoch' => 7,
+        'reachout_time_lock' => { 'is_active' => true, 'time_enforcement_ends' => '2026-06-19T21:52:39.000Z' }
+      )
+    end
+
+    it 'broadcasts the updated provider_connection' do
+      sync_dispatcher = Rails.configuration.dispatcher.sync_dispatcher
+      expect(sync_dispatcher).to receive(:dispatch).with(
+        Events::Types::INBOX_PROVIDER_CONNECTION_UPDATED,
+        anything,
+        hash_including(inbox: channel.inbox)
+      )
+
+      channel.update_reachout_time_lock!({ is_active: true })
+    end
+
+    it 'is a no-op when the lock is unchanged' do
+      channel.update_reachout_time_lock!({ is_active: true })
+
+      sync_dispatcher = Rails.configuration.dispatcher.sync_dispatcher
+      expect(sync_dispatcher).not_to receive(:dispatch)
+
+      channel.update_reachout_time_lock!({ is_active: true })
+    end
+  end
+
+  describe '#update_new_chat_cap!' do
+    let(:channel) do
+      create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,
+                                provider_connection: { 'connection' => 'open', 'epoch' => 7 })
+    end
+
+    it 'persists only the UI-relevant keys, dropping server_sent_timestamp' do
+      channel.update_new_chat_cap!({
+                                     capping_status: 'CAPPED',
+                                     ote_status: 'ELIGIBLE',
+                                     mv_status: 'NOT_ELIGIBLE',
+                                     total_quota: 100,
+                                     used_quota: 100,
+                                     cycle_start_timestamp: '1781640000',
+                                     cycle_end_timestamp: '1781699999',
+                                     server_sent_timestamp: '1781645846'
+                                   })
+
+      expect(channel.reload.provider_connection).to eq(
+        'connection' => 'open',
+        'epoch' => 7,
+        'new_chat_cap' => {
+          'capping_status' => 'CAPPED',
+          'ote_status' => 'ELIGIBLE',
+          'mv_status' => 'NOT_ELIGIBLE',
+          'total_quota' => 100,
+          'used_quota' => 100,
+          'cycle_start_timestamp' => '1781640000',
+          'cycle_end_timestamp' => '1781699999'
+        }
+      )
+    end
+
+    it 'is a no-op when the cap is unchanged' do
+      cap = { capping_status: 'FIRST_WARNING', total_quota: 100, used_quota: 50 }
+      channel.update_new_chat_cap!(cap)
+
+      sync_dispatcher = Rails.configuration.dispatcher.sync_dispatcher
+      expect(sync_dispatcher).not_to receive(:dispatch)
+
+      channel.update_new_chat_cap!(cap)
+    end
+  end
+
   describe '#provider_connection_data' do
     let(:channel) do
       create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,
@@ -594,6 +675,50 @@ RSpec.describe Channel::Whatsapp do
         data = channel.provider_connection_data
 
         expect(data).to eq({ connection: 'open' })
+      end
+    end
+
+    context 'when a reach-out time-lock is present' do
+      let(:channel) do
+        create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,
+                                  provider_connection: {
+                                    'connection' => 'open',
+                                    'reachout_time_lock' => { 'is_active' => true, 'time_enforcement_ends' => '2026-06-19T21:52:39.000Z' }
+                                  })
+      end
+
+      it 'exposes the lock to non-administrators (agents see the banner too)' do
+        account_user = create(:account_user, account: channel.account, role: :agent)
+        allow(Current).to receive(:account_user).and_return(account_user)
+
+        data = channel.provider_connection_data
+
+        expect(data).to eq({
+                             connection: 'open',
+                             reachout_time_lock: { 'is_active' => true, 'time_enforcement_ends' => '2026-06-19T21:52:39.000Z' }
+                           })
+      end
+    end
+
+    context 'when a new-chat cap is present' do
+      let(:channel) do
+        create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,
+                                  provider_connection: {
+                                    'connection' => 'open',
+                                    'new_chat_cap' => { 'capping_status' => 'CAPPED', 'total_quota' => 100, 'used_quota' => 100 }
+                                  })
+      end
+
+      it 'exposes the cap to non-administrators' do
+        account_user = create(:account_user, account: channel.account, role: :agent)
+        allow(Current).to receive(:account_user).and_return(account_user)
+
+        data = channel.provider_connection_data
+
+        expect(data).to eq({
+                             connection: 'open',
+                             new_chat_cap: { 'capping_status' => 'CAPPED', 'total_quota' => 100, 'used_quota' => 100 }
+                           })
       end
     end
   end

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -586,6 +586,15 @@ RSpec.describe Channel::Whatsapp do
 
       channel.update_reachout_time_lock!({ is_active: true })
     end
+
+    it 'returns without raising or broadcasting when passed nil (404/fetch error)' do
+      expect(channel.provider_connection).to be_present # realize the record before arming the dispatch guard
+
+      sync_dispatcher = Rails.configuration.dispatcher.sync_dispatcher
+      expect(sync_dispatcher).not_to receive(:dispatch)
+
+      expect { channel.update_reachout_time_lock!(nil) }.not_to raise_error
+    end
   end
 
   describe '#update_new_chat_cap!' do
@@ -629,6 +638,15 @@ RSpec.describe Channel::Whatsapp do
       expect(sync_dispatcher).not_to receive(:dispatch)
 
       channel.update_new_chat_cap!(cap)
+    end
+
+    it 'returns without raising or broadcasting when passed nil (404/fetch error)' do
+      expect(channel.provider_connection).to be_present # realize the record before arming the dispatch guard
+
+      sync_dispatcher = Rails.configuration.dispatcher.sync_dispatcher
+      expect(sync_dispatcher).not_to receive(:dispatch)
+
+      expect { channel.update_new_chat_cap!(nil) }.not_to raise_error
     end
   end
 

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -250,6 +250,21 @@ describe Whatsapp::IncomingMessageBaileysService do
         end
       end
 
+      context 'with new-chat cap (quota)' do
+        it 'preserves an existing cap when a connection-only update arrives' do
+          inbox.channel.update_provider_connection!(
+            connection: 'open',
+            new_chat_cap: { capping_status: 'CAPPED', total_quota: 100, used_quota: 100 }
+          )
+          params = base_params.merge(data: { connection: 'connecting' })
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection['connection']).to eq('connecting')
+          expect(inbox.channel.provider_connection['new_chat_cap']).to include('capping_status' => 'CAPPED')
+        end
+      end
+
       context 'with lease epochs (multi-instance baileys-api)' do
         it 'persists the epoch alongside the connection state' do
           params = base_params.merge(

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -88,6 +88,35 @@ describe Whatsapp::IncomingMessageBaileysService do
       )
     end
 
+    context 'when processing message-capping.update event' do
+      it 'persists the UI-relevant cap keys and drops server_sent_timestamp' do
+        params = {
+          webhookVerifyToken: webhook_verify_token,
+          event: 'message-capping.update',
+          data: {
+            capping_status: 'FIRST_WARNING',
+            ote_status: 'ELIGIBLE',
+            mv_status: 'NOT_ELIGIBLE',
+            total_quota: 100,
+            used_quota: 80,
+            cycle_end_timestamp: '1781699999',
+            server_sent_timestamp: '1781645846'
+          }
+        }
+
+        described_class.new(inbox: inbox, params: params).perform
+
+        expect(inbox.channel.reload.provider_connection['new_chat_cap']).to eq(
+          'capping_status' => 'FIRST_WARNING',
+          'ote_status' => 'ELIGIBLE',
+          'mv_status' => 'NOT_ELIGIBLE',
+          'total_quota' => 100,
+          'used_quota' => 80,
+          'cycle_end_timestamp' => '1781699999'
+        )
+      end
+    end
+
     context 'when processing connection.update event' do
       let(:base_params) { { webhookVerifyToken: webhook_verify_token, event: 'connection.update' } }
 
@@ -161,6 +190,64 @@ describe Whatsapp::IncomingMessageBaileysService do
         described_class.new(inbox: inbox, params: params).perform
 
         expect(inbox.channel.provider_connection['error']).to be_nil
+      end
+
+      context 'with reach-out time-lock (error 463 / account restriction)' do
+        let(:reachout_data) do
+          { isActive: true, timeEnforcementEnds: '2026-06-19T21:52:39.000Z', enforcementType: 'RESTRICT_ALL_COMPANIONS' }
+        end
+
+        it 'persists the lock from a standalone reachoutTimeLock push and keeps the connection' do
+          inbox.channel.update_provider_connection!(connection: 'open')
+          params = base_params.merge(data: { reachoutTimeLock: reachout_data })
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection['connection']).to eq('open')
+          expect(inbox.channel.provider_connection['reachout_time_lock']).to eq(
+            'is_active' => true,
+            'time_enforcement_ends' => '2026-06-19T21:52:39.000Z',
+            'enforcement_type' => 'RESTRICT_ALL_COMPANIONS'
+          )
+        end
+
+        it 'preserves an existing lock when a connection-only update arrives' do
+          inbox.channel.update_provider_connection!(
+            connection: 'open',
+            reachout_time_lock: { is_active: true, time_enforcement_ends: '2026-06-19T21:52:39.000Z', enforcement_type: 'RESTRICT_ALL_COMPANIONS' }
+          )
+          params = base_params.merge(data: { connection: 'connecting' })
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection['connection']).to eq('connecting')
+          expect(inbox.channel.provider_connection['reachout_time_lock']).to include('is_active' => true)
+        end
+
+        it 'records the cleared state when isActive is false' do
+          params = base_params.merge(data: { reachoutTimeLock: { isActive: false, enforcementType: 'DEFAULT' } })
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection['reachout_time_lock']).to eq('is_active' => false, 'enforcement_type' => 'DEFAULT')
+        end
+
+        it 'persists only is_active when the deadline and type are absent' do
+          params = base_params.merge(data: { reachoutTimeLock: { isActive: true } })
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection['reachout_time_lock']).to eq('is_active' => true)
+        end
+
+        it 'discards a stale-epoch reachoutTimeLock push' do
+          inbox.channel.update_provider_connection!(connection: 'open', epoch: 7)
+          params = base_params.merge(data: { reachoutTimeLock: reachout_data, epoch: 6 })
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(inbox.channel.provider_connection['reachout_time_lock']).to be_nil
+        end
       end
 
       context 'with lease epochs (multi-instance baileys-api)' do

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -763,6 +763,13 @@ describe Whatsapp::Providers::WhatsappBaileysService do
 
       expect(service.fetch_new_chat_cap).to be_nil
     end
+
+    it 'returns nil on a server error (read-only, never marks the connection closed)' do
+      stub_request(:get, url).to_return(status: 500, body: 'Internal Server Error')
+      allow(Rails.logger).to receive(:error)
+
+      expect(service.fetch_new_chat_cap).to be_nil
+    end
   end
 
   describe '#read_messages' do

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -704,6 +704,67 @@ describe Whatsapp::Providers::WhatsappBaileysService do
     end
   end
 
+  describe '#fetch_reachout_timelock' do
+    let(:url) { "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/reachout-timelock" }
+
+    it 'returns the normalized lock when the account is restricted' do
+      stub_request(:get, url).to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: { data: { isActive: true, timeEnforcementEnds: '2026-06-19T21:52:39.000Z', enforcementType: 'RESTRICT_ALL_COMPANIONS' } }.to_json
+      )
+
+      expect(service.fetch_reachout_timelock).to eq(
+        is_active: true,
+        time_enforcement_ends: '2026-06-19T21:52:39.000Z',
+        enforcement_type: 'RESTRICT_ALL_COMPANIONS'
+      )
+    end
+
+    it 'returns is_active false when the account is not restricted' do
+      stub_request(:get, url).to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: { data: { isActive: false, enforcementType: 'DEFAULT' } }.to_json
+      )
+
+      expect(service.fetch_reachout_timelock).to eq(is_active: false, enforcement_type: 'DEFAULT')
+    end
+
+    it 'returns nil on 404 (number not connected, not "unrestricted")' do
+      stub_request(:get, url).to_return(status: 404, body: 'Phone number not connected')
+
+      expect(service.fetch_reachout_timelock).to be_nil
+    end
+
+    it 'returns nil on a server error (read-only, never marks the connection closed)' do
+      stub_request(:get, url).to_return(status: 500, body: 'Internal Server Error')
+      allow(Rails.logger).to receive(:error)
+
+      expect(service.fetch_reachout_timelock).to be_nil
+    end
+  end
+
+  describe '#fetch_new_chat_cap' do
+    let(:url) { "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/new-chat-cap" }
+
+    it 'returns the raw cap info on success' do
+      stub_request(:get, url).to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'application/json' },
+        body: { data: { capping_status: 'CAPPED', total_quota: 100, used_quota: 100, ote_status: 'ELIGIBLE' } }.to_json
+      )
+
+      expect(service.fetch_new_chat_cap).to eq(capping_status: 'CAPPED', total_quota: 100, used_quota: 100, ote_status: 'ELIGIBLE')
+    end
+
+    it 'returns nil on 404 (number not connected)' do
+      stub_request(:get, url).to_return(status: 404, body: 'Phone number not connected')
+
+      expect(service.fetch_new_chat_cap).to be_nil
+    end
+  end
+
   describe '#read_messages' do
     it 'send read messages request' do
       stub_request(:post, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/read-messages")


### PR DESCRIPTION
Mostra o estado de restrição do WhatsApp (Baileys) numa barra no topo da conversa, para o agente saber que um número está bloqueado para iniciar conversas novas **antes** de tentar enviar. Cobre dois sinais autoritativos que o `baileys-api` passou a expor: o **reach-out time-lock** (erro 463, quando a Meta trava o início de novas conversas a partir do número) e o **novo cap de mensagens de primeira conversa** (programa de cota da Meta).

A barra é um aviso, não um bloqueio: espelha o padrão da barra de "inbox Baileys desconectado" e não desabilita o compositor.

## Closes

- Handoff interno de restrição do WhatsApp (erro 463 / reach-out time-lock). Vincular issue/Linear se houver.

## How to test

1. Abrir uma conversa de um inbox WhatsApp Baileys.
2. No `rails console`, simular cada estado e ver a barra aparecer em tempo real:
   - **Reach-out:** `ch = Channel::Whatsapp.find_by(provider: 'baileys'); ch.update_reachout_time_lock!({ 'is_active' => true, 'time_enforcement_ends' => 3.days.from_now.utc.iso8601, 'enforcement_type' => 'RESTRICT_ALL_COMPANIONS' })` → barra vermelha com o prazo; depois `ch.update_reachout_time_lock!({ 'is_active' => false })` e a barra some.
   - **Cap (aviso):** `ch.update_new_chat_cap!({ 'capping_status' => 'FIRST_WARNING', 'total_quota' => 100, 'used_quota' => 80 })` → barra âmbar com "80 de 100".
   - **Cap (atingido):** `ch.update_new_chat_cap!({ 'capping_status' => 'CAPPED', 'total_quota' => 100, 'used_quota' => 100 })` → barra vermelha.
3. Confirmar que para contas fora do programa (`NOT_ELIGIBLE` / `NONE`) nenhuma barra aparece (sem regressão).

## What changed

- Persiste `reachout_time_lock` e `new_chat_cap` dentro do jsonb `provider_connection` (sem migration), via push (`connection.update` / `message-capping.update`) e poll de 5 min (`BaileysConnectionCheckJob`).
- Serializa os dois campos nos **dois** caminhos: REST (`provider_connection_data`) e websocket (`ActionCableListener`), para a barra não sumir no próximo push.
- Helper puro `dashboard/helper/whatsapp.js` + computeds e dois `<Banner>` no `MessagesView`.
- Cores: âmbar para aviso de cota, vermelho para reach-out e cota atingida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/325)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WhatsApp reachout restriction banners in the conversation dashboard, including deadline messaging and correct show/hide behavior.
  * Added WhatsApp new chat cap banners for warning/capped states with dynamic quota details.
  * Extended real-time inbox updates so agents receive reachout time-lock and new chat cap status changes promptly.

* **Tests**
  * Expanded automated coverage for reachout restriction and message-cap banner logic, including malformed/absent data handling, connection-only update preservation, and webhook/connection update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->