### PR TITLE
fix(instagram): route each webhook event in a batch to its own handler

### DIFF
--- a/app/jobs/webhooks/instagram_events_job.rb
+++ b/app/jobs/webhooks/instagram_events_job.rb
@@ -82,11 +82,9 @@ class Webhooks::InstagramEventsJob < MutexApplicationJob
   end
 
   def instagram_id(messaging)
-    if agent_message_via_echo?(messaging)
-      messaging[:sender][:id]
-    else
-      messaging[:recipient][:id]
-    end
+    return messaging.dig(:sender, :id) if agent_message_via_echo?(messaging)
+
+    messaging.dig(:recipient, :id)
   end
 
   def ig_account_id
@@ -115,6 +113,10 @@ class Webhooks::InstagramEventsJob < MutexApplicationJob
   end
 
   def find_channel(instagram_id)
+    # `channel_facebook_pages.instagram_id` is nullable, so a blank lookup would match an arbitrary
+    # page from any account instead of returning nothing.
+    return if instagram_id.blank?
+
     # There will be chances for the instagram account to be connected to a facebook page,
     # so we need to check for both instagram and facebook page channels
     # priority is for instagram channel which created via instagram login
@@ -125,8 +127,10 @@ class Webhooks::InstagramEventsJob < MutexApplicationJob
     channel
   end
 
+  # Resolved per event: a single webhook batch mixes event types, and the job iterates over every
+  # entry and every messaging item within it.
   def event_name(messaging)
-    @event_name ||= SUPPORTED_EVENTS.find { |key| messaging.key?(key) }
+    SUPPORTED_EVENTS.find { |key| messaging[key].present? }
   end
 
   def message(messaging, channel)

--- a/app/services/instagram/read_status_service.rb
+++ b/app/services/instagram/read_status_service.rb
@@ -7,10 +7,6 @@ class Instagram::ReadStatusService
     ::Conversations::UpdateMessageStatusJob.perform_later(message.conversation.id, message.created_at) if message.present?
   end
 
-  def instagram_id
-    params[:recipient][:id]
-  end
-
   def message
     return unless params[:read][:mid]
 

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -382,6 +382,52 @@ describe Webhooks::InstagramEventsJob do
         expect(instagram_inbox.messages.count).to eq 1
         expect(instagram_inbox.messages.last.content_attributes['is_unsupported']).to be_nil
       end
+
+      context 'when a single webhook batch carries more than one event' do
+        let(:read_messaging) { build(:messaging_seen_event).with_indifferent_access[:entry][0][:messaging][0] }
+        let(:dm_messaging) { build(:instagram_message_create_event).with_indifferent_access[:entry][0][:messaging][0] }
+
+        it 'routes each event to its own handler when the read event comes first' do
+          entry = { id: 'ig-entry-id', time: '2021-09-08T06:34:04+0000', messaging: [read_messaging, dm_messaging] }
+
+          expect(Instagram::ReadStatusService).to receive(:new).with(params: read_messaging,
+                                                                     channel: instagram_inbox.channel).and_call_original
+          instagram_webhook.perform_now([entry])
+
+          expect(instagram_inbox.messages.count).to eq 1
+        end
+
+        it 'routes each event to its own handler when the message event comes first' do
+          entry = { id: 'ig-entry-id', time: '2021-09-08T06:34:04+0000', messaging: [dm_messaging, read_messaging] }
+
+          expect(Instagram::ReadStatusService).to receive(:new).with(params: read_messaging,
+                                                                     channel: instagram_inbox.channel).and_call_original
+          instagram_webhook.perform_now([entry])
+
+          expect(instagram_inbox.messages.count).to eq 1
+        end
+
+        it 'routes each event to its own handler when they arrive in separate entries' do
+          read_entry = { id: 'ig-entry-id-1', time: '2021-09-08T06:34:04+0000', messaging: [read_messaging] }
+          dm_entry = { id: 'ig-entry-id-2', time: '2021-09-08T06:34:05+0000', messaging: [dm_messaging] }
+
+          expect(Instagram::ReadStatusService).to receive(:new).with(params: read_messaging,
+                                                                     channel: instagram_inbox.channel).and_call_original
+          instagram_webhook.perform_now([read_entry, dm_entry])
+
+          expect(instagram_inbox.messages.count).to eq 1
+        end
+      end
+
+      it 'skips a messaging payload without a recipient instead of matching an unrelated channel' do
+        # channel_facebook_pages.instagram_id is nullable, so a blank lookup would match an arbitrary page
+        create(:channel_facebook_page, account: create(:account))
+        read_messaging = build(:messaging_seen_event).with_indifferent_access[:entry][0][:messaging][0].except('recipient')
+        entry = { id: 'ig-entry-id', time: '2021-09-08T06:34:04+0000', messaging: [read_messaging] }
+
+        expect(Instagram::ReadStatusService).not_to receive(:new)
+        expect { instagram_webhook.perform_now([entry]) }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/jobs/webhooks/instagram_events_job_spec.rb
+++ b/spec/jobs/webhooks/instagram_events_job_spec.rb
@@ -218,6 +218,38 @@ describe Webhooks::InstagramEventsJob do
         expect(instagram_messenger_inbox.messages.count).to be 1
         expect(instagram_messenger_inbox.messages.last.content_attributes['is_unsupported']).to be true
       end
