### PR TITLE
feat(whatsapp): import an already-linked WhatsApp Web session

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -99,8 +99,11 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
              status: :unprocessable_entity and return
     end
 
+    session = import_session_params[:session].to_h
+    render json: { error: 'Session payload is required' }, status: :unprocessable_entity and return if session.blank?
+
     channel.import_session(
-      session: import_session_params[:session].to_h,
+      session: session,
       candidate_index: import_session_params[:candidate_index].to_i
     )
     head :ok

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
   before_action :validate_limit, only: [:create]
   # we are already handling the authorization in fetch inbox
   # rubocop:disable Rails/LexicallyScopedActionFilter -- health is defined in WhatsappHealthManagement concern
-  before_action :check_authorization, except: [:show, :health, :setup_channel_provider]
+  before_action :check_authorization, except: [:show, :health, :setup_channel_provider, :import_whatsapp_session]
   before_action :validate_whatsapp_cloud_channel, only: [:health]
   # rubocop:enable Rails/LexicallyScopedActionFilter
   include Api::V1::Accounts::Concerns::WhatsappHealthManagement
@@ -87,6 +87,25 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
     head :ok
   end
 
+  # Hot-loads a WhatsApp Web session extracted by the browser extension into a
+  # disconnected Baileys inbox. Authorized like setup_channel_provider (any agent
+  # assigned to the inbox, via fetch_inbox -> show?), since connecting a number
+  # to an assigned inbox is the same privilege as scanning a QR for it.
+  def import_whatsapp_session
+    channel = @inbox.channel
+
+    unless channel.is_a?(Channel::Whatsapp) && channel.provider == 'baileys'
+      render json: { error: 'Session import is only supported for Baileys WhatsApp channels' },
+             status: :unprocessable_entity and return
+    end
+
+    channel.import_session(
+      session: import_session_params[:session].to_h,
+      candidate_index: import_session_params[:candidate_index].to_i
+    )
+    head :ok
+  end
+
   def disconnect_channel_provider
     channel = @inbox.channel
 
@@ -146,6 +165,23 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
   def fetch_inbox
     @inbox = Current.account.inboxes.find(params[:id])
     authorize @inbox, :show?
+  end
+
+  # The session is opaque credentials forwarded verbatim to the Baileys API,
+  # which validates its schema. We still permit an explicit shape (rather than
+  # permit!) so nothing unexpected is forwarded. camelCase keys match the
+  # extractor's output.
+  def import_session_params
+    params.permit(
+      :candidate_index,
+      session: [
+        :registrationId, :advSecretKey, :id, :lid, :platform, :pushName, :routingInfo,
+        { noiseCandidates: %i[private public] },
+        { identityKey: %i[private public] },
+        { account: %i[details accountSignatureKey accountSignature deviceSignature] },
+        { signedPreKey: %i[keyId private public signature] }
+      ]
+    )
   end
 
   def fetch_agent_bot

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -107,6 +107,8 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
       candidate_index: import_session_params[:candidate_index].to_i
     )
     head :ok
+  rescue Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError
+    render json: { error: 'WhatsApp provider is currently unavailable. Please try again.' }, status: :service_unavailable
   end
 
   def disconnect_channel_provider

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -332,7 +332,11 @@
             "RECONNECTING": "Connecting...",
             "LINK_DEVICE": "Link device",
             "DISCONNECT": "Disconnect",
-            "CONNECTED": "Your device has been connected successfully. You can now start sending and receiving messages."
+            "CONNECTED": "Your device has been connected successfully. You can now start sending and receiving messages.",
+            "IMPORT_SESSION_TITLE": "QR code not working?",
+            "IMPORT_SESSION_SHOW_MORE": "Show more",
+            "IMPORT_SESSION_DESC": "WhatsApp now requires a passkey when linking some accounts, which blocks the QR code. Install the browser extension to import a session you're already logged into on WhatsApp Web.",
+            "IMPORT_SESSION_INSTALL": "Install the extension"
           }
         },
         "SUBMIT_BUTTON": "Create WhatsApp Channel",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/inboxMgmt.json
@@ -332,7 +332,11 @@
             "RECONNECTING": "Conectando...",
             "LINK_DEVICE": "Conectar dispositivo",
             "DISCONNECT": "Desconectar",
-            "CONNECTED": "Seu dispositivo foi conectado com sucesso. Agora você pode começar a enviar e receber mensagens."
+            "CONNECTED": "Seu dispositivo foi conectado com sucesso. Agora você pode começar a enviar e receber mensagens.",
+            "IMPORT_SESSION_TITLE": "O QR code não funciona?",
+            "IMPORT_SESSION_SHOW_MORE": "Ver mais",
+            "IMPORT_SESSION_DESC": "O WhatsApp passou a exigir chave de acesso ao vincular algumas contas, o que bloqueia o QR code. Instale a extensão de navegador para importar uma sessão em que você já está logado no WhatsApp Web.",
+            "IMPORT_SESSION_INSTALL": "Instalar a extensão"
           }
         },
         "SUBMIT_BUTTON": "Criar canal do WhatsApp",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
