### PR TITLE
fix(cable): keep private notes out of contact-bound conversation payloads

### DIFF
--- a/app/jobs/action_cable_broadcast_job.rb
+++ b/app/jobs/action_cable_broadcast_job.rb
@@ -28,12 +28,22 @@ class ActionCableBroadcastJob < ApplicationJob
     account = Account.find(data[:account_id])
     conversation = account.conversations.find_by!(display_id: data[:id])
     fresh_data = conversation.push_event_data.merge(account_id: data[:account_id])
+    # Refresh values, never widen the payload. Contact-bound broadcasts reach
+    # this job already stripped of agent-only keys (ActionCableListener
+    # #broadcast_to_contact), and `push_event_data` would hand the contact right
+    # back the private note that stripping removed. An agent-only key is
+    # therefore refreshed only when the caller sent it in the first place.
+    fresh_data = fresh_data.except(*absent_agent_only_keys(data))
     # The refreshed payload comes from the conversation row; transient per-event
     # metadata set by the listener (eg. `source: 'reaction_toggle'` so the
     # frontend skips SCROLL_TO_MESSAGE) lives only on the original `data` hash,
     # so carry it forward explicitly.
     fresh_data[:event_metadata] = data[:event_metadata] if data[:event_metadata].present?
     fresh_data
+  end
+
+  def absent_agent_only_keys(data)
+    Conversations::EventDataPresenter::AGENT_ONLY_PUSH_KEYS.reject { |key| data.key?(key) }
   end
 
   def broadcast_to_members(members, event_name, broadcast_data)

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -145,9 +145,12 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
 
   def conversation_created(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox)
+    # Built once and shared: `push_event_data` is several queries deep, and the
+    # contact's copy is a subset of the agents', never a fresher read.
+    payload = conversation.push_event_data
 
-    broadcast(account, tokens, CONVERSATION_CREATED, conversation.push_event_data)
+    broadcast(account, user_tokens(account, conversation.inbox.members), CONVERSATION_CREATED, payload)
+    broadcast_to_contact(account, conversation, CONVERSATION_CREATED, payload)
   end
 
   def conversation_read(event)
@@ -159,19 +162,21 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
 
   def conversation_status_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox)
+    payload = conversation.push_event_data
 
-    broadcast(account, tokens, CONVERSATION_STATUS_CHANGED, conversation.push_event_data)
+    broadcast(account, user_tokens(account, conversation.inbox.members), CONVERSATION_STATUS_CHANGED, payload)
+    broadcast_to_contact(account, conversation, CONVERSATION_STATUS_CHANGED, payload)
   end
 
   def conversation_updated(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox)
 
     payload = conversation.push_event_data
     metadata = event.data[:broadcast_metadata]
     payload = payload.merge(event_metadata: metadata) if metadata.present?
-    broadcast(account, tokens, CONVERSATION_UPDATED, payload)
+
+    broadcast(account, user_tokens(account, conversation.inbox.members), CONVERSATION_UPDATED, payload)
+    broadcast_to_contact(account, conversation, CONVERSATION_UPDATED, payload)
   end
 
   def conversation_unread_count_changed(event)
@@ -193,7 +198,7 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
       account,
       tokens,
       CONVERSATION_TYPING_ON,
-      conversation: conversation.push_event_data,
+      conversation: typing_conversation_data(conversation),
       user: user.push_event_data,
       is_private: event.data[:is_private] || false
     )
@@ -209,7 +214,7 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
       account,
       tokens,
       CONVERSATION_RECORDING,
-      conversation: conversation.push_event_data,
+      conversation: typing_conversation_data(conversation),
       user: user.push_event_data,
       is_private: event.data[:is_private] || false
     )
@@ -225,7 +230,7 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
       account,
       tokens,
       CONVERSATION_TYPING_OFF,
-      conversation: conversation.push_event_data,
+      conversation: typing_conversation_data(conversation),
       user: user.push_event_data,
       is_private: event.data[:is_private] || false
     )
@@ -298,6 +303,26 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
 
   def account_token(account)
     "account_#{account.id}"
