### PR TITLE
fix(internal-chat): send attachments on thread replies

### DIFF
--- a/app/javascript/dashboard/api/internalChatMessages.js
+++ b/app/javascript/dashboard/api/internalChatMessages.js
@@ -18,6 +18,8 @@ class InternalChatMessagesAPI extends ApiClient {
     if (data.content) formData.append('content', data.content);
     if (data.parent_id) formData.append('parent_id', data.parent_id);
     if (data.echo_id) formData.append('echo_id', data.echo_id);
+    if (data.also_send_in_channel)
+      formData.append('also_send_in_channel', data.also_send_in_channel);
     files.forEach(file => {
       formData.append('attachments[][file]', file);
     });

--- a/app/javascript/dashboard/routes/dashboard/internalChat/ThreadPanel.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/ThreadPanel.vue
@@ -140,6 +140,7 @@ async function handleSendReply(content, options = {}) {
         channelId: props.channelId,
         parentMessageId: props.parentMessage.id,
         data: { content, also_send_in_channel: !!options.alsoSendInChannel },
+        files: options.files || [],
       });
       deleteThreadDraft();
       await nextTick();

--- a/app/javascript/dashboard/store/modules/internalChat/messages.js
+++ b/app/javascript/dashboard/store/modules/internalChat/messages.js
@@ -162,13 +162,20 @@ const actions = {
     }
   },
 
-  sendThreadReply: async ({ commit }, { channelId, parentMessageId, data }) => {
+  sendThreadReply: async (
+    { commit },
+    { channelId, parentMessageId, data, files = [] }
+  ) => {
     commit('SET_UI_FLAG', { isSending: true });
     try {
-      const response = await InternalChatMessagesAPI.createMessage(channelId, {
-        ...data,
-        parent_id: parentMessageId,
-      });
+      const response = await InternalChatMessagesAPI.createMessage(
+        channelId,
+        {
+          ...data,
+          parent_id: parentMessageId,
+        },
+        files
+      );
       const message = response.data;
       commit('ADD_THREAD_REPLY', {
         parentMessageId,

--- a/app/javascript/dashboard/store/modules/specs/internalChat/messages.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/internalChat/messages.spec.js
@@ -1,0 +1,111 @@
+import axios from 'axios';
+import messagesModule from '../../internalChat/messages';
+
+const { actions } = messagesModule;
+
+const commit = vi.fn();
+global.axios = axios;
+vi.mock('axios');
+
+describe('#actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('#sendThreadReply', () => {
+    it('sends a plain JSON payload when there are no files', async () => {
+      axios.post.mockResolvedValue({ data: { id: 7, parent_id: 3 } });
+
+      await actions.sendThreadReply(
+        { commit },
+        {
+          channelId: 1,
+          parentMessageId: 3,
+          data: { content: 'hi', also_send_in_channel: false },
+        }
+      );
+
+      const [, payload] = axios.post.mock.calls[0];
+      expect(payload).toEqual({
+        content: 'hi',
+        also_send_in_channel: false,
+        parent_id: 3,
+      });
+      expect(commit).toHaveBeenCalledWith('ADD_THREAD_REPLY', {
+        parentMessageId: 3,
+        reply: { id: 7, parent_id: 3 },
+      });
+    });
+
+    it('sends multipart form data including the files when files are passed', async () => {
+      axios.post.mockResolvedValue({ data: { id: 8, parent_id: 3 } });
+      const file = new File(['png-bytes'], 'image.png', { type: 'image/png' });
+
+      await actions.sendThreadReply(
+        { commit },
+        {
+          channelId: 1,
+          parentMessageId: 3,
+          data: { content: '', also_send_in_channel: true },
+          files: [file],
+        }
+      );
+
+      const [, payload] = axios.post.mock.calls[0];
+      expect(payload).toBeInstanceOf(FormData);
+      expect(payload.getAll('attachments[][file]')).toEqual([file]);
+      expect(payload.get('parent_id')).toBe('3');
+      expect(payload.get('also_send_in_channel')).toBe('true');
+      expect(payload.get('content')).toBeNull();
+      expect(commit).toHaveBeenCalledWith('ADD_THREAD_REPLY', {
+        parentMessageId: 3,
+        reply: { id: 8, parent_id: 3 },
+      });
+    });
+
+    it('adds the reply to the channel when also_send_in_channel is set on the response', async () => {
+      axios.post.mockResolvedValue({
+        data: {
+          id: 9,
+          parent_id: 3,
+          content_attributes: { also_send_in_channel: true },
+        },
+      });
+
+      await actions.sendThreadReply(
+        { commit },
+        {
+          channelId: 1,
+          parentMessageId: 3,
+          data: { content: 'broadcast', also_send_in_channel: true },
+        }
+      );
+
+      expect(commit).toHaveBeenCalledWith('ADD_MESSAGE', {
+        channelId: 1,
+        message: expect.objectContaining({ id: 9 }),
+      });
+    });
+  });
+
+  describe('#sendMessage', () => {
+    it('sends multipart form data including the files when files are passed', async () => {
+      axios.post.mockResolvedValue({ data: { id: 10 } });
+      const file = new File(['png-bytes'], 'image.png', { type: 'image/png' });
+
+      await actions.sendMessage(
+        { commit },
+        { channelId: 1, data: { content: 'hello' }, files: [file] }
+      );
+
+      const [, payload] = axios.post.mock.calls[0];
+      expect(payload).toBeInstanceOf(FormData);
+      expect(payload.getAll('attachments[][file]')).toEqual([file]);
+      expect(payload.get('content')).toBe('hello');
+      expect(commit).toHaveBeenCalledWith('ADD_MESSAGE', {
+        channelId: 1,
+        message: { id: 10 },
+      });
+    });
+  });
+});

--- a/spec/controllers/api/v1/accounts/internal_chat/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/internal_chat/messages_controller_spec.rb
@@ -223,6 +223,35 @@ RSpec.describe 'Internal Chat Messages API', type: :request do
         expect(body['content_attributes']).to include('also_send_in_channel' => true)
       end
 
+      it 'creates an attachment-only thread reply without content' do
+        parent = create(:internal_chat_message, account: account, channel: channel, sender: agent, content: 'parent')
+        file = fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png')
+
+        post "/api/v1/accounts/#{account.id}/internal_chat/channels/#{channel.id}/messages",
+             params: { parent_id: parent.id, attachments: [{ file: file }] },
+             headers: agent.create_new_auth_token
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body['parent_id']).to eq(parent.id)
+        expect(body['attachments'].size).to eq(1)
+      end
+
+      it 'creates a thread reply with attachment, content and also_send_in_channel via multipart' do
+        parent = create(:internal_chat_message, account: account, channel: channel, sender: agent, content: 'parent')
+        file = fixture_file_upload(Rails.root.join('spec/assets/avatar.png'), 'image/png')
+
+        post "/api/v1/accounts/#{account.id}/internal_chat/channels/#{channel.id}/messages",
+             params: { content: 'see attached', parent_id: parent.id, also_send_in_channel: 'true', attachments: [{ file: file }] },
+             headers: agent.create_new_auth_token
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body['content']).to eq('see attached')
+        expect(body['content_attributes']).to include('also_send_in_channel' => true)
+        expect(body['attachments'].size).to eq(1)
+      end
+
       it 'ignores also_send_in_channel when there is no parent_id' do
         post "/api/v1/accounts/#{account.id}/internal_chat/channels/#{channel.id}/messages",
              params: { content: 'plain message', also_send_in_channel: true },