@@ -185,6 +185,7 @@ watchEffect(() => {
             <button
               v-if="!showImportDetails"
               type="button"
+              :aria-expanded="showImportDetails"
               class="text-xs underline text-n-slate-11 hover:text-n-slate-12"
               @click="showImportDetails = true"
             >

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
@@ -23,7 +23,14 @@ const connection = computed(() => providerConnection.value?.connection);
 const qrDataUrl = computed(() => providerConnection.value?.qr_data_url);
 const error = computed(() => providerConnection.value?.error);
 
+// Alternative onboarding when WhatsApp's extra device-linking verification blocks
+// the QR: install the browser extension and import an already-linked session.
+// TODO: move to an installation config once the extension is published.
+const extensionUrl =
+  'https://chromewebstore.google.com/detail/chatwoot-whatsapp-connector';
+
 const loading = ref(false);
+const showImportDetails = ref(false);
 
 const handleError = e => {
   useAlert(e.message);
@@ -161,6 +168,53 @@ watchEffect(() => {
               </router-link>
             </div>
           </template>
+
+          <!-- Fallback kept available in every non-open state, including while the
+               QR is shown: import an already-linked session via the extension. -->
+          <div
+            v-if="connection !== 'open'"
+            class="flex flex-col gap-1 items-center pt-4 mt-2 w-full border-t border-n-weak"
+          >
+            <p class="text-sm font-medium text-center text-n-slate-12">
+              {{
+                $t(
+                  'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.IMPORT_SESSION_TITLE'
+                )
+              }}
+            </p>
+            <button
+              v-if="!showImportDetails"
+              type="button"
+              class="text-xs underline text-n-slate-11 hover:text-n-slate-12"
+              @click="showImportDetails = true"
+            >
+              {{
+                $t(
+                  'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.IMPORT_SESSION_SHOW_MORE'
+                )
+              }}
+            </button>
+            <template v-else>
+              <p class="text-sm text-center text-n-slate-11">
+                {{
+                  $t(
+                    'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.IMPORT_SESSION_DESC'
+                  )
+                }}
+              </p>
+              <a :href="extensionUrl" target="_blank" rel="noopener noreferrer">
+                <Button
+                  link
+                  blue
+                  :label="
+                    $t(
+                      'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.IMPORT_SESSION_INSTALL'
+                    )
+                  "
+                />
+              </a>
+            </template>
+          </div>
         </div>
       </div>
     </div>

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -356,6 +356,7 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
   end
 
   delegate :setup_channel_provider, to: :provider_service
+  delegate :import_session, to: :provider_service
   delegate :presence_subscribe, to: :provider_service
   delegate :send_message, to: :provider_service
   delegate :send_template, to: :provider_service

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -56,6 +56,29 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     true
   end
 
+  # Hot-loads an already-linked WhatsApp Web session extracted by the browser
+  # extension: the Baileys API seeds the credentials and resumes the socket
+  # without a QR. `session` is opaque impersonation credentials — never log it.
+  def import_session(session:, candidate_index: 0)
+    response = HTTParty.post(
+      "#{provider_url}/connections/#{whatsapp_channel.phone_number}/import-session",
+      headers: api_headers,
+      body: {
+        session: session,
+        candidateIndex: candidate_index,
+        clientName: DEFAULT_CLIENT_NAME,
+        webhookUrl: whatsapp_channel.inbox.callback_webhook_url,
+        webhookVerifyToken: whatsapp_channel.provider_config['webhook_verify_token'],
+        includeMedia: false,
+        groupsEnabled: self.class.groups_enabled?
+      }.compact.to_json
+    )
+
+    raise ProviderUnavailableError unless process_response(response)
+
+    true
+  end
+
   # Best-effort disconnect: we tell the Baileys API to drop the session and
   # move on regardless of the response. A stale or already-cleared session
   # (404), a Baileys API hiccup (5xx), or even a network error should not

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -59,6 +59,10 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # Hot-loads an already-linked WhatsApp Web session extracted by the browser
   # extension: the Baileys API seeds the credentials and resumes the socket
   # without a QR. `session` is opaque impersonation credentials — never log it.
+  # Not wrapped in `with_error_handling` (unlike setup_channel_provider): an
+  # import failure surfaces to the client via the connection.update webhook
+  # (provider_connection error), and recovery is a fresh QR setup, not a retry
+  # of the import.
   def import_session(session:, candidate_index: 0)
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/import-session",
@@ -71,7 +75,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         webhookVerifyToken: whatsapp_channel.provider_config['webhook_verify_token'],
         includeMedia: false,
         groupsEnabled: self.class.groups_enabled?
-      }.compact.to_json
+      }.compact.to_json,
+      timeout: 10
     )
 
     raise ProviderUnavailableError unless process_response(response)

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,7 +3,10 @@
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [
   :password, :secret, :_key, :auth, :crypt, :salt, :certificate, :otp, :access, :private, :protected, :ssn,
-  :otp_secret, :otp_code, :backup_code, :mfa_token, :otp_backup_codes
+  :otp_secret, :otp_code, :backup_code, :mfa_token, :otp_backup_codes,
+  # WhatsApp Web session import: `session` is a blob of impersonation credentials
+  # (Noise/Signal keys, ADV signatures). Redact the whole key so no field leaks.
+  :session
 ]
 
 # Regex to filter all occurrences of 'token' in keys except for 'website_token'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -314,6 +314,7 @@ Rails.application.routes.draw do
             get :agent_bot, on: :member
             post :set_agent_bot, on: :member
             post :setup_channel_provider, on: :member
+            post :import_whatsapp_session, on: :member
             post :disconnect_channel_provider, on: :member
             post :convert_provider, on: :member
             delete :avatar, on: :member

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1385,6 +1385,21 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
+      it 'returns unprocessable entity when the session payload is missing' do
+        service_double = instance_double(Whatsapp::Providers::WhatsappBaileysService)
+        allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:new)
+          .with(whatsapp_channel: channel)
+          .and_return(service_double)
+        allow(service_double).to receive(:import_session)
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/import_whatsapp_session",
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(service_double).not_to have_received(:import_session)
+      end
+
       it 'imports the session and returns ok' do
         service_double = instance_double(Whatsapp::Providers::WhatsappBaileysService)
         allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:new)

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1416,6 +1416,22 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(service_double).to have_received(:import_session).with(session: kind_of(Hash), candidate_index: 1)
       end
 