+  end
+
+  # The contact subscribes to the same conversation events as the agents, but
+  # `push_event_data` carries agent-only content — a trailing private note is
+  # what `last_non_activity_message` resolves to. So the contact gets its own
+  # broadcast with those keys stripped, instead of riding along on the agents'
+  # payload. ActionCableBroadcastJob refuses to re-add them when it refreshes
+  # the payload; without that guard this stripping would be undone downstream.
+  def broadcast_to_contact(account, conversation, event_name, payload)
+    broadcast(account, contact_inbox_tokens(conversation.contact_inbox), event_name,
+              payload.except(*Conversations::EventDataPresenter::AGENT_ONLY_PUSH_KEYS))
+  end
+
+  # Typing events reach agents and the contact in a single payload, and the only
+  # thing any subscriber reads off the conversation here is its id. Rather than
+  # doubling the jobs on a per-keystroke path, drop the agent-only keys for
+  # everyone — otherwise every keystroke ships the latest private note to the
+  # contact's websocket.
+  def typing_conversation_data(conversation)
+    conversation.push_event_data.except(*Conversations::EventDataPresenter::AGENT_ONLY_PUSH_KEYS)
   end
 
   def typing_event_listener_tokens(account, conversation, user)

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -1,4 +1,16 @@
 class Conversations::EventDataPresenter < SimpleDelegator
