### PR TITLE
chore(skills): rename release-notes skill to release-user-notes

### DIFF
--- a/.claude/skills/release-user-notes/SKILL.md
+++ b/.claude/skills/release-user-notes/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: release-notes
+name: release-user-notes
 description: Use this skill whenever you are about to cut, edit, or backfill a GitHub release for fazer-ai/chatwoot. Generates the bilingual user-notes blocks (pt-BR + en) embedded in the release body for non-technical end users. Trigger before calling `gh release create`, `gh release edit`, or any flow that touches a release body on this repo (including the `release` skill from fazer-ai-tools and any retroactive backfill of historical releases).
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ---

--- a/.claude/skills/sync-fork/SKILL.md
+++ b/.claude/skills/sync-fork/SKILL.md
@@ -39,7 +39,7 @@ When triggered on a merge, don't just read the file and wing it — walk the ful
 4. Run the **Validation flow** end-to-end (it is mandatory, not optional). Do not commit if any step fails.
 5. Run the **Mandatory subagent review** (see section below) — it is a required gate, not optional. Address every FAIL before merging.
 6. Trigger the upstream CI on the branch (**Validate on upstream CI** section) and wait for green before merging.
-7. For Pro merges, recall that pushing to `chatwoot-pro/main` is directly followed by tagging `vX.Y.Z-fazer-ai-pro.N` and cutting a release — coordinate with the `release-notes` skill (and its `PRIVACY.md` companion) before writing the release body.
+7. For Pro merges, recall that pushing to `chatwoot-pro/main` is directly followed by tagging `vX.Y.Z-fazer-ai-pro.N` and cutting a release — coordinate with the `release-user-notes` skill (and its `PRIVACY.md` companion) before writing the release body.
 
 ## Pre-flight
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Automate this with your worktree tool's create hook (e.g. worktrunk's `pre-start
 ## Release Notes
 
 - Every GitHub release cut from this repo must include the bilingual `user-notes` blocks (pt-BR + en) in the release body, written for non-technical end users.
-- Before running `gh release create`, `gh release edit`, the `release` skill from `fazer-ai-tools`, or any flow that touches a release body (including retroactive backfills), invoke the `release-notes` skill at `.claude/skills/release-notes/SKILL.md` to draft and validate the blocks.
+- Before running `gh release create`, `gh release edit`, the `release` skill from `fazer-ai-tools`, or any flow that touches a release body (including retroactive backfills), invoke the `release-user-notes` skill at `.claude/skills/release-user-notes/SKILL.md` to draft and validate the blocks.
 
 ## Commit Messages
 


### PR DESCRIPTION
O nome `release-notes` colidia com o comando nativo `/release-notes` do Claude Code, que sobrepunha a skill do repo e a tornava impossível de invocar. O nome novo também diz o que ela produz: os blocos `user-notes` bilíngues.

Renomeia o diretório e atualiza as três referências (`AGENTS.md`, a própria skill e o `sync-fork`). Nenhuma mudança de conteúdo além do nome. As URLs públicas `fazer.ai/chatwoot-release-notes` no app não foram tocadas.

O mesmo rename foi feito no fork Pro, para que o próximo merge CE→Pro não traga a pasta antiga de volta e crie duas cópias.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/337)
<!-- Reviewable:end -->