+      it 'returns service unavailable when the provider is unavailable' do
+        service_double = instance_double(Whatsapp::Providers::WhatsappBaileysService)
+        allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:new)
+          .with(whatsapp_channel: channel)
+          .and_return(service_double)
+        allow(service_double).to receive(:import_session)
+          .and_raise(Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError)
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/import_whatsapp_session",
+             params: { session: session_payload },
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:service_unavailable)
+      end
+
       it 'allows agents assigned to the inbox' do
         create(:inbox_member, user: agent, inbox: inbox)
         service_double = instance_double(Whatsapp::Providers::WhatsappBaileysService, import_session: true)

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1373,6 +1373,18 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
+      it 'returns unprocessable entity for a whatsapp channel using a non-baileys provider' do
+        cloud_channel = create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud',
+                                                  sync_templates: false, validate_provider_config: false)
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{cloud_channel.inbox.id}/import_whatsapp_session",
+             params: { session: session_payload },
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
       it 'imports the session and returns ok' do
         service_double = instance_double(Whatsapp::Providers::WhatsappBaileysService)
         allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:new)

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1339,6 +1339,82 @@ RSpec.describe 'Inboxes API', type: :request do
     end
   end
 
+  describe 'POST /api/v1/accounts/:account_id/inboxes/:id/import_whatsapp_session' do
+    let(:channel) { create(:channel_whatsapp, account: account, provider: 'baileys', validate_provider_config: false) }
+    let(:inbox) { channel.inbox }
+    let(:session_payload) do
+      {
+        noiseCandidates: [{ private: 'np0', public: 'nb0' }],
+        identityKey: { private: 'ip', public: 'ib' },
+        registrationId: 42,
+        advSecretKey: 'adv',
+        account: { details: 'd', accountSignatureKey: 'ask', accountSignature: 'as', deviceSignature: 'ds' },
+        id: '551101234567:12@s.whatsapp.net'
+      }
+    end
+
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/import_whatsapp_session"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'returns unprocessable entity for a non-baileys channel' do
+        other = create(:inbox, account: account)
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{other.id}/import_whatsapp_session",
+             params: { session: session_payload },
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'imports the session and returns ok' do
+        service_double = instance_double(Whatsapp::Providers::WhatsappBaileysService)
+        allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:new)
+          .with(whatsapp_channel: channel)
+          .and_return(service_double)
+        allow(service_double).to receive(:import_session).and_return(true)
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/import_whatsapp_session",
+             params: { session: session_payload, candidate_index: 1 },
+             headers: admin.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(service_double).to have_received(:import_session).with(session: kind_of(Hash), candidate_index: 1)
+      end
+
+      it 'allows agents assigned to the inbox' do
+        create(:inbox_member, user: agent, inbox: inbox)
+        service_double = instance_double(Whatsapp::Providers::WhatsappBaileysService, import_session: true)
+        allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:new)
+          .with(whatsapp_channel: channel)
+          .and_return(service_double)
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/import_whatsapp_session",
+             params: { session: session_payload },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns unauthorized for agents not assigned to the inbox' do
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/import_whatsapp_session",
+             params: { session: session_payload },
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   describe 'POST /api/v1/accounts/:account_id/inboxes/:id/disconnect_channel_provider' do
     let(:channel) { create(:channel_whatsapp, account: account, provider: 'baileys', validate_provider_config: false) }
     let(:inbox) { channel.inbox }

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -149,6 +149,55 @@ describe Whatsapp::Providers::WhatsappBaileysService do
     end
   end
 