### PR DESCRIPTION
Attachments added to an Internal Chat **thread reply** were silently dropped: an image-only reply failed with 422 ("Content can't be blank") and an image+text reply posted the text without the image. The main channel composer was unaffected. Thread replies now send their attachments exactly like the main composer, including together with the "also send in channel" option.

## Closes

Closes #341

## How to reproduce

1. Open an Internal Chat channel and open a thread on any message.
2. In the thread reply box, attach an image with no text and send: 422 "Content can't be blank".
3. Attach an image along with text and send: the text posts, the image never appears.

## What changed

The shared `MessageEditor` collects files in both composers, but the thread path dropped them at three points:

- `ThreadPanel.handleSendReply` never read `options.files`; it now forwards them.
- The `sendThreadReply` store action had no `files` parameter (`createMessage` was called with 2 args, so `files` defaulted to `[]`); it now accepts and forwards them.
- The multipart branch of `InternalChatMessagesAPI.createMessage` did not append `also_send_in_channel`, which would have silently broken the thread's broadcast checkbox once files started flowing; it now appends it (backend casts it with `ActiveModel::Type::Boolean`, so the string value is handled).

The backend already permitted `attachments` and skips content presence validation when they are present; no server changes were needed.

Specs: store action specs for `sendThreadReply` (JSON and multipart paths, broadcast commit) and `sendMessage` (multipart), plus request specs posting real multipart attachments (attachment-only thread reply, and attachment+content+`also_send_in_channel`), which were previously uncovered paths.

Verified end to end in the dev app: attachment-only thread reply returns 201 and renders the file in the thread; attachment+text+broadcast persists `also_send_in_channel: true` with the attachment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/344)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching files to internal chat thread replies.
  * Thread replies can now optionally also be sent to the main channel.
  * File attachments continue to be supported for regular internal chat messages.
* **Bug Fixes**
  * Improved handling of replies that combine text, attachments, and channel delivery options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->