### PR TITLE
feat(whatsapp): auto-fill template media URL from the template example

### DIFF
--- a/app/javascript/dashboard/helper/specs/templateHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/templateHelper.spec.js
@@ -96,6 +96,30 @@ describe('templateHelper', () => {
       const result = buildTemplateParameters(imageTemplate, true);
 
       expect(result.header).toEqual({
+        media_url: 'https://example.com/shoes.jpg',
+        media_type: 'image',
+      });
+    });
+
+    it('should pre-fill media_url from the template example header_handle', () => {
+      const imageTemplate = templates.find(
+        t => t.name === 'order_confirmation'
+      );
+      const result = buildTemplateParameters(imageTemplate, true);
+
+      expect(result.header.media_url).toBe('https://example.com/shoes.jpg');
+    });
+
+    it('should leave media_url empty when the template has no example handle', () => {
+      const imageTemplateWithoutExample = {
+        components: [
+          { type: 'HEADER', format: 'IMAGE' },
+          { type: 'BODY', text: 'Hi {{1}}' },
+        ],
+      };
+      const result = buildTemplateParameters(imageTemplateWithoutExample, true);
+
+      expect(result.header).toEqual({
         media_url: '',
         media_type: 'image',
       });

--- a/app/javascript/dashboard/helper/templateHelper.js
+++ b/app/javascript/dashboard/helper/templateHelper.js
@@ -49,7 +49,11 @@ export const buildTemplateParameters = (template, hasMediaHeaderValue) => {
 
   if (hasMediaHeaderValue) {
     if (!allVariables.header) allVariables.header = {};
-    allVariables.header.media_url = '';
+    // Pre-fill with the sample media URL that ships with the template
+    // (components[].example.header_handle[0]) so the agent doesn't have to
+    // paste it manually. The field stays editable in the parser.
+    allVariables.header.media_url =
+      headerComponent.example?.header_handle?.[0] || '';
     allVariables.header.media_type = headerComponent.format.toLowerCase();
 
     // For document templates, include media_name field for filename support


### PR DESCRIPTION
Ao enviar um template de WhatsApp com header de mídia (imagem, vídeo ou documento), o campo de URL da mídia agora já vem preenchido com a URL de exemplo que acompanha o próprio template, em vez de exigir que o atendente cole a URL manualmente. O campo continua editável normalmente, então quem precisa de uma mídia diferente é só trocar.

## How to test
1. Em um inbox de WhatsApp (Cloud API/360Dialog) com templates de mídia sincronizados, abra uma conversa.
2. Na reply box, clique no botão de templates do WhatsApp e selecione um template com header de imagem/vídeo/documento.
3. Confirme que o campo de URL da mídia já vem preenchido com a URL do template (a mesma usada no preview).
4. Confirme que dá para editar/limpar o campo normalmente.
5. Para um template de mídia sem URL de exemplo, o campo deve continuar vazio (fallback).

O mesmo comportamento vale para os fluxos de Nova Conversa e Campanhas, que reutilizam o mesmo parser.

## What changed
- `buildTemplateParameters` (`templateHelper.js`) passa a inicializar `header.media_url` com `components[].example.header_handle[0]` quando existe, caindo para `''` quando ausente. Escopo: imagem/vídeo/documento (áudio não é header válido no WhatsApp e segue fora).
- Specs atualizadas em `templateHelper.spec.js` cobrindo o pré-preenchimento e o fallback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/327)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Media URL fields in templates with headers now automatically populate with sample values from the template configuration when available, while remaining fully editable.

* **Tests**
  * Expanded test coverage for media URL field initialization in template parameter building, validating both pre-filled value and empty state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->