+  describe '#import_session' do
+    let(:import_url) do
+      "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/import-session"
+    end
+    let(:session) do
+      {
+        'noiseCandidates' => [{ 'private' => 'np0', 'public' => 'nb0' }],
+        'identityKey' => { 'private' => 'ip', 'public' => 'ib' },
+        'registrationId' => 42,
+        'advSecretKey' => 'adv',
+        'account' => { 'details' => 'd', 'accountSignatureKey' => 'ask', 'accountSignature' => 'as', 'deviceSignature' => 'ds' },
+        'id' => '551101234567:12@s.whatsapp.net'
+      }
+    end
+
+    context 'when response is successful' do
+      it 'posts the session to the import endpoint' do
+        request = stub_request(:post, import_url)
+                  .with(
+                    headers: stub_headers(whatsapp_channel),
+                    body: {
+                      session: session,
+                      candidateIndex: 2,
+                      clientName: 'chatwoot-test',
+                      webhookUrl: whatsapp_channel.inbox.callback_webhook_url,
+                      webhookVerifyToken: whatsapp_channel.provider_config['webhook_verify_token'],
+                      includeMedia: false,
+                      groupsEnabled: described_class.groups_enabled?
+                    }.to_json
+                  )
+                  .to_return(status: 202)
+
+        expect(service.import_session(session: session, candidate_index: 2)).to be(true)
+        expect(request).to have_been_requested
+      end
+    end
+
+    context 'when response is unsuccessful' do
+      it 'raises ProviderUnavailableError' do
+        stub_request(:post, import_url).to_return(status: 409, body: 'conflict')
+        allow(Rails.logger).to receive(:error)
+
+        expect do
+          service.import_session(session: session)
+        end.to raise_error(described_class::ProviderUnavailableError)
+      end
+    end
+  end
+
   describe '#disconnect_channel_provider' do
     let(:disconnect_url) { "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}" }
 

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -193,7 +193,7 @@ describe Whatsapp::Providers::WhatsappBaileysService do
 
         expect do
           service.import_session(session: session)
-        end.to raise_error(described_class::ProviderUnavailableError)
+        end.to(raise_error { |error| expect(error.class.name).to eq(described_class::ProviderUnavailableError.name) })
       end
     end
   end


### PR DESCRIPTION
Brings a Baileys WhatsApp inbox online by importing a session already linked in WhatsApp Web (via the fazer.ai browser extension), for cases where the QR-code login is blocked by WhatsApp's extra device-linking verification. The connection modal surfaces this as a fallback ("QR code not working?"), kept available even while the QR is on screen, behind a discreet "Show more".

## What changed
- `POST /api/v1/accounts/:account_id/inboxes/:id/import_whatsapp_session` — agent-accessible endpoint that validates the channel is Baileys and relays the extracted session to the Baileys API via `WhatsappBaileysService#import_session`.
- `Channel::Whatsapp#import_session` delegate.
- Connection modal: import-session affordance with progressive "Show more" disclosure, shown in every non-`open` state (including while the QR is displayed).
- i18n (en + pt_BR); "passkey" rendered as "chave de acesso" in pt_BR.

## How to test
1. Create a Baileys WhatsApp inbox and open its connection modal.
2. With the QR showing, note the "QR code not working?" fallback; expand "Show more" to reveal the extension install link.
3. Import a session with the extension → the inbox comes online without scanning the QR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/330)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account inbox action to import a pre-linked WhatsApp Web session for Baileys-backed disconnected inboxes.
  * Updated the WhatsApp “Link your device” modal to offer an extension-based fallback when the QR flow is blocked, including localized prompts and an install action.
* **Bug Fixes**
  * Restricted session import to supported Baileys WhatsApp inbox configurations.
  * Improved security by redacting WhatsApp session data from application logs.
* **Tests**
  * Added request and provider specs covering success, validation failures, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->