### PR TITLE
fix(whatsapp): point extension install link to the published Chrome Web Store listing

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
@@ -25,9 +25,8 @@ const error = computed(() => providerConnection.value?.error);
 
 // Alternative onboarding when WhatsApp's extra device-linking verification blocks
 // the QR: install the browser extension and import an already-linked session.
-// TODO: move to an installation config once the extension is published.
 const extensionUrl =
-  'https://chromewebstore.google.com/detail/chatwoot-whatsapp-connector';
+  'https://chromewebstore.google.com/detail/fazerai-whatsapp-connecto/nchdjpjplcnggifnemiiclgjplooible';
 
 const loading = ref(false);
 const showImportDetails = ref(false);


### PR DESCRIPTION
Wire the WhatsApp "import an already-linked session" onboarding to the real browser extension. The install link in the disconnected-inbox modal was still pointing at a placeholder Chrome Web Store slug; it now opens the published **fazer.ai WhatsApp Connector** listing.

## What changed
- `WhatsappLinkDeviceModal.vue`: `extensionUrl` now points to the published listing (`.../detail/fazerai-whatsapp-connecto/nchdjpjplcnggifnemiiclgjplooible`) and the stale `TODO` is removed.

## How to test
- Open a disconnected Baileys WhatsApp inbox → device-link modal.
- In the "import an already-linked session" section, click the install-extension link.
- It should open the published extension listing on the Chrome Web Store (not a 404 placeholder).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/332)
<!-- Reviewable:end -->
