### PR TITLE
feat(internal-chat): make the layout usable on small screens

### DIFF
--- a/app/javascript/dashboard/components-next/sidebar/MobileSidebarLauncher.vue
+++ b/app/javascript/dashboard/components-next/sidebar/MobileSidebarLauncher.vue
@@ -26,6 +26,14 @@ const isConversationRoute = computed(() => {
     'conversation_through_unattended',
     'conversation_through_participating',
     'inbox_view_conversation',
+    // Internal chat mirrors the conversation layout on small screens: an open
+    // channel is a screen of its own with a back button, so the launcher would
+    // just float over the composer. It stays visible on internal_chat_home,
+    // which is the list screen and the way back to the global menu.
+    'internal_chat_channel',
+    'internal_chat_dm',
+    'internal_chat_thread',
+    'internal_chat_drafts',
   ];
   return CONVERSATION_ROUTES.includes(route.name);
 });

--- a/app/javascript/dashboard/composables/spec/useInternalChatSidebar.spec.js
+++ b/app/javascript/dashboard/composables/spec/useInternalChatSidebar.spec.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+
+const WIDTH_KEY = 'internal_chat_sidebar_width';
+const COLLAPSED_KEY = 'internal_chat_sidebar_collapsed';
+
+// This project's jsdom environment ships without localStorage, so the suite
+// provides its own in-memory one.
+const createLocalStorageStub = () => {
+  const store = new Map();
+  return {
+    getItem: key => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: key => store.delete(key),
+    clear: () => store.clear(),
+  };
+};
+
+// The composable keeps its state at module scope so the layout and the sidebar
+// share it, which means each example needs a fresh module instance.
+const loadComposable = async () => {
+  vi.resetModules();
+  return import('../useInternalChatSidebar');
+};
+
+describe('useInternalChatSidebar', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createLocalStorageStub());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts expanded at the default width when nothing is stored', async () => {
+    const { useInternalChatSidebar, DEFAULT_WIDTH } = await loadComposable();
+    const { sidebarWidth, isCollapsed } = useInternalChatSidebar();
+
+    expect(sidebarWidth.value).toBe(DEFAULT_WIDTH);
+    expect(isCollapsed.value).toBe(false);
+  });
+
+  it('restores the stored width and collapsed state', async () => {
+    window.localStorage.setItem(WIDTH_KEY, '320');
+    window.localStorage.setItem(COLLAPSED_KEY, 'true');
+
+    const { useInternalChatSidebar } = await loadComposable();
+    const { sidebarWidth, isCollapsed } = useInternalChatSidebar();
+
+    expect(sidebarWidth.value).toBe(320);
+    expect(isCollapsed.value).toBe(true);
+  });
+
+  it('clamps a stored width that falls outside the allowed range', async () => {
+    window.localStorage.setItem(WIDTH_KEY, '9999');
+
+    const { useInternalChatSidebar, MAX_WIDTH } = await loadComposable();
+
+    expect(useInternalChatSidebar().sidebarWidth.value).toBe(MAX_WIDTH);
+  });
+
+  it('clamps drag updates between the drag floor and the max width', async () => {
+    const { useInternalChatSidebar, MAX_WIDTH, DRAG_FLOOR } =
+      await loadComposable();
+    const { sidebarWidth, setSidebarWidth } = useInternalChatSidebar();
+
+    setSidebarWidth(10);
+    expect(sidebarWidth.value).toBe(DRAG_FLOOR);
+
+    setSidebarWidth(10000);
+    expect(sidebarWidth.value).toBe(MAX_WIDTH);
+  });
+
+  it('collapses when the drag is released below the collapse threshold', async () => {
+    const { useInternalChatSidebar, COLLAPSE_AT, DEFAULT_WIDTH } =
+      await loadComposable();
+    const { sidebarWidth, isCollapsed, setSidebarWidth, commitWidth } =
+      useInternalChatSidebar();
+
+    setSidebarWidth(COLLAPSE_AT - 1);
+    commitWidth();
+
+    expect(isCollapsed.value).toBe(true);
+    expect(window.localStorage.getItem(COLLAPSED_KEY)).toBe('true');
+    // The width is kept for the next expand instead of being persisted tiny.
+    expect(sidebarWidth.value).toBe(DEFAULT_WIDTH);
+  });
+
+  it('snaps to the minimum width when released between the threshold and the minimum', async () => {
+    const { useInternalChatSidebar, COLLAPSE_AT, MIN_WIDTH } =
+      await loadComposable();
+    const { sidebarWidth, isCollapsed, setSidebarWidth, commitWidth } =
+      useInternalChatSidebar();
+
+    setSidebarWidth(COLLAPSE_AT + 1);
+    commitWidth();
+
+    expect(isCollapsed.value).toBe(false);
+    expect(sidebarWidth.value).toBe(MIN_WIDTH);
+    expect(window.localStorage.getItem(WIDTH_KEY)).toBe(String(MIN_WIDTH));
+  });
+
+  it('persists a width committed inside the allowed range', async () => {
+    const { useInternalChatSidebar } = await loadComposable();
+    const { sidebarWidth, setSidebarWidth, commitWidth } =
+      useInternalChatSidebar();
+
+    setSidebarWidth(300);
+    commitWidth();
+
+    expect(sidebarWidth.value).toBe(300);
+    expect(window.localStorage.getItem(WIDTH_KEY)).toBe('300');
+  });
+
+  it('restores the last committed width when expanding again', async () => {
+    const { useInternalChatSidebar } = await loadComposable();
+    const { sidebarWidth, isCollapsed, setSidebarWidth, commitWidth, expand } =
+      useInternalChatSidebar();
+
+    setSidebarWidth(360);
+    commitWidth();
+    setSidebarWidth(100);
+    commitWidth();
+    expect(isCollapsed.value).toBe(true);
+
+    expand();
+
+    expect(isCollapsed.value).toBe(false);
+    expect(sidebarWidth.value).toBe(360);
+    expect(window.localStorage.getItem(COLLAPSED_KEY)).toBe('false');
+  });
+
+  it('shares state between callers', async () => {
+    const { useInternalChatSidebar } = await loadComposable();
+    const layout = useInternalChatSidebar();
+    const sidebar = useInternalChatSidebar();
+
+    sidebar.collapse();
+
+    expect(layout.isCollapsed.value).toBe(true);
+  });
+});

