### PR TITLE
fix(cable): build the contact payload from an allowlist instead of a denylist

### DIFF
--- a/app/jobs/action_cable_broadcast_job.rb
+++ b/app/jobs/action_cable_broadcast_job.rb
@@ -28,22 +28,19 @@ class ActionCableBroadcastJob < ApplicationJob
     account = Account.find(data[:account_id])
     conversation = account.conversations.find_by!(display_id: data[:id])
     fresh_data = conversation.push_event_data.merge(account_id: data[:account_id])
-    # Refresh values, never widen the payload. Contact-bound broadcasts reach
-    # this job already stripped of agent-only keys (ActionCableListener
-    # #broadcast_to_contact), and `push_event_data` would hand the contact right
-    # back the private note that stripping removed. An agent-only key is
-    # therefore refreshed only when the caller sent it in the first place.
-    fresh_data = fresh_data.except(*absent_agent_only_keys(data))
+    # Refresh the values, preserve the shape. Contact-bound broadcasts arrive
+    # here already narrowed to the contact allowlist (ActionCableListener
+    # #broadcast_to_contact), and rebuilding from the conversation row would
+    # hand the contact back the whole agent payload. Keeping to the keys the
+    # caller sent means this job never has to know which those are — including
+    # the ones Pro and Enterprise add.
+    fresh_data = fresh_data.slice(*data.keys)
     # The refreshed payload comes from the conversation row; transient per-event
     # metadata set by the listener (eg. `source: 'reaction_toggle'` so the
     # frontend skips SCROLL_TO_MESSAGE) lives only on the original `data` hash,
     # so carry it forward explicitly.
     fresh_data[:event_metadata] = data[:event_metadata] if data[:event_metadata].present?
     fresh_data
-  end
-
-  def absent_agent_only_keys(data)
-    Conversations::EventDataPresenter::AGENT_ONLY_PUSH_KEYS.reject { |key| data.key?(key) }
   end
 
   def broadcast_to_members(members, event_name, broadcast_data)

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -198,9 +198,9 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
       account,
       tokens,
       CONVERSATION_TYPING_ON,
-      conversation: typing_conversation_data(conversation),
-      user: user.push_event_data,
-      is_private: event.data[:is_private] || false
+      { conversation: typing_conversation_data(conversation),
+        user: user.push_event_data,
+        is_private: event.data[:is_private] || false }
     )
   end
 
@@ -214,9 +214,9 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
       account,
       tokens,
       CONVERSATION_RECORDING,
-      conversation: typing_conversation_data(conversation),
-      user: user.push_event_data,
-      is_private: event.data[:is_private] || false
+      { conversation: typing_conversation_data(conversation),
+        user: user.push_event_data,
+        is_private: event.data[:is_private] || false }
     )
   end
 
@@ -230,9 +230,9 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
       account,
       tokens,
       CONVERSATION_TYPING_OFF,
-      conversation: typing_conversation_data(conversation),
-      user: user.push_event_data,
-      is_private: event.data[:is_private] || false
+      { conversation: typing_conversation_data(conversation),
+        user: user.push_event_data,
+        is_private: event.data[:is_private] || false }
     )
   end
 
@@ -306,23 +306,28 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
   end
 
   # The contact subscribes to the same conversation events as the agents, but
-  # `push_event_data` carries agent-only content — a trailing private note is
-  # what `last_non_activity_message` resolves to. So the contact gets its own
-  # broadcast with those keys stripped, instead of riding along on the agents'
-  # payload. ActionCableBroadcastJob refuses to re-add them when it refreshes
-  # the payload; without that guard this stripping would be undone downstream.
+  # `push_event_data` is an agent payload. It gets its own broadcast built from
+  # the contact allowlist instead of riding along on the agents' hash.
+  # `payload` is passed in rather than re-derived so per-event extras the caller
+  # merged in (eg. `event_metadata`) survive the narrowing.
+  # ActionCableBroadcastJob preserves the shape it is handed; without that, the
+  # refresh would rebuild the full agent payload and undo this.
   def broadcast_to_contact(account, conversation, event_name, payload)
