### PR TITLE
feat(macros): include macro and executor in macro.executed webhook payload

### DIFF
--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -64,7 +64,11 @@ class Macros::ExecutionService < ActionService
   end
 
   def send_webhook_event(webhook_url)
-    payload = @conversation.webhook_data.merge(event: 'macro.executed')
+    payload = @conversation.webhook_data.merge(
+      event: 'macro.executed',
+      macro: { id: @macro.id, name: @macro.name },
+      executed_by: @user&.webhook_data
+    )
     WebhookJob.perform_later(webhook_url.first, payload)
   end
 end

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -174,5 +174,16 @@ RSpec.describe Macros::ExecutionService, type: :service do
       expect(WebhookJob).to receive(:perform_later)
       service.send(:send_webhook_event, ['https://example.com/webhook'])
     end
+
+    it 'includes the macro and the executing user in the payload' do
+      expect(WebhookJob).to receive(:perform_later) do |url, payload|
+        expect(url).to eq('https://example.com/webhook')
+        expect(payload[:event]).to eq('macro.executed')
+        expect(payload[:macro]).to eq({ id: macro.id, name: macro.name })
+        expect(payload[:executed_by]).to eq(user.webhook_data)
+      end
+
+      service.send(:send_webhook_event, ['https://example.com/webhook'])
+    end
   end
 end


### PR DESCRIPTION
O evento de webhook `macro.executed` agora informa **qual macro** foi executada e **quem** a executou. Antes, o payload trazia apenas os dados da conversa e `event: 'macro.executed'`, sem identificar a macro nem o agente, deixando o consumidor externo sem contexto sobre a origem da execução.

## How to test

1. Crie uma macro com uma ação **Send Webhook Event** apontando para uma URL capturável (ex.: webhook.site).
2. Execute a macro em uma conversa pelo dashboard.
3. Verifique o payload recebido na URL. Ele deve conter, além dos dados da conversa:
   - `event: "macro.executed"`
   - `macro: { id, name }` — a macro executada
   - `executed_by: { id, name, email, type: "user" }` — o agente que disparou

## What changed

- `Macros::ExecutionService#send_webhook_event` passa a mesclar `macro` e `executed_by` no payload. O agente já estava disponível como `@user`; `executed_by` reusa o serializer canônico `User#webhook_data`.
- Spec de regressão em `spec/services/macros/execution_service_spec.rb` validando os novos campos do payload.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/329)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook events for executed macros now include more complete details, such as the macro’s name and ID plus the acting user’s information.
  * Webhook payloads continue to include existing conversation data while sending a clearer event type for downstream integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->