--- a/app/javascript/dashboard/composables/useInternalChatSidebar.js
+++ b/app/javascript/dashboard/composables/useInternalChatSidebar.js
@@ -1,0 +1,76 @@
+import { ref } from 'vue';
+
+const WIDTH_STORAGE_KEY = 'internal_chat_sidebar_width';
+const COLLAPSED_STORAGE_KEY = 'internal_chat_sidebar_collapsed';
+
+export const DEFAULT_WIDTH = 256;
+export const MIN_WIDTH = 200;
+export const MAX_WIDTH = 420;
+// Releasing the drag below this collapses the sidebar. Between this and
+// MIN_WIDTH it snaps back to MIN_WIDTH instead.
+export const COLLAPSE_AT = 140;
+// Visual floor while dragging, so the sidebar can shrink past MIN_WIDTH and
+// show that letting go there collapses it.
+export const DRAG_FLOOR = 96;
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const readStoredWidth = () => {
+  const stored = Number(window.localStorage.getItem(WIDTH_STORAGE_KEY));
+  if (!stored) return DEFAULT_WIDTH;
+  return clamp(stored, MIN_WIDTH, MAX_WIDTH);
+};
+
+// Module scope so the layout (expand rail) and the sidebar itself share one
+// state without threading it through props, same idea as the shared popover
+// state in components-next/sidebar/provider.js.
+const sidebarWidth = ref(readStoredWidth());
+const isCollapsed = ref(
+  window.localStorage.getItem(COLLAPSED_STORAGE_KEY) === 'true'
+);
+// Width to restore when the sidebar is expanded again.
+let expandedWidth = sidebarWidth.value;
+
+export function useInternalChatSidebar() {
+  const setSidebarWidth = width => {
+    sidebarWidth.value = clamp(width, DRAG_FLOOR, MAX_WIDTH);
+  };
+
+  const expand = () => {
+    isCollapsed.value = false;
+    sidebarWidth.value = expandedWidth;
+    window.localStorage.setItem(COLLAPSED_STORAGE_KEY, 'false');
+  };
+
+  const collapse = () => {
+    isCollapsed.value = true;
+    sidebarWidth.value = expandedWidth;
+    window.localStorage.setItem(COLLAPSED_STORAGE_KEY, 'true');
+  };
+
+  const toggleCollapsed = () => {
+    if (isCollapsed.value) expand();
+    else collapse();
+  };
+
+  // Called when a drag ends: either collapse, or settle on a usable width.
+  const commitWidth = () => {
+    if (sidebarWidth.value < COLLAPSE_AT) {
+      collapse();
+      return;
+    }
+    expandedWidth = clamp(sidebarWidth.value, MIN_WIDTH, MAX_WIDTH);
+    sidebarWidth.value = expandedWidth;
+    window.localStorage.setItem(WIDTH_STORAGE_KEY, String(expandedWidth));
+  };
+
+  return {
+    sidebarWidth,
+    isCollapsed,
+    setSidebarWidth,
+    commitWidth,
+    expand,
+    collapse,
+    toggleCollapsed,
+  };
+}

--- a/app/javascript/dashboard/i18n/locale/en/internalChat.json
+++ b/app/javascript/dashboard/i18n/locale/en/internalChat.json
@@ -4,7 +4,18 @@
     "BACK": "Back to channels",
     "SIDEBAR": {
       "EXPAND": "Expand channel list",
-      "COLLAPSE": "Collapse channel list"
+      "COLLAPSE": "Collapse channel list",
+      "RESIZE": "Resize channel list"
+    },
+    "REACTIONS": {
+      "THUMBS_UP": "Thumbs up",
+      "HEART": "Heart",
+      "JOY": "Laughing",
+      "SURPRISED": "Surprised",
+      "SAD": "Sad",
+      "PRAY": "Thank you",
+      "FIRE": "Fire",
+      "PARTY": "Celebrate"
     },
     "CHANNELS": "Channels",
     "DIRECT_MESSAGES": "Direct Messages",

