### PR TITLE
feat(internal-chat): surface mentions and DMs in native notifications

### DIFF
--- a/app/builders/notification_builder.rb
+++ b/app/builders/notification_builder.rb
@@ -39,11 +39,14 @@ class NotificationBuilder
     )
   end
 
-  # Non-conversation actors (e.g. internal chat channels) have no contact to block.
+  # Resolve the conversation the same way user_can_access_conversation? does, so message actors
+  # from blocked contacts stay suppressed. Non-conversation actors (e.g. internal chat channels)
+  # have no conversation/contact to block.
   def blocked_conversation?
-    return false unless primary_actor.is_a?(Conversation)
+    conversation = primary_actor.is_a?(Conversation) ? primary_actor : primary_actor.try(:conversation)
+    return false if conversation.blank?
 
-    primary_actor.contact.blocked? && notification_type != 'conversation_mention'
+    conversation.contact.blocked? && notification_type != 'conversation_mention'
   end
 
   def user_can_access_conversation?

--- a/app/builders/notification_builder.rb
+++ b/app/builders/notification_builder.rb
@@ -26,7 +26,7 @@ class NotificationBuilder
     # Create conversation_creation notification only if user is subscribed to it
     return if notification_type == 'conversation_creation' && !user_subscribed_to_notification?
     # skip notifications for blocked conversations except for user mentions
-    return if primary_actor.contact.blocked? && notification_type != 'conversation_mention'
+    return if blocked_conversation?
     # respect conversation access (inbox/team membership and custom-role permissions)
     return unless user_can_access_conversation?
 
@@ -37,6 +37,13 @@ class NotificationBuilder
       # secondary_actor is secondary_actor if present, else current_user
       secondary_actor: secondary_actor || current_user
     )
+  end
+
+  # Non-conversation actors (e.g. internal chat channels) have no contact to block.
+  def blocked_conversation?
+    return false unless primary_actor.is_a?(Conversation)
+
+    primary_actor.contact.blocked? && notification_type != 'conversation_mention'
   end
 
   def user_can_access_conversation?

--- a/app/javascript/dashboard/components-next/Inbox/InboxCard.vue
+++ b/app/javascript/dashboard/components-next/Inbox/InboxCard.vue
@@ -44,7 +44,11 @@ const getMessageClasses = {
 
 const primaryActor = computed(() => props.inboxItem?.primaryActor);
 const meta = computed(() => primaryActor.value?.meta);
-const assigneeMeta = computed(() => meta.value?.sender);
+// Conversations expose the sender under primaryActor.meta.sender; internal chat
+// notifications (channel primary actor) carry it on the message secondary actor.
+const assigneeMeta = computed(
+  () => meta.value?.sender || props.inboxItem?.secondaryActor?.sender || {}
+);
 const isUnread = computed(() => !props.inboxItem?.readAt);
 const inbox = computed(() => props.stateInbox);
 

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -168,7 +168,9 @@
       "conversation_mention": "Mention",
       "sla_missed_first_response": "SLA Missed",
       "sla_missed_next_response": "SLA Missed",
-      "sla_missed_resolution": "SLA Missed"
+      "sla_missed_resolution": "SLA Missed",
+      "internal_chat_mention": "Mention",
+      "internal_chat_new_message": "Direct Message"
     }
   },
   "NETWORK": {

--- a/app/javascript/dashboard/i18n/locale/en/inbox.json
+++ b/app/javascript/dashboard/i18n/locale/en/inbox.json
@@ -36,6 +36,8 @@
       "SLA_MISSED_RESOLUTION": "SLA breach",
       "PARTICIPATING_CONVERSATION_NEW_MESSAGE": "New message",
       "ASSIGNED_CONVERSATION_NEW_MESSAGE": "New message",
+      "INTERNAL_CHAT_MENTION": "Mentioned",
+      "INTERNAL_CHAT_NEW_MESSAGE": "Direct message",
       "SNOOZED_UNTIL": "Snoozed for {time}",
       "SNOOZED_ENDS": "Snooze ended"
     },

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -198,7 +198,9 @@
           "PARTICIPATING_CONVERSATION_NEW_MESSAGE": "A new message is created in a participating conversation",
           "SLA_MISSED_FIRST_RESPONSE": "A conversation misses first response SLA",
           "SLA_MISSED_NEXT_RESPONSE": "A conversation misses next response SLA",
-          "SLA_MISSED_RESOLUTION": "A conversation misses resolution SLA"
+          "SLA_MISSED_RESOLUTION": "A conversation misses resolution SLA",
+          "INTERNAL_CHAT_MENTION": "You are mentioned in internal chat",
+          "INTERNAL_CHAT_NEW_MESSAGE": "A new direct message in internal chat"
         },
         "BROWSER_PERMISSION": "Enable push notifications for your browser so you’re able to receive them"
       },

--- a/app/javascript/dashboard/i18n/locale/pt_BR/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/generalSettings.json
@@ -168,7 +168,9 @@
       "conversation_mention": "Menção",
       "sla_missed_first_response": "SLA não alcançado",
       "sla_missed_next_response": "SLA não alcançado",
-      "sla_missed_resolution": "SLA não alcançado"
+      "sla_missed_resolution": "SLA não alcançado",
+      "internal_chat_mention": "Menção",
+      "internal_chat_new_message": "Mensagem direta"
     }
   },
   "NETWORK": {

--- a/app/javascript/dashboard/i18n/locale/pt_BR/inbox.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/inbox.json
@@ -36,6 +36,8 @@
       "SLA_MISSED_RESOLUTION": "Quebra SLA",
       "PARTICIPATING_CONVERSATION_NEW_MESSAGE": "Nova Mensagem",
       "ASSIGNED_CONVERSATION_NEW_MESSAGE": "Nova Mensagem",
+      "INTERNAL_CHAT_MENTION": "Mencionado",
+      "INTERNAL_CHAT_NEW_MESSAGE": "Mensagem direta",
       "SNOOZED_UNTIL": "Adiado para {time}",
       "SNOOZED_ENDS": "Adiamento encerrado"
     },

--- a/app/javascript/dashboard/i18n/locale/pt_BR/settings.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/settings.json
@@ -187,7 +187,9 @@
           "PARTICIPATING_CONVERSATION_NEW_MESSAGE": "Uma nova mensagem foi criada em uma conversa que você participa",
           "SLA_MISSED_FIRST_RESPONSE": "Uma conversa perde o SLA de primeira resposta",
           "SLA_MISSED_NEXT_RESPONSE": "Uma conversa perde o SLA da próxima resposta",
