### PR TITLE
fix(whatsapp): revoke messages deleted while the send is still in flight

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -25,15 +25,22 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
   def destroy
     authorize message, :destroy?
 
-    ActiveRecord::Base.transaction do
+    # Locking the row serializes this with an outgoing send still in flight, and the `source_id` is
+    # read inside that critical section: either we get there first and the send revokes the message
+    # when it persists the `source_id`, or the send got there first and we see the real `source_id`
+    # here. Exactly one of the two sides enqueues the provider delete.
+    reached_provider = false
+    message.with_lock do
       message.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: { deleted: true })
       message.attachments.destroy_all
+      reached_provider = message.source_id.present?
     end
-    delete_message_on_channel
+    delete_message_on_channel if reached_provider
   end
 
   def retry
     return if message.blank?
+    return head :unprocessable_entity if message.deleted?
     return head :unprocessable_entity unless message.failed? && (message.outgoing? || message.template?)
 
     service = Messages::StatusUpdateService.new(message, 'sent')
@@ -101,11 +108,8 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
   def delete_message_on_channel
     return unless @conversation.inbox.channel.respond_to?(:delete_message)
-    return if message.source_id.blank?
 
-    @conversation.inbox.channel.delete_message(message, conversation: @conversation)
-  rescue StandardError => e
-    Rails.logger.error "Failed to delete message on channel: #{e.message}"
+    ::Messages::DeleteOnChannelJob.perform_later(message.id)
   end
 
   def edit_message_on_channel(new_content, original_content)

--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -40,12 +40,8 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
   def retry
     return if message.blank?
-    return head :unprocessable_entity if message.deleted?
-    return head :unprocessable_entity unless message.failed? && (message.outgoing? || message.template?)
+    return head :unprocessable_entity unless reset_message_for_retry
 
-    service = Messages::StatusUpdateService.new(message, 'sent')
-    service.perform
-    message.update!(content_attributes: {}, source_id: nil)
     ::SendReplyJob.perform_later(message.id)
   rescue StandardError => e
     render_could_not_create_error(e.message)
@@ -110,6 +106,22 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
     return unless @conversation.inbox.channel.respond_to?(:delete_message)
 
     ::Messages::DeleteOnChannelJob.perform_later(message.id)
+  end
+
+  # The `deleted?` check and the `content_attributes` reset have to share the lock the DELETE endpoint
+  # takes: a delete landing between them would have its flag wiped by the reset, and the job `retry`
+  # queues afterwards would then push the "deleted" placeholder to the contact.
+  def reset_message_for_retry
+    retryable = false
+    message.with_lock do
+      next if message.deleted?
+      next unless message.failed? && (message.outgoing? || message.template?)
+
+      retryable = true
+      Messages::StatusUpdateService.new(message, 'sent').perform
+      message.update!(content_attributes: {}, source_id: nil)
+    end
+    retryable
   end
 
   def edit_message_on_channel(new_content, original_content)

--- a/app/jobs/messages/delete_on_channel_job.rb
+++ b/app/jobs/messages/delete_on_channel_job.rb
@@ -1,0 +1,25 @@
+# Revokes a message on the provider after the agent deleted it in Chatwoot.
+#
+# Runs async with retries because the deletion has two triggers that are mutually exclusive by
+# construction (both take the message row lock): the DELETE endpoint, when the message already has a
+# `source_id`, and `Whatsapp::SendOnWhatsappService`, when the message got deleted while the send was
+# still in flight and the `source_id` only landed afterwards. A provider hiccup on either path would
+# otherwise leave the message deleted in Chatwoot and alive on WhatsApp.
+class Messages::DeleteOnChannelJob < ApplicationJob
+  queue_as :high
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 5 do |job, error|
+    Rails.logger.error "Failed to delete message #{job.arguments.first} on channel: #{error.message}"
+  end
+
+  def perform(message_id)
+    message = Message.find_by(id: message_id)
+    return if message.blank?
+
+    channel = message.inbox.channel
+    return unless channel.respond_to?(:delete_message)
+    return if message.source_id.blank?
+
+    channel.delete_message(message, conversation: message.conversation)
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -253,6 +253,23 @@ class Message < ApplicationRecord
     ActiveModel::Type::Boolean.new.cast(content_attributes['is_reaction']) == true
   end
 
