### PR TITLE
fix(baileys): render album items and lottie stickers instead of unsupported bubbles

### DIFF
--- a/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
@@ -72,7 +72,7 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
   # flow could have picked (or created) a different one. Find the row first,
   # then operate on its real `existing.conversation`.
   def mark_existing_reaction_as_removed(sender:)
-    target_external_id = unwrap_ephemeral_message(@raw_message[:message]).dig(:reactionMessage, :key, :id)
+    target_external_id = unwrap_message_content(@raw_message[:message]).dig(:reactionMessage, :key, :id)
     return if target_external_id.blank?
 
     existing = find_existing_reaction(sender, target_external_id)
@@ -117,7 +117,7 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
 
   def build_message_content_attributes
     type = message_type
-    msg = unwrap_ephemeral_message(@raw_message[:message])
+    msg = unwrap_message_content(@raw_message[:message])
     content_attributes = { external_created_at: baileys_extract_message_timestamp(@raw_message[:messageTimestamp]) }
     content_attributes[:external_sender_name] = 'WhatsApp' unless incoming?
 
@@ -153,7 +153,7 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
 
   def attach_media_to_message
     attachment_file = download_attachment_file
-    msg = unwrap_ephemeral_message(@raw_message[:message])
+    msg = unwrap_message_content(@raw_message[:message])
 
     attachment = @message.attachments.build(
       account_id: @message.account_id,
@@ -174,7 +174,7 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
   end
 
   def build_attachment_filename
-    msg = unwrap_ephemeral_message(@raw_message[:message])
+    msg = unwrap_message_content(@raw_message[:message])
     filename = msg.dig(:documentMessage, :fileName) ||
                msg.dig(:documentWithCaptionMessage, :message, :documentMessage, :fileName) ||
                rich_media_header&.dig(:node, :fileName)
@@ -187,7 +187,7 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
   # Location carries no downloadable bytes; persist coordinates as a native
   # location attachment so the dashboard renders it in the map bubble.
   def attach_location_to_message
-    loc = unwrap_ephemeral_message(@raw_message[:message])
+    loc = unwrap_message_content(@raw_message[:message])
     loc = loc[:locationMessage] || loc[:liveLocationMessage]
     return if loc.blank?
 

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -3,8 +3,21 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
 
   private
 
-  def unwrap_ephemeral_message(msg)
-    msg.key?(:ephemeralMessage) ? msg.dig(:ephemeralMessage, :message) : msg
+  # WhatsApp nests the real payload inside wrapper nodes: ephemeralMessage
+  # (disappearing chats), associatedChildMessage (album items) and
+  # lottieStickerMessage (animated stickers). Wrappers can nest, so unwrap
+  # until the content surfaces (iteration bound mirrors Baileys'
+  # normalizeMessageContent).
+  MESSAGE_WRAPPER_KEYS = %i[ephemeralMessage associatedChildMessage lottieStickerMessage].freeze
+
+  def unwrap_message_content(msg)
+    5.times do
+      wrapper_key = MESSAGE_WRAPPER_KEYS.find { |key| msg.key?(key) }
+      break unless wrapper_key
+
+      msg = msg.dig(wrapper_key, :message) || {}
+    end
+    msg
   end
 
   def raw_message_id
@@ -40,7 +53,7 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
   end
 
   def message_type # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity,Metrics/MethodLength,Metrics/AbcSize
-    msg = unwrap_ephemeral_message(@raw_message[:message])
+    msg = unwrap_message_content(@raw_message[:message])
     # A Click-to-WhatsApp ad-click can arrive as an extendedTextMessage carrying
     # only the ad context (no text). Classify it as text so it renders with the
     # ad headline/body as fallback content instead of being dropped/unsupported.
@@ -70,6 +83,8 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
       'location'
     elsif msg.key?(:protocolMessage)
       'protocol'
+    elsif msg.key?(:albumMessage)
+      'album'
     elsif msg.key?(:messageContextInfo) && msg.keys.count == 1
       'context'
     elsif Whatsapp::Baileys::RichMessageParser.rich?(msg)
@@ -80,7 +95,7 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
   end
 
   def message_content # rubocop:disable Metrics/CyclomaticComplexity
-    msg = unwrap_ephemeral_message(@raw_message[:message])
+    msg = unwrap_message_content(@raw_message[:message])
     case message_type
     when 'text'
       text = msg[:conversation] || msg.dig(:extendedTextMessage, :text)
@@ -104,7 +119,7 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
   # The shared contacts of the current message: the entries of a
   # contactsArrayMessage, or the single contactMessage wrapped in an array.
   def baileys_contacts
-    msg = unwrap_ephemeral_message(@raw_message[:message])
+    msg = unwrap_message_content(@raw_message[:message])
     msg.dig(:contactsArrayMessage, :contacts).presence || [msg[:contactMessage]].compact
   end
 
@@ -137,7 +152,7 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
   # Returns the `contextInfo` for the current message type, where the
   # Click-to-WhatsApp ad metadata (`externalAdReply`) lives.
   def message_context_info # rubocop:disable Metrics/CyclomaticComplexity
-    msg = unwrap_ephemeral_message(@raw_message[:message])
+    msg = unwrap_message_content(@raw_message[:message])
     case message_type
     when 'text' then msg.dig(:extendedTextMessage, :contextInfo)
     when 'image' then msg.dig(:imageMessage, :contextInfo)
@@ -166,7 +181,7 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
   def rich_media_header
     return unless message_type == 'rich'
 
-    Whatsapp::Baileys::RichMessageParser.new(unwrap_ephemeral_message(@raw_message[:message])).media_header
+    Whatsapp::Baileys::RichMessageParser.new(unwrap_message_content(@raw_message[:message])).media_header
   end
 
   def file_content_type
@@ -179,7 +194,7 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
   end
 
   def message_mimetype # rubocop:disable Metrics/CyclomaticComplexity
-    msg = unwrap_ephemeral_message(@raw_message[:message])
+    msg = unwrap_message_content(@raw_message[:message])
     case message_type
     when 'image'
       msg.dig(:imageMessage, :mimetype)
@@ -259,19 +274,22 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
       .find { |normalizer| normalizer.handles_country?(value) }
   end
 
+  # An albumMessage is only the marker announcing a media group; each item
+  # arrives as its own associatedChildMessage upsert, so the marker itself
+  # renders nothing.
   def ignore_message?
-    message_type.in?(%w[protocol context edited])
+    message_type.in?(%w[protocol context edited album])
   end
 
   # A protocolMessage of type REVOKE is the contact deleting a message for everyone.
   # Baileys delivers it as a messages.upsert entry whose protocolMessage.key.id
   # points at the original message.
   def protocol_revoke?
-    unwrap_ephemeral_message(@raw_message[:message] || {}).dig(:protocolMessage, :type) == 'REVOKE'
+    unwrap_message_content(@raw_message[:message] || {}).dig(:protocolMessage, :type) == 'REVOKE'
   end
 
   def protocol_revoke_target_id
-    unwrap_ephemeral_message(@raw_message[:message] || {}).dig(:protocolMessage, :key, :id)
+    unwrap_message_content(@raw_message[:message] || {}).dig(:protocolMessage, :key, :id)
   end
 
   def reaction_removal?
@@ -282,7 +300,7 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
   # written later in build_message_content_attributes), so read the target id
   # straight from the raw reaction webhook here.
   def reaction_target_external_id
-    unwrap_ephemeral_message(@raw_message[:message]).dig(:reactionMessage, :key, :id)
+    unwrap_message_content(@raw_message[:message]).dig(:reactionMessage, :key, :id)
   end
 
   def try_update_contact_avatar(contact = nil)

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -398,6 +398,126 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
     end
   end
 
+  describe 'album and wrapped media handling' do
+    let(:phone) { '5511912345678' }
+    let(:lid) { '12345678' }
+
+    context 'when receiving an album marker message' do
+      it 'ignores the marker and creates no message' do
+        raw_message = {
+          key: { id: 'msg_album_marker', remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false,
+                 addressingMode: 'pn' },
+          pushName: 'Gabriel',
+          messageTimestamp: timestamp,
+          message: {
+            messageContextInfo: {
+              deviceListMetadata: {},
+              deviceListMetadataVersion: 2
+            },
+            albumMessage: { expectedImageCount: 2, expectedVideoCount: 0 }
+          }
+        }
+        params = {
+          webhookVerifyToken: webhook_verify_token,
+          event: 'messages.upsert',
+          data: { type: 'notify', messages: [raw_message] }
+        }
+
+        expect do
+          Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+        end.not_to change(Message, :count)
+      end
+    end
+
+    context 'when receiving an album child image message' do
+      it 'unwraps the wrapper and processes the message with media' do
+        raw_message = {
+          key: { id: 'msg_album_child_1', remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false,
+                 addressingMode: 'pn' },
+          pushName: 'Gabriel',
+          messageTimestamp: timestamp,
+          message: {
+            messageContextInfo: {
+              deviceListMetadata: {},
+              deviceListMetadataVersion: 2
+            },
+            associatedChildMessage: {
+              message: {
+                imageMessage: {
+                  caption: 'Album photo',
+                  mimetype: 'image/jpeg',
+                  url: 'https://example.com/img.jpg'
+                }
+              }
+            }
+          }
+        }
+        params = {
+          webhookVerifyToken: webhook_verify_token,
+          event: 'messages.upsert',
+          data: { type: 'notify', messages: [raw_message] }
+        }
+
+        stub_request(:get, whatsapp_channel.media_url('msg_album_child_1'))
+          .to_return(status: 200, body: 'fake image data')
+
+        expect do
+          Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+        end.to change(inbox.messages, :count).by(1)
+
+        message = inbox.messages.last
+        expect(message.content).to eq('Album photo')
+        expect(message.is_unsupported).to be_falsey
+        expect(message.attachments.count).to eq(1)
+        expect(message.attachments.first.file_type).to eq('image')
+      end
+    end
+
+    context 'when receiving a lottie sticker message' do
+      it 'unwraps the wrapper and processes the sticker with media' do
+        raw_message = {
+          key: { id: 'msg_lottie_1', remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false,
+                 addressingMode: 'pn' },
+          pushName: 'Gabriel',
+          messageTimestamp: timestamp,
+          message: {
+            messageContextInfo: {
+              deviceListMetadata: {},
+              deviceListMetadataVersion: 2,
+              messageSecret: 'secret'
+            },
+            lottieStickerMessage: {
+              message: {
+                stickerMessage: {
+                  mimetype: 'application/was',
+                  url: 'https://example.com/sticker.was',
+                  isLottie: true
+                }
+              }
+            }
+          }
+        }
+        params = {
+          webhookVerifyToken: webhook_verify_token,
+          event: 'messages.upsert',
+          data: { type: 'notify', messages: [raw_message] }
+        }
+
+        stub_request(:get, whatsapp_channel.media_url('msg_lottie_1'))
+          .to_return(status: 200, body: 'fake sticker data')
+
+        expect do
+          Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+        end.to change(inbox.messages, :count).by(1)
+
+        message = inbox.messages.last
+        expect(message.is_unsupported).to be_falsey
+        expect(message.attachments.count).to eq(1)
+        expect(message.attachments.first.file_type).to eq('image')
+      end
+    end
+  end
+
   describe 'filename extraction' do
     let(:phone) { '5511912345678' }
 

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -473,6 +473,54 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       end
     end
 
+    context 'when receiving an album child nested inside an ephemeral message' do
+      it 'unwraps the nested wrappers and processes the message with media' do
+        raw_message = {
+          key: { id: 'msg_nested_wrappers_1', remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false,
+                 addressingMode: 'pn' },
+          pushName: 'Gabriel',
+          messageTimestamp: timestamp,
+          message: {
+            messageContextInfo: {
+              deviceListMetadata: {},
+              deviceListMetadataVersion: 2
+            },
+            ephemeralMessage: {
+              message: {
+                associatedChildMessage: {
+                  message: {
+                    imageMessage: {
+                      caption: 'Nested album photo',
+                      mimetype: 'image/jpeg',
+                      url: 'https://example.com/nested.jpg'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        params = {
+          webhookVerifyToken: webhook_verify_token,
+          event: 'messages.upsert',
+          data: { type: 'notify', messages: [raw_message] }
+        }
+
+        stub_request(:get, whatsapp_channel.media_url('msg_nested_wrappers_1'))
+          .to_return(status: 200, body: 'fake image data')
+
+        expect do
+          Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+        end.to change(inbox.messages, :count).by(1)
+
+        message = inbox.messages.last
+        expect(message.content).to eq('Nested album photo')
+        expect(message.is_unsupported).to be_falsey
+        expect(message.attachments.count).to eq(1)
+        expect(message.attachments.first.file_type).to eq('image')
+      end
+    end
+
     context 'when receiving a lottie sticker message' do
       it 'unwraps the wrapper and processes the sticker with media' do
         raw_message = {


### PR DESCRIPTION
When a contact (or the agent's phone) sends several photos/videos at once, WhatsApp delivers them as an album; when someone sends an animated (Lottie) sticker, it arrives in a wrapper node. The Baileys handler recognized neither, so each album item and every Lottie sticker showed up in the conversation as an "unsupported message" bubble with no media. In a one-day sample at a large deployment, album items alone accounted for roughly a third of the unsupported incoming messages.

## How to reproduce

1. On a WhatsApp (Baileys) inbox, have a contact select 2+ photos and send them together (album).
2. Today: the conversation shows "unsupported message" bubbles; with this PR the marker is ignored and each photo renders as a regular image message.
3. Same for an animated sticker from the sticker store: today an unsupported bubble, now a sticker message.

## What changed

- `unwrap_ephemeral_message` generalized into `unwrap_message_content`, which also unwraps `associatedChildMessage` (album items) and `lottieStickerMessage`, with a bounded loop mirroring Baileys' `normalizeMessageContent`.
- `albumMessage` classified as a new `album` type and ignored: it is only the marker announcing the media group; each item arrives as its own upsert.
- Specs for the three flows (marker ignored, album child image with media, lottie sticker with media).

> Note: media download for wrapped messages also requires fazer-ai/baileys-api#367; without it the unwrapped message is created but the attachment download falls back to the current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/345)
<!-- Reviewable:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of WhatsApp messages wrapped in multiple layers.
  * Added support for processing associated child images and animated stickers with media attachments.
  * Improved reaction, location, filename, protocol, and message-content parsing.
  * Album marker messages are now ignored without creating duplicate or empty messages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->