-          "SLA_MISSED_RESOLUTION": "Uma conversa perde o SLA de resolução"
+          "SLA_MISSED_RESOLUTION": "Uma conversa perde o SLA de resolução",
+          "INTERNAL_CHAT_MENTION": "Você é mencionado no chat interno",
+          "INTERNAL_CHAT_NEW_MESSAGE": "Uma nova mensagem direta no chat interno"
         },
         "BROWSER_PERMISSION": "Ative notificações push em seu navegador para poder recebê-las"
       },

--- a/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
@@ -178,12 +178,13 @@ const markAndUpdateCount = async ({ id, primaryActorId, primaryActorType }) => {
 
 const openInternalChatChannel = async notificationItem => {
   const { primaryActor, notificationType } = notificationItem;
-  if (!primaryActor) return;
 
   useTrack(INBOX_EVENTS.OPEN_CONVERSATION_VIA_INBOX, { notificationType });
 
   try {
     await markAndUpdateCount(notificationItem);
+    // Stale record without actor data: still mark it read, but there's nowhere to navigate.
+    if (!primaryActor) return;
     router.push({
       name:
         primaryActor.channelType === 'dm'

--- a/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
@@ -165,13 +165,49 @@ const setSavedFilter = () => {
   store.dispatch('notifications/setNotificationFilters', inboxFilters.value);
 };
 
-const openConversation = async notificationItem => {
-  const {
+const markAndUpdateCount = async ({ id, primaryActorId, primaryActorType }) => {
+  await store.dispatch('notifications/read', {
     id,
     primaryActorId,
     primaryActorType,
+    unreadCount: meta.value.unreadCount,
+  });
+  // to update the unread count in the store realtime
+  store.dispatch('notifications/unReadCount');
+};
+
+const openInternalChatChannel = async notificationItem => {
+  const { primaryActor, notificationType } = notificationItem;
+
+  useTrack(INBOX_EVENTS.OPEN_CONVERSATION_VIA_INBOX, { notificationType });
+
+  try {
+    await markAndUpdateCount(notificationItem);
+    router.push({
+      name:
+        primaryActor.channelType === 'dm'
+          ? 'internal_chat_dm'
+          : 'internal_chat_channel',
+      params: {
+        accountId: route.params.accountId,
+        channelId: primaryActor.id,
+      },
+    });
+  } catch {
+    // error
+  }
+};
+
+const openConversation = async notificationItem => {
+  const { notificationType } = notificationItem;
+
+  if (notificationType?.startsWith('internal_chat')) {
+    openInternalChatChannel(notificationItem);
+    return;
+  }
+
+  const {
     primaryActor: { inboxId, id: conversationId },
-    notificationType,
   } = notificationItem;
 
   if (route.params.id === String(conversationId)) return;
@@ -181,15 +217,7 @@ const openConversation = async notificationItem => {
   });
 
   try {
-    await store.dispatch('notifications/read', {
-      id,
-      primaryActorId,
-      primaryActorType,
-      unreadCount: meta.value.unreadCount,
-    });
-
-    // to update the unread count in the store realtime
-    store.dispatch('notifications/unReadCount');
+    await markAndUpdateCount(notificationItem);
 
     router.push({
       name: 'inbox_view_conversation',

--- a/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
+++ b/app/javascript/dashboard/routes/dashboard/inbox/InboxList.vue
@@ -178,6 +178,7 @@ const markAndUpdateCount = async ({ id, primaryActorId, primaryActorType }) => {
 
 const openInternalChatChannel = async notificationItem => {
   const { primaryActor, notificationType } = notificationItem;
+  if (!primaryActor) return;
 
   useTrack(INBOX_EVENTS.OPEN_CONVERSATION_VIA_INBOX, { notificationType });
 

--- a/app/javascript/dashboard/routes/dashboard/inbox/helpers/InboxViewHelpers.js
+++ b/app/javascript/dashboard/routes/dashboard/inbox/helpers/InboxViewHelpers.js
@@ -13,4 +13,6 @@ export const NOTIFICATION_TYPES_MAPPING = {
   SLA_MISSED_FIRST_RESPONSE: ['i-lucide-heart-crack', 'text-n-ruby-11'],
   SLA_MISSED_NEXT_RESPONSE: ['i-lucide-heart-crack', 'text-n-ruby-11'],
   SLA_MISSED_RESOLUTION: ['i-lucide-heart-crack', 'text-n-ruby-11'],
+  INTERNAL_CHAT_MENTION: ['i-lucide-at-sign', 'text-n-blue-11'],
+  INTERNAL_CHAT_NEW_MESSAGE: ['i-lucide-message-square-plus', 'text-n-blue-11'],
 };

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationTable.vue
@@ -45,6 +45,29 @@ export default {
   },
   methods: {
     dynamicTime,
+    isInternalChat(notification) {
+      return notification.notification_type?.startsWith('internal_chat');
+    },
+    notificationTitle(notification) {
+      if (this.isInternalChat(notification)) {
+        const channel = notification.primary_actor;
+        if (channel?.channel_type !== 'dm' && channel?.name) {
+          return `#${channel.name}`;
+        }
+        return notification.secondary_actor?.sender?.name || '';
+      }
+      return `#${
+        notification.primary_actor
+          ? notification.primary_actor.id
+          : this.$t('NOTIFICATIONS_PAGE.DELETE_TITLE')
+      }`;
+    },
+    notificationAvatar(notification) {
+      if (this.isInternalChat(notification)) {
+        return notification.secondary_actor?.sender;
+      }
+      return notification.primary_actor?.meta?.assignee;
+    },
   },
 };
 </script>
@@ -82,13 +105,7 @@ export default {
               class="overflow-hidden flex-view notification-contant--wrap whitespace-nowrap text-ellipsis"
             >
               <h5 class="notification--title">
-                {{
-                  `#${
-                    notificationItem.primary_actor
-                      ? notificationItem.primary_actor.id
-                      : $t(`NOTIFICATIONS_PAGE.DELETE_TITLE`)
-                  }`
-                }}
+                {{ notificationTitle(notificationItem) }}
               </h5>
               <span
                 class="overflow-hidden notification--message-title whitespace-nowrap text-ellipsis"
@@ -108,10 +125,10 @@ export default {
           </td>
           <td class="thumbnail--column">
             <Avatar
-              v-if="notificationItem.primary_actor.meta.assignee"
-              :src="notificationItem.primary_actor.meta.assignee.thumbnail"
+              v-if="notificationAvatar(notificationItem)"
+              :src="notificationAvatar(notificationItem).thumbnail"
               :size="28"
-              :name="notificationItem.primary_actor.meta.assignee.name"
+              :name="notificationAvatar(notificationItem).name"
               rounded-full
             />
           </td>

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationsView.vue
@@ -45,6 +45,8 @@ export default {
         unreadCount: this.meta.unreadCount,
       });
 
+      if (!primaryActor) return;
+
       if (notificationType.startsWith('internal_chat')) {
         this.$router.push({
           name:

--- a/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationsView.vue
+++ b/app/javascript/dashboard/routes/dashboard/notifications/components/NotificationsView.vue
@@ -27,11 +27,11 @@ export default {
       window.history.pushState({}, null, `${this.$route.path}?page=${page}`);
       this.$store.dispatch('notifications/get', { page });
     },
-    openConversation(notification) {
+    openNotification(notification) {
       const {
         primary_actor_id: primaryActorId,
         primary_actor_type: primaryActorType,
-        primary_actor: { id: conversationId },
+        primary_actor: primaryActor,
         notification_type: notificationType,
       } = notification;
 
@@ -45,8 +45,22 @@ export default {
         unreadCount: this.meta.unreadCount,
       });
 
+      if (notificationType.startsWith('internal_chat')) {
+        this.$router.push({
+          name:
+            primaryActor.channel_type === 'dm'
+              ? 'internal_chat_dm'
+              : 'internal_chat_channel',
+          params: {
+            accountId: this.accountId,
+            channelId: primaryActor.id,
+          },
+        });
+        return;
+      }
+
       this.$router.push(
-        `/app/accounts/${this.accountId}/conversations/${conversationId}`
+        `/app/accounts/${this.accountId}/conversations/${primaryActor.id}`
       );
     },
     onMarkAllDoneClick() {
@@ -64,7 +78,7 @@ export default {
         :notifications="records"
         :is-loading="uiFlags.isFetching"
         :is-updating="uiFlags.isUpdating"
-        :on-click-notification="openConversation"
+        :on-click-notification="openNotification"
         :on-mark-all-done-click="onMarkAllDoneClick"
       />
       <TableFooter

--- a/app/javascript/dashboard/routes/dashboard/settings/profile/NotificationPreferences.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/NotificationPreferences.vue
@@ -51,6 +51,12 @@ export default {
             ].includes(notification.value)
       );
     },
+    // Some types (e.g. internal chat) don't support email delivery yet
+    emailNotificationTypes() {
+      return this.filteredNotificationTypes.filter(
+        notification => !notification.pushOnly
+      );
+    },
   },
   watch: {
     emailFlags(value) {
@@ -213,6 +219,7 @@ export default {
             :class="`col-span-${type === 'push' ? 3 : 2}`"
           >
             <CheckBox
+              v-if="!(type === 'email' && notification.pushOnly)"
               :value="`${type}_${notification.value}`"
               :is-checked="
                 checkFlagStatus(type, notification.value, selectedPushFlags)
@@ -230,7 +237,7 @@ export default {
       </span>
       <div class="flex flex-col gap-4">
         <div
-          v-for="(notification, index) in filteredNotificationTypes"
+          v-for="(notification, index) in emailNotificationTypes"
           :key="index"
           class="flex flex-row items-start gap-2"
         >

--- a/app/javascript/dashboard/routes/dashboard/settings/profile/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/profile/constants.js
@@ -34,6 +34,17 @@ export const NOTIFICATION_TYPES = [
     label: 'PROFILE_SETTINGS.FORM.NOTIFICATIONS.TYPES.SLA_MISSED_RESOLUTION',
     value: 'sla_missed_resolution',
   },
+  {
+    label: 'PROFILE_SETTINGS.FORM.NOTIFICATIONS.TYPES.INTERNAL_CHAT_MENTION',
+    value: 'internal_chat_mention',
+    pushOnly: true,
+  },
+  {
+    label:
+      'PROFILE_SETTINGS.FORM.NOTIFICATIONS.TYPES.INTERNAL_CHAT_NEW_MESSAGE',
+    value: 'internal_chat_new_message',
+    pushOnly: true,
+  },
 ];
 
 export const EVENT_TYPES = {

--- a/app/javascript/dashboard/store/modules/notifications/mutations.js
+++ b/app/javascript/dashboard/store/modules/notifications/mutations.js
@@ -25,12 +25,15 @@ export const mutations = {
   },
   [types.SET_NOTIFICATIONS]: ($state, data) => {
     data.forEach(notification => {
-      // Find existing notification with same primary_actor_id (primary_actor_id is unique)
+      // Find existing notification for the same primary actor (scoped by type, since a
+      // conversation and e.g. an internal chat channel can share the same primary_actor_id)
       const existingNotification = Object.values($state.records).find(
-        record => record.primary_actor_id === notification.primary_actor_id
+        record =>
+          record.primary_actor_id === notification.primary_actor_id &&
+          record.primary_actor_type === notification.primary_actor_type
       );
       // This is to handle the case where the same notification is received multiple times
-      // On reconnect, if there is existing notification with same primary_actor_id,
+      // On reconnect, if there is existing notification with same primary actor,
       // it will be deleted and the new one will be added. So it will solve with duplicate notification
       if (existingNotification) {
         delete $state.records[existingNotification.id];

--- a/app/javascript/dashboard/store/modules/specs/notifications/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/notifications/mutations.spec.js
@@ -67,6 +67,37 @@ describe('#mutations', () => {
         4: { id: 4, primary_actor_id: 4 },
       });
     });
+
+    it('keeps notifications with the same primary_actor_id but different types', () => {
+      const state = { records: {} };
+      mutations[types.SET_NOTIFICATIONS](state, [
+        { id: 1, primary_actor_id: 1, primary_actor_type: 'Conversation' },
+        {
+          id: 2,
+          primary_actor_id: 1,
+          primary_actor_type: 'InternalChat::Channel',
+        },
+      ]);
+      expect(state.records).toEqual({
+        1: { id: 1, primary_actor_id: 1, primary_actor_type: 'Conversation' },
+        2: {
+          id: 2,
+          primary_actor_id: 1,
+          primary_actor_type: 'InternalChat::Channel',
+        },
+      });
+    });
+
+    it('deduplicates notifications sharing the same primary actor type and id', () => {
+      const state = { records: {} };
+      mutations[types.SET_NOTIFICATIONS](state, [
+        { id: 1, primary_actor_id: 1, primary_actor_type: 'Conversation' },
+        { id: 2, primary_actor_id: 1, primary_actor_type: 'Conversation' },
+      ]);
+      expect(state.records).toEqual({
+        2: { id: 2, primary_actor_id: 1, primary_actor_type: 'Conversation' },
+      });
+    });
   });
   describe('#UPDATE_NOTIFICATION', () => {
     it('update notifications ', () => {

--- a/app/jobs/notification/remove_duplicate_notification_job.rb
+++ b/app/jobs/notification/remove_duplicate_notification_job.rb
@@ -6,9 +6,11 @@ class Notification::RemoveDuplicateNotificationJob < ApplicationJob
 
     user_id = notification.user_id
     primary_actor_id = notification.primary_actor_id
+    primary_actor_type = notification.primary_actor_type
 
-    # Find older notifications with the same user and primary_actor_id
-    duplicate_notifications = Notification.where(user_id: user_id, primary_actor_id: primary_actor_id)
+    # Find older notifications with the same user and primary actor (scoped by type so
+    # e.g. an internal chat channel notification can't collapse a conversation one sharing the same id)
+    duplicate_notifications = Notification.where(user_id: user_id, primary_actor_id: primary_actor_id, primary_actor_type: primary_actor_type)
                                           .order(created_at: :desc)
 
     # Skip the first one (the latest notification) and destroy the rest

--- a/app/models/internal_chat/channel.rb
+++ b/app/models/internal_chat/channel.rb
@@ -81,6 +81,17 @@ class InternalChat::Channel < ApplicationRecord
     channel_type_dm?
   end
 
+  def push_event_data
+    {
+      id: id,
+      uuid: uuid,
+      name: name,
+      channel_type: channel_type,
+      account_id: account_id,
+      meta: {}
+    }
+  end
+
   private
 
   def generate_uuid

--- a/app/models/internal_chat/message.rb
+++ b/app/models/internal_chat/message.rb
@@ -74,6 +74,16 @@ class InternalChat::Message < ApplicationRecord
     replies_count
   end
 
+  def push_event_data
+    {
+      id: id,
+      content: content,
+      content_type: content_type,
+      internal_chat_channel_id: internal_chat_channel_id,
+      sender: sender&.push_event_data
+    }
+  end
+
   private
 
   # Atomic compare-and-set so concurrent message creates can never regress

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -43,8 +43,14 @@ class Notification < ApplicationRecord
     participating_conversation_new_message: 5,
     sla_missed_first_response: 6,
     sla_missed_next_response: 7,
-    sla_missed_resolution: 8
+    sla_missed_resolution: 8,
+    internal_chat_mention: 9,
+    internal_chat_new_message: 10
   }.freeze
+
+  # Internal chat notifications don't have email mailers/templates yet, so email
+  # delivery is deferred (see #process_notification_delivery).
+  INTERNAL_CHAT_NOTIFICATION_TYPES = %w[internal_chat_mention internal_chat_new_message].freeze
 
   enum notification_type: NOTIFICATION_TYPES
 
@@ -53,7 +59,7 @@ class Notification < ApplicationRecord
   after_destroy_commit :dispatch_destroy_event
   after_update_commit :dispatch_update_event
 
-  PRIMARY_ACTORS = ['Conversation'].freeze
+  PRIMARY_ACTORS = ['Conversation', 'InternalChat::Channel'].freeze
 
   def push_event_data
     # Secondary actor could be nil for cases like system assigning conversation
@@ -81,7 +87,8 @@ class Notification < ApplicationRecord
       notification_type: notification_type,
       primary_actor_id: primary_actor_id,
       primary_actor_type: primary_actor_type,
-      primary_actor: primary_actor.push_event_data.with_indifferent_access.slice('conversation_id', 'id')
+      # channel_type is only present for internal chat channels; conversations omit it
+      primary_actor: primary_actor.push_event_data.with_indifferent_access.slice('conversation_id', 'id', 'channel_type')
     }
   end
 
@@ -95,7 +102,9 @@ class Notification < ApplicationRecord
       'conversation_mention' => 'notifications.notification_title.conversation_mention',
       'sla_missed_first_response' => 'notifications.notification_title.sla_missed_first_response',
       'sla_missed_next_response' => 'notifications.notification_title.sla_missed_next_response',
-      'sla_missed_resolution' => 'notifications.notification_title.sla_missed_resolution'
+      'sla_missed_resolution' => 'notifications.notification_title.sla_missed_resolution',
+      'internal_chat_mention' => 'notifications.notification_title.internal_chat_mention',
+      'internal_chat_new_message' => 'notifications.notification_title.internal_chat_new_message'
     }
 
     i18n_key = notification_title_map[notification_type]
@@ -106,6 +115,8 @@ class Notification < ApplicationRecord
     elsif %w[conversation_assignment assigned_conversation_new_message participating_conversation_new_message
              conversation_mention].include?(notification_type)
       I18n.t(i18n_key, display_id: conversation.display_id)
+    elsif INTERNAL_CHAT_NOTIFICATION_TYPES.include?(notification_type)
+      I18n.t(i18n_key, name: internal_chat_actor_name)
     else
       I18n.t(i18n_key, display_id: primary_actor.display_id)
     end
@@ -116,7 +127,8 @@ class Notification < ApplicationRecord
     case notification_type
     when 'conversation_creation', 'sla_missed_first_response'
       message_body(conversation.messages.first)
-    when 'assigned_conversation_new_message', 'participating_conversation_new_message', 'conversation_mention'
+    when 'assigned_conversation_new_message', 'participating_conversation_new_message', 'conversation_mention',
+         'internal_chat_mention', 'internal_chat_new_message'
       message_body(secondary_actor)
     when 'conversation_assignment', 'sla_missed_next_response', 'sla_missed_resolution'
       message_body((conversation.messages.incoming.last || conversation.messages.outgoing.last))
@@ -130,6 +142,15 @@ class Notification < ApplicationRecord
   end
 
   private
+
+  # For internal chat, primary_actor is an InternalChat::Channel. Named channels use
+  # their (#-prefixed) name; DMs have no name, so fall back to the sender's name.
+  def internal_chat_actor_name
+    channel = primary_actor
+    return secondary_actor&.sender&.name.to_s if channel.dm? || channel.name.blank?
+
+    "##{channel.name}"
+  end
 
   def message_body(actor)
     sender_name = sender_name(actor)
@@ -146,10 +167,17 @@ class Notification < ApplicationRecord
     attachments = actor.try(:attachments)
 
     if content.present?
-      transform_user_mention_content(content.truncate_words(10))
+      transform_user_mention_content(strip_internal_chat_mentions(content).truncate_words(10))
     else
       attachments.present? ? I18n.t('notifications.attachment') : I18n.t('notifications.no_content')
     end
+  end
+
+  # Internal chat mentions are stored as bare (mention://user|team/ID/Name); render them as @Name.
+  # Conversation mentions wrap the same URL in a markdown link ([text](mention://...)); the negative
+  # lookbehind skips those so CommonMarker (in transform_user_mention_content) keeps handling them.
+  def strip_internal_chat_mentions(content)
+    content.gsub(%r{(?<!\])\(mention://(?:user|team)/\d+/(.+?)\)}) { "@#{CGI.unescape(Regexp.last_match(1))}" }
   end
 
   def process_notification_delivery
@@ -158,9 +186,14 @@ class Notification < ApplicationRecord
     # Should we do something about the case where user subscribed to both push and email ?
     # In future, we could probably add condition here to enqueue the job for 30 seconds later
     # when push enabled and then check in email job whether notification has been read already.
-    Notification::EmailNotificationJob.perform_later(self) if user_subscribed_to_notification?('email')
+    Notification::EmailNotificationJob.perform_later(self) if email_delivery_supported? && user_subscribed_to_notification?('email')
 
     Notification::RemoveDuplicateNotificationJob.perform_later(self)
+  end
+
+  # Internal chat types have no email mailer/templates yet (deferred), so skip email delivery.
+  def email_delivery_supported?
+    INTERNAL_CHAT_NOTIFICATION_TYPES.exclude?(notification_type)
   end
 
   def user_subscribed_to_notification?(delivery_type)

--- a/app/services/internal_chat/notification_service.rb
+++ b/app/services/internal_chat/notification_service.rb
@@ -32,22 +32,23 @@ class InternalChat::NotificationService
     account_user&.administrator? || message.channel.channel_members.exists?(user_id: message.sender_id, role: :admin)
   end
 
+  # Mentions always notify (even when muted); DMs notify unless muted; regular channel
+  # messages don't create a native notification (the per-channel unread badge covers them).
   def notify_member(member)
     if user_mentioned?(member.user_id)
-      broadcast_notification(member.user, :internal_chat_mention)
-    elsif !member.muted?
-      broadcast_notification(member.user, :internal_chat_message)
+      create_notification(member.user, 'internal_chat_mention')
+    elsif message.channel.dm? && !member.muted?
+      create_notification(member.user, 'internal_chat_new_message')
     end
   end
 
-  def broadcast_notification(user, type)
-    payload = {
-      notification_type: type,
-      account_id: message.account_id,
-      channel_id: message.internal_chat_channel_id,
-      message_id: message.id,
-      sender: message.sender&.push_event_data
-    }
-    ::ActionCableBroadcastJob.perform_later([user.pubsub_token], 'notification.created', payload)
+  def create_notification(user, notification_type)
+    NotificationBuilder.new(
+      notification_type: notification_type,
+      user: user,
+      account: message.account,
+      primary_actor: message.channel,
+      secondary_actor: message
+    ).perform
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,6 +263,8 @@ en:
       sla_missed_first_response: 'SLA target first response missed for conversation (#%{display_id})'
       sla_missed_next_response: 'SLA target next response missed for conversation (#%{display_id})'
       sla_missed_resolution: 'SLA target resolution missed for conversation (#%{display_id})'
+      internal_chat_mention: 'You have been mentioned in %{name}'
+      internal_chat_new_message: 'New message from %{name}'
     attachment: 'Attachment'
     no_content: 'No content'
   conversations:

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -238,6 +238,8 @@ pt_BR:
       sla_missed_first_response: 'Meta de SLA de Primeira Resposta não alcançada para a conversa (#%{display_id})'
       sla_missed_next_response: 'Meta de SLA de Próxima Resposta não alcançada para a conversa (#%{display_id})'
       sla_missed_resolution: 'Meta de SLA de Resolução não alcançada para a conversa (#%{display_id})'
+      internal_chat_mention: 'Você foi mencionado em %{name}'
+      internal_chat_new_message: 'Nova mensagem de %{name}'
     attachment: 'Anexo'
     no_content: 'Sem conteúdo'
   conversations:

--- a/spec/builders/notification_builder_spec.rb
+++ b/spec/builders/notification_builder_spec.rb
@@ -160,5 +160,22 @@ describe NotificationBuilder do
         end.not_to(change { outsider.notifications.count })
       end
     end
+
+    context 'when the primary actor is an internal chat channel' do
+      let!(:channel) { create(:internal_chat_channel, :dm, account: account) }
+      let!(:message) { create(:internal_chat_message, account: account, channel: channel) }
+
+      it 'creates a notification without requiring conversation access or a contact' do
+        expect do
+          described_class.new(
+            notification_type: 'internal_chat_new_message',
+            user: user,
+            account: account,
+            primary_actor: channel,
+            secondary_actor: message
+          ).perform
+        end.to change { user.notifications.count }.by(1)
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/accounts/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/notifications_controller_spec.rb
@@ -73,6 +73,23 @@ RSpec.describe 'Notifications API', type: :request do
         expect(notification1.reload.read_at).not_to eq('')
         expect(notification2.reload.read_at).to be_nil
       end
+
+      it 'scopes read_all to an internal chat channel primary actor' do
+        channel = create(:internal_chat_channel, :public_channel, account: account)
+        message = create(:internal_chat_message, account: account, channel: channel)
+        channel_notification = create(:notification, account: account, user: admin, notification_type: 'internal_chat_mention',
+                                                     primary_actor: channel, secondary_actor: message)
+
+        post "/api/v1/accounts/#{account.id}/notifications/read_all",
+             headers: admin.create_new_auth_token,
+             params: { primary_actor_id: channel.id, primary_actor_type: 'InternalChat::Channel' },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(channel_notification.reload.read_at).not_to be_nil
+        expect(notification1.reload.read_at).to be_nil
+        expect(notification2.reload.read_at).to be_nil
+      end
     end
   end
 

--- a/spec/controllers/api/v1/accounts/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/notifications_controller_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe 'Notifications API', type: :request do
 
       it 'scopes read_all to an internal chat channel primary actor' do
         channel = create(:internal_chat_channel, :public_channel, account: account)
+        # Force a same-id collision across actor types so the test fails if read_all ignores primary_actor_type
+        notification1.update_column(:primary_actor_id, channel.id) # rubocop:disable Rails/SkipsModelValidations
         message = create(:internal_chat_message, account: account, channel: channel)
         channel_notification = create(:notification, account: account, user: admin, notification_type: 'internal_chat_mention',
                                                      primary_actor: channel, secondary_actor: message)

--- a/spec/jobs/notification/remove_duplicate_notification_job_spec.rb
+++ b/spec/jobs/notification/remove_duplicate_notification_job_spec.rb
@@ -19,4 +19,19 @@ RSpec.describe Notification::RemoveDuplicateNotificationJob do
     described_class.perform_now(duplicate_notification)
     expect(Notification.count).to eq(1)
   end
+
+  it 'does not remove notifications of a different primary_actor_type that share the same id' do
+    conversation_notification = create(:notification, user: user, notification_type: 'conversation_creation', primary_actor: conversation)
+
+    # Force a same-id collision across actor types (channel notification pointing at the conversation's id)
+    channel_notification = build(:notification, user: user, account: conversation.account,
+                                                notification_type: 'internal_chat_mention', primary_actor: conversation)
+    channel_notification.assign_attributes(primary_actor_type: 'InternalChat::Channel', primary_actor_id: conversation.id)
+    channel_notification.save!(validate: false)
+
+    described_class.perform_now(channel_notification)
+
+    expect(Notification.exists?(conversation_notification.id)).to be(true)
+    expect(Notification.exists?(channel_notification.id)).to be(true)
+  end
 end

--- a/spec/models/internal_chat/channel_spec.rb
+++ b/spec/models/internal_chat/channel_spec.rb
@@ -137,5 +137,11 @@ RSpec.describe InternalChat::Channel do
         meta: {}
       )
     end
+
+    it 'exposes the dm channel_type and nil name for direct messages' do
+      channel = create(:internal_chat_channel, :dm)
+
+      expect(channel.push_event_data).to include(channel_type: 'dm', name: nil)
+    end
   end
 end

--- a/spec/models/internal_chat/channel_spec.rb
+++ b/spec/models/internal_chat/channel_spec.rb
@@ -123,4 +123,19 @@ RSpec.describe InternalChat::Channel do
       end
     end
   end
+
+  describe '#push_event_data' do
+    it 'exposes the fields needed to route and render a notification' do
+      channel = create(:internal_chat_channel, :public_channel, name: 'general')
+
+      expect(channel.push_event_data).to eq(
+        id: channel.id,
+        uuid: channel.uuid,
+        name: 'general',
+        channel_type: 'public_channel',
+        account_id: channel.account_id,
+        meta: {}
+      )
+    end
+  end
 end

--- a/spec/models/internal_chat/message_spec.rb
+++ b/spec/models/internal_chat/message_spec.rb
@@ -127,4 +127,19 @@ RSpec.describe InternalChat::Message do
         .to change { channel.reload.messages_count }.by(1)
     end
   end
+
+  describe '#push_event_data' do
+    it 'exposes the message payload used as a notification secondary actor' do
+      sender = create(:user)
+      message = create(:internal_chat_message, sender: sender, content: 'hello')
+
+      expect(message.push_event_data).to eq(
+        id: message.id,
+        content: 'hello',
+        content_type: 'text',
+        internal_chat_channel_id: message.internal_chat_channel_id,
+        sender: sender.push_event_data
+      )
+    end
+  end
 end

--- a/spec/models/internal_chat/message_spec.rb
+++ b/spec/models/internal_chat/message_spec.rb
@@ -141,5 +141,11 @@ RSpec.describe InternalChat::Message do
         sender: sender.push_event_data
       )
     end
+
+    it 'exposes a nil sender for messages without a sender' do
+      message = create(:internal_chat_message, sender: nil, content: 'system note')
+
+      expect(message.push_event_data[:sender]).to be_nil
+    end
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -198,4 +198,62 @@ has been assigned to you"
       expect { notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  context 'with internal chat notifications' do
+    let(:account) { create(:account) }
+    let(:sender) { create(:user, account: account, name: 'Alice') }
+
+    it 'builds the mention title from the channel name' do
+      channel = create(:internal_chat_channel, :public_channel, account: account, name: 'general')
+      message = create(:internal_chat_message, account: account, channel: channel, sender: sender, content: 'ping')
+      notification = create(:notification, account: account, notification_type: 'internal_chat_mention',
+                                           primary_actor: channel, secondary_actor: message)
+
+      expect(notification.push_message_title).to eq 'You have been mentioned in #general'
+    end
+
+    it 'builds the direct message title from the sender name' do
+      channel = create(:internal_chat_channel, :dm, account: account)
+      message = create(:internal_chat_message, account: account, channel: channel, sender: sender, content: 'hi')
+      notification = create(:notification, account: account, notification_type: 'internal_chat_new_message',
+                                           primary_actor: channel, secondary_actor: message)
+
+      expect(notification.push_message_title).to eq 'New message from Alice'
+    end
+
+    it 'builds the body from the secondary actor message' do
+      channel = create(:internal_chat_channel, :dm, account: account)
+      message = create(:internal_chat_message, account: account, channel: channel, sender: sender, content: 'hello there')
+      notification = create(:notification, account: account, notification_type: 'internal_chat_new_message',
+                                           primary_actor: channel, secondary_actor: message)
+
+      expect(notification.push_message_body).to eq 'Alice: hello there'
+    end
+
+    it 'renders internal chat mentions as @Name in the body' do
+      channel = create(:internal_chat_channel, :public_channel, account: account, name: 'general')
+      recipient = create(:user, account: account, name: 'John')
+      message = create(:internal_chat_message, account: account, channel: channel, sender: sender,
+                                               content: "hey (mention://user/#{recipient.id}/John) look")
+      notification = create(:notification, account: account, notification_type: 'internal_chat_mention',
+                                           primary_actor: channel, secondary_actor: message)
+
+      expect(notification.push_message_body).to eq 'Alice: hey @John look'
+    end
+
+    it 'includes id and channel_type in the fcm push data' do
+      channel = create(:internal_chat_channel, :dm, account: account)
+      message = create(:internal_chat_message, account: account, channel: channel, sender: sender, content: 'hi')
+      notification = create(:notification, account: account, notification_type: 'internal_chat_new_message',
+                                           primary_actor: channel, secondary_actor: message)
+
+      expect(notification.fcm_push_data[:primary_actor]).to eq({ 'id' => channel.id, 'channel_type' => 'dm' })
+    end
+
+    it 'defers email delivery (no mailer yet)' do
+      expect(described_class.new(notification_type: 'internal_chat_mention').send(:email_delivery_supported?)).to be(false)
+      expect(described_class.new(notification_type: 'internal_chat_new_message').send(:email_delivery_supported?)).to be(false)
+      expect(described_class.new(notification_type: 'conversation_creation').send(:email_delivery_supported?)).to be(true)
+    end
+  end
 end

--- a/spec/services/internal_chat/notification_service_spec.rb
+++ b/spec/services/internal_chat/notification_service_spec.rb
@@ -5,170 +5,119 @@ require 'rails_helper'
 RSpec.describe InternalChat::NotificationService do
   let(:account) { create(:account) }
   let(:sender) { create(:user, account: account, role: :agent) }
-  let(:channel) { create(:internal_chat_channel, :public_channel, account: account) }
-  let(:message) { create(:internal_chat_message, account: account, channel: channel, sender: sender, content: 'Hello everyone') }
-
-  before do
-    dispatcher = double
-    allow(dispatcher).to receive(:dispatch)
-    allow(Rails.configuration).to receive(:dispatcher).and_return(dispatcher)
-    allow(ActionCableBroadcastJob).to receive(:perform_later)
-  end
 
   describe '#perform' do
-    it 'broadcasts message notifications for channel members except the sender' do
-      member1 = create(:user, account: account, role: :agent)
-      member2 = create(:user, account: account, role: :agent)
-      create(:internal_chat_channel_member, channel: channel, user: sender)
-      create(:internal_chat_channel_member, channel: channel, user: member1)
-      create(:internal_chat_channel_member, channel: channel, user: member2)
+    context 'with a text channel message' do
+      let(:channel) { create(:internal_chat_channel, :public_channel, account: account) }
 
-      described_class.new(message: message).perform
+      it 'does not create notifications for a regular (non-mention) message' do
+        member = create(:user, account: account, role: :agent)
+        create(:internal_chat_channel_member, channel: channel, user: sender)
+        create(:internal_chat_channel_member, channel: channel, user: member)
+        message = create(:internal_chat_message, account: account, channel: channel, sender: sender, content: 'Hello everyone')
 
-      expect(ActionCableBroadcastJob).to have_received(:perform_later).with(
-        [member1.pubsub_token], 'notification.created', hash_including(notification_type: :internal_chat_message)
-      )
-      expect(ActionCableBroadcastJob).to have_received(:perform_later).with(
-        [member2.pubsub_token], 'notification.created', hash_including(notification_type: :internal_chat_message)
-      )
-      expect(ActionCableBroadcastJob).not_to have_received(:perform_later).with(
-        [sender.pubsub_token], 'notification.created', anything
-      )
-    end
+        expect { described_class.new(message: message).perform }.not_to change(Notification, :count)
+      end
 
-    it 'does not broadcast message notifications for muted members' do
-      muted_member = create(:user, account: account, role: :agent)
-      create(:internal_chat_channel_member, channel: channel, user: sender)
-      create(:internal_chat_channel_member, :muted, channel: channel, user: muted_member)
-
-      described_class.new(message: message).perform
-
-      expect(ActionCableBroadcastJob).not_to have_received(:perform_later).with(
-        [muted_member.pubsub_token], 'notification.created', anything
-      )
-    end
-
-    it 'broadcasts mention notifications for mentioned users' do
-      mentioned_user = create(:user, account: account, role: :agent)
-      create(:internal_chat_channel_member, channel: channel, user: sender)
-      create(:internal_chat_channel_member, channel: channel, user: mentioned_user)
-
-      mention_message = create(
-        :internal_chat_message, account: account, channel: channel, sender: sender,
-                                content: "Hey (mention://user/#{mentioned_user.id}/#{mentioned_user.name}) check this"
-      )
-
-      described_class.new(message: mention_message).perform
-
-      expect(ActionCableBroadcastJob).to have_received(:perform_later).with(
-        [mentioned_user.pubsub_token], 'notification.created', hash_including(notification_type: :internal_chat_mention)
-      )
-    end
-
-    it 'broadcasts mention notifications for @all when sender is admin' do
-      admin_sender = create(:user, account: account, role: :administrator)
-      member1 = create(:user, account: account, role: :agent)
-      member2 = create(:user, account: account, role: :agent)
-      create(:internal_chat_channel_member, channel: channel, user: admin_sender)
-      create(:internal_chat_channel_member, channel: channel, user: member1)
-      create(:internal_chat_channel_member, channel: channel, user: member2)
-
-      all_message = create(
-        :internal_chat_message, account: account, channel: channel, sender: admin_sender,
-                                content: '@all please review'
-      )
-
-      described_class.new(message: all_message).perform
-
-      expect(ActionCableBroadcastJob).to have_received(:perform_later).with(
-        [member1.pubsub_token], 'notification.created', hash_including(notification_type: :internal_chat_mention)
-      )
-      expect(ActionCableBroadcastJob).to have_received(:perform_later).with(
-        [member2.pubsub_token], 'notification.created', hash_including(notification_type: :internal_chat_mention)
-      )
-      expect(ActionCableBroadcastJob).not_to have_received(:perform_later).with(
-        [admin_sender.pubsub_token], 'notification.created', anything
-      )
-    end
-
-    it 'treats mentioned muted members as mentioned (mention overrides mute)' do
-      muted_member = create(:user, account: account, role: :agent)
-      create(:internal_chat_channel_member, channel: channel, user: sender)
-      create(:internal_chat_channel_member, :muted, channel: channel, user: muted_member)
-
-      mention_message = create(
-        :internal_chat_message, account: account, channel: channel, sender: sender,
-                                content: "Hey (mention://user/#{muted_member.id}/#{muted_member.name}) check this"
-      )
-
-      described_class.new(message: mention_message).perform
-
-      expect(ActionCableBroadcastJob).to have_received(:perform_later).with(
-        [muted_member.pubsub_token], 'notification.created', hash_including(notification_type: :internal_chat_mention)
-      )
-    end
-
-    it 'does not create Notification database records' do
-      member = create(:user, account: account, role: :agent)
-      create(:internal_chat_channel_member, channel: channel, user: sender)
-      create(:internal_chat_channel_member, channel: channel, user: member)
-
-      expect { described_class.new(message: message).perform }.not_to change(Notification, :count)
-    end
-
-    it 'does not broadcast anything when sender is the only member' do
-      create(:internal_chat_channel_member, channel: channel, user: sender)
-
-      described_class.new(message: message).perform
-
-      expect(ActionCableBroadcastJob).not_to have_received(:perform_later)
-    end
-
-    it 'does not broadcast anything when channel has no members' do
-      described_class.new(message: message).perform
-
-      expect(ActionCableBroadcastJob).not_to have_received(:perform_later)
-    end
-
-    it 'does not send @all mention notifications when sender is a non-admin agent' do
-      member = create(:user, account: account, role: :agent)
-      create(:internal_chat_channel_member, channel: channel, user: sender)
-      create(:internal_chat_channel_member, channel: channel, user: member)
-
-      all_message = create(
-        :internal_chat_message, account: account, channel: channel, sender: sender,
-                                content: '@all please review'
-      )
-
-      described_class.new(message: all_message).perform
-
-      # Should still receive regular message notification, not mention notification
-      expect(ActionCableBroadcastJob).to have_received(:perform_later).with(
-        [member.pubsub_token], 'notification.created', hash_including(notification_type: :internal_chat_message)
-      )
-      expect(ActionCableBroadcastJob).not_to have_received(:perform_later).with(
-        [member.pubsub_token], 'notification.created', hash_including(notification_type: :internal_chat_mention)
-      )
-    end
-
-    it 'includes the correct payload structure' do
-      member = create(:user, account: account, role: :agent)
-      create(:internal_chat_channel_member, channel: channel, user: sender)
-      create(:internal_chat_channel_member, channel: channel, user: member)
-
-      described_class.new(message: message).perform
-
-      expect(ActionCableBroadcastJob).to have_received(:perform_later).with(
-        [member.pubsub_token],
-        'notification.created',
-        hash_including(
-          notification_type: :internal_chat_message,
-          account_id: account.id,
-          channel_id: channel.id,
-          message_id: message.id,
-          sender: sender.push_event_data
+      it 'creates a mention notification for a mentioned user' do
+        mentioned_user = create(:user, account: account, role: :agent)
+        create(:internal_chat_channel_member, channel: channel, user: sender)
+        create(:internal_chat_channel_member, channel: channel, user: mentioned_user)
+        message = create(
+          :internal_chat_message, account: account, channel: channel, sender: sender,
+                                  content: "Hey (mention://user/#{mentioned_user.id}/#{mentioned_user.name}) check this"
         )
-      )
+
+        described_class.new(message: message).perform
+
+        notification = Notification.find_by(user: mentioned_user, notification_type: 'internal_chat_mention')
+        expect(notification).to have_attributes(primary_actor: channel, secondary_actor: message, account: account)
+      end
+
+      it 'does not create a notification for the sender' do
+        create(:internal_chat_channel_member, channel: channel, user: sender)
+        message = create(
+          :internal_chat_message, account: account, channel: channel, sender: sender,
+                                  content: "(mention://user/#{sender.id}/#{sender.name}) note to self"
+        )
+
+        described_class.new(message: message).perform
+
+        expect(Notification.where(user: sender)).not_to exist
+      end
+
+      it 'creates mention notifications for @all when the sender is an admin' do
+        admin_sender = create(:user, account: account, role: :administrator)
+        member1 = create(:user, account: account, role: :agent)
+        member2 = create(:user, account: account, role: :agent)
+        create(:internal_chat_channel_member, channel: channel, user: admin_sender)
+        create(:internal_chat_channel_member, channel: channel, user: member1)
+        create(:internal_chat_channel_member, channel: channel, user: member2)
+        message = create(:internal_chat_message, account: account, channel: channel, sender: admin_sender, content: '@all please review')
+
+        described_class.new(message: message).perform
+
+        expect(Notification.where(notification_type: 'internal_chat_mention', primary_actor: channel).pluck(:user_id))
+          .to contain_exactly(member1.id, member2.id)
+      end
+
+      it 'does not create notifications for @all when the sender is a non-admin agent' do
+        member = create(:user, account: account, role: :agent)
+        create(:internal_chat_channel_member, channel: channel, user: sender)
+        create(:internal_chat_channel_member, channel: channel, user: member)
+        message = create(:internal_chat_message, account: account, channel: channel, sender: sender, content: '@all please review')
+
+        expect { described_class.new(message: message).perform }.not_to change(Notification, :count)
+      end
+
+      it 'creates a mention notification even when the mentioned member has muted the channel' do
+        muted_member = create(:user, account: account, role: :agent)
+        create(:internal_chat_channel_member, channel: channel, user: sender)
+        create(:internal_chat_channel_member, :muted, channel: channel, user: muted_member)
+        message = create(
+          :internal_chat_message, account: account, channel: channel, sender: sender,
+                                  content: "Hey (mention://user/#{muted_member.id}/#{muted_member.name}) check this"
+        )
+
+        described_class.new(message: message).perform
+
+        expect(Notification.where(user: muted_member, notification_type: 'internal_chat_mention')).to exist
+      end
+    end
+
+    context 'with a direct message' do
+      let(:channel) { create(:internal_chat_channel, :dm, account: account) }
+      let(:recipient) { create(:user, account: account, role: :agent) }
+
+      before do
+        create(:internal_chat_channel_member, channel: channel, user: sender)
+        create(:internal_chat_channel_member, channel: channel, user: recipient)
+      end
+
+      it 'creates a new_message notification for the recipient' do
+        message = create(:internal_chat_message, account: account, channel: channel, sender: sender, content: 'hey there')
+
+        described_class.new(message: message).perform
+
+        notification = Notification.find_by(user: recipient, notification_type: 'internal_chat_new_message')
+        expect(notification).to have_attributes(primary_actor: channel, secondary_actor: message)
+      end
+
+      it 'does not notify the sender' do
+        message = create(:internal_chat_message, account: account, channel: channel, sender: sender, content: 'hey there')
+
+        described_class.new(message: message).perform
+
+        expect(Notification.where(user: sender)).not_to exist
+      end
+
+      it 'does not create a notification when the recipient muted the DM' do
+        recipient_membership = channel.channel_members.find_by(user: recipient)
+        recipient_membership.update!(muted: true)
+        message = create(:internal_chat_message, account: account, channel: channel, sender: sender, content: 'hey there')
+
+        expect { described_class.new(message: message).perform }.not_to change(Notification, :count)
+      end
     end
   end
 end


### PR DESCRIPTION
Internal chat mentions and direct messages now surface through Chatwoot's native notification system. Previously the internal chat had a separate, ephemeral broadcast that never reached the notification inbox, was not persisted, and ignored the user's notification settings. Now a mention or a DM creates a real `Notification` record, so it shows up in the notification inbox ("Caixa de Entrada"), triggers web/mobile push, and respects each user's per-type push preferences. Regular (non-mention) channel messages stay as unread badges only, so the inbox does not get flooded.

## What changed
- New notification types `internal_chat_mention` and `internal_chat_new_message`; `InternalChat::NotificationService` now builds real notifications via `NotificationBuilder` (primary actor = channel, secondary actor = message), reusing the native push/settings/dedup pipeline.
- `Notification` presentation branches for the new types (title, body, FCM payload); email delivery is deferred (guarded, and the email checkbox is hidden for these types in preferences).
- Notification inbox (`InboxList`/`InboxCard`) and the legacy notifications page render and route internal chat notifications to the channel, with a sender-avatar fallback.
- Bug fixes uncovered while integrating: cross-type `primary_actor_id` collisions are now scoped by type (dedupe job + inbox store mutation), and `read_all` is scoped to `InternalChat::Channel` so opening one notification no longer marks all as read. Notification bodies render internal chat mentions as `@Name` instead of raw markup.

## How to test
1. With two agents in the same account who share an internal chat channel, have agent A `@`-mention agent B in a text channel.
2. Agent B's notification count ("Caixa de Entrada") increments in real time; the entry shows the sender avatar, the message body, and a "Mentioned" label. Clicking it opens the channel and marks only that notification read.
3. Send a DM to B and send several messages — B gets a "Direct message" notification and the inbox keeps a single entry per DM. Muting the DM stops new-message notifications (mentions still notify).
4. Send a plain channel message (no mention) — B does not get a native notification, only the per-channel unread badge.
5. In Profile → Notifications, the two internal chat types appear with a push checkbox only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/334)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added internal chat notification types for **mentions** and **direct messages**, including localized labels in settings, inbox, and notification titles.
  * Internal chat notifications now route to the correct **DM** or **channel** views, with updated titles/avatars.
* **Improvements**
  * Refined internal chat notification creation rules (mentions always generate; muted/non-mentioned behavior differs for DM vs channels).
  * Email delivery is disabled for internal chat notification types; push payloads include internal channel context.
  * Inbox and notification click flows now share consistent “mark as read” + realtime count updates.
* **Bug Fixes**
  * Deduplication and read-all scoping now distinguish by **actor ID + actor type**.
* **Tests**
  * Expanded coverage for internal chat notification creation, rendering, delivery, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->