### PR TITLE
fix(api): token-authenticated requests 500 on agent_bots, labels and captain endpoints

### DIFF
--- a/app/controllers/api/v1/accounts/agent_bots_controller.rb
+++ b/app/controllers/api/v1/accounts/agent_bots_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::AgentBotsController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action :check_authorization
   before_action :agent_bot, except: [:index, :create]
 

--- a/app/controllers/api/v1/accounts/captain/preferences_controller.rb
+++ b/app/controllers/api/v1/accounts/captain/preferences_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::Captain::PreferencesController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action :authorize_account_update, only: [:update]
 
   def show

--- a/app/controllers/api/v1/accounts/labels_controller.rb
+++ b/app/controllers/api/v1/accounts/labels_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::LabelsController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action :fetch_label, except: [:index, :create]
   before_action :check_authorization
 

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistant_responses_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistant_responses_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::Captain::AssistantResponsesController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action -> { check_authorization(Captain::Assistant) }
 
   before_action :set_current_page, only: [:index]

--- a/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/assistants_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::Captain::AssistantsController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action -> { check_authorization(Captain::Assistant) }
 
   before_action :set_assistant, only: [:show, :update, :destroy, :playground, :stats, :summary, :drilldown]

--- a/enterprise/app/controllers/api/v1/accounts/captain/bulk_actions_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/bulk_actions_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::Captain::BulkActionsController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action -> { check_authorization(Captain::Assistant) }
   before_action :validate_params
   before_action :type_matches?

--- a/enterprise/app/controllers/api/v1/accounts/captain/custom_tools_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/custom_tools_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::Captain::CustomToolsController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action :ensure_custom_tools_enabled
   before_action -> { check_authorization(Captain::CustomTool) }
   before_action :set_custom_tool, only: [:show, :update, :destroy]

--- a/enterprise/app/controllers/api/v1/accounts/captain/documents_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/documents_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::Captain::DocumentsController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action -> { check_authorization(Captain::Assistant) }
 
   before_action :set_current_page, only: [:index]

--- a/enterprise/app/controllers/api/v1/accounts/captain/inboxes_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/inboxes_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::Captain::InboxesController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action -> { check_authorization(Captain::Assistant) }
 
   before_action :set_assistant

--- a/enterprise/app/controllers/api/v1/accounts/captain/scenarios_controller.rb
+++ b/enterprise/app/controllers/api/v1/accounts/captain/scenarios_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::Accounts::Captain::ScenariosController < Api::V1::Accounts::BaseController
-  before_action :current_account
   before_action -> { check_authorization(Captain::Scenario) }
   before_action :set_assistant
   before_action :set_scenario, only: [:show, :update, :destroy]

--- a/spec/controllers/api/v1/accounts/agent_bots_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/agent_bots_controller_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe 'Agent Bot API', type: :request do
         expect(response).to have_http_status(:success)
         expect(response.body).to include(agent_bot.access_token.token)
       end
+
+      it 'returns the agent bots when authenticating with an api_access_token header' do
+        get "/api/v1/accounts/#{account.id}/agent_bots",
+            headers: { api_access_token: admin.access_token.token },
+            as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(agent_bot.name)
+      end
     end
   end
 
@@ -130,6 +139,15 @@ RSpec.describe 'Agent Bot API', type: :request do
       it 'creates the agent bot when administrator' do
         expect do
           post "/api/v1/accounts/#{account.id}/agent_bots", headers: admin.create_new_auth_token,
+                                                            params: valid_params
+        end.to change(AgentBot, :count).by(1)
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'creates the agent bot when administrator authenticates with an api_access_token header' do
+        expect do
+          post "/api/v1/accounts/#{account.id}/agent_bots", headers: { api_access_token: admin.access_token.token },
                                                             params: valid_params
         end.to change(AgentBot, :count).by(1)
 

--- a/spec/controllers/api/v1/accounts/base_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/base_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Accounts::BaseController do
+  describe 'callback ordering' do
+    # Re-declaring `before_action :current_account` in a subclass makes Rails
+    # de-duplicate the callback and move it to the end of the chain, so
+    # `validate_token_api_access` runs while `Current.account` is still nil and
+    # every request authenticated with the `api_access_token` header fails
+    # with a 500.
+    it 'runs current_account before validate_token_api_access in every descendant' do
+      Rails.application.eager_load!
+
+      ([described_class] + described_class.descendants).each do |controller|
+        filters = controller._process_action_callbacks.select { |callback| callback.kind == :before }.map(&:filter)
+        validate_index = filters.index(:validate_token_api_access)
+        next if validate_index.nil?
+
+        expect(filters.index(:current_account)).to be < validate_index,
+                                                   "#{controller.name} runs validate_token_api_access before current_account"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Requests to the account REST API authenticated with the `api-access-token` header were failing with HTTP 500 (`NoMethodError: undefined method 'api_and_webhooks_enabled?' for nil`) on several endpoints: agent bots, labels, captain preferences and all enterprise captain endpoints. This blocked the fazer.ai agents integration from binding an agent to any inbox. Dashboard (cookie session) requests were unaffected.

## Closes

- Closes #339
- Incorporates #340 (commit cherry-picked with original authorship, thanks @otimizzeai) and extends the same fix to every other affected controller.

## How to reproduce

```sh
curl -s -o /dev/null -w '%{http_code}\n' \
  -H "api-access-token: <admin token>" \
  https://<host>/api/v1/accounts/<id>/agent_bots
# 500 before this fix, 200 after
```

Same for `/labels` and the `/captain/*` endpoints.

## What changed

`Api::V1::Accounts::BaseController` declares `before_action :current_account` followed by `before_action :validate_token_api_access` (added by upstream 4.16.0, chatwoot/chatwoot#14973). Subclasses that re-declare `before_action :current_account` make Rails de-duplicate the callback and move it to the end of the chain, so `validate_token_api_access` runs while `Current.account` is still nil:

```text
AgentBots (before): ... -> validate_token_api_access -> current_account -> check_authorization  💥
AgentBots (after):  ... -> current_account -> validate_token_api_access -> check_authorization  ✅
```

- Removes the redundant `before_action :current_account` from the 10 affected controllers (`agent_bots`, `labels`, `captain/preferences` and 7 enterprise captain controllers). `conversations/direct_uploads` keeps its declaration: it inherits from `ActiveStorage::DirectUploadsController` and builds its own (correctly ordered) chain.
- Adds request specs covering `api_access_token` auth on agent bots (regression for the reported case).
- Adds a structural spec asserting `current_account` runs before `validate_token_api_access` in every descendant of `Api::V1::Accounts::BaseController`, so a future re-declaration fails CI instead of shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/342)
<!-- Reviewable:end -->