+  def deleted?
+    ActiveModel::Type::Boolean.new.cast(content_attributes['deleted']) == true
+  end
+
+  # `content_attributes` is a single JSON column, so writing any of its store accessors from a stale
+  # object rewrites the whole hash and drops flags another request set in the meantime — e.g. `deleted`,
+  # written by the DELETE endpoint while an outgoing message was still in flight on the provider.
+  # Reloads the row under FOR UPDATE before writing, which also serializes with those concurrent writers.
+  def update_under_lock!(attributes)
+    # `lock!` refuses to run on a record with unsaved changes. Flush what the caller left dirty — a
+    # plain `update!` would have written it too — but never the stale `content_attributes` hash, since
+    # writing it back is the very thing this method exists to prevent.
+    restore_attributes(['content_attributes']) if content_attributes_changed?
+    save! if changed?
+    with_lock { update!(attributes) }
+  end
+
   def valid_first_reply?
     return false unless human_response? && !private?
     return false if reaction?

--- a/app/services/base/send_on_channel_service.rb
+++ b/app/services/base/send_on_channel_service.rb
@@ -47,7 +47,9 @@ class Base::SendOnChannelService
     # private notes aren't send to the channels
     # we should also avoid the case of message loops, when outgoing messages are created from channel
     # voice_call bubbles are call status indicators, not deliverable messages
-    message.private? || outgoing_message_originated_from_channel? || message.content_type == 'voice_call'
+    # a message deleted before the job got to run must not reach the contact — its content is already
+    # the "deleted" placeholder and its attachments are gone, so sending it would leak the placeholder
+    message.private? || outgoing_message_originated_from_channel? || message.content_type == 'voice_call' || message.deleted?
   end
 
   def validate_target_channel

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -141,7 +141,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       @message_content = { text: @message.outgoing_content }.merge(reply_context)
       merge_mention_data
     else
-      @message.update!(is_unsupported: true)
+      @message.update_under_lock!(is_unsupported: true)
       return
     end
 
@@ -751,7 +751,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     return unless timestamp
 
     external_created_at = baileys_extract_message_timestamp(timestamp)
-    @message.update!(external_created_at: external_created_at)
+    @message.update_under_lock!(external_created_at: external_created_at)
   end
 
   def build_participant_contacts(participants, inbox, skip_avatars: false)

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -14,7 +14,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
       return channel.provider == 'baileys' ? send_baileys_session_message : send_session_message
     end
 
-    message.update!(status: :failed, external_error: I18n.t('errors.whatsapp.message_outside_messaging_window'))
+    message.update_under_lock!(status: :failed, external_error: I18n.t('errors.whatsapp.message_outside_messaging_window'))
   end
 
   def send_template_message
@@ -27,7 +27,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     name, namespace, lang_code, processed_parameters = processor.call
 
     if name.blank?
-      message.update!(status: :failed, external_error: 'Template not found or invalid template name')
+      message.update_under_lock!(status: :failed, external_error: 'Template not found or invalid template name')
       return
     end
 
@@ -37,12 +37,18 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
                                          lang_code: lang_code,
                                          parameters: processed_parameters
                                        }, message)
-    message.update!(source_id: message_id) if message_id.present?
+    persist_source_id(message_id)
   end
 
   def send_baileys_session_message
     validate_announcement_mode!
-    with_baileys_channel_lock_on_outgoing_message(channel.id) { send_session_message }
+    with_baileys_channel_lock_on_outgoing_message(channel.id) do
+      # Waiting on the channel lock can take minutes when the inbox is busy, so re-check right before
+      # hitting the provider: the agent may have deleted the message while this job was queued.
+      next if deleted_in_database?
+
+      send_session_message
+    end
   end
 
   def validate_announcement_mode!
@@ -50,7 +56,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     return unless conversation.contact.additional_attributes&.dig('announce') == true
     return if inbox_admin_in_group?
 
-    message.update!(status: :failed, external_error: 'Only administrators are allowed to send messages in this group')
+    message.update_under_lock!(status: :failed, external_error: 'Only administrators are allowed to send messages in this group')
     raise StandardError, 'Only admins can send messages in this group'
   end
 
@@ -72,7 +78,27 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
 
   def send_session_message
     message_id = channel.send_message(recipient_id, message)