+    # `performer` is skipped rather than allowlisted: it is merged in below,
+    # after the narrowing, and carries the acting agent's name and availability
+    # status. The widget never reads it. Typing events keep it — they already
+    # send `user` on purpose so the widget can render "agent is typing".
     broadcast(account, contact_inbox_tokens(conversation.contact_inbox), event_name,
-              payload.except(*Conversations::EventDataPresenter::AGENT_ONLY_PUSH_KEYS))
+              Conversations::EventDataPresenter.contact_slice(payload), include_performer: false)
   end
 
-  # Typing events reach agents and the contact in a single payload, and the only
-  # thing any subscriber reads off the conversation here is its id. Rather than
-  # doubling the jobs on a per-keystroke path, drop the agent-only keys for
-  # everyone — otherwise every keystroke ships the latest private note to the
-  # contact's websocket.
+  # Typing events reach agents and the contact in a single payload, and no
+  # subscriber reads more than the conversation id here — the dashboard handlers
+  # key their timers off `conversation.id` and nothing else. So this ships the
+  # contact-sized payload to everyone rather than doubling the jobs on a
+  # per-keystroke path.
   def typing_conversation_data(conversation)
-    conversation.push_event_data.except(*Conversations::EventDataPresenter::AGENT_ONLY_PUSH_KEYS)
+    conversation.contact_push_event_data
   end
 
   def typing_event_listener_tokens(account, conversation, user)
@@ -377,13 +382,13 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
                          clean, clean])
   end
 
-  def broadcast(account, tokens, event_name, data)
+  def broadcast(account, tokens, event_name, data, include_performer: true)
     return if tokens.blank?
 
     payload = data.merge(account_id: account.id)
     # So the frondend knows who performed the action.
     # Useful in cases like conversation assignment for generating a notification with assigner name.
-    payload[:performer] = Current.user&.push_event_data if Current.user.present?
+    payload[:performer] = Current.user&.push_event_data if include_performer && Current.user.present?
 
     ::ActionCableBroadcastJob.perform_later(tokens.uniq, event_name, payload)
   end

--- a/app/models/concerns/push_data_helper.rb
+++ b/app/models/concerns/push_data_helper.rb
@@ -5,6 +5,13 @@ module PushDataHelper
     Conversations::EventDataPresenter.new(self).push_data
   end
 
+  # The narrowed copy for broadcasts that reach the contact. Anything Pro or
+  # Enterprise bolts onto `push_data` is excluded automatically, because the
+  # presenter allowlists rather than denylists.
+  def contact_push_event_data
+    Conversations::EventDataPresenter.new(self).contact_push_data
+  end
+
   def lock_event_data
     Conversations::EventDataPresenter.new(self).lock_data
   end

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -1,15 +1,48 @@
 class Conversations::EventDataPresenter < SimpleDelegator