--- a/app/javascript/dashboard/i18n/locale/en/internalChat.json
+++ b/app/javascript/dashboard/i18n/locale/en/internalChat.json
@@ -1,6 +1,11 @@
 {
   "INTERNAL_CHAT": {
     "TITLE": "Internal Chat",
+    "BACK": "Back to channels",
+    "SIDEBAR": {
+      "EXPAND": "Expand channel list",
+      "COLLAPSE": "Collapse channel list"
+    },
     "CHANNELS": "Channels",
     "DIRECT_MESSAGES": "Direct Messages",
     "FAVORITES": "Favorites",
@@ -75,6 +80,7 @@
       "BOLD": "Bold",
       "ITALIC": "Italic",
       "CODE": "Code",
+      "MORE_ACTIONS": "More actions",
       "COPY_LINK": "Copy link",
       "LINK_COPIED": "Message link copied to clipboard",
       "DELETED_USER": "Deleted User"

--- a/app/javascript/dashboard/i18n/locale/pt_BR/internalChat.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/internalChat.json
@@ -1,6 +1,11 @@
 {
   "INTERNAL_CHAT": {
     "TITLE": "Chat Interno",
+    "BACK": "Voltar para os canais",
+    "SIDEBAR": {
+      "EXPAND": "Expandir lista de canais",
+      "COLLAPSE": "Recolher lista de canais"
+    },
     "CHANNELS": "Canais",
     "DIRECT_MESSAGES": "Mensagens Diretas",
     "FAVORITES": "Favoritos",
@@ -75,6 +80,7 @@
       "BOLD": "Negrito",
       "ITALIC": "It\u00e1lico",
       "CODE": "C\u00f3digo",
+      "MORE_ACTIONS": "Mais ações",
       "COPY_LINK": "Copiar link",
       "LINK_COPIED": "Link da mensagem copiado",
       "DELETED_USER": "Usuário excluído"

--- a/app/javascript/dashboard/i18n/locale/pt_BR/internalChat.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/internalChat.json
@@ -4,7 +4,18 @@
     "BACK": "Voltar para os canais",
     "SIDEBAR": {
       "EXPAND": "Expandir lista de canais",
-      "COLLAPSE": "Recolher lista de canais"
+      "COLLAPSE": "Recolher lista de canais",
+      "RESIZE": "Redimensionar lista de canais"
+    },
+    "REACTIONS": {
+      "THUMBS_UP": "Joinha",
+      "HEART": "Coração",
+      "JOY": "Risada",
+      "SURPRISED": "Surpreso",
+      "SAD": "Triste",
+      "PRAY": "Obrigado",
+      "FIRE": "Fogo",
+      "PARTY": "Comemorar"
     },
     "CHANNELS": "Canais",
     "DIRECT_MESSAGES": "Mensagens Diretas",

--- a/app/javascript/dashboard/routes/dashboard/internalChat/ChannelHeader.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/ChannelHeader.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRoute, useRouter } from 'vue-router';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import { useMapGetter } from 'dashboard/composables/store';
@@ -19,8 +20,19 @@ const props = defineProps({
 const emit = defineEmits(['settings', 'scrollToPinned']);
 
 const { t } = useI18n();
+const route = useRoute();
+const router = useRouter();
 
 const currentUser = useMapGetter('getCurrentUser');
+
+// Below md the channel list and the channel are separate screens, so the header
+// needs a way back to the list.
+function goBackToChannels() {
+  router.push({
+    name: 'internal_chat_home',
+    params: { accountId: route.params.accountId },
+  });
+}
 
 const isDM = computed(() => {
   return props.channel.channel_type === 'dm';
@@ -90,6 +102,15 @@ const pinnedCountLabel = computed(() => {
     <div
       class="flex h-[53px] items-center gap-3 border-b border-n-slate-5 bg-n-solid-2 px-4"
     >
+      <button
+        type="button"
+        class="flex flex-shrink-0 items-center justify-center rounded-lg p-1.5 text-n-slate-11 transition-colors hover:bg-n-alpha-2 hover:text-n-slate-12 md:hidden"
+        :title="t('INTERNAL_CHAT.BACK')"
+        :aria-label="t('INTERNAL_CHAT.BACK')"
+        @click="goBackToChannels"
+      >
+        <Icon icon="i-lucide-arrow-left" class="size-4" />
+      </button>
       <div class="flex items-center gap-2 min-w-0 flex-1">
         <Avatar
           v-if="isDM"

--- a/app/javascript/dashboard/routes/dashboard/internalChat/ChannelSettings.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/ChannelSettings.vue
@@ -5,6 +5,8 @@ import { useStore } from 'dashboard/composables/store';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import InternalChatChannelsAPI from 'dashboard/api/internalChatChannels';
+import { vOnClickOutside } from '@vueuse/components';
+import { useBreakpoints, breakpointsTailwind } from '@vueuse/core';
 
 const props = defineProps({
   channel: { type: Object, required: true },
@@ -27,6 +29,15 @@ const emit = defineEmits([
 
 const store = useStore();
 const { t } = useI18n();
+
+const breakpoints = useBreakpoints(breakpointsTailwind);
+const isBelowLarge = breakpoints.smaller('lg');
+
+// The panel only overlays the conversation below lg. As a desktop column it has
+// to stay put when the user clicks a message next to it.
+const closeOnClickOutside = () => {
+  if (isBelowLarge.value) emit('close');
+};
 
 const isDM = computed(() => props.channel.channel_type === 'dm');
 const isPrivate = computed(
@@ -154,7 +165,15 @@ defineExpose({ fetchMembers });
 </script>
 
 <template>
-  <div class="flex h-full w-80 flex-col border-l border-n-slate-5 bg-n-solid-1">
+  <div
+    v-on-click-outside="[
+      closeOnClickOutside,
+      {
+        ignore: ['dialog', '[data-popover-content]', '[data-popover-backdrop]'],
+      },
+    ]"
+    class="fixed inset-y-0 z-40 flex w-full max-w-sm flex-col bg-n-solid-1 shadow-lg border-n-slate-5 ltr:right-0 ltr:border-l rtl:left-0 rtl:border-r lg:static lg:h-full lg:w-80 lg:max-w-none lg:shadow-none"
+  >
     <div
       class="flex h-[53px] items-center justify-between border-b border-n-slate-5 px-4"
     >

--- a/app/javascript/dashboard/routes/dashboard/internalChat/ChannelSidebar.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/ChannelSidebar.vue
@@ -12,6 +12,12 @@ import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
 import Draggable from 'vuedraggable';
 import { emitter } from 'shared/helpers/mitt';
 import ProFeatureNudge from './ProFeatureNudge.vue';
+import {
+  useBreakpoints,
+  breakpointsTailwind,
+  useEventListener,
+} from '@vueuse/core';
+import { useInternalChatSidebar } from 'dashboard/composables/useInternalChatSidebar';
 
 const store = useStore();
 const { t } = useI18n();
@@ -20,6 +26,52 @@ const router = useRouter();
 
 const currentRole = useMapGetter('getCurrentRole');
 const isAdmin = computed(() => currentRole.value === 'administrator');
+const isRTL = useMapGetter('accounts/isRTL');
+
+const breakpoints = useBreakpoints(breakpointsTailwind);
+const isSmallScreen = breakpoints.smaller('md');
+
+const { sidebarWidth, setSidebarWidth, commitWidth, collapse } =
+  useInternalChatSidebar();
+
+// Resize handle, mirroring components-next/sidebar/Sidebar.vue
+const isResizing = ref(false);
+const startX = ref(0);
+const startWidth = ref(0);
+
+const getClientX = event =>
+  event.touches ? event.touches[0].clientX : event.clientX;
+
+const onResizeStart = event => {
+  isResizing.value = true;
+  startX.value = getClientX(event);
+  startWidth.value = sidebarWidth.value;
+  Object.assign(document.body.style, {
+    cursor: 'col-resize',
+    userSelect: 'none',
+  });
+  event.preventDefault();
+};
+
+const onResizeMove = event => {
+  if (!isResizing.value) return;
+  const delta = isRTL.value
+    ? startX.value - getClientX(event)
+    : getClientX(event) - startX.value;
+  setSidebarWidth(startWidth.value + delta);
+};
+
+const onResizeEnd = () => {
+  if (!isResizing.value) return;
+  isResizing.value = false;
+  Object.assign(document.body.style, { cursor: '', userSelect: '' });
+  commitWidth();
+};
+
+useEventListener(document, 'mousemove', onResizeMove);
+useEventListener(document, 'mouseup', onResizeEnd);
+useEventListener(document, 'touchmove', onResizeMove, { passive: false });
+useEventListener(document, 'touchend', onResizeEnd);
 
 const searchQuery = ref('');
 let searchDebounceTimer = null;
@@ -435,11 +487,25 @@ async function handleDeleteCategory() {
 </script>
 
 <template>
-  <div class="flex h-full w-64 flex-col border-r border-n-slate-5 bg-n-solid-2">
+  <div
+    class="relative h-full w-full flex-col border-r border-n-slate-5 bg-n-solid-2 md:w-auto md:flex-shrink-0"
+    :style="isSmallScreen ? undefined : { width: `${sidebarWidth}px` }"
+  >
     <div class="px-3 pt-3 pb-1">
-      <h1 class="mb-2 text-base font-semibold text-n-slate-12">
-        {{ t('INTERNAL_CHAT.TITLE') }}
-      </h1>
+      <div class="mb-2 flex items-center justify-between gap-2">
+        <h1 class="min-w-0 truncate text-base font-semibold text-n-slate-12">
+          {{ t('INTERNAL_CHAT.TITLE') }}
+        </h1>
+        <button
+          type="button"
+          class="hidden flex-shrink-0 items-center justify-center rounded p-1 text-n-slate-11 transition-colors hover:bg-n-alpha-2 hover:text-n-slate-12 md:flex"
+          :title="t('INTERNAL_CHAT.SIDEBAR.COLLAPSE')"
+          :aria-label="t('INTERNAL_CHAT.SIDEBAR.COLLAPSE')"
+          @click="collapse"
+        >
+          <Icon icon="i-lucide-panel-left-close" class="size-4" />
+        </button>
+      </div>
       <div
         class="flex h-7 items-center gap-1.5 rounded-lg bg-n-alpha-1 px-2 py-1"
       >
@@ -750,7 +816,7 @@ async function handleDeleteCategory() {
           </span>
           <button
             v-if="isAdmin"
-            class="text-n-slate-9 opacity-0 transition-opacity hover:text-n-ruby-11 group-hover/cat:opacity-100"
+            class="text-n-slate-9 transition-opacity hover:text-n-ruby-11 md:opacity-0 md:group-hover/cat:opacity-100"
             @click.stop="confirmDeleteCategory(category.id)"
           >
             <Icon icon="i-lucide-trash-2" class="size-3" />
@@ -759,7 +825,7 @@ async function handleDeleteCategory() {
         <div v-show="!isSectionCollapsed(`category-${category.id}`)">
           <Draggable
             :list="getCategoryChannelList(category.id)"
-            :disabled="!isAdmin"
+            :disabled="!isAdmin || isSmallScreen"
             group="channels"
             item-key="id"
             ghost-class="opacity-30"
@@ -855,7 +921,7 @@ async function handleDeleteCategory() {
         <div v-show="!isSectionCollapsed('channels')">
           <Draggable
             :list="localUncategorizedChannels"
-            :disabled="!isAdmin"
+            :disabled="!isAdmin || isSmallScreen"
             group="channels"
             item-key="id"
             ghost-class="opacity-30"
@@ -1088,6 +1154,19 @@ async function handleDeleteCategory() {
           {{ t('INTERNAL_CHAT.NO_CHANNELS') }}
         </p>
       </div>
+    </div>
+
+    <!-- Resize handle (desktop only) -->
+    <div
+      class="absolute top-0 z-40 hidden h-full w-1 cursor-col-resize group ltr:right-0 rtl:left-0 md:block"
+      @mousedown="onResizeStart"
+      @touchstart="onResizeStart"
+      @dblclick="collapse"
+    >
+      <div
+        class="absolute top-0 h-full w-px bg-transparent transition-colors group-hover:bg-n-brand ltr:right-0 rtl:left-0"
+        :class="{ 'bg-n-brand': isResizing }"
+      />
     </div>
 
     <CreateChannelModal ref="createChannelModalRef" />

--- a/app/javascript/dashboard/routes/dashboard/internalChat/ChannelSidebar.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/ChannelSidebar.vue
@@ -17,7 +17,11 @@ import {
   breakpointsTailwind,
   useEventListener,
 } from '@vueuse/core';
-import { useInternalChatSidebar } from 'dashboard/composables/useInternalChatSidebar';
+import {
+  useInternalChatSidebar,
+  MIN_WIDTH,
+  MAX_WIDTH,
+} from 'dashboard/composables/useInternalChatSidebar';
 
 const store = useStore();
 const { t } = useI18n();
@@ -33,6 +37,14 @@ const isSmallScreen = breakpoints.smaller('md');
 
 const { sidebarWidth, setSidebarWidth, commitWidth, collapse } =
   useInternalChatSidebar();
+
+// Arrow keys on the focused handle, so resizing isn't pointer-only.
+const KEYBOARD_STEP = 16;
+
+const nudgeWidth = delta => {
+  setSidebarWidth(sidebarWidth.value + (isRTL.value ? -delta : delta));
+  commitWidth();
+};
 
 // Resize handle, mirroring components-next/sidebar/Sidebar.vue
 const isResizing = ref(false);
@@ -488,7 +500,7 @@ async function handleDeleteCategory() {
 
 <template>
   <div
-    class="relative h-full w-full flex-col border-r border-n-slate-5 bg-n-solid-2 md:w-auto md:flex-shrink-0"
+    class="relative flex h-full w-full flex-col border-r border-n-slate-5 bg-n-solid-2 md:w-auto md:flex-shrink-0"
     :style="isSmallScreen ? undefined : { width: `${sidebarWidth}px` }"
   >
     <div class="px-3 pt-3 pb-1">
@@ -1159,9 +1171,20 @@ async function handleDeleteCategory() {
     <!-- Resize handle (desktop only) -->
     <div
       class="absolute top-0 z-40 hidden h-full w-1 cursor-col-resize group ltr:right-0 rtl:left-0 md:block"
+      role="separator"
+      aria-orientation="vertical"
+      tabindex="0"
+      :aria-label="t('INTERNAL_CHAT.SIDEBAR.RESIZE')"
+      :aria-valuenow="sidebarWidth"
+      :aria-valuemin="MIN_WIDTH"
+      :aria-valuemax="MAX_WIDTH"
       @mousedown="onResizeStart"
       @touchstart="onResizeStart"
       @dblclick="collapse"
+      @keydown.left.prevent="nudgeWidth(-KEYBOARD_STEP)"
+      @keydown.right.prevent="nudgeWidth(KEYBOARD_STEP)"
+      @keydown.enter.prevent="collapse"
+      @keydown.space.prevent="collapse"
     >
       <div
         class="absolute top-0 h-full w-px bg-transparent transition-colors group-hover:bg-n-brand ltr:right-0 rtl:left-0"

--- a/app/javascript/dashboard/routes/dashboard/internalChat/ChannelView.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/ChannelView.vue
@@ -23,6 +23,7 @@ import ChannelSettings from './ChannelSettings.vue';
 import EditMembersModal from './EditMembersModal.vue';
 import ProFeatureNudge from './ProFeatureNudge.vue';
 import { useInternalChatPro } from 'dashboard/composables/useInternalChatPro';
+import { useBreakpoints, breakpointsTailwind } from '@vueuse/core';
 
 const props = defineProps({
   channelId: {
@@ -35,6 +36,9 @@ const store = useStore();
 const { t } = useI18n();
 const route = useRoute();
 const router = useRouter();
+
+const breakpoints = useBreakpoints(breakpointsTailwind);
+const isBelowLarge = breakpoints.smaller('lg');
 
 const typingUsers = computed(() => {
   return (
@@ -53,8 +57,11 @@ const proNudgeRef = ref(null);
 const proNudgeFeature = ref('polls');
 const { pollsEnabled } = useInternalChatPro();
 const editingMessage = ref(null);
+// Below lg the settings panel covers the conversation, so a stored "open" from
+// a desktop session must not be what greets you when you open a channel here.
 const showSettings = ref(
-  localStorage.getItem('internal_chat_settings_open') === 'true'
+  !isBelowLarge.value &&
+    localStorage.getItem('internal_chat_settings_open') === 'true'
 );
 const isLoadingMore = ref(false);
 const isViewingHistory = ref(false);

--- a/app/javascript/dashboard/routes/dashboard/internalChat/DraftsList.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/DraftsList.vue
@@ -23,6 +23,14 @@ const uiFlags = computed(() => {
   return store.getters['internalChat/drafts/getUIFlags'];
 });
 
+// Below md the channel list and this view are separate screens.
+function goBackToChannels() {
+  router.push({
+    name: 'internal_chat_home',
+    params: { accountId: accountId.value },
+  });
+}
+
 function timeSince(dateString) {
   const date = new Date(dateString);
   const now = new Date();
@@ -107,6 +115,15 @@ onMounted(() => {
     <div
       class="flex h-[53px] items-center border-b border-n-slate-5 bg-n-solid-2 px-4"
     >
+      <button
+        type="button"
+        class="mr-1 flex flex-shrink-0 items-center justify-center rounded-lg p-1.5 text-n-slate-11 transition-colors hover:bg-n-alpha-2 hover:text-n-slate-12 md:hidden"
+        :title="t('INTERNAL_CHAT.BACK')"
+        :aria-label="t('INTERNAL_CHAT.BACK')"
+        @click="goBackToChannels"
+      >
+        <Icon icon="i-lucide-arrow-left" class="size-4" />
+      </button>
       <Icon icon="i-lucide-file-edit" class="mr-2 size-5 text-n-slate-11" />
       <h2 class="text-sm font-semibold text-n-slate-12">
         {{ t('INTERNAL_CHAT.DRAFT.TITLE') }}

--- a/app/javascript/dashboard/routes/dashboard/internalChat/EmojiReactionPicker.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/EmojiReactionPicker.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 import { vOnClickOutside } from '@vueuse/components';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
+import { QUICK_EMOJIS, findOwnReaction } from './reactions';
 
 const props = defineProps({
   reactions: {
@@ -16,17 +17,6 @@ const props = defineProps({
 
 const emit = defineEmits(['select', 'remove', 'close']);
 
-const QUICK_EMOJIS = [
-  { emoji: '\uD83D\uDC4D', label: 'thumbs up' },
-  { emoji: '\u2764\uFE0F', label: 'heart' },
-  { emoji: '\uD83D\uDE02', label: 'joy' },
-  { emoji: '\uD83D\uDE2E', label: 'surprised' },
-  { emoji: '\uD83D\uDE22', label: 'sad' },
-  { emoji: '\uD83D\uDE4F', label: 'pray' },
-  { emoji: '\uD83D\uDD25', label: 'fire' },
-  { emoji: '\uD83C\uDF89', label: 'party' },
-];
-
 const isOpen = ref(false);
 
 function toggle() {
@@ -34,8 +24,10 @@ function toggle() {
 }
 
 function selectEmoji(emoji) {
-  const existingReaction = props.reactions.find(
-    r => r.emoji === emoji && r.user_id === props.currentUserId
+  const existingReaction = findOwnReaction(
+    props.reactions,
+    emoji,
+    props.currentUserId
   );
   if (existingReaction) {
     emit('remove', existingReaction.id);

--- a/app/javascript/dashboard/routes/dashboard/internalChat/EmojiReactionPicker.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/EmojiReactionPicker.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { vOnClickOutside } from '@vueuse/components';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import { QUICK_EMOJIS, findOwnReaction } from './reactions';
@@ -16,6 +17,8 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['select', 'remove', 'close']);
+
+const { t } = useI18n();
 
 const isOpen = ref(false);
 
@@ -58,9 +61,9 @@ function close() {
     >
       <button
         v-for="item in QUICK_EMOJIS"
-        :key="item.label"
+        :key="item.labelKey"
         class="flex items-center justify-center rounded p-1 text-base hover:bg-n-alpha-2"
-        :title="item.label"
+        :title="t(`INTERNAL_CHAT.REACTIONS.${item.labelKey}`)"
         @click="selectEmoji(item.emoji)"
       >
         {{ item.emoji }}

--- a/app/javascript/dashboard/routes/dashboard/internalChat/InternalChatLayout.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/InternalChatLayout.vue
@@ -7,10 +7,13 @@ import { useAlert } from 'dashboard/composables';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import ChannelSidebar from './ChannelSidebar.vue';
 import ChannelView from './ChannelView.vue';
+import { useInternalChatSidebar } from 'dashboard/composables/useInternalChatSidebar';
 
 const store = useStore();
 const route = useRoute();
 const { t } = useI18n();
+
+const { isCollapsed, expand } = useInternalChatSidebar();
 
 const activeChannelId = computed(() => {
   return Number(route.params.channelId) || null;
@@ -23,6 +26,22 @@ const activeChannel = computed(() => {
 
 const isDraftsRoute = computed(() => {
   return route.name === 'internal_chat_drafts';
+});
+
+const hasActivePane = computed(() => {
+  return Boolean(
+    (activeChannelId.value && activeChannel.value) || isDraftsRoute.value
+  );
+});
+
+// Below md the channel list is a screen of its own, so it gives way as soon as
+// a channel (or the drafts view) is open. On desktop both columns coexist and
+// the list only disappears when the user collapses it.
+const sidebarDisplayClass = computed(() => {
+  if (hasActivePane.value) {
+    return isCollapsed.value ? 'hidden' : 'hidden md:flex';
+  }
+  return isCollapsed.value ? 'flex md:hidden' : 'flex';
 });
 
 async function fetchChannels() {
@@ -46,8 +65,24 @@ onMounted(async () => {
 
 <template>
   <div class="flex h-full w-full">
-    <ChannelSidebar />
-    <div class="flex-1 min-w-0">
+    <ChannelSidebar :class="sidebarDisplayClass" />
+    <!-- Collapsed rail: lives here, and not in the channel header, so the list
+    can be reopened from the empty state and the drafts view too. -->
+    <div
+      v-if="isCollapsed"
+      class="hidden h-full w-9 flex-shrink-0 flex-col items-center border-r border-n-slate-5 bg-n-solid-2 pt-3 md:flex"
+    >
+      <button
+        type="button"
+        class="flex items-center justify-center rounded-lg p-1.5 text-n-slate-11 transition-colors hover:bg-n-alpha-2 hover:text-n-slate-12"
+        :title="t('INTERNAL_CHAT.SIDEBAR.EXPAND')"
+        :aria-label="t('INTERNAL_CHAT.SIDEBAR.EXPAND')"
+        @click="expand"
+      >
+        <Icon icon="i-lucide-panel-left-open" class="size-4" />
+      </button>
+    </div>
+    <div class="flex-1 min-w-0" :class="{ 'hidden md:block': !hasActivePane }">
       <ChannelView
         v-if="activeChannelId && activeChannel"
         :key="activeChannelId"

--- a/app/javascript/dashboard/routes/dashboard/internalChat/MessageBubble.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/MessageBubble.vue
@@ -11,8 +11,10 @@ import { useAlert } from 'dashboard/composables';
 import Avatar from 'dashboard/components-next/avatar/Avatar.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import Dialog from 'dashboard/components-next/dialog/Dialog.vue';
+import Popover from 'dashboard/components-next/popover/Popover.vue';
 import ReactionDisplay from './ReactionDisplay.vue';
 import EmojiReactionPicker from './EmojiReactionPicker.vue';
+import { QUICK_EMOJIS, findOwnReaction } from './reactions';
 import PollDisplay from './PollDisplay.vue';
 import ConversationPreviewCard from './ConversationPreviewCard.vue';
 
@@ -235,6 +237,17 @@ function handleRemoveReaction(reactionId) {
   });
 }
 
+// Used by the touch action menu, where the emoji row reacts inline instead of
+// nesting EmojiReactionPicker inside the popover.
+function toggleReaction(emoji) {
+  const own = findOwnReaction(reactions.value, emoji, props.currentUserId);
+  if (own) {
+    handleRemoveReaction(own.id);
+  } else {
+    handleAddReaction(emoji);
+  }
+}
+
 function handleVote(payload) {
   emit('vote', payload);
 }
@@ -401,7 +414,7 @@ function handleUnvote(payload) {
     </div>
     <div
       v-if="!isDeleted"
-      class="absolute right-2 top-0 flex items-center gap-0.5 rounded-md bg-n-solid-2 border border-n-slate-5 shadow-sm px-0.5 py-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-10"
+      class="absolute right-2 top-0 hidden items-center gap-0.5 rounded-md bg-n-solid-2 border border-n-slate-5 shadow-sm px-0.5 py-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity z-10 md:flex"
     >
       <EmojiReactionPicker
         :reactions="reactions"
@@ -453,6 +466,109 @@ function handleUnvote(payload) {
       >
         <Icon icon="i-lucide-trash-2" class="size-4" />
       </button>
+    </div>
+
+    <!-- Touch: the hover toolbar above is unreachable, so the same actions live
+    in a popover, which the design system renders as a modal below md. -->
+    <div v-if="!isDeleted" class="absolute right-2 top-0 z-10 md:hidden">
+      <Popover>
+        <template #default>
+          <button
+            type="button"
+            class="flex items-center justify-center rounded-md border border-n-slate-5 bg-n-solid-2 p-1.5 text-n-slate-11 shadow-sm"
+            :title="t('INTERNAL_CHAT.MESSAGE.MORE_ACTIONS')"
+            :aria-label="t('INTERNAL_CHAT.MESSAGE.MORE_ACTIONS')"
+          >
+            <Icon icon="i-lucide-ellipsis" class="size-4" />
+          </button>
+        </template>
+        <template #content="{ hide }">
+          <div class="flex min-w-56 flex-col p-1.5">
+            <div class="grid grid-cols-8 gap-0.5 border-b border-n-weak pb-1.5">
+              <button
+                v-for="item in QUICK_EMOJIS"
+                :key="item.label"
+                type="button"
+                class="flex min-w-0 items-center justify-center rounded p-1 text-base hover:bg-n-alpha-2"
+                :title="item.label"
+                :aria-label="item.label"
+                @click="
+                  hide();
+                  toggleReaction(item.emoji);
+                "
+              >
+                {{ item.emoji }}
+              </button>
+            </div>
+            <button
+              v-if="!inThread"
+              type="button"
+              class="flex items-center gap-2 rounded-lg px-2 py-2 text-sm text-n-slate-12 hover:bg-n-alpha-2"
+              @click="
+                hide();
+                handleReply();
+              "
+            >
+              <Icon icon="i-lucide-reply" class="size-4 text-n-slate-11" />
+              {{ t('INTERNAL_CHAT.MESSAGE.REPLY') }}
+            </button>
+            <button
+              type="button"
+              class="flex items-center gap-2 rounded-lg px-2 py-2 text-sm text-n-slate-12 hover:bg-n-alpha-2"
+              @click="
+                hide();
+                handleCopyLink();
+              "
+            >
+              <Icon icon="i-lucide-link" class="size-4 text-n-slate-11" />
+              {{ t('INTERNAL_CHAT.MESSAGE.COPY_LINK') }}
+            </button>
+            <button
+              v-if="canPin && !inThread"
+              type="button"
+              class="flex items-center gap-2 rounded-lg px-2 py-2 text-sm text-n-slate-12 hover:bg-n-alpha-2"
+              @click="
+                hide();
+                handlePin();
+              "
+            >
+              <Icon
+                :icon="isPinned ? 'i-lucide-pin-off' : 'i-lucide-pin'"
+                class="size-4 text-n-slate-11"
+              />
+              {{
+                isPinned
+                  ? t('INTERNAL_CHAT.PIN.UNPIN')
+                  : t('INTERNAL_CHAT.PIN.PIN')
+              }}
+            </button>
+            <button
+              v-if="canEdit"
+              type="button"
+              class="flex items-center gap-2 rounded-lg px-2 py-2 text-sm text-n-slate-12 hover:bg-n-alpha-2"
+              @click="
+                hide();
+                handleEdit();
+              "
+            >
+              <Icon icon="i-lucide-pencil" class="size-4 text-n-slate-11" />
+              {{ t('INTERNAL_CHAT.MESSAGE.EDIT') }}
+            </button>
+            <button
+              v-if="canDelete"
+              type="button"
+              class="flex items-center gap-2 rounded-lg px-2 py-2 text-sm text-n-ruby-11 hover:bg-n-ruby-3"
+              @click="
+                hide();
+                handleDelete();
+              "
+            >
+              <Icon icon="i-lucide-trash-2" class="size-4" />
+              {{ t('INTERNAL_CHAT.MESSAGE.DELETE') }}
+            </button>
+          </div>
+        </template>
+      </Popover>
     </div>
 
     <Dialog

--- a/app/javascript/dashboard/routes/dashboard/internalChat/MessageBubble.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/MessageBubble.vue
@@ -487,11 +487,11 @@ function handleUnvote(payload) {
             <div class="grid grid-cols-8 gap-0.5 border-b border-n-weak pb-1.5">
               <button
                 v-for="item in QUICK_EMOJIS"
-                :key="item.label"
+                :key="item.labelKey"
                 type="button"
                 class="flex min-w-0 items-center justify-center rounded p-1 text-base hover:bg-n-alpha-2"
-                :title="item.label"
-                :aria-label="item.label"
+                :title="t(`INTERNAL_CHAT.REACTIONS.${item.labelKey}`)"
+                :aria-label="t(`INTERNAL_CHAT.REACTIONS.${item.labelKey}`)"
                 @click="
                   hide();
                   toggleReaction(item.emoji);

--- a/app/javascript/dashboard/routes/dashboard/internalChat/MessageEditor.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/MessageEditor.vue
@@ -281,7 +281,7 @@ defineExpose({ focus, setContent, getContent });
       <div
         v-for="(file, index) in attachedFiles"
         :key="index"
-        class="flex w-60 items-center gap-1.5 rounded-md bg-n-slate-3 p-1.5"
+        class="flex w-full items-center gap-1.5 rounded-md bg-n-slate-3 p-1.5 sm:w-60"
       >
         <div class="flex-shrink-0">
           <img
@@ -343,15 +343,18 @@ defineExpose({ focus, setContent, getContent });
       />
       <button
         type="button"
-        class="flex-shrink-0 flex items-center justify-center rounded-lg p-1.5 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12 transition-colors"
+        class="flex-shrink-0 flex items-center justify-center rounded-lg p-2 md:p-1.5 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12 transition-colors"
         :title="t('INTERNAL_CHAT.MESSAGE.UPLOAD_FILE')"
         @click="openFilePicker"
       >
         <Icon icon="i-lucide-paperclip" class="size-4" />
       </button>
+      <!-- Mention shortcuts are hidden on the narrowest screens: they only type
+      a character the on-screen keyboard already offers, and the room they take
+      is worth more to the editor itself. -->
       <button
         type="button"
-        class="flex-shrink-0 flex items-center justify-center rounded-lg p-1.5 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12 transition-colors"
+        class="flex-shrink-0 hidden sm:flex items-center justify-center rounded-lg p-2 md:p-1.5 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12 transition-colors"
         :title="t('INTERNAL_CHAT.MESSAGE.MENTION_USER')"
         @click="insertMentionTrigger('@')"
       >
@@ -359,7 +362,7 @@ defineExpose({ focus, setContent, getContent });
       </button>
       <button
         type="button"
-        class="flex-shrink-0 flex items-center justify-center rounded-lg p-1.5 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12 transition-colors"
+        class="flex-shrink-0 hidden sm:flex items-center justify-center rounded-lg p-2 md:p-1.5 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12 transition-colors"
         :title="t('INTERNAL_CHAT.MESSAGE.MENTION_CONVERSATION')"
         @click="insertMentionTrigger('#')"
       >
@@ -368,7 +371,7 @@ defineExpose({ focus, setContent, getContent });
       <button
         v-if="showPoll"
         type="button"
-        class="flex-shrink-0 flex items-center justify-center rounded-lg p-1.5 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12 transition-colors"
+        class="flex-shrink-0 flex items-center justify-center rounded-lg p-2 md:p-1.5 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12 transition-colors"
         :title="t('INTERNAL_CHAT.POLL.CREATE')"
         @click="emit('create-poll')"
       >
@@ -376,7 +379,7 @@ defineExpose({ focus, setContent, getContent });
       </button>
       <button
         type="button"
-        class="flex-shrink-0 flex items-center justify-center rounded-lg p-1.5 transition-colors"
+        class="flex-shrink-0 flex items-center justify-center rounded-lg p-2 md:p-1.5 transition-colors"
         :class="
           canSend
             ? 'bg-n-brand text-white hover:opacity-90'

--- a/app/javascript/dashboard/routes/dashboard/internalChat/MessageEditor.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/MessageEditor.vue
@@ -35,7 +35,7 @@ const emit = defineEmits([
   'send',
   'typing',
   'draftUpdate',
-  'create-poll',
+  'createPoll',
   'cancelEdit',
 ]);
 
@@ -373,7 +373,7 @@ defineExpose({ focus, setContent, getContent });
         type="button"
         class="flex-shrink-0 flex items-center justify-center rounded-lg p-2 md:p-1.5 text-n-slate-11 hover:bg-n-alpha-2 hover:text-n-slate-12 transition-colors"
         :title="t('INTERNAL_CHAT.POLL.CREATE')"
-        @click="emit('create-poll')"
+        @click="emit('createPoll')"
       >
         <Icon icon="i-lucide-bar-chart-2" class="size-4" />
       </button>

--- a/app/javascript/dashboard/routes/dashboard/internalChat/ThreadPanel.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/ThreadPanel.vue
@@ -14,6 +14,8 @@ import Icon from 'dashboard/components-next/icon/Icon.vue';
 import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
 import MessageBubble from './MessageBubble.vue';
 import MessageEditor from './MessageEditor.vue';
+import { vOnClickOutside } from '@vueuse/components';
+import { useBreakpoints, breakpointsTailwind } from '@vueuse/core';
 
 const props = defineProps({
   channelId: {
@@ -42,6 +44,15 @@ const emit = defineEmits(['close']);
 
 const store = useStore();
 const { t } = useI18n();
+
+const breakpoints = useBreakpoints(breakpointsTailwind);
+const isBelowLarge = breakpoints.smaller('lg');
+
+// The panel only overlays the conversation below lg. As a desktop column it has
+// to stay put when the user clicks a message next to it.
+const closeOnClickOutside = () => {
+  if (isBelowLarge.value) emit('close');
+};
 
 const isLoading = ref(false);
 const isSending = ref(false);
@@ -302,7 +313,13 @@ onBeforeUnmount(() => {
 
 <template>
   <div
-    class="flex h-full w-96 flex-col overflow-x-clip border-l border-n-slate-5 bg-n-solid-1"
+    v-on-click-outside="[
+      closeOnClickOutside,
+      {
+        ignore: ['dialog', '[data-popover-content]', '[data-popover-backdrop]'],
+      },
+    ]"
+    class="fixed inset-y-0 z-40 flex w-full max-w-sm flex-col overflow-x-clip bg-n-solid-1 shadow-lg border-n-slate-5 ltr:right-0 ltr:border-l rtl:left-0 rtl:border-r lg:static lg:h-full lg:w-96 lg:max-w-none lg:shadow-none"
   >
     <div
       class="flex h-[53px] items-center justify-between border-b border-n-slate-5 px-4"

--- a/app/javascript/dashboard/routes/dashboard/internalChat/reactions.js
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/reactions.js
@@ -1,12 +1,14 @@
+// `labelKey` is resolved under INTERNAL_CHAT.REACTIONS by the components that
+// render these, since the label surfaces as a tooltip and an accessible label.
 export const QUICK_EMOJIS = [
-  { emoji: '👍', label: 'thumbs up' },
-  { emoji: '❤️', label: 'heart' },
-  { emoji: '😂', label: 'joy' },
-  { emoji: '😮', label: 'surprised' },
-  { emoji: '😢', label: 'sad' },
-  { emoji: '🙏', label: 'pray' },
-  { emoji: '🔥', label: 'fire' },
-  { emoji: '🎉', label: 'party' },
+  { emoji: '👍', labelKey: 'THUMBS_UP' },
+  { emoji: '❤️', labelKey: 'HEART' },
+  { emoji: '😂', labelKey: 'JOY' },
+  { emoji: '😮', labelKey: 'SURPRISED' },
+  { emoji: '😢', labelKey: 'SAD' },
+  { emoji: '🙏', labelKey: 'PRAY' },
+  { emoji: '🔥', labelKey: 'FIRE' },
+  { emoji: '🎉', labelKey: 'PARTY' },
 ];
 
 export const findOwnReaction = (reactions, emoji, userId) =>

--- a/app/javascript/dashboard/routes/dashboard/internalChat/reactions.js
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/reactions.js
@@ -1,0 +1,13 @@
+export const QUICK_EMOJIS = [
+  { emoji: '👍', label: 'thumbs up' },
+  { emoji: '❤️', label: 'heart' },
+  { emoji: '😂', label: 'joy' },
+  { emoji: '😮', label: 'surprised' },
+  { emoji: '😢', label: 'sad' },
+  { emoji: '🙏', label: 'pray' },
+  { emoji: '🔥', label: 'fire' },
+  { emoji: '🎉', label: 'party' },
+];
+
+export const findOwnReaction = (reactions, emoji, userId) =>
+  reactions.find(r => r.emoji === emoji && r.user_id === userId) || null;


### PR DESCRIPTION
O chat interno foi escrito desktop-only: a lista de canais tinha largura fixa de 256px e os painéis de thread (384px) e de configurações (320px) disputavam espaço com as mensagens. Num celular de 375px a coluna de mensagens colapsava a zero, e num tablet de 900px sobravam cerca de 60px. Esta PR torna a tela utilizável em telas pequenas e, de quebra, dá controle de espaço no desktop.

Abaixo de 768px a lista de canais e o canal aberto viram telas separadas, como a inbox já se comporta no mobile, com botão voltar no header do canal e na tela de rascunhos. Os painéis de thread e de configurações passam a sobrepor a conversa abaixo de 1024px em vez de espremê-la. No desktop a lista ganhou borda arrastável e botão de recolher, com a largura e o estado guardados no navegador. As ações de mensagem, que só apareciam no hover e eram inalcançáveis no toque, ganharam um menu próprio em telas pequenas.

## Closes

N/A

## How to test

1. Abra o chat interno num navegador com a janela em 375px de largura. Sem canal selecionado, a lista ocupa a tela inteira; ao abrir um canal, ele ocupa a tela e aparece um botão de voltar.
2. Ainda em 375px, abra uma thread e as configurações do canal: os dois cobrem a conversa e fecham no X. Abra "Excluir canal" ou "Editar membros" de dentro das configurações e confirme que o painel não fecha por baixo.
3. Toque no botão de três pontos de uma mensagem: o menu traz a fileira de emojis e as ações (responder, copiar link, fixar, editar, excluir).
4. Em torno de 900px, abra a thread e confirme que ela passa por cima da conversa em vez de espremê-la.
5. Em 1440px, arraste a borda direita da lista de canais para redimensionar; solte bem à esquerda para recolher. Reabra pela faixa fina, recarregue a página e confirme que a largura e o estado voltam como estavam.
6. Confirme que o botão flutuante do menu global some quando um canal está aberto no celular e reaparece na lista de canais.

## What changed

- `InternalChatLayout.vue` centraliza a decisão de visibilidade da lista e hospeda a faixa de reabertura, para que o empty state e a tela de rascunhos também consigam expandi-la.
- Novo `useInternalChatSidebar.js` com a lógica de largura/colapso, persistida em `localStorage`. Preferi isso a `uiSettings.sidebar_width`, que é da sidebar global e gravaria na API a cada quadro do arrasto.
- `ThreadPanel` e `ChannelSettings` seguem o padrão de `ConversationSidebar.vue`, com a fronteira em `lg` em vez de `md` porque entre 768 e 1024 ainda não cabem sidebar global, lista, painel e conversa juntos. O `ignore` do clique-fora inclui `dialog` porque `Dialog.vue` usa `<dialog>` nativo no top layer.
- `MessageBubble` mantém a barra de hover em `md:` e usa o `Popover` do design system abaixo disso, com os emojis inline para não aninhar dois popovers. `reactions.js` extrai a lista de emojis e a busca da reação própria, antes duplicadas.
- `MobileSidebarLauncher` passa a esconder o botão flutuante nas rotas de canal do chat interno, como já faz nas conversas; segue visível em `internal_chat_home`, que é a tela raiz da feature.
- `ChannelView` deixa de restaurar o painel de configurações aberto quando a tela é pequena, senão abrir um canal no celular cairia direto nas configurações em tela cheia.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/354)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved internal chat responsiveness across mobile, tablet, and desktop layouts.
  * Resize, collapse, and restore the channel sidebar, with preferences remembered.
  * Added mobile back navigation for channels and drafts.
  * Added mobile message actions, including reactions, replies, copying links, pinning, editing, and deleting.
  * Improved responsive channel settings and thread panels with easier dismissal.
  * Added localized labels in English and Brazilian Portuguese.
* **Bug Fixes**
  * Improved reaction handling and sidebar behavior across chat views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->