### PR TITLE
feat(super-admin): block message deletion for basic agents

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -23,6 +23,8 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
   end
 
   def destroy
+    authorize message, :destroy?
+
     ActiveRecord::Base.transaction do
       message.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: { deleted: true })
       message.attachments.destroy_all

--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -36,7 +36,8 @@ class AccountDashboard < Administrate::BaseDashboard
     account_users: Field::HasMany,
     custom_attributes: Field::String,
     hide_agent_unassigned_tab: Field::Boolean,
-    hide_agent_all_tab: HideAgentAllTabField
+    hide_agent_all_tab: HideAgentAllTabField,
+    disable_agent_message_deletion: Field::Boolean
   }.merge(enterprise_attribute_types).freeze
 
   # COLLECTION_ATTRIBUTES
@@ -74,6 +75,7 @@ class AccountDashboard < Administrate::BaseDashboard
     account_users
     hide_agent_unassigned_tab
     hide_agent_all_tab
+    disable_agent_message_deletion
   ] + enterprise_show_page_attributes).freeze
 
   # FORM_ATTRIBUTES
@@ -93,6 +95,7 @@ class AccountDashboard < Administrate::BaseDashboard
     status
     hide_agent_unassigned_tab
     hide_agent_all_tab
+    disable_agent_message_deletion
   ] + enterprise_form_attributes).freeze
 
   # COLLECTION_FILTERS

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -4,6 +4,7 @@ import { useTimeoutFn } from '@vueuse/core';
 import { provideMessageContext } from './provider.js';
 import { useTrack } from 'dashboard/composables';
 import { useMapGetter } from 'dashboard/composables/store';
+import { useAccount } from 'dashboard/composables/useAccount';
 import { emitter } from 'shared/helpers/mitt';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -11,6 +12,10 @@ import { LocalStorage } from 'shared/helpers/localStorage';
 import { ACCOUNT_EVENTS } from 'dashboard/helper/AnalyticsHelper/events';
 import { LOCAL_STORAGE_KEYS } from 'dashboard/constants/localStorage';
 import { getInboxIconByType } from 'dashboard/helper/inbox';