-  # Keys in `push_data` that must never reach a contact. `last_non_activity_message`
-  # is the one that bites: `non_activity_messages` filters `message_type`, not
-  # `private`, so a trailing private note is exactly what that field resolves to.
-  # Agents need it (it is what keeps the chat list preview fresh), but the contact
-  # subscribes to `conversation.created`, `conversation.status_changed`,
-  # `conversation.updated` and the typing events too, so those broadcasts strip
-  # these keys before the payload leaves the server (ActionCableListener), and
-  # ActionCableBroadcastJob refuses to re-add them when it refreshes a payload.
-  # The REST payload is unaffected: `/conversations` is agent-authenticated, so
-  # the jbuilder keeps serving the private note as the chat list preview.
-  AGENT_ONLY_PUSH_KEYS = %i[last_non_activity_message].freeze
+  # What a contact is allowed to receive over the cable. This is an ALLOWLIST on
+  # purpose: `contact_push_data` is built FROM this list, never subtracted from
+  # `push_data`. A new field therefore reaches agents only, until someone adds it
+  # here deliberately.
+  #
+  # A denylist was tried first and failed open. Every field added to `push_data`
+  # leaked by default, and two did within a month: `last_non_activity_message`
+  # (which resolves to a trailing private note, since `non_activity_messages`
+  # filters `message_type` but not `private`) and, on Pro, `kanban_task` (board
+  # name, funnel step names, and the agent roster with availability). Anything
+  # operational — labels, custom attributes, priority, assignee, SLA — is agent
+  # context and stays out by construction.
+  #
+  # The list is this short because that is what the contact actually consumes:
+  # the widget store keeps only `id` and `status` from cable payloads
+  # (widget/store/modules/conversationAttributes.js), and the typing handlers
+  # read only `conversation.id`. The rest is here because it describes the
+  # contact's own side of the conversation and costs nothing to keep, so a
+  # widget change does not immediately land on this list. Everything else the
+  # widget needs comes from its own REST endpoint, which is scoped to the
+  # contact and unaffected by this.
+  #
+  # Only the cable is narrowed. `/api/v1/accounts/.../conversations` is
+  # agent-authenticated and keeps serving the full payload.
+  CONTACT_PUSH_KEYS = %i[
+    id status can_reply channel messages unread_count
+    agent_last_seen_at contact_last_seen_at created_at updated_at timestamp
+  ].freeze
+
+  # Transient per-event tags the listener merges onto a payload after building
+  # it. They are not `push_data` fields, so they are named separately, but they
+  # are contact-safe and have to survive the narrowing.
+  CONTACT_SAFE_EVENT_KEYS = %i[event_metadata].freeze
+
+  # The contact's copy of `push_data`. See CONTACT_PUSH_KEYS before widening it.
+  def contact_push_data
+    push_data.slice(*CONTACT_PUSH_KEYS)
+  end
+
+  # Narrows an already-built agent payload instead of rebuilding it, so a
+  # listener that broadcasts to both audiences pays for `push_data` once.
+  def self.contact_slice(payload)
+    payload.slice(*CONTACT_PUSH_KEYS, *CONTACT_SAFE_EVENT_KEYS)
+  end
 
   def push_data # rubocop:disable Metrics/MethodLength
     {

--- a/spec/jobs/action_cable_broadcast_job_spec.rb
+++ b/spec/jobs/action_cable_broadcast_job_spec.rb
@@ -45,22 +45,28 @@ RSpec.describe ActionCableBroadcastJob do
     end
 
     # The refresh rebuilds the payload from the conversation row, so it is the
-    # one place that can silently undo the contact-bound redaction done by
-    # ActionCableListener#broadcast_to_contact — and hand the contact's browser
-    # the private note over the websocket. The rule it encodes: refresh values,
-    # never widen the payload.
-    context 'when a contact-bound payload arrives stripped of agent-only keys' do
+    # one place that can silently undo the narrowing done by
+    # ActionCableListener#broadcast_to_contact and hand the contact's browser the
+    # full agent payload. The rule it encodes: refresh the values, preserve the
+    # shape. That keeps this job from having to know which keys are agent-only —
+    # including the ones Pro and Enterprise add to `push_data`.
+    context 'when a contact-bound payload arrives narrowed to the allowlist' do
       let(:event_name) { 'conversation.updated' }
-      let(:data) { base_data }
+      let(:data) do
+        Conversations::EventDataPresenter.contact_slice(conversation.push_event_data)
+                                         .merge(account_id: account.id)
+      end
 
       before do
         create(:message, conversation: conversation, account: account,
                          message_type: :outgoing, private: true, content: 'Internal only: overdue invoice')
       end
 
-      it 'does not re-add last_non_activity_message' do
+      it 'does not widen it back to the agent payload' do
         expect(ActionCable.server).to receive(:broadcast) do |_member, payload|
           expect(payload[:data]).not_to have_key(:last_non_activity_message)
+          expect(payload[:data]).not_to have_key(:labels)
+          expect(payload[:data]).not_to have_key(:custom_attributes)
           # The refresh still ran — this is not a pass-through.
           expect(payload[:data][:status]).to eq(conversation.status)
         end
@@ -70,7 +76,10 @@ RSpec.describe ActionCableBroadcastJob do
 
     context 'when an agent-bound payload carries agent-only keys' do
       let(:event_name) { 'conversation.updated' }
-      let(:data) { base_data.merge(last_non_activity_message: { id: 0, content: 'stale snapshot' }) }
+      let(:data) do
+        conversation.push_event_data.merge(account_id: account.id,
+                                           last_non_activity_message: { id: 0, content: 'stale snapshot' })
+      end
 
       before do
         create(:message, conversation: conversation, account: account,

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -7,12 +7,11 @@ describe ActionCableListener do
   let!(:agent) { create(:user, account: account, role: :agent) }
   let!(:conversation) { create(:conversation, account: account, inbox: inbox, assignee: agent) }
 
-  # Typing payloads reach the contact, so they ship without the agent-only keys
-  # (`last_non_activity_message` resolves to a trailing private note). Building
-  # the expectation from the same constant the listener uses keeps this honest:
-  # adding a key to AGENT_ONLY_PUSH_KEYS updates both sides at once.
+  # Typing payloads reach the contact, so they ship the contact-sized hash.
+  # Building the expectation from the same allowlist the listener uses keeps
+  # this honest: changing CONTACT_PUSH_KEYS updates both sides at once.
   let(:redacted_conversation_data) do
-    conversation.push_event_data.except(*Conversations::EventDataPresenter::AGENT_ONLY_PUSH_KEYS)
+    conversation.push_event_data.slice(*Conversations::EventDataPresenter::CONTACT_PUSH_KEYS)
   end
 
   before do
@@ -256,7 +255,7 @@ describe ActionCableListener do
       listener.conversation_updated(event)
     end
 
-    it 'sends the contact its own broadcast without the agent-only keys' do
+    it 'sends the contact its own broadcast built from the allowlist' do
       expect(ActionCableBroadcastJob).to receive(:perform_later).with(
         [conversation.contact_inbox.pubsub_token],
         'conversation.updated',
@@ -308,6 +307,10 @@ describe ActionCableListener do
   # and these three events broadcast to `contact_inbox_tokens`. Assert on the
   # note's literal content so the example fails loudly if the payload is ever
   # re-unified, whatever key the content ends up under.
+  #
+  # The `agent context` example below is the general guard: the private note is
+  # only the leak that was found first, and asserting on the allowlist catches
+  # the next field someone adds to `push_data` without asserting on each by name.
   describe 'private note leakage to the contact' do
     let(:secret) { 'Internal only: customer has an overdue invoice' }
     let(:contact_token) { conversation.contact_inbox.pubsub_token }
@@ -338,6 +341,42 @@ describe ActionCableListener do
 
       expect(payloads.size).to eq(6)
       expect(payloads.to_s).not_to include(secret)
+    end
+
+    # The general guard, and the whole point of the allowlist. It asserts on the
+    # SHAPE of the contact payload instead of on any one field, so the next key
+    # added to `push_data` — CE, Enterprise or Pro — fails here rather than
+    # shipping to the contact's browser. `last_non_activity_message` and Pro's
+    # `kanban_task` both got in because the previous denylist only knew about
+    # the fields someone had remembered to name.
+    it 'never sends the contact a key outside the allowlist' do
+      keys = []
+      allow(ActionCableBroadcastJob).to receive(:perform_later) do |tokens, _event, payload|
+        keys.concat(payload.keys) if tokens.include?(contact_token)
+      end
+
+      listener.conversation_created(Events::Base.new(:'conversation.created', Time.zone.now, conversation: conversation))
+      listener.conversation_status_changed(Events::Base.new(:'conversation.status_changed', Time.zone.now, conversation: conversation))
+      listener.conversation_updated(Events::Base.new(:'conversation.updated', Time.zone.now, conversation: conversation))
+
+      allowed = Conversations::EventDataPresenter::CONTACT_PUSH_KEYS +
+                Conversations::EventDataPresenter::CONTACT_SAFE_EVENT_KEYS +
+                %i[account_id]
+      expect(keys.uniq - allowed).to be_empty
+    end
+
+    it 'keeps the operational fields agents work with out of the contact copy' do
+      conversation.update!(custom_attributes: { internal_score: 'high risk' }, priority: 'urgent')
+      conversation.add_labels(['inadimplente'])
+
+      payload = nil
+      allow(ActionCableBroadcastJob).to receive(:perform_later) do |tokens, _event, data|
+        payload = data if tokens.include?(contact_token)
+      end
+      listener.conversation_updated(Events::Base.new(:'conversation.updated', Time.zone.now, conversation: conversation))
+
+      expect(payload.keys).not_to include(:labels, :custom_attributes, :priority, :meta, :additional_attributes)
+      expect(payload.to_s).not_to include('inadimplente', 'high risk')
     end
 
     it 'still gives the agents the private note as the chat list preview' do

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Conversations::EventDataPresenter do
       expect(data[:content]).to eq('Hello there')
     end
 
-    # Deliberate, and the reason AGENT_ONLY_PUSH_KEYS exists: `non_activity_messages`
+    # Deliberate, and the reason the contact allowlist exists: `non_activity_messages`
     # filters `message_type`, not `private`, so the agent-facing chat list preview
     # reads the private note when that is the newest thing that happened. Keeping
     # it out of the contact's browser is the broadcast layer's job (see
@@ -119,7 +119,7 @@ RSpec.describe Conversations::EventDataPresenter do
                               message_type: :outgoing, private: true, content: 'Internal only')
 
       expect(presenter.push_data[:last_non_activity_message][:id]).to eq(note.id)
-      expect(described_class::AGENT_ONLY_PUSH_KEYS).to include(:last_non_activity_message)
+      expect(described_class::CONTACT_PUSH_KEYS).not_to include(:last_non_activity_message)
     end
 
     # Counterpart of the seed: the chat list preview must never read


### PR DESCRIPTION
Follow-up to #357, which fixed one leak but left the mechanism that produces them.

That fix removed a named list of agent-only fields from what the customer's browser receives. The problem is the direction: everything on a conversation payload reaches the customer by default, and stops only if someone remembers to add it to the list. Two fields got through that way within a month — the private note, and on Pro the kanban card, which carries the board name, the funnel step names, and the roster of agents with their availability.

This inverts it. The customer's copy is now built from a list of what they are allowed to receive, so a new field goes to agents only until someone deliberately opens it up. Nothing on screen changes for either side.

## What changed

- `CONTACT_PUSH_KEYS` in `Conversations::EventDataPresenter` is the allowlist; `contact_slice` narrows an already-built agent payload so a listener broadcasting to both audiences still pays for `push_data` once.
- `ActionCableBroadcastJob` refreshes values while preserving the shape it was handed. It no longer needs to know which keys are agent-only — which is what makes this work for Pro and Enterprise without a shared constant to extend or a merge conflict to resolve on every sync.
- `performer` is skipped for contact broadcasts. It is merged after the narrowing and carries the acting agent's name and availability status. Typing events keep it, since they already send `user` on purpose.
- `AGENT_ONLY_PUSH_KEYS` is gone, along with the job's guard that depended on it.

## Why the list is this short

Verified before narrowing: the widget store keeps only `id` and `status` from cable payloads (`widget/store/modules/conversationAttributes.js`), and the typing handlers read only the conversation id. Every use of `meta` in the widget is on a *message*, not a conversation, and `contact_last_seen_at` is read from the widget's own REST endpoint, not the cable. The remaining keys are there because they describe the customer's own side of the conversation and cost nothing to keep, so a small widget change does not immediately land on this list.

Only the cable is narrowed. The agent-authenticated `/conversations` payload and the widget's contact-scoped REST endpoint are both untouched.

## How to reproduce the class of bug

1. As an agent, add a label like `inadimplente` and a custom attribute to a conversation in a website widget inbox.
2. As the visitor, open DevTools → Network → WS.
3. Resolve the conversation.

Before: the frame carries `labels`, `custom_attributes`, `priority`, `meta.assignee` and, on Pro, the kanban board with its funnel steps. After: none of them.

## Notes

Verified at runtime by capturing what each pubsub token receives: the contact payload drops from 25 keys to 12, all four events are still delivered, and the agents' payload is unchanged. Merging this into Pro with no Pro-side change removes `kanban_task` from the contact copy automatically, which is the property this PR is really after.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/358)
<!-- Reviewable:end -->