+
+      context 'when a single webhook batch carries more than one event' do
+        let(:read_messaging) { build(:messaging_seen_event).with_indifferent_access[:entry][0][:messaging][0] }
+        let(:dm_messaging) { build(:instagram_message_create_event).with_indifferent_access[:entry][0][:messaging][0] }
+
+        before do
+          allow(Koala::Facebook::API).to receive(:new).and_return(fb_object)
+          allow(fb_object).to receive(:get_object).and_return(
+            return_object_for(dm_messaging[:sender][:id]).with_indifferent_access
+          )
+        end
+
+        it 'routes each event to its own handler when the read event comes first' do
+          entry = { id: 'ig-entry-id', time: '2021-09-08T06:34:04+0000', messaging: [read_messaging, dm_messaging] }
+
+          expect(Instagram::ReadStatusService).to receive(:new).with(params: read_messaging,
+                                                                     channel: instagram_messenger_inbox.channel).and_call_original
+          instagram_webhook.perform_now([entry])
+
+          expect(instagram_messenger_inbox.messages.count).to eq 1
+        end
+
+        it 'routes each event to its own handler when the message event comes first' do
+          entry = { id: 'ig-entry-id', time: '2021-09-08T06:34:04+0000', messaging: [dm_messaging, read_messaging] }
+
+          expect(Instagram::ReadStatusService).to receive(:new).with(params: read_messaging,
+                                                                     channel: instagram_messenger_inbox.channel).and_call_original
+          instagram_webhook.perform_now([entry])
+
+          expect(instagram_messenger_inbox.messages.count).to eq 1
+        end
+      end
     end
 
     context 'when handling messaging events for Instagram via Instagram login' do


### PR DESCRIPTION
Eventos de leitura do Instagram (`messaging_seen`) deixam de derrubar o processamento do webhook. O Instagram entrega os eventos em lote, e quando um mesmo lote trazia uma mensagem e uma confirmação de leitura juntas, o segundo evento era entregue ao tratador do primeiro: o job quebrava com `NoMethodError`, entrava em retry e o restante do lote não era processado. Na prática, uma caixa ativa com bot gerava erro constante no log e mensagens que chegavam com atraso ou não chegavam. Agora cada evento do lote é roteado pelo seu próprio tipo, e o status de leitura, que antes se perdia nesses lotes, passa a ser aplicado.

## Closes

- Closes #360

## How to reproduce

Antes desta correção, com um canal `Channel::Instagram` (Instagram API with Instagram Login) e o campo `messaging_seen` assinado, que é o padrão de `Channel::Instagram#subscribe`:

1. Envie uma mensagem pela caixa de entrada e faça o contato abrir a conversa no Instagram, para que o eco da resposta e o evento de leitura cheguem no mesmo POST do webhook.
2. `Webhooks::InstagramEventsJob` levanta `NoMethodError: undefined method '[]' for nil` em `base_message_text.rb:38` (lote `[message, read]`) ou em `read_status_service.rb:15` (lote `[read, message]`), e o job vai para a fila de retry.

O mesmo vale para dois eventos de tipos diferentes em entries separadas do mesmo lote.

## What changed

- `event_name` deixa de ser memoizado na instância do job e passa a ser resolvido por item de `messaging`. Era memoizado enquanto o job itera sobre todas as entries do lote e sobre todos os itens de `messaging` de cada entry, então o primeiro evento decidia o tratador de todos os outros.
- O critério passa a ser `messaging[key].present?` em vez de `messaging.key?(key)`, então uma chave presente mas vazia vira no-op em vez de estourar dentro do tratador.
- `instagram_id` usa `dig`, alinhado com `Webhooks::InstagramController#instagram_id_from_messaging`. Um `messaging` sem `recipient` derrubava o job antes mesmo do roteamento.
- `find_channel` ignora id em branco. `channel_facebook_pages.instagram_id` é nullable e não tem índice único, então uma busca com id em branco casaria uma página arbitrária, de qualquer conta. Sem essa guarda, o `dig` acima trocaria um erro por roteamento cruzado entre contas.
- Removido `Instagram::ReadStatusService#instagram_id`, sem callers no projeto.

Os três arquivos são idênticos aos do `chatwoot/chatwoot@develop`, ou seja, o defeito é herdado do upstream. Levar a correção para lá fica como follow-up.

Fora do escopo: a chave do mutex em `perform` é derivada apenas do primeiro `messaging` da primeira entry, então num lote misto o lock protege o contato errado. Não causa o erro acima, é limitação de eficácia do lock.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/361)
<!-- Reviewable:end -->