+import {
+  canDeleteMessages,
+  getUserRole,
+} from 'dashboard/helper/permissionsHelper.js';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import {
   MESSAGE_TYPES,
@@ -160,6 +165,17 @@ const inboxGetter = useMapGetter('inboxes/getInbox');
 const inbox = computed(() => inboxGetter.value(props.inboxId) || {});
 const router = useRouter();
 const { replaceInstallationName } = useBranding();
+const { accountId: currentAccountId, currentAccount } = useAccount();
+const currentUser = useMapGetter('getCurrentUser');
+
+// Mirrors `MessagePolicy#destroy?`: hiding the option is a convenience, the
+// endpoint enforces the same rule.
+const canDeleteMessage = computed(() =>
+  canDeleteMessages({
+    userRole: getUserRole(currentUser.value, currentAccountId.value),
+    accountSettings: currentAccount.value?.settings || {},
+  })
+);
 
 /**
  * Computes the message variant based on props
@@ -420,6 +436,7 @@ const contextMenuEnabledOptions = computed(() => {
   return {
     copy: hasText,
     delete:
+      canDeleteMessage.value &&
       (hasText || hasAttachments || hasRichContent) &&
       !isFailedOrProcessing &&
       !isMessageDeleted.value,

--- a/app/javascript/dashboard/helper/permissionsHelper.js
+++ b/app/javascript/dashboard/helper/permissionsHelper.js
@@ -98,3 +98,22 @@ export const getVisibleAssigneeTabPermissions = ({
     ...(hideAll ? {} : { all }),
   };
 };
+
+/**
+ * Resolves whether the user may delete messages, applying the account-level
+ * toggle that blocks deletion for basic agents. Admins and custom roles are
+ * never affected.
+ *
+ * The UI gate mirrors `MessagePolicy#destroy?` — hiding the option is a
+ * convenience, the endpoint enforces the same rule.
+ *
+ * @param {Object} params
+ * @param {String} params.userRole - Resolved user role for the account.
+ * @param {Object} [params.accountSettings] - Account settings holding the toggle.
+ * @returns {Boolean} Whether message deletion is allowed.
+ */
+export const canDeleteMessages = ({ userRole, accountSettings = {} } = {}) => {
+  if (userRole !== 'agent') return true;
+
+  return !accountSettings.disable_agent_message_deletion;
+};

--- a/app/javascript/dashboard/helper/specs/permissionsHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/permissionsHelper.spec.js
@@ -4,6 +4,7 @@ import {
   hasPermissions,
   filterItemsByPermission,
   getVisibleAssigneeTabPermissions,
+  canDeleteMessages,
 } from '../permissionsHelper';
 import { ASSIGNEE_TYPE_TAB_PERMISSIONS } from 'dashboard/constants/permissions';
 
@@ -224,5 +225,37 @@ describe('#getVisibleAssigneeTabPermissions', () => {
     });
 
     expect(Object.keys(result)).toEqual(['me']);
+  });
+});
+
+describe('#canDeleteMessages', () => {
+  const blocked = { disable_agent_message_deletion: true };
+
+  it('allows agents when the toggle is off', () => {
+    expect(canDeleteMessages({ userRole: 'agent', accountSettings: {} })).toBe(
+      true
+    );
+  });
+
+  it('blocks agents when the toggle is on', () => {
+    expect(
+      canDeleteMessages({ userRole: 'agent', accountSettings: blocked })
+    ).toBe(false);
+  });
+
+  it('allows administrators even when the toggle is on', () => {
+    expect(
+      canDeleteMessages({ userRole: 'administrator', accountSettings: blocked })
+    ).toBe(true);
+  });
+
+  it('allows custom roles even when the toggle is on', () => {
+    expect(
+      canDeleteMessages({ userRole: 'custom_role', accountSettings: blocked })
+    ).toBe(true);
+  });
+
+  it('allows deletion when called without arguments', () => {
+    expect(canDeleteMessages()).toBe(true);
   });
 });

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -55,16 +55,7 @@ class Account < ApplicationRecord
   store_accessor :settings, :reporting_timezone
   store_accessor :settings, :keep_pending_on_bot_failure
   store_accessor :settings, :captain_auto_resolve_mode
-  store_accessor :settings, :hide_agent_unassigned_tab, :hide_agent_all_tab
-  before_validation :enforce_agent_assignee_tabs_constraint
-
-  def hide_agent_unassigned_tab=(value)
-    super(ActiveModel::Type::Boolean.new.cast(value))
-  end
-
-  def hide_agent_all_tab=(value)
-    super(ActiveModel::Type::Boolean.new.cast(value))
-  end
+  include AccountAgentRestrictions
 
   include AccountCaptainAutoResolve
 
@@ -220,10 +211,6 @@ class Account < ApplicationRecord
     return if reporting_timezone.blank? || ActiveSupport::TimeZone[reporting_timezone].present?
 
     errors.add(:reporting_timezone, I18n.t('errors.account.reporting_timezone.invalid'))
-  end
-
-  def enforce_agent_assignee_tabs_constraint
-    self.hide_agent_all_tab = true if hide_agent_unassigned_tab
   end
 
   def validate_support_email_format

--- a/app/models/concerns/account_agent_restrictions.rb
+++ b/app/models/concerns/account_agent_restrictions.rb
@@ -1,0 +1,39 @@
+# Account-level toggles that restrict what basic agents may do. They live in the
+# `settings` jsonb rather than `feature_flags` — see the "Account-level toggles"
+# section in AGENTS.md — and are exposed to superadmins via `AccountDashboard`.
+#
+# Include this AFTER the other `store_accessor :settings` calls in `Account`.
+# The writers below rely on `super` reaching the store-accessor module, which
+# only sits below this concern in the ancestor chain when that module was
+# already built by an earlier `store_accessor` call.
+module AccountAgentRestrictions
+  extend ActiveSupport::Concern
+
+  included do
+    store_accessor :settings, :hide_agent_unassigned_tab, :hide_agent_all_tab, :disable_agent_message_deletion
+
+    before_validation :enforce_agent_assignee_tabs_constraint
+  end
+
+  # The superadmin form posts "1"/"0" and the settings JSON schema only accepts
+  # booleans, so every toggle casts its input on the way in.
+  def hide_agent_unassigned_tab=(value)
+    super(ActiveModel::Type::Boolean.new.cast(value))
+  end
+
+  def hide_agent_all_tab=(value)
+    super(ActiveModel::Type::Boolean.new.cast(value))
+  end
+
+  def disable_agent_message_deletion=(value)
+    super(ActiveModel::Type::Boolean.new.cast(value))
+  end
+
+  private
+
+  # Hiding "Unassigned" while leaving "All" visible would defeat the toggle:
+  # unassigned conversations stay reachable through the "All" tab.
+  def enforce_agent_assignee_tabs_constraint
+    self.hide_agent_all_tab = true if hide_agent_unassigned_tab
+  end
+end

