### PR TITLE
feat(filters): filter conversations and contacts by missing custom attribute

### DIFF
--- a/app/javascript/dashboard/components-next/filter/ConditionRow.vue
+++ b/app/javascript/dashboard/components-next/filter/ConditionRow.vue
@@ -138,6 +138,20 @@ const onAsyncSearch = query => {
   debouncedAsyncSearch(query);
 };
 
+/**
+ * Returns the empty value matching an input type, so the model stays compatible
+ * with the component that renders it. For example, a multi-select expects an
+ * array while a plain text input expects a string.
+ * @param {string} type - The input type
+ * @returns {Array|Object|string}
+ */
+const emptyValueForInputType = type => {
+  if (type === 'multiSelect') return [];
+  if (['searchSelect', 'asyncSearchSelect', 'booleanSelect'].includes(type))
+    return {};
+  return '';
+};
+
 const resetModelOnAttributeKeyChange = newAttributeKey => {
   /**
    * Resets the filter values and operator when the attribute key changes. This ensures that
@@ -147,21 +161,21 @@ const resetModelOnAttributeKeyChange = newAttributeKey => {
    */
   const filter = getFilterFromFilterTypes(newAttributeKey);
   const newOperator = getOperator(filter, filterOperator.value);
-  const newInputType = getInputType(newOperator, filter);
-  if (newInputType === 'multiSelect') {
-    values.value = [];
-  } else if (
-    ['searchSelect', 'asyncSearchSelect', 'booleanSelect'].includes(
-      newInputType
-    )
-  ) {
-    values.value = {};
-  } else {
-    values.value = '';
-  }
+  values.value = emptyValueForInputType(getInputType(newOperator, filter));
   asyncOptions.value = [];
   filterOperator.value = newOperator.value;
 };
+
+// Operators like `is_present` hide the input, so any previously typed value has to go with it.
+// Otherwise it stays in the model and gets persisted when the filter is saved as a folder.
+watch(currentOperator, (newOperator, oldOperator) => {
+  if (!newOperator || newOperator.value === oldOperator?.value) return;
+  if (newOperator.hasInput && oldOperator?.hasInput) return;
+
+  values.value = newOperator.hasInput
+    ? emptyValueForInputType(getInputType(newOperator, currentFilter.value))
+    : [];
+});
 
 watch([attributeKey, values, filterOperator], () => {
   showErrors.value = false;

--- a/app/javascript/dashboard/components-next/filter/operators.js
+++ b/app/javascript/dashboard/components-next/filter/operators.js
@@ -112,6 +112,13 @@ export function useOperators() {
   ]);
 
   /** @type {import('vue').ComputedRef<Array<Operator>>} */
+  const containmentWithPresenceOperators = computed(() => [
+    ...containmentOperators.value,
+    operators.value[FILTER_OPS.IS_PRESENT],
+    operators.value[FILTER_OPS.IS_NOT_PRESENT],
+  ]);
+
+  /** @type {import('vue').ComputedRef<Array<Operator>>} */
   const comparisonOperators = computed(() => [
     operators.value[FILTER_OPS.EQUAL_TO],
     operators.value[FILTER_OPS.NOT_EQUAL_TO],
@@ -135,20 +142,13 @@ export function useOperators() {
    */
   const getOperatorTypes = key => {
     switch (key) {
-      case 'list':
-        return equalityOperators.value;
       case 'text':
-        return containmentOperators.value;
-      case 'number':
-        return equalityOperators.value;
-      case 'link':
-        return equalityOperators.value;
+        return containmentWithPresenceOperators.value;
       case 'date':
         return comparisonOperators.value;
-      case 'checkbox':
-        return equalityOperators.value;
+      // list, number, link and checkbox
       default:
-        return equalityOperators.value;
+        return presenceOperators.value;
     }
   };
 
@@ -157,6 +157,7 @@ export function useOperators() {
     equalityOperators,
     presenceOperators,
     containmentOperators,
+    containmentWithPresenceOperators,
     comparisonOperators,
     dateOperators,
     getOperatorTypes,

--- a/app/javascript/dashboard/components-next/filter/operators.spec.js
+++ b/app/javascript/dashboard/components-next/filter/operators.spec.js
@@ -1,0 +1,56 @@
+import { useOperators } from './operators';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: key => key }),
+}));
+
+describe('useOperators', () => {
+  const operatorValuesFor = attributeDisplayType =>
+    useOperators()
+      .getOperatorTypes(attributeDisplayType)
+      .map(operator => operator.value);
+
+  describe('getOperatorTypes', () => {
+    it.each(['list', 'number', 'link', 'checkbox', 'unknown'])(
+      'offers equality and presence operators for the %s type',
+      attributeDisplayType => {
+        expect(operatorValuesFor(attributeDisplayType)).toEqual([
+          'equal_to',
+          'not_equal_to',
+          'is_present',
+          'is_not_present',
+        ]);
+      }
+    );
+
+    it('offers containment and presence operators for the text type', () => {
+      expect(operatorValuesFor('text')).toEqual([
+        'equal_to',
+        'not_equal_to',
+        'contains',
+        'does_not_contain',
+        'is_present',
+        'is_not_present',
+      ]);
+    });
+
+    it('offers comparison operators for the date type', () => {
+      expect(operatorValuesFor('date')).toEqual([
+        'equal_to',
+        'not_equal_to',
+        'is_present',
+        'is_not_present',
+        'is_greater_than',
+        'is_less_than',
+      ]);
+    });
+  });
+
+  it('marks presence operators as not requiring an input', () => {
+    const { operators } = useOperators();
+
+    expect(operators.value.is_present.hasInput).toBe(false);
+    expect(operators.value.is_not_present.hasInput).toBe(false);
+    expect(operators.value.equal_to.hasInput).toBe(true);
+  });
+});