-    message.update!(source_id: message_id) if message_id.present?
+    persist_source_id(message_id)
+  end
+
+  # The message may have been deleted while this send was in flight — the DELETE endpoint found no
+  # `source_id` to revoke and skipped the provider, so it is on us to revoke it now that we have one.
+  # The flag is read from the same locked read the write took, which is also where the DELETE endpoint
+  # reads the `source_id`: whoever enters that critical section first leaves the revocation to the
+  # other side, so the provider delete is enqueued exactly once.
+  def persist_source_id(message_id)
+    return if message_id.blank?
+
+    message.update_under_lock!(source_id: message_id)
+    return unless message.deleted?
+
+    ::Messages::DeleteOnChannelJob.perform_later(message.id)
+  end
+
+  # Reads the flag straight from the database: a full `message.reload` would also drop the cached
+  # conversation/inbox/channel chain this service leans on.
+  def deleted_in_database?
+    Message.select(:id, :content_attributes).find_by(id: message.id)&.deleted?
   end
 
   def recipient_id

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -324,23 +324,19 @@ RSpec.describe 'Conversation Messages API', type: :request do
                       )
                       .to_return(status: 200, body: '{}')
 
-        delete "/api/v1/accounts/#{account.id}/conversations/#{whatsapp_conversation.display_id}/messages/#{message_with_source.id}",
-               headers: agent.create_new_auth_token,
-               as: :json
+        perform_enqueued_jobs(only: Messages::DeleteOnChannelJob) do
+          delete "/api/v1/accounts/#{account.id}/conversations/#{whatsapp_conversation.display_id}/messages/#{message_with_source.id}",
+                 headers: agent.create_new_auth_token,
+                 as: :json
+        end
 
         expect(response).to have_http_status(:success)
         expect(message_with_source.reload.deleted).to be true
         expect(delete_stub).to have_been_requested
       end
 
-      it 'does not fail when channel delete_message raises an error' do
-        stub_request(:delete, delete_request_path)
-          .to_return(status: 400, body: 'Provider error')
-
-        stub_request(:post, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
-          .to_return(status: 200)
-
-        allow(Rails.logger).to receive(:error)
+      it 'does not fail when the provider is unreachable' do
+        stub_request(:delete, delete_request_path).to_return(status: 400, body: 'Provider error')
 
         delete "/api/v1/accounts/#{account.id}/conversations/#{whatsapp_conversation.display_id}/messages/#{message_with_source.id}",
                headers: agent.create_new_auth_token,
@@ -348,15 +344,19 @@ RSpec.describe 'Conversation Messages API', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(message_with_source.reload.deleted).to be true
+        # the deletion is retried by the job, so a provider hiccup never fails the agent's request
+        expect(Messages::DeleteOnChannelJob).to have_been_enqueued.with(message_with_source.id)
       end
 
       it 'skips channel deletion when message has no source_id' do
         message_without_source = create(:message, account: account, conversation: whatsapp_conversation, inbox: whatsapp_inbox, source_id: nil)
         delete_stub = stub_request(:delete, delete_request_path).to_return(status: 200, body: '{}')
 
-        delete "/api/v1/accounts/#{account.id}/conversations/#{whatsapp_conversation.display_id}/messages/#{message_without_source.id}",
-               headers: agent.create_new_auth_token,
-               as: :json
+        perform_enqueued_jobs(only: Messages::DeleteOnChannelJob) do
+          delete "/api/v1/accounts/#{account.id}/conversations/#{whatsapp_conversation.display_id}/messages/#{message_without_source.id}",
+                 headers: agent.create_new_auth_token,
+                 as: :json
+        end
 
         expect(response).to have_http_status(:success)
         expect(message_without_source.reload.deleted).to be true
@@ -475,6 +475,22 @@ RSpec.describe 'Conversation Messages API', type: :request do
              as: :json
 
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns unprocessable_entity for deleted messages' do
+        deleted_failed = create(:message, account: account, message_type: :outgoing, status: :failed,
+                                          content: 'This message was deleted', content_attributes: { deleted: true })
+        create(:inbox_member, inbox: deleted_failed.conversation.inbox, user: agent)
+        clear_enqueued_jobs # drop the SendReplyJob queued by the message creation itself
+
+        post "/api/v1/accounts/#{account.id}/conversations/#{deleted_failed.conversation.display_id}/messages/#{deleted_failed.id}/retry",
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        # retrying would wipe content_attributes and push the placeholder to the contact
+        expect(deleted_failed.reload).to be_deleted
+        expect(SendReplyJob).not_to have_been_enqueued.with(deleted_failed.id)
       end
     end
 

--- a/spec/jobs/messages/delete_on_channel_job_spec.rb
+++ b/spec/jobs/messages/delete_on_channel_job_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Messages::DeleteOnChannelJob do
+  subject(:job) { described_class.perform_later(message.id) }
+
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_whatsapp, provider: 'baileys', account: account, validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:contact) { create(:contact, account: account, phone_number: '+551187654321', identifier: nil) }
+  let(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '551187654321') }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:message) do
+    create(:message, message_type: :outgoing, conversation: conversation, account: account, inbox: inbox, source_id: 'wa_msg_123')
+  end
+  let(:delete_url) { "#{channel.provider_config['provider_url']}/connections/#{channel.phone_number}/messages" }
+
+  it 'enqueues the job on the high queue' do
+    expect { job }.to have_enqueued_job(described_class).on_queue('high')
+  end
+
+  it 'deletes the message on the channel' do
+    delete_stub = stub_request(:delete, delete_url)
+                  .with { |req| JSON.parse(req.body)['key'].slice('id', 'fromMe') == { 'id' => 'wa_msg_123', 'fromMe' => true } }
+                  .to_return(status: 200, body: '{}')
+
+    described_class.perform_now(message.id)
+
+    expect(delete_stub).to have_been_requested
+  end
+
+  it 'does nothing when the message no longer exists' do
+    delete_stub = stub_request(:delete, delete_url).to_return(status: 200, body: '{}')
+
+    expect { described_class.perform_now(message.id + 1000) }.not_to raise_error
+    expect(delete_stub).not_to have_been_requested
+  end
+
+  it 'does nothing when the message has no source_id' do
+    delete_stub = stub_request(:delete, delete_url).to_return(status: 200, body: '{}')
+    message.update!(source_id: nil)
+
+    described_class.perform_now(message.id)
+
+    expect(delete_stub).not_to have_been_requested
+  end
+
+  it 'does nothing when the channel does not support deletion' do
+    web_widget_message = create(:message, message_type: :outgoing, source_id: 'some_id')
+    delete_stub = stub_request(:delete, delete_url).to_return(status: 200, body: '{}')
+
+    described_class.perform_now(web_widget_message.id)
+
+    expect(delete_stub).not_to have_been_requested
+  end
+
+  it 'retries when the provider fails, so a hiccup does not leave the message alive on WhatsApp' do
+    stub_request(:delete, delete_url).to_return(status: 500, body: 'provider down')
+    # the provider service marks the connection as closed and tries to reconnect on any error
+    stub_request(:post, "#{channel.provider_config['provider_url']}/connections/#{channel.phone_number}").to_return(status: 200)
+
+    expect { described_class.perform_now(message.id) }.to have_enqueued_job(described_class).with(message.id)
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -935,6 +935,53 @@ RSpec.describe Message do
     end
   end
 
