### PR TITLE
test(integrations): re-resolve the RealtimeKit validator constant per example

### DIFF
--- a/spec/lib/integrations/cloudflare/realtime_kit_credentials_validator_spec.rb
+++ b/spec/lib/integrations/cloudflare/realtime_kit_credentials_validator_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Integrations::Cloudflare::RealtimeKitCredentialsValidator do
+  # A zeitwerk reload earlier in the suite leaves the `described_class` captured
+  # when this file was loaded pointing at a stale copy, while `stub_const` resolves
+  # the name against the freshly-loaded one. The paging example then stubs
+  # APPS_PAGE_SIZE on one class and calls the other, which keeps the real value and
+  # stops after the first page. Re-resolving the constant on every example keeps
+  # both sides on the same class.
+  let(:described_class) { Integrations::Cloudflare::RealtimeKitCredentialsValidator } # rubocop:disable RSpec/DescribedClass
+
   let(:account_id) { 'account_id' }
   let(:app_id) { 'app_id' }
   let(:api_token) { 'api_token' }


### PR DESCRIPTION
Corrige uma falha de CI no `chatwoot-pro`, onde o spec do validador de credenciais do Cloudflare RealtimeKit falhava no exemplo de paginação (`accepts a RealtimeKit App ID from a later apps page`) com `expected true, got false`.

Nada muda em produção: a alteração é só no spec.

## How to reproduce

A falha depende de um reload do zeitwerk acontecer antes deste arquivo no mesmo processo do RSpec, o que só acontece na composição de shards do `chatwoot-pro` (899 arquivos de spec contra 893 no CE, então o round-robin de 16 nós agrupa vizinhos diferentes). Para reproduzir de forma determinística, basta forçar o reload dentro do exemplo:

```ruby
Rails.application.reloader.reload!
stub_const("#{described_class}::APPS_PAGE_SIZE", 1)
# described_class::APPS_PAGE_SIZE => 50   (cópia velha)
# Integrations::Cloudflare::RealtimeKitCredentialsValidator::APPS_PAGE_SIZE => 1  (cópia nova)
```

Com as duas referências divergindo, `stub_const` aplica o page size na classe recém-carregada e o exemplo chama a antiga, que mantém o valor real. Em `next_apps_page?` a conta vira `1 * 50 < 2`, o serviço para na primeira página, não encontra o app e devolve insucesso.

## What changed

- `let(:described_class)` re-resolvendo a constante a cada exemplo, o mesmo padrão já usado em `spec/models/internal_chat/channel_member_spec.rb` e `spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb`, com o comentário explicando o porquê.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/355)
<!-- Reviewable:end -->