--- a/app/javascript/dashboard/components-next/filter/specs/ConditionRow.spec.js
+++ b/app/javascript/dashboard/components-next/filter/specs/ConditionRow.spec.js
@@ -1,0 +1,84 @@
+import { mount } from '@vue/test-utils';
+import ConditionRow from '../ConditionRow.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: key => key }),
+}));
+
+const operator = (value, hasInput) => ({
+  value,
+  label: value,
+  hasInput,
+  inputOverride: null,
+  icon: null,
+});
+
+const listFilterType = {
+  attributeKey: 'conversation_type',
+  value: 'conversation_type',
+  attributeName: 'Conversation type',
+  label: 'Conversation type',
+  inputType: 'searchSelect',
+  options: [{ id: 'platinum', name: 'platinum' }],
+  filterOperators: [
+    operator('equal_to', true),
+    operator('not_equal_to', true),
+    operator('is_present', false),
+    operator('is_not_present', false),
+  ],
+  attributeModel: 'customAttributes',
+};
+
+const mountConditionRow = props =>
+  mount(ConditionRow, {
+    props: {
+      filterTypes: [listFilterType],
+      attributeKey: 'conversation_type',
+      filterOperator: 'equal_to',
+      values: { id: 'platinum', name: 'platinum' },
+      ...props,
+    },
+    global: {
+      stubs: {
+        Button: true,
+        Input: true,
+        FilterSelect: true,
+        MultiSelect: true,
+        SingleSelect: true,
+      },
+    },
+  });
+
+describe('ConditionRow', () => {
+  it('clears the value when switching to an operator without input', async () => {
+    const wrapper = mountConditionRow();
+
+    await wrapper.setProps({ filterOperator: 'is_not_present' });
+
+    expect(wrapper.emitted('update:values').at(-1)).toEqual([[]]);
+  });
+
+  it('restores an empty value of the right shape when the input comes back', async () => {
+    const wrapper = mountConditionRow({ filterOperator: 'is_not_present' });
+
+    await wrapper.setProps({ filterOperator: 'equal_to' });
+
+    expect(wrapper.emitted('update:values').at(-1)).toEqual([{}]);
+  });
+
+  it('keeps the value when switching between operators that take input', async () => {
+    const wrapper = mountConditionRow();
+
+    await wrapper.setProps({ filterOperator: 'not_equal_to' });
+
+    expect(wrapper.emitted('update:values')).toBeUndefined();
+  });
+
+  it('hides the input for operators without input', async () => {
+    const wrapper = mountConditionRow({ filterOperator: 'is_present' });
+
+    expect(wrapper.findComponent({ name: 'SingleSelect' }).exists()).toBe(
+      false
+    );
+  });
+});