+  # Keys in `push_data` that must never reach a contact. `last_non_activity_message`
+  # is the one that bites: `non_activity_messages` filters `message_type`, not
+  # `private`, so a trailing private note is exactly what that field resolves to.
+  # Agents need it (it is what keeps the chat list preview fresh), but the contact
+  # subscribes to `conversation.created`, `conversation.status_changed`,
+  # `conversation.updated` and the typing events too, so those broadcasts strip
+  # these keys before the payload leaves the server (ActionCableListener), and
+  # ActionCableBroadcastJob refuses to re-add them when it refreshes a payload.
+  # The REST payload is unaffected: `/conversations` is agent-authenticated, so
+  # the jbuilder keeps serving the private note as the chat list preview.
+  AGENT_ONLY_PUSH_KEYS = %i[last_non_activity_message].freeze
+
   def push_data # rubocop:disable Metrics/MethodLength
     {
       additional_attributes: additional_attributes,

--- a/spec/jobs/action_cable_broadcast_job_spec.rb
+++ b/spec/jobs/action_cable_broadcast_job_spec.rb
@@ -44,6 +44,47 @@ RSpec.describe ActionCableBroadcastJob do
       end
     end
 
+    # The refresh rebuilds the payload from the conversation row, so it is the
+    # one place that can silently undo the contact-bound redaction done by
+    # ActionCableListener#broadcast_to_contact — and hand the contact's browser
+    # the private note over the websocket. The rule it encodes: refresh values,
+    # never widen the payload.
+    context 'when a contact-bound payload arrives stripped of agent-only keys' do
+      let(:event_name) { 'conversation.updated' }
+      let(:data) { base_data }
+
+      before do
+        create(:message, conversation: conversation, account: account,
+                         message_type: :outgoing, private: true, content: 'Internal only: overdue invoice')
+      end
+
+      it 'does not re-add last_non_activity_message' do
+        expect(ActionCable.server).to receive(:broadcast) do |_member, payload|
+          expect(payload[:data]).not_to have_key(:last_non_activity_message)
+          # The refresh still ran — this is not a pass-through.
+          expect(payload[:data][:status]).to eq(conversation.status)
+        end
+        described_class.new.perform(members, event_name, data)
+      end
+    end
+
+    context 'when an agent-bound payload carries agent-only keys' do
+      let(:event_name) { 'conversation.updated' }
+      let(:data) { base_data.merge(last_non_activity_message: { id: 0, content: 'stale snapshot' }) }
+
+      before do
+        create(:message, conversation: conversation, account: account,
+                         message_type: :outgoing, private: true, content: 'Internal only: overdue invoice')
+      end
+
+      it 'refreshes them instead of dropping them' do
+        expect(ActionCable.server).to receive(:broadcast) do |_member, payload|
+          expect(payload[:data][:last_non_activity_message][:content]).to eq('Internal only: overdue invoice')
+        end
+        described_class.new.perform(members, event_name, data)
+      end
+    end
+
     context 'when the event is not in the refresh list' do
       let(:event_name) { 'message.created' }
       let(:data) { base_data.merge(event_metadata: { source: 'reaction_toggle' }) }

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -7,6 +7,14 @@ describe ActionCableListener do
   let!(:agent) { create(:user, account: account, role: :agent) }
   let!(:conversation) { create(:conversation, account: account, inbox: inbox, assignee: agent) }
 
+  # Typing payloads reach the contact, so they ship without the agent-only keys
+  # (`last_non_activity_message` resolves to a trailing private note). Building
+  # the expectation from the same constant the listener uses keeps this honest:
+  # adding a key to AGENT_ONLY_PUSH_KEYS updates both sides at once.
+  let(:redacted_conversation_data) do
+    conversation.push_event_data.except(*Conversations::EventDataPresenter::AGENT_ONLY_PUSH_KEYS)
+  end
+
   before do
     create(:inbox_member, inbox: inbox, user: agent)
     Current.user = nil
@@ -89,7 +97,7 @@ describe ActionCableListener do
         a_collection_containing_exactly(
           admin.pubsub_token, conversation.contact_inbox.pubsub_token
         ),
-        'conversation.typing_on', { conversation: conversation.push_event_data,
+        'conversation.typing_on', { conversation: redacted_conversation_data,
                                     user: agent.push_event_data,
                                     account_id: account.id,
                                     is_private: false }
@@ -109,7 +117,7 @@ describe ActionCableListener do
         a_collection_containing_exactly(
           admin.pubsub_token, agent.pubsub_token
         ),
-        'conversation.typing_on', { conversation: conversation.push_event_data,
+        'conversation.typing_on', { conversation: redacted_conversation_data,
                                     user: conversation.contact.push_event_data,
                                     account_id: account.id,
                                     is_private: false }
@@ -129,7 +137,7 @@ describe ActionCableListener do
         a_collection_containing_exactly(
           admin.pubsub_token, agent.pubsub_token, conversation.contact_inbox.pubsub_token
         ),
-        'conversation.typing_on', { conversation: conversation.push_event_data,
+        'conversation.typing_on', { conversation: redacted_conversation_data,
                                     user: agent_bot.push_event_data,
                                     account_id: account.id,
                                     is_private: false }
@@ -149,7 +157,7 @@ describe ActionCableListener do
         a_collection_containing_exactly(
           admin.pubsub_token, conversation.contact_inbox.pubsub_token
         ),
-        'conversation.typing_off', { conversation: conversation.push_event_data,
+        'conversation.typing_off', { conversation: redacted_conversation_data,
                                      user: agent.push_event_data,
                                      account_id: account.id,
                                      is_private: false }
@@ -231,15 +239,28 @@ describe ActionCableListener do
 
     before do
       conversation.add_labels(['support'])
+      # Agents and the contact now get one broadcast each. Every example below
+      # pins exactly one of the two, so the other still has to be allowed
+      # through or it trips the constrained expectation.
+      allow(ActionCableBroadcastJob).to receive(:perform_later)
     end
 
     it 'sends update to inbox members' do
       expect(conversation.inbox.reload.inbox_members.count).to eq(1)
 
       expect(ActionCableBroadcastJob).to receive(:perform_later).with(
-        [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],
+        [agent.pubsub_token, admin.pubsub_token],
         'conversation.updated',
         conversation.push_event_data.merge(account_id: account.id)
+      )
+      listener.conversation_updated(event)
+    end
+
+    it 'sends the contact its own broadcast without the agent-only keys' do
+      expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+        [conversation.contact_inbox.pubsub_token],
+        'conversation.updated',
+        redacted_conversation_data.merge(account_id: account.id)
       )
       listener.conversation_updated(event)
     end
@@ -248,7 +269,7 @@ describe ActionCableListener do
       expect(conversation.reload.push_event_data[:labels]).to eq(conversation.labels.pluck(:name))
 
       expect(ActionCableBroadcastJob).to receive(:perform_later).with(
-        [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],
+        [agent.pubsub_token, admin.pubsub_token],
         'conversation.updated',
         conversation.push_event_data.merge(account_id: account.id)
       )
@@ -260,11 +281,67 @@ describe ActionCableListener do
       tagged_event = Events::Base.new(event_name, Time.zone.now, conversation: conversation, broadcast_metadata: metadata)
 
       expect(ActionCableBroadcastJob).to receive(:perform_later).with(
-        [agent.pubsub_token, admin.pubsub_token, conversation.contact_inbox.pubsub_token],
+        [agent.pubsub_token, admin.pubsub_token],
         'conversation.updated',
         conversation.push_event_data.merge(account_id: account.id, event_metadata: metadata)
       )
       listener.conversation_updated(tagged_event)
+    end
+
+    # The contact still needs the event (the widget refreshes its own state off
+    # it), so the fix is a narrower payload, not a dropped broadcast.
+    it 'still reaches the contact when metadata is present' do
+      metadata = { source: 'reaction_toggle' }
+      tagged_event = Events::Base.new(event_name, Time.zone.now, conversation: conversation, broadcast_metadata: metadata)
+
+      expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+        [conversation.contact_inbox.pubsub_token],
+        'conversation.updated',
+        redacted_conversation_data.merge(account_id: account.id, event_metadata: metadata)
+      )
+      listener.conversation_updated(tagged_event)
+    end
+  end
+
+  # The bug this guards: `last_non_activity_message` filters `message_type` but
+  # not `private`, so a trailing private note is exactly what it resolves to —
+  # and these three events broadcast to `contact_inbox_tokens`. Assert on the
+  # note's literal content so the example fails loudly if the payload is ever
+  # re-unified, whatever key the content ends up under.
+  describe 'private note leakage to the contact' do
+    let(:secret) { 'Internal only: customer has an overdue invoice' }
+    let(:contact_token) { conversation.contact_inbox.pubsub_token }
+
+    before do
+      create(:message, conversation: conversation, account: account, inbox: inbox,
+                       message_type: :outgoing, private: true, content: secret)
+    end
+
+    it 'keeps the private note out of every contact-bound conversation payload' do
+      payloads = []
+      allow(ActionCableBroadcastJob).to receive(:perform_later) do |tokens, _event, payload|
+        payloads << payload if tokens.include?(contact_token)
+      end
+
+      listener.conversation_created(Events::Base.new(:'conversation.created', Time.zone.now, conversation: conversation))
+      listener.conversation_status_changed(Events::Base.new(:'conversation.status_changed', Time.zone.now, conversation: conversation))
+      listener.conversation_updated(Events::Base.new(:'conversation.updated', Time.zone.now, conversation: conversation))
+      listener.conversation_typing_on(Events::Base.new(:'conversation.typing_on', Time.zone.now,
+                                                       conversation: conversation, user: agent, is_private: true))
+
+      expect(payloads.size).to eq(4)
+      expect(payloads.to_s).not_to include(secret)
+    end
+
+    it 'still gives the agents the private note as the chat list preview' do
+      allow(ActionCableBroadcastJob).to receive(:perform_later)
+      expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+        a_collection_including(agent.pubsub_token),
+        'conversation.updated',
+        hash_including(last_non_activity_message: hash_including(content: secret))
+      )
+
+      listener.conversation_updated(Events::Base.new(:'conversation.updated', Time.zone.now, conversation: conversation))
     end
   end
 

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -326,10 +326,17 @@ describe ActionCableListener do
       listener.conversation_created(Events::Base.new(:'conversation.created', Time.zone.now, conversation: conversation))
       listener.conversation_status_changed(Events::Base.new(:'conversation.status_changed', Time.zone.now, conversation: conversation))
       listener.conversation_updated(Events::Base.new(:'conversation.updated', Time.zone.now, conversation: conversation))
+      # All three typing events share `typing_conversation_data`, so all three
+      # belong here — they are also the highest-frequency vector, firing per
+      # keystroke rather than per status change.
       listener.conversation_typing_on(Events::Base.new(:'conversation.typing_on', Time.zone.now,
                                                        conversation: conversation, user: agent, is_private: true))
+      listener.conversation_recording(Events::Base.new(:'conversation.recording', Time.zone.now,
+                                                       conversation: conversation, user: agent, is_private: true))
+      listener.conversation_typing_off(Events::Base.new(:'conversation.typing_off', Time.zone.now,
+                                                        conversation: conversation, user: agent, is_private: true))
 
-      expect(payloads.size).to eq(4)
+      expect(payloads.size).to eq(6)
       expect(payloads.to_s).not_to include(secret)
     end
 

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -107,6 +107,21 @@ RSpec.describe Conversations::EventDataPresenter do
       expect(data[:content]).to eq('Hello there')
     end
 
+    # Deliberate, and the reason AGENT_ONLY_PUSH_KEYS exists: `non_activity_messages`
+    # filters `message_type`, not `private`, so the agent-facing chat list preview
+    # reads the private note when that is the newest thing that happened. Keeping
+    # it out of the contact's browser is the broadcast layer's job (see
+    # spec/listeners/action_cable_listener_spec.rb) — do NOT "fix" a leak by
+    # narrowing this query, that would blank the preview for agents on the REST
+    # path too, where no contact is listening.
+    it 'includes private notes' do
+      note = create(:message, conversation: conversation, account: conversation.account,
+                              message_type: :outgoing, private: true, content: 'Internal only')
+
+      expect(presenter.push_data[:last_non_activity_message][:id]).to eq(note.id)
+      expect(described_class::AGENT_ONLY_PUSH_KEYS).to include(:last_non_activity_message)
+    end
+
     # Counterpart of the seed: the chat list preview must never read
     # "Conversation was marked resolved by ...". If this and #push_data messages
     # ever agree on the same row for this scenario, the queries got merged.


### PR DESCRIPTION
Private notes written by agents could reach the customer's browser. When a conversation event was broadcast over the websocket, the payload carried the conversation's latest non-activity message as the chat list preview — and that message is a private note whenever the note is the most recent thing an agent wrote. Website widget visitors subscribe to that stream, so the note landed in their browser even though nothing on screen displayed it.

Agents keep seeing private notes as the chat list preview exactly as before. Only what travels to the customer changed.

## How to reproduce

1. Open a conversation in a website widget inbox and leave the widget open as the visitor.
2. As an agent, write a private note.
3. Resolve the conversation, change a label, or just start typing again.
4. In the visitor's browser, open DevTools → Network → WS and read the incoming frame: `last_non_activity_message.content` holds the private note.

## What changed

`Conversation#last_non_activity_message` uses the `non_activity_messages` scope, which filters `message_type` but not `private`. That field is part of `push_event_data`, and six listener broadcasts mix agent and contact recipients: `conversation.created`, `conversation.status_changed`, `conversation.updated`, and `typing_on` / `typing_off` / `recording`, which fire per keystroke.

- `Conversations::EventDataPresenter::AGENT_ONLY_PUSH_KEYS` is the single source of truth for what a contact must never receive.
- The three conversation events now send the contact its own broadcast with those keys stripped. The typing events drop them for every recipient — no subscriber reads more than the conversation id there, so splitting the job on a per-keystroke path would be wasted work.
- `ActionCableBroadcastJob` refuses to re-add an agent-only key that was absent from the payload it was handed. This one is load-bearing: `prepare_broadcast_data` rebuilds the payload from the conversation row for every `CONVERSATION_UPDATE_EVENT`, so stripping in the listener alone would be silently undone.

The model query is deliberately left alone. `/conversations` is agent-authenticated, and narrowing it would blank the preview for agents on the REST path, where no contact is listening.

## Notes

Verified at runtime by capturing what each pubsub token actually receives, with the job running inline: before the change the contact's payload contains the note and the key; after, the key is gone, all four events are still delivered, and the agents' preview is unchanged. Removing either guard makes the specs fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/357)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private agent notes are no longer exposed in contact-facing conversation updates, typing events, or recording events.
  * Agent views continue receiving the latest private-note information.
  * Conversation broadcasts now provide appropriately tailored data for agents and contacts.
* **Tests**
  * Added coverage to verify private-note protection and correct payload updates across conversation events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->