--- a/app/models/concerns/account_settings_schema.rb
+++ b/app/models/concerns/account_settings_schema.rb
@@ -13,6 +13,7 @@ module AccountSettingsSchema
         'keep_pending_on_bot_failure': { 'type': %w[boolean null] },
         'hide_agent_unassigned_tab': { 'type': %w[boolean null] },
         'hide_agent_all_tab': { 'type': %w[boolean null] },
+        'disable_agent_message_deletion': { 'type': %w[boolean null] },
         'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': ['evaluated', 'legacy', 'disabled', nil] },
         'conversation_required_attributes': {
           'type': %w[array null],

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -1,0 +1,27 @@
+class MessagePolicy < ApplicationPolicy
+  def destroy?
+    return true unless deletion_blocked_for_agents?
+
+    administrator? || agent_bot? || custom_role?
+  end
+
+  private
+
+  def deletion_blocked_for_agents?
+    account&.disable_agent_message_deletion.present?
+  end
+
+  def administrator?
+    account_user&.administrator?
+  end
+
+  def agent_bot?
+    user.is_a?(AgentBot)
+  end
+
+  def custom_role?
+    account_user&.custom_role_id.present?
+  end
+end
+
+MessagePolicy.prepend_mod_with('MessagePolicy')

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -359,6 +359,35 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(message_with_source.reload.deleted).to be true
       end
     end
+
+    context 'when the account blocks agent message deletion' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+      let(:administrator) { create(:user, account: account, role: :administrator) }
+
+      before do
+        create(:inbox_member, inbox: conversation.inbox, user: agent)
+        create(:inbox_member, inbox: conversation.inbox, user: administrator)
+        account.update!(disable_agent_message_deletion: true)
+      end
+
+      it 'refuses the deletion for an agent' do
+        delete "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/messages/#{message.id}",
+               headers: agent.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(message.reload.deleted).to be_falsey
+      end
+
+      it 'still allows an administrator to delete' do
+        delete "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/messages/#{message.id}",
+               headers: administrator.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(message.reload.deleted).to be true
+      end
+    end
   end
 
   describe 'POST /api/v1/accounts/{account.id}/conversations/:conversation_id/messages/:id/retry' do

--- a/spec/enterprise/policies/message_policy_spec.rb
+++ b/spec/enterprise/policies/message_policy_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe MessagePolicy, type: :policy do
+  subject { described_class }
+
+  let(:account) { create(:account) }
+  let(:agent) { create(:user, account: account, role: :agent) }
+  let(:agent_account_user) { agent.account_users.find_by(account: account) }
+  let(:context) { { user: agent, account: account, account_user: agent_account_user } }
+
+  let(:message) { create(:message, account: account) }
+
+  permissions :destroy? do
+    context 'when the account blocks agent message deletion' do
+      before { account.update!(disable_agent_message_deletion: true) }
+
+      it 'still allows a user with a custom role' do
+        custom_role = create(:custom_role, account: account, permissions: ['conversation_manage'])
+        agent_account_user.update!(custom_role: custom_role)
+
+        expect(subject).to permit(context, message)
+      end
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -326,6 +326,30 @@ RSpec.describe Account do
       end
     end
 
+    context 'when toggling agent message deletion' do
+      it 'casts form input to boolean' do
+        account.disable_agent_message_deletion = '1'
+        expect(account.disable_agent_message_deletion).to be true
+
+        account.disable_agent_message_deletion = '0'
+        expect(account.disable_agent_message_deletion).to be false
+      end
+
+      it 'persists across save with the schema validator passing' do
+        account.update!(disable_agent_message_deletion: 'true')
+        reloaded = described_class.find(account.id)
+
+        expect(reloaded.disable_agent_message_deletion).to be true
+        expect(reloaded.settings['disable_agent_message_deletion']).to be true
+      end
+
+      it 'rejects non-boolean values via the JSON schema validator' do
+        account.settings = { disable_agent_message_deletion: 'maybe' }
+        expect(account).to be_invalid
+        expect(account.errors.messages).to have_key(:disable_agent_message_deletion)
+      end
+    end
+
     context 'when using with_auto_resolve scope' do
       it 'finds accounts with auto_resolve_after set' do
         account.update!(auto_resolve_after: 40 * 24 * 60)

--- a/spec/policies/message_policy_spec.rb
+++ b/spec/policies/message_policy_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe MessagePolicy, type: :policy do
+  subject { described_class }
+
+  let(:account) { create(:account) }
+  let(:administrator) { create(:user, account: account, role: :administrator) }
+  let(:agent) { create(:user, account: account, role: :agent) }
+  let(:agent_bot) { create(:agent_bot) }
+  let(:administrator_context) { { user: administrator, account: account, account_user: administrator.account_users.find_by(account: account) } }
+  let(:agent_context) { { user: agent, account: account, account_user: agent.account_users.find_by(account: account) } }
+  let(:agent_bot_context) { { user: agent_bot, account: account, account_user: nil } }
+
+  let(:message) { create(:message, account: account) }
+
+  permissions :destroy? do
+    context 'when the account does not block agent message deletion' do
+      it 'allows an agent to delete' do
+        expect(subject).to permit(agent_context, message)
+      end
+    end
+
+    context 'when the account blocks agent message deletion' do
+      before { account.update!(disable_agent_message_deletion: true) }
+
+      it 'denies an agent' do
+        expect(subject).not_to permit(agent_context, message)
+      end
+
+      it 'allows an administrator' do
+        expect(subject).to permit(administrator_context, message)
+      end
+
+      it 'allows an agent bot' do
+        expect(subject).to permit(agent_bot_context, message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new super admin toggle per account, **Disable agent message deletion**. When it is on, basic agents no longer see the "Delete" option on messages and cannot delete them through the API. Administrators and users with a custom role keep deleting as before.

This closes a real gap rather than just hiding a button: message deletion had no authorization of its own. The endpoint only inherited `authorize @conversation, :show?` from the base controller, so any agent with inbox access could delete **any** message in a conversation, including messages written by other agents and incoming contact messages. Deletion also propagates to the channel as a WhatsApp "delete for everyone", so a UI-only gate would not have been enough.

## How to test

1. As a super admin, open the account edit page and tick **Disable agent message deletion**.
2. Log in as a user whose role is *agent*, open a conversation and right-click a message. The **Delete** option is gone (and no stray separator is left behind).
3. Log in as an administrator: **Delete** is still there and still works.
4. Untick the toggle, reload as the agent: **Delete** comes back.

## What changed

- `disable_agent_message_deletion` lives in the `settings` jsonb, not `feature_flags`, following the "Account-level toggles" guidance in `AGENTS.md`.
- The existing `hide_agent_unassigned_tab` / `hide_agent_all_tab` toggles move into a new `AccountAgentRestrictions` concern together with the new one. This groups the agent restrictions in one place and keeps `Account` under the class-length limit.
- `MessagePolicy` is new and is the first authorization on `MessagesController#destroy`. It runs before the soft delete and before the channel propagation, and allows administrators, custom roles and agent bots.
- On the frontend, `canDeleteMessages()` in `permissionsHelper.js` mirrors the policy and feeds `contextMenuEnabledOptions` in `Message.vue`. `MessageContextMenu.vue` needed no change since it already guards every delete affordance behind `enabledOptions['delete']`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/335)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an account setting to prevent agents from deleting messages.
  * Added permission controls so administrators, bots, and custom-role users can still delete messages when the restriction is enabled.
  * Added the setting to the account administration interface.

* **Bug Fixes**
  * Unauthorized message deletion attempts are now blocked consistently in the interface and API.
  * Existing agent visibility settings continue to be validated and enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->