### PR TITLE
fix(conversations): keep activity messages in the history on cold open

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -198,7 +198,12 @@ const actions = {
       try {
         await dispatch('fetchPreviousMessages', {
           after,
-          before: data.messages[0].id,
+          // A conversation with no messages at all seeds an empty array.
+          // Without the cursor the finder returns the latest page instead, so
+          // the fetch still resolves and SET_CHAT_DATA_FETCHED runs — reading
+          // `.id` off `undefined` here used to throw and leave the chat stuck
+          // with `dataFetched` unset, which also blocks scroll pagination.
+          before: data.messages[0]?.id,
           conversationId: data.id,
         });
         commit(types.SET_CHAT_DATA_FETCHED, data.id);

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -762,6 +762,24 @@ describe('#addMentions', () => {
       expect(localDispatch).not.toHaveBeenCalled();
     });
 
+    it('should fetch without a cursor when the conversation has no messages', async () => {
+      const localCommit = vi.fn();
+      const localDispatch = vi.fn().mockResolvedValue();
+      const data = { id: 42, messages: [] };
+
+      await actions.setActiveChat(
+        { commit: localCommit, dispatch: localDispatch },
+        { data }
+      );
+
+      expect(localDispatch).toHaveBeenCalledWith('fetchPreviousMessages', {
+        after: undefined,
+        before: undefined,
+        conversationId: 42,
+      });
+      expect(localCommit).toHaveBeenCalledWith(types.SET_CHAT_DATA_FETCHED, 42);
+    });
+
     it('should commit SET_CHAT_DATA_FETCHED by ID, not mutate the data object directly (race condition fix)', async () => {
       const localCommit = vi.fn();
       const localDispatch = vi.fn().mockResolvedValue();

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -171,6 +171,34 @@ class Conversation < ApplicationRecord
     messages.where(account_id: account_id)&.incoming&.last
   end
 
+  # Seeds `currentChat.messages` in the dashboard AND doubles as the `before`
+  # cursor in setActiveChat → fetchPreviousMessages, where MessageFinder pages
+  # with `id < before`. It must therefore be the newest message the dashboard
+  # renders. Filtering by `message_type` or `private` here silently hides every
+  # message created after the one we pick — that is how activity messages
+  # ("Conversation was marked resolved by ...") vanished from the history.
+  # Chat list previews use `last_non_activity_message`: keep the two separate.
+  # Agent-facing payloads only — the cable broadcast reaches the contact too and
+  # keeps its own narrower query (see EventDataPresenter#push_messages).
+  def dashboard_seed_message
+    messages.where(account_id: account_id)
+            .hide_removed_reactions
+            .includes([{ attachments: [{ file_attachment: [:blob] }] }])
+            .reorder(created_at: :desc)
+            .first
+  end
+
+  # Drives the chat list preview, which must never read "Conversation was
+  # marked resolved by ...". Unlike `dashboard_seed_message`, skipping activity
+  # messages here is intentional.
+  def last_non_activity_message
+    messages.where(account_id: account_id)
+            .non_activity_messages
+            .hide_removed_reactions
+            .reorder(created_at: :desc)
+            .first
+  end
+
   def toggle_status
     # FIXME: implement state machine with aasm
     self.status = open? ? :resolved : :open

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -195,6 +195,7 @@ class Conversation < ApplicationRecord
     messages.where(account_id: account_id)
             .non_activity_messages
             .hide_removed_reactions
+            .includes([{ attachments: [{ file_attachment: [:blob] }] }])
             .reorder(created_at: :desc)
             .first
   end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -180,11 +180,15 @@ class Conversation < ApplicationRecord
   # Chat list previews use `last_non_activity_message`: keep the two separate.
   # Agent-facing payloads only — the cable broadcast reaches the contact too and
   # keeps its own narrower query (see EventDataPresenter#push_messages).
+  # The `id` tie-break is load-bearing: pagination compares ids, so on a
+  # `created_at` tie the cursor has to be the highest id or the rows between
+  # them fall through the same crack. Imports write second-precision
+  # timestamps in bulk (DataImports::Intercom::Importer), so ties are real.
   def dashboard_seed_message
     messages.where(account_id: account_id)
             .hide_removed_reactions
             .includes([{ attachments: [{ file_attachment: [:blob] }] }])
-            .reorder(created_at: :desc)
+            .reorder(created_at: :desc, id: :desc)
             .first
   end
 
@@ -196,7 +200,7 @@ class Conversation < ApplicationRecord
             .non_activity_messages
             .hide_removed_reactions
             .includes([{ attachments: [{ file_attachment: [:blob] }] }])
-            .reorder(created_at: :desc)
+            .reorder(created_at: :desc, id: :desc)
             .first
   end
 

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -33,20 +33,25 @@ class Conversations::EventDataPresenter < SimpleDelegator
 
   private
 
+  # This payload also reaches the contact: ActionCableListener broadcasts
+  # `conversation.created`, `conversation.status_changed` and
+  # `conversation.updated` to `user_tokens + contact_inbox_tokens` in a single
+  # message. `.chat` (no activity, no private) is what keeps agent-only content
+  # out of the contact's browser, so this array is deliberately NOT the
+  # dashboard seed — that one lives in the conversation jbuilder
+  # (`Conversation#dashboard_seed_message`) and is wider on purpose. Do not
+  # "mirror the jbuilder" here before splitting the broadcast audience.
   def push_messages
     [messages.where(account_id: account_id).chat.last&.push_event_data].compact
   end
 
-  # Mirrors the conversation jbuilder so cable subscribers can refresh the chat
-  # list preview after in-place reaction updates (the snake-cased field is read
-  # by the frontend store and `MessagePreview` to derive the latest visible
+  # Same query and reaction enrichment as the `last_non_activity_message` field
+  # in the conversation jbuilder, so cable subscribers can refresh the chat list
+  # preview after in-place reaction updates (the snake-cased field is read by
+  # the frontend store and `MessagePreview` to derive the latest visible
   # message). Without this, the snapshot taken at fetch time stays stale.
   def push_last_non_activity_message
-    msg = messages.where(account_id: account_id)
-                  .non_activity_messages
-                  .hide_removed_reactions
-                  .reorder(created_at: :desc)
-                  .first
+    msg = last_non_activity_message
     return nil unless msg
 
     data = msg.push_event_data

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -27,19 +27,12 @@ json.meta do
 end
 
 json.id conversation.display_id
-# Seeds `currentChat.messages` and is also the source for the `before` cursor
-# in setActiveChat → fetchPreviousMessages. Must include private notes: the
-# `chat` scope filters them out, so a trailing private note would never enter
-# the store on cold open and the bubble wouldn't render until a non-private
-# message arrived after it.
-last_message = conversation.messages
-                           .where(account_id: conversation.account_id)
-                           .non_activity_messages
-                           .hide_removed_reactions
-                           .includes([{ attachments: [{ file_attachment: [:blob] }] }])
-                           .reorder(created_at: :desc)
-                           .first
-json.messages last_message ? [last_message.push_event_data] : []
+# Two distinct queries on purpose: the seed below is the pagination cursor and
+# must be the newest renderable message, while `last_non_activity_message` is
+# the chat list preview and must skip activity messages. See the invariants
+# documented on both `Conversation` methods before touching either.
+seed_message = conversation.dashboard_seed_message
+json.messages seed_message ? [seed_message.push_event_data] : []
 
 json.account_id conversation.account_id
 json.uuid conversation.uuid
@@ -59,11 +52,12 @@ json.updated_at conversation.updated_at.to_f
 json.timestamp conversation.last_activity_at.to_i
 json.first_reply_created_at conversation.first_reply_created_at.to_i
 json.unread_count conversation.unread_incoming_messages.count
-if last_message
+last_non_activity_message = conversation.last_non_activity_message
+if last_non_activity_message
   json.last_non_activity_message do
-    json.merge! last_message.push_event_data
-    if last_message.reaction?
-      target_id = last_message.content_attributes['in_reply_to']
+    json.merge! last_non_activity_message.push_event_data
+    if last_non_activity_message.reaction?
+      target_id = last_non_activity_message.content_attributes['in_reply_to']
       target = target_id.present? ? conversation.messages.find_by(id: target_id) : nil
       # strip_tags so the preview of an HTML/email target doesn't render as
       # literal "<p>..." markup in the chat list card. Wrap with `String.new`

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -48,8 +48,52 @@ RSpec.describe 'Conversations API', type: :request do
             headers: agent.create_new_auth_token,
             as: :json
 
-        body = JSON.parse(response.body, symbolize_names: true)
-        expect(body[:data][:payload].first[:messages].first[:id]).to eq(private_note.id)
+        payload = JSON.parse(response.body, symbolize_names: true)[:data][:payload].first
+        expect(payload[:messages].first[:id]).to eq(private_note.id)
+        # The card preview shows private notes too — only activity messages are
+        # filtered out of `last_non_activity_message`.
+        expect(payload[:last_non_activity_message][:id]).to eq(private_note.id)
+      end
+
+      # Regression (#350): the seed is the `before` cursor and pages with
+      # `id < before`, so filtering activity messages out of it hid every
+      # status/assignment change created after the last regular message. The
+      # card preview reads `last_non_activity_message`, which is a separate
+      # query — do not collapse the two again.
+      it 'seeds the latest message even when it is an activity message, without leaking it into the preview' do
+        message = create(:message, conversation: conversation, account: account)
+        activity = create(:message, conversation: conversation, account: account, message_type: :activity,
+                                    content: 'Conversation was marked resolved by John')
+
+        get "/api/v1/accounts/#{account.id}/conversations",
+            headers: agent.create_new_auth_token,
+            as: :json
+
+        payload = JSON.parse(response.body, symbolize_names: true)[:data][:payload].first
+        expect(payload[:messages].first[:id]).to eq(activity.id)
+        expect(payload[:last_non_activity_message][:id]).to eq(message.id)
+      end
+
+      # Regression (#350): the seed and the message pagination have to line up.
+      # This walks the exact path the dashboard takes on cold open — read the
+      # seed from the list, then page with it as the `before` cursor.
+      it 'reaches every activity message through the seed cursor' do
+        create(:message, conversation: conversation, account: account)
+        activity = create(:message, conversation: conversation, account: account, message_type: :activity,
+                                    content: 'Conversation was marked resolved by John')
+
+        get "/api/v1/accounts/#{account.id}/conversations",
+            headers: agent.create_new_auth_token,
+            as: :json
+        seed = JSON.parse(response.body, symbolize_names: true)[:data][:payload].first[:messages]
+
+        get "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/messages",
+            params: { before: seed.first[:id] },
+            headers: agent.create_new_auth_token,
+            as: :json
+        paginated = JSON.parse(response.body, symbolize_names: true)[:payload]
+
+        expect(seed.pluck(:id) + paginated.pluck(:id)).to include(activity.id)
       end
 
       it 'returns conversations with empty messages array for conversations with out messages' do

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -658,6 +658,19 @@ RSpec.describe Conversation do
 
       expect(conversation.dashboard_seed_message).to eq(regular)
     end
+
+    # Pagination compares ids, so on a `created_at` tie the cursor has to be the
+    # highest id — otherwise the rows between the two land outside both the seed
+    # and the `id < cursor` page. Bulk imports write second-precision
+    # timestamps, so ties are not hypothetical.
+    it 'breaks created_at ties by id' do
+      timestamp = 1.hour.ago
+      regular.update!(created_at: timestamp)
+      newest = create(:message, conversation: conversation, account: conversation.account)
+      newest.update!(created_at: timestamp)
+
+      expect(conversation.dashboard_seed_message).to eq(newest)
+    end
   end
 
   describe '#last_non_activity_message' do

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -634,6 +634,50 @@ RSpec.describe Conversation do
     end
   end
 
+  # The dashboard pages backwards from this message with `id < cursor`, so any
+  # message_type/private filter here hides everything created after it.
+  describe '#dashboard_seed_message' do
+    let(:conversation) { create(:conversation) }
+    let!(:regular) { create(:message, conversation: conversation, account: conversation.account) }
+
+    it 'returns the newest message when it is an activity message' do
+      activity = create(:message, conversation: conversation, account: conversation.account, message_type: :activity)
+
+      expect(conversation.dashboard_seed_message).to eq(activity)
+    end
+
+    it 'returns the newest message when it is a private note' do
+      private_note = create(:message, conversation: conversation, account: conversation.account, private: true)
+
+      expect(conversation.dashboard_seed_message).to eq(private_note)
+    end
+
+    it 'skips reactions whose user-facing state is removed' do
+      create(:message, conversation: conversation, account: conversation.account, content: '',
+                       content_attributes: { is_reaction: true, deleted: true })
+
+      expect(conversation.dashboard_seed_message).to eq(regular)
+    end
+  end
+
+  describe '#last_non_activity_message' do
+    let(:conversation) { create(:conversation) }
+    let!(:regular) { create(:message, conversation: conversation, account: conversation.account) }
+
+    it 'skips activity messages' do
+      create(:message, conversation: conversation, account: conversation.account, message_type: :activity)
+
+      expect(conversation.last_non_activity_message).to eq(regular)
+    end
+
+    it 'skips reactions whose user-facing state is removed' do
+      create(:message, conversation: conversation, account: conversation.account, content: '',
+                       content_attributes: { is_reaction: true, deleted: true })
+
+      expect(conversation.last_non_activity_message).to eq(regular)
+    end
+  end
+
   describe 'unread_incoming_messages' do
     subject(:unread_incoming_messages) { conversation.unread_incoming_messages }
 

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe Conversations::EventDataPresenter do
     end
   end
 
+  describe '#push_data messages' do
+    # `push_data` is broadcast to the contact as well (ActionCableListener
+    # bundles `user_tokens + contact_inbox_tokens` for conversation.created /
+    # status_changed / updated), so this array has to stay free of activity
+    # messages and private notes. It is NOT the dashboard seed — that one lives
+    # in the conversation jbuilder and is deliberately wider. If this spec
+    # breaks because someone mirrored the jbuilder here, the fix is to split
+    # the broadcast audience, not to widen the query.
+    it 'excludes activity messages and private notes' do
+      chat_message = create(:message, conversation: conversation, account: conversation.account, message_type: :outgoing)
+      create(:message, conversation: conversation, account: conversation.account, private: true)
+      create(:message, conversation: conversation, account: conversation.account,
+                       message_type: :activity, content: 'Conversation was marked resolved by John')
+
+      expect(presenter.push_data[:messages].pluck(:id)).to eq([chat_message.id])
+    end
+  end
+
   describe '#push_data last_non_activity_message' do
     it 'is nil when the conversation has no non-activity messages' do
       expect(presenter.push_data[:last_non_activity_message]).to be_nil
@@ -87,6 +105,18 @@ RSpec.describe Conversations::EventDataPresenter do
 
       expect(data[:id]).to eq(message.id)
       expect(data[:content]).to eq('Hello there')
+    end
+
+    # Counterpart of the seed: the chat list preview must never read
+    # "Conversation was marked resolved by ...". If this and #push_data messages
+    # ever agree on the same row for this scenario, the queries got merged.
+    it 'skips activity messages' do
+      message = create(:message, conversation: conversation, account: conversation.account,
+                                 message_type: :outgoing, content: 'Hello there')
+      create(:message, conversation: conversation, account: conversation.account,
+                       message_type: :activity, content: 'Conversation was marked resolved by John')
+
+      expect(presenter.push_data[:last_non_activity_message][:id]).to eq(message.id)
     end
 
     it 'skips reactions whose user-facing state is removed' do


### PR DESCRIPTION
Closes #350.

## O bug

O payload da conversa semeia `currentChat.messages` e o id dessa mensagem vira o cursor `before` em `setActiveChat → fetchPreviousMessages`, onde o `MessageFinder` pagina com `id < before`. Desde #276 esse seed excluía activity messages, então toda mudança de status/atribuição/label criada **depois** da última mensagem normal ficava fora dos dois fluxos: filtrada do seed e acima do cursor da paginação.

Resultado: "Conversation was marked resolved by X" sumia da thread ao recarregar e só voltava quando chegava uma mensagem normal depois dela.

O #281 agravou ao derivar `messages` e `last_non_activity_message` da mesma variável. São invariantes opostos:

- o **cursor** precisa da mensagem mais recente que o dashboard renderiza;
- o **preview do card** precisa da mais recente que não seja activity.

O upstream não tem o bug: usa `.last` sem filtro de tipo.

## Impacto medido

Numa conta de produção, nos últimos 7 dias: de 305 pares consecutivos de auto-atribuição na mesma conversa, **185 (61%) tinham a atribuição anterior invisível** no histórico; 14 desses com mais de 60s de intervalo (incluindo casos de 1h30 e 1h16). Os agentes se atribuíam por cima uns dos outros porque a atribuição anterior não aparecia na thread.

## A correção

- Duas queries nomeadas em `Conversation` (`dashboard_seed_message` e `last_non_activity_message`), cada uma com o comentário do seu invariante. O jbuilder consome as duas separadamente.
- `EventDataPresenter#push_last_non_activity_message` passa a usar o método do model, eliminando a query duplicada entre os dois arquivos.
- `EventDataPresenter#push_messages` **continua** com `.chat`, de propósito: esse payload é broadcast também para o contato (o `ActionCableListener` junta `user_tokens + contact_inbox_tokens` num envio só), então alargá-lo colocaria nota privada e activity no browser do contato. O comentário no método registra isso.
- `setActiveChat` deixa de lançar `TypeError` em conversa sem nenhuma mensagem, o que deixava `dataFetched` sem valor e travava a paginação por scroll pelo resto da sessão.

## Blindagem contra regressão

Esta área já regrediu duas vezes pela mesma causa. Os specs cobrem os dois lados no mesmo exemplo, então **reunificar as queries quebra o teste** em qualquer das duas direções: `messages` tem que trazer a activity e `last_non_activity_message` não pode ser a activity.

Confirmei que os specs novos falham sem o fix (stash no código de produção): `expected 2439, got 2438` no seed, `expected [2440] to include 2441` no end-to-end, `TypeError` no store.

## Validação manual

A/B na mesma tela com e sem o fix:

| | histórico após F5 |
|---|---|
| com o fix | mensagem + "marked open by system" + "Atribuído a John" + "marked resolved by system" |
| sem o fix | só a mensagem |

Também validado: activity criada ao vivo sobrevive ao reload; nota privada continua aparecendo (o #281 não regrediu); e o card da lista segue mostrando a última mensagem real, não a activity.

## Nota para quem revisar

Não sugira reaproveitar o seed como preview quando ele não for activity. Esse acoplamento é exatamente o que causou o bug, e o upstream também faz as duas queries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/356)
<!-- Reviewable:end -->