+  describe '#deleted?' do
+    let(:conversation) { create(:conversation) }
+
+    it 'returns true when the agent deleted the message' do
+      message = create(:message, conversation: conversation, content_attributes: { deleted: true })
+      expect(message.deleted?).to be true
+    end
+
+    it 'returns false for regular messages' do
+      message = create(:message, conversation: conversation, content_attributes: {})
+      expect(message.deleted?).to be false
+    end
+  end
+
+  describe '#update_under_lock!' do
+    let(:conversation) { create(:conversation) }
+    let(:message) { create(:message, conversation: conversation, content_attributes: {}) }
+
+    it 'keeps content_attributes another request wrote while this object went stale' do
+      described_class.find(message.id).update!(content_attributes: { deleted: true })
+
+      message.update_under_lock!(external_error: 'boom')
+
+      expect(message.reload.content_attributes).to include('deleted' => true, 'external_error' => 'boom')
+    end
+
+    it 'persists changes the caller left unsaved, as a plain update! would' do
+      # the template path mutates additional_attributes in place and relies on the source_id write to save it
+      message.additional_attributes = { 'format_version' => 'legacy' }
+
+      message.update_under_lock!(source_id: 'wamid.123')
+
+      expect(message.reload.source_id).to eq('wamid.123')
+      expect(message.additional_attributes).to include('format_version' => 'legacy')
+    end
+
+    it 'drops stale in-memory content_attributes rather than clobbering the row' do
+      described_class.find(message.id).update!(content_attributes: { deleted: true })
+      message.external_error = 'written from a stale copy'
+
+      message.update_under_lock!(source_id: 'wamid.123')
+
+      expect(message.reload).to be_deleted
+      expect(message.external_error).to be_nil
+    end
+  end
+
   describe '.hide_removed_reactions' do
     let(:conversation) { create(:conversation) }
 

