### PR TITLE
fix(internal-chat): allow deleting a user who created channels or has drafts

### DIFF
--- a/app/models/internal_chat/channel.rb
+++ b/app/models/internal_chat/channel.rb
@@ -30,7 +30,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (category_id => internal_chat_categories.id)
-#  fk_rails_...  (created_by_id => users.id)
+#  fk_rails_...  (created_by_id => users.id) ON DELETE => nullify
 #
 class InternalChat::Channel < ApplicationRecord
   self.table_name = 'internal_chat_channels'

--- a/app/models/internal_chat/draft.rb
+++ b/app/models/internal_chat/draft.rb
@@ -23,7 +23,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (internal_chat_channel_id => internal_chat_channels.id)
-#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (user_id => users.id) ON DELETE => cascade
 #
 class InternalChat::Draft < ApplicationRecord
   self.table_name = 'internal_chat_drafts'

--- a/db/migrate/20260703000000_add_on_delete_to_internal_chat_user_foreign_keys.rb
+++ b/db/migrate/20260703000000_add_on_delete_to_internal_chat_user_foreign_keys.rb
@@ -1,0 +1,19 @@
+class AddOnDeleteToInternalChatUserForeignKeys < ActiveRecord::Migration[7.1]
+  def up
+    # Channels keep their history when the creator is deleted: just clear created_by.
+    remove_foreign_key :internal_chat_channels, column: :created_by_id
+    add_foreign_key :internal_chat_channels, :users, column: :created_by_id, on_delete: :nullify
+
+    # Drafts are personal and ephemeral: drop them with their owner.
+    remove_foreign_key :internal_chat_drafts, :users
+    add_foreign_key :internal_chat_drafts, :users, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :internal_chat_channels, column: :created_by_id
+    add_foreign_key :internal_chat_channels, :users, column: :created_by_id
+
+    remove_foreign_key :internal_chat_drafts, :users
+    add_foreign_key :internal_chat_drafts, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_12_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_03_000000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -1603,9 +1603,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_000000) do
   add_foreign_key "internal_chat_channel_teams", "internal_chat_channels"
   add_foreign_key "internal_chat_channel_teams", "teams"
   add_foreign_key "internal_chat_channels", "internal_chat_categories", column: "category_id"
-  add_foreign_key "internal_chat_channels", "users", column: "created_by_id"
+  add_foreign_key "internal_chat_channels", "users", column: "created_by_id", on_delete: :nullify
   add_foreign_key "internal_chat_drafts", "internal_chat_channels"
-  add_foreign_key "internal_chat_drafts", "users"
+  add_foreign_key "internal_chat_drafts", "users", on_delete: :cascade
   add_foreign_key "internal_chat_message_attachments", "internal_chat_messages"
   add_foreign_key "internal_chat_messages", "accounts", on_delete: :cascade
   add_foreign_key "internal_chat_messages", "internal_chat_channels"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -324,6 +324,18 @@ RSpec.describe User do
 
       expect(scheduled_message.reload.author_id).to be_nil
     end
+
+    it 'nullifies created internal chat channels and destroys the user drafts' do
+      account = create(:account)
+      create(:account_user, user: user, account: account)
+      channel = create(:internal_chat_channel, account: account, created_by: user)
+      draft = create(:internal_chat_draft, account: account, user: user, channel: channel)
+
+      expect { user.destroy! }.not_to raise_error
+
+      expect(channel.reload.created_by_id).to be_nil
+      expect(InternalChat::Draft.exists?(draft.id)).to be(false)
+    end
   end
 
   describe 'sync_user_sessions callback' do


### PR DESCRIPTION
Deleting an agent who had created Internal Chat channels (or who had drafts) failed with a 500 error. Deletion now completes cleanly: channels the agent created are preserved (only the creator reference is cleared) and the agent's drafts are removed.

## How to reproduce
1. With Internal Chat enabled, have an agent create a channel (and/or leave a draft in one).
2. Try to delete that agent from Settings → Agents.
3. Before: 500 error (`PG::ForeignKeyViolation` on `internal_chat_channels`, constraint `fk_rails_ae5ae2466b`). After: the agent is deleted successfully.

## What changed
- Migration adding the missing `on_delete` to the two `internal_chat_*` → `users` foreign keys (the other four already had it):
  - `internal_chat_channels.created_by_id` → `nullify` (keeps the channel and its history; the model already treats `created_by` as optional)
  - `internal_chat_drafts.user_id` → `cascade` (drafts are personal and ephemeral)
- Regression spec on `User` deletion covering both paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/331)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a user now clears their reference from created chat channels instead of removing the channels.
  * Related chat drafts are now removed automatically when the owning user is deleted.
  * Added coverage to verify these delete behaviors work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->