### PR TITLE
fix(dashboard): allow attachments when starting WhatsApp conversations

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
@@ -80,6 +80,17 @@ const shouldShowEmojiButton = computed(() => {
   );
 });
 
+// Attachments on conversation-create are supported for email/web widget and
+// for WhatsApp providers that send free-form media (Baileys, Z-API). The
+// template-based WhatsApp flows (Cloud, Twilio) can't start with media.
+const shouldShowAttachButton = computed(() => {
+  return (
+    props.isEmailOrWebWidgetInbox ||
+    props.isWhatsappBaileysInbox ||
+    props.isWhatsappZapiInbox
+  );
+});
+
 const isRegularMessageMode = computed(() => {
   return (
     (!props.isWhatsappInbox && !props.isTwilioWhatsAppInbox) ||
@@ -177,7 +188,7 @@ const keyboardEvents = {
 useKeyboardEvents(keyboardEvents);
 
 const onPaste = e => {
-  if (!props.isEmailOrWebWidgetInbox) return;
+  if (!shouldShowAttachButton.value) return;
 
   const files = e.clipboardData?.files;
   if (!files?.length) return;
@@ -230,7 +241,7 @@ useEventListener(document, 'paste', onPaste);
         />
       </div>
       <FileUpload
-        v-if="isEmailOrWebWidgetInbox"
+        v-if="shouldShowAttachButton"
         ref="uploadAttachment"
         input-id="composeNewConversationAttachment"
         :size="4096 * 4096"

--- a/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
@@ -105,10 +105,26 @@ const inboxChannelType = computed(() => props.targetInbox?.channelType || '');
 
 const voiceCallEnabled = computed(() => isVoiceCallEnabled(props.targetInbox));
 
+// Template-based WhatsApp flows (Cloud, Twilio) compose the content from the
+// template, so `message` stays optional there. Free-form WhatsApp providers
+// (Baileys, Z-API) send exactly what the form holds: without text nor an
+// attachment the backend would create an empty message that the provider
+// flags as unsupported, so require one of them.
 const validationRules = computed(() => ({
   selectedContact: { required },
   targetInbox: { required },
-  message: { required: requiredIf(!inboxTypes.value.isWhatsapp) },
+  message: {
+    required: requiredIf(() => {
+      if (!inboxTypes.value.isWhatsapp) return true;
+      if (
+        inboxTypes.value.isWhatsappBaileys ||
+        inboxTypes.value.isWhatsappZapi
+      ) {
+        return state.attachedFiles.length === 0;
+      }
+      return false;
+    }),
+  },
   subject: { required: requiredIf(inboxTypes.value.isEmail) },
 }));
 


### PR DESCRIPTION
Agents starting a WhatsApp (Baileys/Z-API) conversation from the New Conversation composer had no way to attach a file: the attach button only rendered for email/web widget inboxes, and pasting a file was ignored. Since the message text is also optional for WhatsApp inboxes (template-based flows compose it from the template), agents ended up creating conversations with an empty first message — which the provider cannot send and flags as an "unsupported message" bubble — and then re-sending the media from inside the conversation. In a one-day sample at a large deployment this produced over a hundred empty first-message bubbles.

## How to test

1. Open the New Conversation composer, pick a contact and a WhatsApp (Baileys) inbox.
2. The attach button now shows; attach a PDF or image (or paste it) and hit send without typing text: the conversation is created with the media as the first message.
3. Try to send with no text and no attachment: the form now requires one of them (message field flagged invalid).
4. Email/web widget and template-based WhatsApp (Cloud, Twilio) flows behave as before.

## What changed

- `ActionButtons.vue`: attach button and paste handling enabled for Baileys/Z-API inboxes (`shouldShowAttachButton`).
- `ComposeNewConversationForm.vue`: `message` is required for Baileys/Z-API when no files are attached; template-based WhatsApp flows keep it optional.
- No backend change needed: conversation-create already ships attachments via `FormData` (`message[attachments][]`), the same path the email composer uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/347)
<!-- Reviewable:end -->