--- a/spec/services/whatsapp/delete_vs_send_race_spec.rb
+++ b/spec/services/whatsapp/delete_vs_send_race_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+# Regression: deleting a message while it is still on its way to the provider used to leave it alive
+# on WhatsApp and deleted in Chatwoot — the DELETE endpoint found no `source_id` to revoke and the
+# send job went on to deliver the "deleted" placeholder to the contact.
+RSpec.describe 'WhatsApp delete vs send race', type: :request do
+  let(:account) { create(:account) }
+  let(:agent) { create(:user, account: account, role: :administrator) }
+  let(:channel) { create(:channel_whatsapp, provider: 'baileys', account: account, validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:contact) { create(:contact, account: account, phone_number: '+551187654321', identifier: nil) }
+  let(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '551187654321') }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  let(:send_url) { "#{channel.provider_config['provider_url']}/connections/#{channel.phone_number}/send-message" }
+  let(:delete_url) { "#{channel.provider_config['provider_url']}/connections/#{channel.phone_number}/messages" }
+  let(:send_success_body) { { data: { key: { id: 'wa_msg_123' }, messageTimestamp: 1_700_000_000 } }.to_json }
+
+  let!(:delete_stub) { stub_request(:delete, delete_url).to_return(status: 200, body: '{}') }
+  let!(:send_stub) do
+    stub_request(:post, send_url).to_return(status: 200, body: send_success_body, headers: { 'content-type' => 'application/json' })
+  end
+
+  before do
+    create(:inbox_member, inbox: inbox, user: agent)
+    # keeps the 24h messaging window open
+    create(:message, message_type: :incoming, content: 'oi', conversation: conversation, account: account, inbox: inbox)
+  end
+
+  def delete_message_via_api(message)
+    delete "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/messages/#{message.id}",
+           headers: agent.create_new_auth_token,
+           as: :json
+  end
+
+  context 'when the agent deletes before SendReplyJob runs' do
+    it 'aborts the send instead of delivering the deleted placeholder' do
+      message = create(:message, message_type: :outgoing, content: 'segredo que não era pra vazar',
+                                 conversation: conversation, account: account, inbox: inbox, source_id: nil)
+      expect(SendReplyJob).to have_been_enqueued.with(message.id)
+
+      delete_message_via_api(message)
+      expect(response).to have_http_status(:success)
+
+      SendReplyJob.perform_now(message.id)
+
+      expect(send_stub).not_to have_been_requested
+      expect(delete_stub).not_to have_been_requested
+      expect(message.reload).to be_deleted
+      expect(message.source_id).to be_nil
+    end
+  end
+
+  context 'when the agent deletes while the job waits on the baileys channel lock' do
+    it 're-checks under the lock and aborts the send' do
+      message = create(:message, message_type: :outgoing, content: 'esperando o lock',
+                                 conversation: conversation, account: account, inbox: inbox, source_id: nil)
+      service = Whatsapp::SendOnWhatsappService.new(message: message)
+      # another request deletes it while this job sits in the queue, so `message` here is stale
+      Message.find(message.id).update!(content: 'This message was deleted', content_attributes: { deleted: true })
+
+      service.perform
+
+      expect(send_stub).not_to have_been_requested
+      expect(message.reload).to be_deleted
+    end
+  end
+
+  context 'when the agent deletes while the send is in flight on the provider' do
+    it 'keeps the message deleted and revokes it on the provider once the source_id lands' do
+      message = create(:message, message_type: :outgoing, content: 'mensagem em voo',
+                                 conversation: conversation, account: account, inbox: inbox, source_id: nil)
+
+      stub_request(:post, send_url).to_return do |_req|
+        # the agent hits "Delete" while the provider is still processing the send
+        delete_message_via_api(message)
+        { status: 200, body: send_success_body, headers: { 'content-type' => 'application/json' } }
+      end
+
+      perform_enqueued_jobs(only: Messages::DeleteOnChannelJob) do
+        Whatsapp::SendOnWhatsappService.new(message: message).perform
+      end
+
+      message.reload
+      expect(message).to be_deleted
+      expect(message.content).to eq('This message was deleted')
+      expect(message.source_id).to eq('wa_msg_123')
+      # exactly once: the DELETE endpoint saw no source_id under the lock and left the revocation to us
+      expect(delete_stub).to have_been_requested.once
+    end
+  end
+
+  context 'when the message carries an attachment' do
+    it 'aborts the send that was scheduled with the 2s attachment delay' do
+      message = build(:message, message_type: :outgoing, content: 'legenda da foto',
+                                conversation: conversation, account: account, inbox: inbox, source_id: nil)
+      attachment = message.attachments.new(account_id: account.id, file_type: :image)
+      attachment.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
+      message.save!
+      expect(SendReplyJob).to have_been_enqueued.with(message.id).at(a_value_within(5.seconds).of(2.seconds.from_now))
+
+      delete_message_via_api(message)
+      expect(response).to have_http_status(:success)
+      expect(message.reload.attachments).to be_empty
+
+      SendReplyJob.perform_now(message.id)
+
+      expect(send_stub).not_to have_been_requested
+      expect(delete_stub).not_to have_been_requested
+    end
+  end
+end


