### PR TITLE
feat(baileys): reset a rejected session on explicit reconnect

### DIFF
--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -9,6 +9,11 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   DEFAULT_CLIENT_NAME = ENV.fetch('BAILEYS_PROVIDER_DEFAULT_CLIENT_NAME', nil)
   DEFAULT_URL = ENV.fetch('BAILEYS_PROVIDER_DEFAULT_URL', nil)
   DEFAULT_API_KEY = ENV.fetch('BAILEYS_PROVIDER_DEFAULT_API_KEY', nil)
+  # Consecutive failed reconnect cycles (provider quarantine strikes, see
+  # baileys-api) after which a reconnect attempt discards the stored session
+  # first. 3 full cycles span several minutes of backoff — a rejected
+  # session, not a transient blip.
+  RECONNECT_LOOP_RESET_STRIKES = 3
 
   def self.groups_enabled?
     ENV.fetch('BAILEYS_WHATSAPP_GROUPS_ENABLED', 'false') == 'true'
@@ -38,6 +43,15 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   end
 
   def setup_channel_provider
+    # A session the server keeps rejecting can only be recovered by pairing a
+    # fresh QR, but the provider always resumes stored creds when they exist —
+    # so an operator asking to reconnect such a channel would just restart the
+    # loop. Discard the dead session first; the setup below then gets a QR.
+    # Gated on human intent by construction: this method only runs from
+    # explicit setup/reconnect requests and from the connection-check job,
+    # which is scheduled exclusively for channels that are `open`.
+    disconnect_channel_provider if rejected_session?
+
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}",
       headers: api_headers,
@@ -101,6 +115,18 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   rescue StandardError => e
     Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider failed (ignored): #{e.message}")
     true
+  end
+
+  # Confirmed reconnect loop: the provider reported enough consecutive failed
+  # reconnect cycles (quarantine strikes ride the reconnect_loop_detected
+  # webhook and are persisted on provider_connection). An `open` channel never
+  # qualifies — any healthy open clears the quarantine upstream, and the
+  # strikes field is wiped by the next connection.update without it.
+  def rejected_session?
+    connection = whatsapp_channel.provider_connection || {}
+    return false if connection['connection'] == 'open'
+
+    connection.dig('quarantine', 'strikes').to_i >= RECONNECT_LOOP_RESET_STRIKES
   end
 
   def send_message(recipient_id, message)

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -147,6 +147,67 @@ describe Whatsapp::Providers::WhatsappBaileysService do
         expect(Rails.logger).to have_received(:error).with('error message').twice
       end
     end
+
+    context 'with a confirmed reconnect loop (quarantine strikes at the reset threshold)' do
+      before do
+        whatsapp_channel.update_provider_connection!(
+          connection: 'reconnecting',
+          quarantine: { strikes: 3, until: '2026-07-31T12:00:00.000Z' }
+        )
+      end
+
+      it 'discards the stored session before requesting the new connection, so a QR is offered' do
+        delete_stub = stub_request(:delete, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
+                      .to_return(status: 200)
+        post_stub = stub_request(:post, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
+                    .to_return(status: 200)
+
+        expect(service.setup_channel_provider).to be(true)
+
+        expect(delete_stub).to have_been_requested
+        expect(post_stub).to have_been_requested
+      end
+    end
+
+    context 'with quarantine strikes below the reset threshold' do
+      before do
+        whatsapp_channel.update_provider_connection!(
+          connection: 'reconnecting',
+          quarantine: { strikes: 2, until: '2026-07-31T12:00:00.000Z' }
+        )
+      end
+
+      it 'does not discard the stored session' do
+        post_stub = stub_request(:post, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
+                    .to_return(status: 200)
+
+        expect(service.setup_channel_provider).to be(true)
+
+        expect(post_stub).to have_been_requested
+        expect(a_request(:delete, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}"))
+          .not_to have_been_made
+      end
+    end
+
+    context 'when the channel is open despite stale quarantine data' do
+      before do
+        whatsapp_channel.update_provider_connection!(
+          connection: 'open',
+          quarantine: { strikes: 5, until: '2026-07-31T12:00:00.000Z' }
+        )
+      end
+
+      it 'never discards the stored session of an open channel' do
+        post_stub = stub_request(:post, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
+                    .to_return(status: 200)
+
+        expect(service.setup_channel_provider).to be(true)
+
+        expect(post_stub).to have_been_requested
+        expect(a_request(:delete, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}"))
+          .not_to have_been_made
+      end
+    end
   end
 
   describe '#import_session' do


### PR DESCRIPTION
## Contexto

Terceira peça da correção dos reconnect loops (com fazer-ai/baileys-api#365/#366 e #343). Quando o provider rejeita a sessão armazenada a cada handshake, "reconectar" só resume as mesmas credenciais mortas e reinicia o loop; a única recuperação é descartar a sessão e parear um QR novo — o que exigia conhecer (e chamar manualmente) o `disconnect_channel_provider`, sem botão na UI.

## O que muda

`setup_channel_provider` agora descarta a sessão armazenada ANTES do setup quando o canal está num reconnect loop confirmado:

- Critério objetivo: `provider_connection.quarantine.strikes >= 3` (o campo é persistido do webhook `reconnect_loop_detected` pelo #343; 3 ciclos completos falhos com backoff = minutos de rejeição contínua, não um blip transitório).
- Canal `open` nunca qualifica (guard extra; um open saudável já limpa a quarentena upstream).
- Intenção humana preservada por construção: o setup só roda em pedidos explícitos de setup/reconexão e no connection-check job, que é agendado exclusivamente para canais `open`.

Resultado UX: o admin abre a tela de conexão da inbox problemática → a sessão morta é descartada automaticamente → o QR aparece → escaneia. Zero botão novo.

**Rejeitado de propósito**: auto-disconnect por heurística no servidor (sem humano). Um outage prolongado derrubaria dezenas de números em ciclos falhos e apagaria credenciais válidas em massa, forçando re-pareamento geral. Destruição de credencial exige uma pessoa na frente da tela — que é justamente quem pode escanear o QR resultante.

## Dependência

Requer baileys-api >= v3.5.4 (#366) para o discard funcionar em sessões sem socket vivo (offline logout). Em providers antigos o DELETE responde 404 e o comportamento degrada para o atual.

## Testes

103 exemplos, 0 falhas. Casos novos: strikes no limiar → DELETE antes do POST; abaixo do limiar → sem DELETE; canal open com quarantine stale → nunca reseta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/346)
<!-- Reviewable:end -->