--- a/app/javascript/dashboard/helper/customViewsHelper.js
+++ b/app/javascript/dashboard/helper/customViewsHelper.js
@@ -129,6 +129,10 @@ export const getValuesForFilter = (filter, params) => {
 export const generateValuesForEditCustomViews = (filter, params) => {
   const { attribute_key, filter_operator, values } = filter;
   const { filterTypes, allCustomAttributes } = params;
+
+  // Presence operators have no input, so a saved folder holds no value to map back.
+  if (['is_present', 'is_not_present'].includes(filter_operator)) return [];
+
   const inputType = getInputType(attribute_key, filter_operator, filterTypes);
 
   if (inputType === undefined) {

--- a/app/javascript/dashboard/helper/specs/customViewsHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/customViewsHelper.spec.js
@@ -274,6 +274,24 @@ describe('customViewsHelper', () => {
       expect(generateValuesForEditCustomViews(filter, params)).toEqual('1');
     });
 
+    it.each(['is_present', 'is_not_present'])(
+      'should return an empty array for the %s operator',
+      filterOperator => {
+        const params = {
+          filterTypes: advancedFilterTypes,
+          allCustomAttributes: [
+            { attribute_key: 'text_attribute', attribute_display_type: 'text' },
+          ],
+        };
+        const filter = {
+          attribute_key: 'text_attribute',
+          filter_operator: filterOperator,
+          values: [],
+        };
+        expect(generateValuesForEditCustomViews(filter, params)).toEqual([]);
+      }
+    );
+
     it('returns contact name for contact filters when contact is available', () => {
       const filter = {
         attribute_key: 'contact_id',

--- a/app/services/filters/custom_attribute_filter_helper.rb
+++ b/app/services/filters/custom_attribute_filter_helper.rb
@@ -21,20 +21,18 @@ module Filters::CustomAttributeFilterHelper
 
   def build_custom_attr_query(query_hash, current_index)
     filter_operator_value = filter_operation(query_hash, current_index)
-    query_operator = query_hash[:query_operator]
+    data_type = attribute_data_type
     table_name = attribute_model == 'conversation_attribute' ? 'conversations' : 'contacts'
+    attribute_expression = data_type == 'text' ? "LOWER(#{table_name}.custom_attributes ->> ?)" : "(#{table_name}.custom_attributes ->> ?)"
 
-    query = if attribute_data_type == 'text'
-              ActiveRecord::Base.sanitize_sql_array(
-                ["LOWER(#{table_name}.custom_attributes ->> ?)::#{attribute_data_type} #{filter_operator_value} #{query_operator} ", @attribute_key]
-              )
-            else
-              ActiveRecord::Base.sanitize_sql_array(
-                ["(#{table_name}.custom_attributes ->> ?)::#{attribute_data_type} #{filter_operator_value} #{query_operator} ", @attribute_key]
-              )
-            end
+    condition = ActiveRecord::Base.sanitize_sql_array(
+      ["#{attribute_expression}::#{data_type} #{filter_operator_value}", @attribute_key]
+    )
+    condition += not_in_custom_attr_query(table_name, query_hash, data_type)
 
-    query + not_in_custom_attr_query(table_name, query_hash, attribute_data_type)
+    # The condition is wrapped so the optional `OR ... IS NULL` clause stays scoped to this attribute
+    # instead of spilling over the query operator that chains it to the next condition.
+    "(#{condition}) #{query_hash[:query_operator]} "
   end
 
   def custom_attribute(attribute_key, account, custom_attribute_type)

--- a/spec/services/contacts/filter_service_spec.rb
+++ b/spec/services/contacts/filter_service_spec.rb
@@ -408,6 +408,57 @@ describe Contacts::FilterService do
         expect(result[:contacts].pluck(:id)).to include(el_contact.id)
       end
 
+      it 'filters contacts where the custom attribute is present' do
+        params[:payload] = [
+          {
+            attribute_key: 'customer_type',
+            filter_operator: 'is_present',
+            values: [],
+            query_operator: nil
+          }.with_indifferent_access
+        ]
+
+        result = filter_service.new(account, first_user, params).perform
+
+        expect(result[:contacts].pluck(:id)).to contain_exactly(el_contact.id, cs_contact.id)
+      end
+
+      it 'filters contacts where the custom attribute is not present' do
+        params[:payload] = [
+          {
+            attribute_key: 'customer_type',
+            filter_operator: 'is_not_present',
+            values: [],
+            query_operator: nil
+          }.with_indifferent_access
+        ]
+
+        result = filter_service.new(account, first_user, params).perform
+
+        expect(result[:contacts].pluck(:id)).to contain_exactly(en_contact.id)
+      end
+
+      it 'keeps the null check scoped when not_equal_to is not the last condition' do
+        params[:payload] = [
+          {
+            attribute_key: 'customer_type',
+            filter_operator: 'not_equal_to',
+            values: ['platinum'],
+            query_operator: 'AND'
+          }.with_indifferent_access,
+          {
+            attribute_key: 'contact_additional_information',
+            filter_operator: 'equal_to',
+            values: ['test custom data'],
+            query_operator: nil
+          }.with_indifferent_access
+        ]
+
+        result = filter_service.new(account, first_user, params).perform
+
+        expect(result[:contacts].pluck(:id)).to contain_exactly(en_contact.id)
+      end
+
       it 'binds custom date comparison values as dates' do
         date_value = '2024-01-01'
         params[:payload] = [

--- a/spec/services/conversations/filter_service_frontend_alignment_spec.rb
+++ b/spec/services/conversations/filter_service_frontend_alignment_spec.rb
@@ -250,5 +250,67 @@ describe Conversations::FilterService do
         expect(result[:conversations].length).to be 1
       end
     end
+
+    context 'with a not_equal_to filter on a custom attribute' do
+      let!(:platinum_conversation) do
+        create(:conversation, account: account, inbox: inbox, assignee: user_1, status: 'open',
+                              custom_attributes: { conversation_type: 'platinum' })
+      end
+      let!(:silver_conversation) do
+        create(:conversation, account: account, inbox: inbox, assignee: user_1, status: 'open',
+                              custom_attributes: { conversation_type: 'silver' })
+      end
+      let!(:resolved_conversation_without_attribute) do
+        create(:conversation, account: account, inbox: inbox, assignee: user_1, status: 'resolved')
+      end
+
+      it 'builds a valid query when the custom attribute is not the last condition' do
+        params[:payload] = [
+          {
+            attribute_key: 'conversation_type',
+            filter_operator: 'not_equal_to',
+            values: ['platinum'],
+            custom_attribute_type: '',
+            query_operator: 'AND'
+          }.with_indifferent_access,
+          {
+            attribute_key: 'status',
+            filter_operator: 'equal_to',
+            values: ['open'],
+            query_operator: nil
+          }.with_indifferent_access
+        ]
+
+        result = described_class.new(params, user_1, account).perform
+
+        conversation_ids = result[:conversations].pluck(:id)
+        expect(conversation_ids).to contain_exactly(silver_conversation.id)
+        expect(conversation_ids).not_to include(platinum_conversation.id)
+      end
+
+      it 'keeps the null check scoped to the custom attribute condition' do
+        params[:payload] = [
+          {
+            attribute_key: 'status',
+            filter_operator: 'equal_to',
+            values: ['open'],
+            query_operator: 'AND'
+          }.with_indifferent_access,
+          {
+            attribute_key: 'conversation_type',
+            filter_operator: 'not_equal_to',
+            values: ['platinum'],
+            custom_attribute_type: '',
+            query_operator: nil
+          }.with_indifferent_access
+        ]
+
+        result = described_class.new(params, user_1, account).perform
+
+        conversation_ids = result[:conversations].pluck(:id)
+        expect(conversation_ids).to contain_exactly(silver_conversation.id)
+        expect(conversation_ids).not_to include(resolved_conversation_without_attribute.id)
+      end
+    end
   end
 end

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -485,6 +485,62 @@ describe Conversations::FilterService do
         result = filter_service.new(params, user_1, account).perform
         expect(result[:conversations].length).to be 1
       end
+
+      it 'filters conversations where the custom attribute is present' do
+        params[:payload] = [
+          {
+            attribute_key: 'conversation_type',
+            filter_operator: 'is_present',
+            values: [],
+            query_operator: nil,
+            custom_attribute_type: ''
+          }.with_indifferent_access
+        ]
+
+        result = filter_service.new(params, user_1, account).perform
+
+        expect(result[:conversations].pluck(:id)).to contain_exactly(en_conversation_2.id, user_2_assigned_conversation.id)
+      end
+
+      it 'filters conversations where the custom attribute is not present' do
+        params[:payload] = [
+          {
+            attribute_key: 'conversation_type',
+            filter_operator: 'is_not_present',
+            values: [],
+            query_operator: nil,
+            custom_attribute_type: ''
+          }.with_indifferent_access
+        ]
+
+        result = filter_service.new(params, user_1, account).perform
+
+        conversation_ids = result[:conversations].pluck(:id)
+        expect(conversation_ids).to include(en_conversation_1.id)
+        expect(conversation_ids).not_to include(en_conversation_2.id, user_2_assigned_conversation.id)
+      end
+
+      it 'filters conversations where the custom attribute is not present combined with another condition' do
+        params[:payload] = [
+          {
+            attribute_key: 'conversation_type',
+            filter_operator: 'is_not_present',
+            values: [],
+            query_operator: 'AND',
+            custom_attribute_type: ''
+          }.with_indifferent_access,
+          {
+            attribute_key: 'status',
+            filter_operator: 'equal_to',
+            values: ['pending'],
+            query_operator: nil
+          }.with_indifferent_access
+        ]
+
+        result = filter_service.new(params, user_1, account).perform
+
+        expect(result[:conversations].pluck(:id)).to contain_exactly(en_conversation_1.id)
+      end
     end
   end
 


### PR DESCRIPTION
Agora dá para filtrar conversas e contatos por **ausência de um atributo customizado** direto na tela de filtros. Antes, um atributo customizado só oferecia "Igual a" e "Diferente", com um valor por condição, então não havia como pedir "conversas que ainda não foram tabuladas" sem encadear uma condição por valor possível. O seletor passa a oferecer "Está presente" e "Não está presente" para todo tipo de atributo customizado (texto, número, lista, link e checkbox; data já tinha).

Junto vai a correção de um bug de SQL que atingia qualquer condição de atributo customizado com "Diferente":

- quando a condição **não** era a última da cadeia, o filtro retornava erro 500 (`PG::SyntaxError: syntax error at or near "OR"`);
- quando era a última, ela ainda vazava registros com o atributo nulo por cima das outras condições, porque `A AND B OR C` no Postgres é `(A AND B) OR C`.

O mesmo bug está reportado no upstream em chatwoot/chatwoot#10377 (PR chatwoot/chatwoot#10378, aberto e nunca mergeado), então o arquivo continua vindo quebrado a cada sync com o `develop`.

## Closes

n/a

## How to test

1. Em Configurações → Atributos customizados, crie um atributo de conversa do tipo lista (ex.: `TABULAÇÃO`) com algumas opções.
2. Preencha o atributo em duas ou três conversas e deixe o resto sem ele.
3. Na tela de conversas, abra os filtros: escolha o atributo e confira que aparecem "Está presente" e "Não está presente"; ao escolher um deles o campo de valor some.
4. Aplique "Não está presente" → só as conversas sem o atributo.
5. Monte uma cadeia com a condição do atributo **antes** de outra (ex.: `TABULAÇÃO Diferente de X` **E** `Status Igual a Aberta`) → antes dava erro 500, agora filtra corretamente.
6. Inverta a ordem (status primeiro, atributo por último) → o resultado tem que ser o mesmo, sem conversas resolvidas aparecendo.
7. Salve o filtro como pasta, recarregue, aplique a pasta e reabra o modal de edição dela → antes o editor quebrava com `TypeError` para atributo de texto.
8. Repita o passo 4 na tela de contatos com um atributo de contato.

## What changed

- `app/services/filters/custom_attribute_filter_helper.rb`: a condição é montada, recebe o `OR ... IS NULL` quando for `not_equal_to`, é envolvida em parênteses e só então ganha o `AND`/`OR` que a liga à próxima.
- `components-next/filter/operators.js`: `getOperatorTypes` passa a incluir os operadores de presença. Ele alimenta apenas `buildAttributesFilterTypes`, então nenhum atributo padrão muda e não há risco de `InvalidOperator` contra `lib/filters/filter_keys.yml`.
- `components-next/filter/ConditionRow.vue`: ao trocar para um operador sem input, o valor é limpo (senão fica pendurado no modelo e é gravado na pasta salva); ao voltar para um operador com input, é reinicializado no formato do campo.
- `helper/customViewsHelper.js`: `generateValuesForEditCustomViews` devolve vazio para os operadores de presença, que não têm valor para mapear de volta.
- Specs de regressão no `Conversations::FilterService` (inclusive o arquivo de alinhamento frontend/backend) e no `Contacts::FilterService`, mais testes de frontend para os operadores, o `ConditionRow` e o helper de custom views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/352)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom attribute filters for presence, absence, equality, and “not equal” conditions.
  * Corrected filtering when custom attribute conditions are combined with other contact or conversation filters.
  * Filter values now clear or reset appropriately when switching between operators that do or do not require input.
  * Prevented saved presence filters from displaying incorrect values when editing custom views.

* **Tests**
  * Added coverage for filter behavior across contacts, conversations, and custom views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->