### PR TITLE
fix: remove duplicate before_action :current_account in AgentBotsController

### DIFF
--- a/app/controllers/api/v1/accounts/agent_bots_controller.rb
+++ b/app/controllers/api/v1/accounts/agent_bots_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::AgentBotsController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action :check_authorization
   before_action :agent_bot, except: [:index, :create]
 


### PR DESCRIPTION
Fixes #339.

`Api::V1::Accounts::AgentBotsController` re-declares `before_action :current_account`,
which its parent `Api::V1::Accounts::BaseController` already declares. Rails de-duplicates
the callback and moves it to the end of the chain, so `validate_token_api_access` runs
*before* `Current.account` is populated:

```
AgentBots: ... authenticate_user! -> validate_token_api_access -> current_account -> check_authorization
Inboxes:   ... authenticate_user! -> current_account -> validate_token_api_access -> fetch_inbox
```

Every request authenticated with the `api-access-token` header then fails with:

```
NoMethodError (undefined method 'api_and_webhooks_enabled?' for nil)
```

Dashboard (cookie session) requests are unaffected, which is why this is easy to miss.
`InboxesController` does not re-declare the callback and behaves correctly.

**Impact:** the fazer.ai agents integration cannot bind an agent to any inbox
(`could not sync the bot with Chatwoot`).

**Verification:** removing the line in a running container and restarting makes
`GET /api/v1/accounts/:id/agent_bots` return 200, and the agent/inbox binding completes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/340)
<!-- Reviewable:end -->
