### PR TITLE
fix(baileys): honest signaling when a reconnect loop is detected

### DIFF
--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -29,6 +29,7 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
       connection: data[:connection] || inbox.channel.provider_connection['connection'],
       qr_data_url: data[:qrDataUrl] || nil,
       error: data[:error] ? I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}", default: data[:error].to_s.humanize) : nil,
+      quarantine: quarantine_payload(data),
       reachout_time_lock: reachout_time_lock_payload(data),
       # new_chat_cap never rides a connection.update (it arrives via message-capping.update / the
       # poll). update_provider_connection! replaces provider_connection wholesale, so without
@@ -36,6 +37,21 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
       # off until the next cap push/poll. Preserve the existing value; .compact omits it when unset.
       new_chat_cap: inbox.channel.provider_connection['new_chat_cap'],
       epoch: data[:epoch]
+    }.compact
+  end
+
+  # Rides only the reconnect_loop_detected webhook (baileys-api quarantines a phone after a
+  # full failed reconnect cycle and reports how many cycles failed and when it will retry).
+  # Shares the error's lifecycle on purpose: any later connection.update without it (e.g. the
+  # next retry cycle's "reconnecting") clears it together with the error, so the UI never
+  # shows a stale "retrying at ..." for a phone that already reconnected.
+  def quarantine_payload(data)
+    raw = data[:quarantine]
+    return nil if raw.blank?
+
+    {
+      strikes: raw[:strikes],
+      until: raw[:until]
     }.compact
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,7 +195,7 @@ en:
       channel:
         provider_connection:
           wrong_phone_number: The phone number you are trying to link is not the same as the one you have configured. Please make sure the phone number is correct before scanning the QR code.
-          reconnect_loop_detected: The connection could not be re-established after several attempts. Please try reconnecting the inbox.
+          reconnect_loop_detected: The connection could not be re-established after several attempts. Automatic retries continue at increasing intervals. If this persists, disconnect the inbox and pair it again by scanning a new QR code.
     custom_filters:
       number_of_records: Limit reached. The maximum number of allowed custom filters for a user per account is 1000.
       invalid_attribute: Invalid attribute key - [%{key}]. The key should be one of [%{allowed_keys}] or a custom attribute defined in the account.

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -175,7 +175,7 @@ pt_BR:
       channel:
         provider_connection:
           wrong_phone_number: O número de telefone que você está tentando conectar não é o mesmo que o configurado. Certifique-se de que o número está correto antes de escanear o QR code.
-          reconnect_loop_detected: Não foi possível restabelecer a conexão após várias tentativas. Tente reconectar a caixa de entrada.
+          reconnect_loop_detected: Não foi possível restabelecer a conexão após várias tentativas. Novas tentativas automáticas continuam em intervalos crescentes. Se o problema persistir, desconecte a caixa de entrada e conecte novamente escaneando um novo QR code.
     custom_filters:
       number_of_records: Limite atingido. O número máximo de filtros personalizados permitidos para um usuário por conta é de 1000.
       invalid_attribute: Chave de atributo inválido - [%{key}]. A chave deve ser uma das [%{allowed_keys}] ou um atributo personalizado definido na conta.

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -192,6 +192,29 @@ describe Whatsapp::IncomingMessageBaileysService do
         expect(inbox.channel.provider_connection['error']).to be_nil
       end
 
+      it 'persists the quarantine reported with a reconnect loop and clears it on the next update' do
+        params = base_params.merge(
+          {
+            data: {
+              error: 'reconnect_loop_detected',
+              quarantine: { strikes: 3, until: '2026-07-31T12:00:00.000Z' }
+            }
+          }
+        )
+
+        described_class.new(inbox: inbox, params: params).perform
+
+        expect(inbox.channel.provider_connection).to include(
+          'error' => I18n.t('errors.inboxes.channel.provider_connection.reconnect_loop_detected'),
+          'quarantine' => { 'strikes' => 3, 'until' => '2026-07-31T12:00:00.000Z' }
+        )
+
+        next_cycle = base_params.merge({ data: { connection: 'connecting' } })
+        described_class.new(inbox: inbox, params: next_cycle).perform
+
+        expect(inbox.channel.reload.provider_connection['quarantine']).to be_nil
+      end
+
       context 'with reach-out time-lock (error 463 / account restriction)' do
         let(:reachout_data) do
           { isActive: true, timeEnforcementEnds: '2026-06-19T21:52:39.000Z', enforcementType: 'RESTRICT_ALL_COMPANIONS' }


### PR DESCRIPTION
## Contexto

Companion de fazer-ai/baileys-api#365 (quarentena com backoff para reconnect loops).

Em produção, 5 inboxes ficaram semanas com a mensagem "The connection could not be re-established after several attempts. **Please try reconnecting the inbox.**" — instrução que não resolve: o reconnect resume as mesmas credenciais que o WhatsApp rejeita (`stream:error 503`) e o loop recomeça. QR novo só aparece depois de desconectar a inbox (limpar o auth state no provider).

## O que muda

- **Locales (en/pt_BR)**: a mensagem de `reconnect_loop_detected` passa a dizer a verdade — tentativas automáticas continuam em intervalos crescentes (a quarentena do provider), e se persistir o caminho é desconectar a inbox e parear de novo com um QR novo.
- **`connection_update.rb`**: persiste o campo novo `quarantine: { strikes, until }` que o baileys-api agora envia junto do `reconnect_loop_detected`, com o mesmo ciclo de vida do `error` (qualquer `connection.update` posterior sem o campo limpa os dois) para a UI nunca mostrar estado velho. Fica disponível em `provider_connection` para a UI exibir "próxima tentativa às X" no futuro.

Retrocompatível: payloads sem `quarantine` (baileys-api antigo) seguem funcionando igual.

## Testes

- `spec/services/whatsapp/incoming_message_baileys_service_spec.rb`: novo caso cobrindo persistência e limpeza do `quarantine` (97 exemplos, 0 falhas).
- Rubocop limpo nos arquivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/343)
<!-- Reviewable:end -->