### PR DESCRIPTION
## Problema

Deletar uma mensagem numa inbox WhatsApp enquanto o envio ao provedor ainda não terminou deixava a mensagem **viva no WhatsApp e apagada no Chatwoot**. Três janelas, todas reproduzidas antes do fix:

| Cenário | Comportamento anterior |
| --- | --- |
| Delete antes do `SendReplyJob` rodar | O contato recebia literalmente `{"text": "This message was deleted"}`; nenhum DELETE no provedor |
| Delete durante o `POST /send-message` | Mensagem entregue com o conteúdo original, flag `deleted` **perdida**, bolha voltava a aparecer como mensagem normal com o texto do placeholder |
| Mensagem com anexo (2s de espera garantidos) | Anexo destruído, WhatsApp recebia o placeholder como texto |

Causas: `delete_message_on_channel` desistia com `return if message.source_id.blank?`, o `source_id` só era gravado depois do POST retornar, nada no caminho de envio checava a flag `deleted`, e `content_attributes` (uma coluna JSON única) era regravado a partir de objetos stale, apagando a flag.

A janela é grande na prática: `wait: 2.seconds` para anexos, lock de canal do Baileys esperando até 130s, timeout de 120s no POST e retentativas de job por `Net::ReadTimeout`.

## Correção

- **Nenhum canal envia mensagem deletada** — `Base::SendOnChannelService#invalid_message?` passa a recusá-las, com re-check tardio dentro do lock do Baileys.
- **Reconciliação pós-envio** — o `source_id` é gravado sob lock e, se a mensagem virou deletada nesse meio-tempo, a revogação é enfileirada. O `destroy` lê o `source_id` dentro da mesma seção crítica, então exatamente um dos dois lados enfileira o delete.
- **`Messages::DeleteOnChannelJob`** — a revogação no provedor virou job com 5 tentativas e backoff, em vez de falhar em silêncio com um log.
- **`Message#update_under_lock!`** — escritas em accessors de `content_attributes` recarregam a linha sob `FOR UPDATE`, eliminando o lost update da flag `deleted`.
- **`retry` bloqueado em mensagem deletada** — antes limparia `content_attributes` e reenviaria o placeholder.

Resultado: deletar durante a janela **cancela** o envio; deletar depois **revoga** no provedor. Nada muda no frontend.

## Mudanças de comportamento

- A revogação no provedor é assíncrona: a resposta do DELETE volta antes de a revogação sair.
- `POST .../messages/:id/retry` responde 422 para mensagem deletada.

## Testes

- `spec/services/whatsapp/delete_vs_send_race_spec.rb` (novo): os 3 cenários de regressão + re-check sob o lock do canal.
- `spec/jobs/messages/delete_on_channel_job_spec.rb` (novo): guards e retry no erro do provedor.
- `message_spec.rb`: `deleted?` e os invariantes do `update_under_lock!`.
- `messages_controller_spec.rb`: ajustado para o delete assíncrono + `retry` bloqueado.

3980 exemplos em `spec/services`, `spec/jobs`, `spec/models` e `spec/controllers/.../conversations`: só falha `whatsapp_cloud_service_spec.rb:187` (audio/opus), pré-existente e confirmada num checkout limpo de `main`. Rubocop limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/353)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message deletion reliability during simultaneous sending.
  - Deleted messages are no longer sent or retried.
  - Channel deletions now complete asynchronously with automatic retries for provider failures.
  - Prevented concurrent updates from overwriting message changes.
  - Ensured provider messages are revoked exactly once when deletion occurs during sending.
- **Tests**
  - Added coverage for deletion, retry behavior, unsupported channels, and send/delete race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->