### PR TITLE
fix(baileys): stop the WhatsApp echo of an agent reply from duplicating it

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages/reactions_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages/reactions_controller.rb
@@ -96,7 +96,10 @@ class Api::V1::Accounts::Conversations::Messages::ReactionsController < Api::V1:
 
     # Reset source_id so SendOnChannelService doesn't treat this as a message
     # echoed back from the provider and skip the resend. The provider assigns a
-    # fresh source_id on success via send_session_message.
+    # fresh source_id on success via send_session_message. The reserved id goes
+    # with it: this row is about to be sent again, and reusing the id of the
+    # previous reaction would make WhatsApp see the resend as that same message.
+    new_attrs.delete('pending_source_id')
     existing.update!(content: new_content, content_attributes: new_attrs, source_id: nil)
   end
 

--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -31,7 +31,11 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
     # here. Exactly one of the two sides enqueues the provider delete.
     reached_provider = false
     message.with_lock do
-      message.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: { deleted: true })
+      # The reserved provider id survives the wipe: a send still in flight is what this delete races
+      # with, and dropping the reservation would leave its echo unmatchable — the deleted content
+      # would come back as a fresh incoming-looking message.
+      deleted_attributes = { deleted: true, pending_source_id: message.pending_source_id }.compact
+      message.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: deleted_attributes)
       message.attachments.destroy_all
       reached_provider = message.source_id.present?
     end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -119,12 +119,13 @@ class Message < ApplicationRecord
   # [:referral] : Click-to-WhatsApp ad metadata (source ad, headline, ctwa_clid, ...) attached to the first message after an ad click
   # [:rich] : Structured WhatsApp "rich" message (template/interactive/buttons/list) with title/body/footer/buttons rendered as a card
   # [:deleted_by_contact] : The contact deleted/revoked the message on WhatsApp; we keep the content visible and only flag it
+  # [:pending_source_id] : Provider message id reserved before the send (Baileys), used to match the provider echo back to this row
 
   store :content_attributes, accessors: [:submitted_email, :items, :submitted_values, :email, :in_reply_to, :deleted,
                                          :external_created_at, :story_sender, :story_id, :external_error,
                                          :translations, :in_reply_to_external_id, :is_unsupported, :data,
                                          :is_reaction, :is_edited, :previous_content, :zapi_args, :referral, :rich,
-                                         :deleted_by_contact], coder: JSON
+                                         :deleted_by_contact, :pending_source_id], coder: JSON
 
   store :external_source_ids, accessors: [:slack], coder: JSON, prefix: :external_source_id
 

--- a/app/services/whatsapp/baileys_handlers/concerns/group_contact_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/group_contact_message_handler.rb
@@ -28,12 +28,11 @@ module Whatsapp::BaileysHandlers::Concerns::GroupContactMessageHandler # rubocop
   def process_group_message
     @group_contact_inbox, @group_contact = find_or_create_group_contact
 
-    consolidate_contact(baileys_sender_phone, baileys_sender_lid, baileys_sender_identifier)
-    @sender_contact = find_or_create_sender_contact
-    if @sender_contact
-      update_contact_whatsapp_info(@sender_contact, baileys_sender_phone, baileys_sender_identifier, name: extract_sender_name)
-      try_update_contact_avatar(@sender_contact)
-    end
+    # The echo of a message Chatwoot sent under a reserved id is already stored; confirming it
+    # before the conversation is picked keeps it from reopening (or opening) a group thread for it.
+    return if confirm_reserved_outgoing_message(@group_contact)
+
+    resolve_group_sender_contact
 
     # Reaction removals don't produce a new Message row; handle them before
     # find_or_create_group_conversation so a blank webhook can't create a
@@ -60,6 +59,15 @@ module Whatsapp::BaileysHandlers::Concerns::GroupContactMessageHandler # rubocop
       sender: @sender_contact,
       attach_media: should_attach_media?
     )
+  end
+
+  def resolve_group_sender_contact
+    consolidate_contact(baileys_sender_phone, baileys_sender_lid, baileys_sender_identifier)
+    @sender_contact = find_or_create_sender_contact
+    return if @sender_contact.blank?
+
+    update_contact_whatsapp_info(@sender_contact, baileys_sender_phone, baileys_sender_identifier, name: extract_sender_name)
+    try_update_contact_avatar(@sender_contact)
   end
 
   def find_or_create_participant_contact(participant)

--- a/app/services/whatsapp/baileys_handlers/concerns/individual_contact_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/individual_contact_message_handler.rb
@@ -5,7 +5,7 @@ module Whatsapp::BaileysHandlers::Concerns::IndividualContactMessageHandler
 
   private
 
-  def handle_individual_contact_message # rubocop:disable Metrics/CyclomaticComplexity
+  def handle_individual_contact_message
     return unless extract_from_jid(type: 'lid')
 
     @lock_acquired = acquire_message_processing_lock
@@ -14,32 +14,38 @@ module Whatsapp::BaileysHandlers::Concerns::IndividualContactMessageHandler
     # Lock by contact phone to prevent race conditions when multiple messages
     # from the same contact arrive simultaneously (e.g., WhatsApp albums).
     contact_phone = extract_from_jid(type: 'pn') || extract_from_jid(type: 'lid')
-    with_contact_lock(contact_phone) do
-      # Re-check after acquiring lock to handle race conditions where:
-      # 1. An agent sends a message from Chatwoot (slow API call)
-      # 2. WhatsApp sends webhook before source_id is saved
-      # 3. Webhook handler times out waiting for channel lock and proceeds
-      # 4. By now, source_id should be set, so we can find the message
-      return if find_message_by_source_id(raw_message_id)
-
-      set_contact
-
-      unless @contact
-        Rails.logger.warn "Contact not found for message: #{raw_message_id}"
-        return
-      end
-
-      # Reaction removals don't produce a new Message row; handle them before
-      # set_conversation so a blank webhook can't open/create a stray thread.
-      next mark_existing_reaction_as_removed(sender: @contact) if reaction_removal?
-
-      set_first_touch_attribution
-      set_conversation
-      handle_create_message
-      dispatch_incoming_typing_off
-    end
+    with_contact_lock(contact_phone) { process_individual_contact_message }
   ensure
     clear_message_source_id_from_redis if @lock_acquired
+  end
+
+  def process_individual_contact_message
+    # Re-check after acquiring lock to handle race conditions where:
+    # 1. An agent sends a message from Chatwoot (slow API call)
+    # 2. WhatsApp sends webhook before source_id is saved
+    # 3. Webhook handler times out waiting for channel lock and proceeds
+    # 4. By now, source_id should be set, so we can find the message
+    return if find_message_by_source_id(raw_message_id)
+
+    set_contact
+
+    unless @contact
+      Rails.logger.warn "Contact not found for message: #{raw_message_id}"
+      return
+    end
+
+    # The echo of a message Chatwoot sent under a reserved id is already stored; confirming it
+    # before set_conversation keeps it from reopening (or opening) a thread for it.
+    return if confirm_reserved_outgoing_message(@contact)
+
+    # Reaction removals don't produce a new Message row; handle them before
+    # set_conversation so a blank webhook can't open/create a stray thread.
+    return mark_existing_reaction_as_removed(sender: @contact) if reaction_removal?
+
+    set_first_touch_attribution
+    set_conversation
+    handle_create_message
+    dispatch_incoming_typing_off
   end
 
   # First-touch attribution: set before set_conversation so conversation_params

--- a/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
@@ -4,7 +4,6 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
   private
 
   def build_and_save_message(conversation:, sender:, attach_media: false)
-    return if confirm_reserved_outgoing_message(conversation)
     return build_and_save_contact_messages(conversation: conversation, sender: sender) if message_type == 'contact'
 
     @message = conversation.messages.build(content: message_content, **webhook_message_attributes(sender))
@@ -38,19 +37,24 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
   # never saw and would be stored as a new sender-less outgoing message, rendered as if an agent had
   # replied from the phone. Baileys sends reserve their WhatsApp id before the request
   # (`reserve_source_id`), so match on that instead and just fill in the `source_id` the response
-  # never delivered. Scoped to the conversation the echo resolved to, which is the one holding the
-  # message we sent.
-  def confirm_reserved_outgoing_message(conversation)
+  # never delivered.
+  #
+  # Runs before the conversation is picked: a delayed echo whose original thread was resolved
+  # meanwhile would otherwise reopen it or open a stray new one just to hold a message that is
+  # already stored. The lookup spans every conversation the contact has in this inbox, since that
+  # is where the sent message can be, and answers with the conversation actually holding it.
+  def confirm_reserved_outgoing_message(contact)
     return false if incoming?
 
-    reserved = conversation.messages
-                           .where(message_type: :outgoing)
-                           .where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' = ?", raw_message_id)
-                           .first
+    reserved = Message.where(conversation_id: contact.conversations.where(inbox_id: inbox.id).select(:id))
+                      .where(message_type: :outgoing)
+                      .where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' = ?", raw_message_id)
+                      .first
     return false if reserved.nil?
 
     reserved.update_under_lock!(source_id: raw_message_id) if reserved.source_id.blank?
     @message = reserved
+    @conversation = reserved.conversation
     true
   end
 

--- a/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
@@ -4,17 +4,10 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
   private
 
   def build_and_save_message(conversation:, sender:, attach_media: false)
+    return if confirm_reserved_outgoing_message(conversation)
     return build_and_save_contact_messages(conversation: conversation, sender: sender) if message_type == 'contact'
 
-    @message = conversation.messages.build(
-      content: message_content,
-      account_id: inbox.account_id,
-      inbox_id: inbox.id,
-      source_id: raw_message_id,
-      sender: incoming? ? sender : nil,
-      message_type: incoming? ? :incoming : :outgoing,
-      content_attributes: build_message_content_attributes
-    )
+    @message = conversation.messages.build(content: message_content, **webhook_message_attributes(sender))
 
     attach_media_to_message if attach_media
     attach_location_to_message if message_type == 'location'
@@ -24,6 +17,41 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
     inbox.channel.received_messages([@message], conversation) if incoming?
 
     @message
+  end
+
+  # Columns shared by every message built from the current webhook: an incoming message keeps its
+  # sender, while a message the session sent (echoed back by WhatsApp) is stored sender-less.
+  def webhook_message_attributes(sender)
+    {
+      account_id: inbox.account_id,
+      inbox_id: inbox.id,
+      source_id: raw_message_id,
+      sender: incoming? ? sender : nil,
+      message_type: incoming? ? :incoming : :outgoing,
+      content_attributes: build_message_content_attributes
+    }
+  end
+
+  # WhatsApp echoes back every message the session sends, including the ones Chatwoot itself
+  # dispatched. Those echoes are normally recognized by `source_id`, which is only written from the
+  # send response — when that response is lost and the job retries, the echo carries an id Chatwoot
+  # never saw and would be stored as a new sender-less outgoing message, rendered as if an agent had
+  # replied from the phone. Baileys sends reserve their WhatsApp id before the request
+  # (`reserve_source_id`), so match on that instead and just fill in the `source_id` the response
+  # never delivered. Scoped to the conversation the echo resolved to, which is the one holding the
+  # message we sent.
+  def confirm_reserved_outgoing_message(conversation)
+    return false if incoming?
+
+    reserved = conversation.messages
+                           .where(message_type: :outgoing)
+                           .where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' = ?", raw_message_id)
+                           .first
+    return false if reserved.nil?
+
+    reserved.update_under_lock!(source_id: raw_message_id) if reserved.source_id.blank?
+    @message = reserved
+    true
   end
 
   # Mirrors the Cloud provider (create_contact_messages): one message per shared
@@ -39,11 +67,7 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
     fields = baileys_contact_fields(contact)
     return if fields[:phone].blank? && fields[:name].blank?
 
-    message = conversation.messages.build(
-      content: baileys_contact_line(contact), account_id: inbox.account_id, inbox_id: inbox.id,
-      source_id: raw_message_id, sender: incoming? ? sender : nil,
-      message_type: incoming? ? :incoming : :outgoing, content_attributes: build_message_content_attributes
-    )
+    message = conversation.messages.build(content: baileys_contact_line(contact), **webhook_message_attributes(sender))
     attach_contact_card(message, fields)
     message.save!
     message

--- a/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
@@ -52,10 +52,18 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
                       .first
     return false if reserved.nil?
 
-    reserved.update_under_lock!(source_id: raw_message_id) if reserved.source_id.blank?
+    confirm_source_id(reserved) if reserved.source_id.blank?
     @message = reserved
     @conversation = reserved.conversation
     true
+  end
+
+  # Mirrors Whatsapp::SendOnWhatsappService#persist_source_id: the id the send never got to store is
+  # what a revoke needs, so a message deleted while that send was in flight can only be taken off the
+  # contact's phone once this echo supplies it.
+  def confirm_source_id(reserved)
+    reserved.update_under_lock!(source_id: raw_message_id)
+    ::Messages::DeleteOnChannelJob.perform_later(reserved.id) if reserved.deleted?
   end
 
   # Mirrors the Cloud provider (create_contact_messages): one message per shared

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -720,19 +720,22 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # closes that window, and a Sidekiq retry reuses it so WhatsApp still sees a single message.
   # Shape mirrors Baileys' generateMessageIDV2: the "3EB0" prefix followed by 18 uppercase hex chars.
   #
-  # Written with `update_columns` under the row lock: the reservation is bookkeeping for a send that
-  # has not happened yet, so it must not fire `message.updated` (cable, webhooks, agent bots, search
-  # reindex) nor bump `updated_at`, which the idempotency key above is built from — a retry has to
-  # reuse the same key. `lock!` re-reads the row first, so the merge below can't write back a stale
-  # `content_attributes`.
+  # The whole read-or-generate runs under the row lock, which re-reads the row: this send may have
+  # been queued behind the channel lock for minutes, and a reaction toggle in the meantime clears the
+  # reservation precisely to force a fresh id — sending under the id we loaded before waiting would
+  # resend the previous reaction and leave its echo unmatchable.
+  #
+  # Written with `update_columns`: the reservation is bookkeeping for a send that has not happened
+  # yet, so it must not fire `message.updated` (cable, webhooks, agent bots, search reindex) nor bump
+  # `updated_at`, which the idempotency key above is built from — a retry has to reuse the same key.
   def reserve_source_id
-    return @message.pending_source_id if @message.pending_source_id.present?
+    @message.with_lock do
+      next @message.pending_source_id if @message.pending_source_id.present?
 
-    "3EB0#{SecureRandom.hex(9).upcase}".tap do |id|
-      @message.with_lock do
-        @message.pending_source_id = id
-        @message.update_columns(content_attributes: @message.content_attributes) # rubocop:disable Rails/SkipsModelValidations
-      end
+      id = "3EB0#{SecureRandom.hex(9).upcase}"
+      @message.pending_source_id = id
+      @message.update_columns(content_attributes: @message.content_attributes) # rubocop:disable Rails/SkipsModelValidations
+      id
     end
   end
 

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -687,6 +687,10 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   end
 
   def send_message_request
+    # Reserved before the request so `updated_at` (and with it the idempotency
+    # key below) is already settled when the body is built.
+    message_id = reserve_source_id
+
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/send-message",
       headers: api_headers,
@@ -698,7 +702,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         # only `id` would make every follow-up send hit the cached response and
         # never reach WhatsApp. Suffixing with updated_at gives each send a fresh
         # key while still letting Sidekiq retries of the same attempt dedupe.
-        chatwootMessageId: "#{@message.id}:#{@message.updated_at.to_f}"
+        chatwootMessageId: "#{@message.id}:#{@message.updated_at.to_f}",
+        messageId: message_id
       }.to_json,
       timeout: 120
     )
@@ -708,6 +713,18 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
 
     update_external_created_at(response)
     response.parsed_response.dig('data', 'key', 'id')
+  end
+
+  # The WhatsApp message id this send will use, picked here instead of letting Baileys generate it.
+  # `source_id` can only be written from the response, so a send whose response never arrives (socket
+  # drop, read timeout, worker restart) leaves us with no way to recognize the `messages.upsert` echo
+  # of our own message — it lands as a fresh "sent from the phone" message. Reserving the id up front
+  # closes that window, and a Sidekiq retry reuses it so WhatsApp still sees a single message.
+  # Shape mirrors Baileys' generateMessageIDV2: the "3EB0" prefix followed by 18 uppercase hex chars.
+  def reserve_source_id
+    return @message.pending_source_id if @message.pending_source_id.present?
+
+    "3EB0#{SecureRandom.hex(9).upcase}".tap { |id| @message.update_under_lock!(pending_source_id: id) }
   end
 
   def process_response(response)

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -687,8 +687,6 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   end
 
   def send_message_request
-    # Reserved before the request so `updated_at` (and with it the idempotency
-    # key below) is already settled when the body is built.
     message_id = reserve_source_id
 
     response = HTTParty.post(
@@ -721,10 +719,21 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # of our own message — it lands as a fresh "sent from the phone" message. Reserving the id up front
   # closes that window, and a Sidekiq retry reuses it so WhatsApp still sees a single message.
   # Shape mirrors Baileys' generateMessageIDV2: the "3EB0" prefix followed by 18 uppercase hex chars.
+  #
+  # Written with `update_columns` under the row lock: the reservation is bookkeeping for a send that
+  # has not happened yet, so it must not fire `message.updated` (cable, webhooks, agent bots, search
+  # reindex) nor bump `updated_at`, which the idempotency key above is built from — a retry has to
+  # reuse the same key. `lock!` re-reads the row first, so the merge below can't write back a stale
+  # `content_attributes`.
   def reserve_source_id
     return @message.pending_source_id if @message.pending_source_id.present?
 
-    "3EB0#{SecureRandom.hex(9).upcase}".tap { |id| @message.update_under_lock!(pending_source_id: id) }
+    "3EB0#{SecureRandom.hex(9).upcase}".tap do |id|
+      @message.with_lock do
+        @message.pending_source_id = id
+        @message.update_columns(content_attributes: @message.content_attributes) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
   end
 
   def process_response(response)

--- a/spec/controllers/api/v1/accounts/conversations/messages/reactions_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages/reactions_controller_spec.rb
@@ -166,6 +166,16 @@ RSpec.describe 'Conversation Message Reactions API', type: :request do
         expect(existing.source_id).to be_nil
       end
 
+      # The row is about to be sent again, so it must not reuse the WhatsApp id reserved for the
+      # previous reaction — the resend would be seen as that same message.
+      it 'drops the reserved provider id so the resend gets a fresh one' do
+        existing.update!(content_attributes: existing.content_attributes.merge('pending_source_id' => 'RESERVED_1'))
+
+        post reactions_url, params: { emoji: '❤️' }, headers: agent.create_new_auth_token, as: :json
+
+        expect(existing.reload.content_attributes['pending_source_id']).to be_nil
+      end
+
       it 'enqueues SendReplyJob with the existing message id when toggling off' do
         expect do
           post reactions_url, params: { emoji: '👍' }, headers: agent.create_new_auth_token, as: :json

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -268,6 +268,20 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(message.reload.content_attributes['bcc_emails']).to be_nil
       end
 
+      # The provider id reserved before an in-flight send is the only handle on the message once the
+      # send response is lost, so the delete must not wipe it along with the rest.
+      it 'keeps the reserved provider id while wiping the other content attributes' do
+        message.update!(content_attributes: message.content_attributes.merge('pending_source_id' => 'RESERVED_1'))
+
+        delete "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/messages/#{message.id}",
+               headers: agent.create_new_auth_token,
+               as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(message.reload.content_attributes['pending_source_id']).to eq 'RESERVED_1'
+        expect(message.content_attributes['bcc_emails']).to be_nil
+      end
+
       it 'deletes interactive messages' do
         interactive_message = create(
           :message, message_type: :outgoing, content: 'test', content_type: 'input_select',

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -938,6 +938,22 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       expect(sent.reload.source_id).to eq('RESERVED_1')
     end
 
+    # A delayed echo must not reopen the thread it belongs to, nor open a new one to hold a message
+    # that is already stored.
+    it 'confirms a reserved message whose conversation was resolved meanwhile' do
+      sent = create(:message, inbox: inbox, conversation: conversation, message_type: :outgoing,
+                              content: '**John** olá', source_id: nil,
+                              content_attributes: { pending_source_id: 'RESERVED_3' })
+      conversation.update!(status: :resolved)
+
+      expect do
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: echo_params('RESERVED_3')).perform
+      end.to not_change(Message, :count).and not_change(Conversation, :count)
+
+      expect(sent.reload.source_id).to eq('RESERVED_3')
+      expect(conversation.reload.status).to eq('resolved')
+    end
+
     it 'keeps the source_id already confirmed by the send response' do
       sent = create(:message, inbox: inbox, conversation: conversation, message_type: :outgoing,
                               content: '**John** olá', source_id: 'RESERVED_2',

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -907,6 +907,61 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
     end
   end
 
+  describe 'echo of a message sent by Chatwoot' do
+    let(:phone) { '5511912345678' }
+    let(:lid) { '12345678' }
+    let(:contact) { create(:contact, account: inbox.account, phone_number: "+#{phone}", identifier: "#{lid}@lid") }
+    let(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: lid) }
+    let(:conversation) { create(:conversation, inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+    def echo_params(id)
+      raw_message = {
+        key: { id: id, remoteJid: "#{lid}@lid", remoteJidAlt: "#{phone}@s.whatsapp.net", fromMe: true, addressingMode: 'lid' },
+        messageTimestamp: timestamp,
+        message: { conversation: '*John* olá' }
+      }
+      { webhookVerifyToken: webhook_verify_token, event: 'messages.upsert', data: { type: 'append', messages: [raw_message] } }
+    end
+
+    # The send response never arrived, so `source_id` is still blank and only the id reserved before
+    # the request identifies the message. Without that match the echo would land as a second message
+    # attributed to WhatsApp instead of the agent.
+    it 'confirms the reserved message instead of creating a duplicate' do
+      sent = create(:message, inbox: inbox, conversation: conversation, message_type: :outgoing,
+                              content: '**John** olá', source_id: nil,
+                              content_attributes: { pending_source_id: 'RESERVED_1' })
+
+      expect do
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: echo_params('RESERVED_1')).perform
+      end.not_to change(Message, :count)
+
+      expect(sent.reload.source_id).to eq('RESERVED_1')
+    end
+
+    it 'keeps the source_id already confirmed by the send response' do
+      sent = create(:message, inbox: inbox, conversation: conversation, message_type: :outgoing,
+                              content: '**John** olá', source_id: 'RESERVED_2',
+                              content_attributes: { pending_source_id: 'RESERVED_2' })
+
+      Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: echo_params('RESERVED_2')).perform
+
+      expect(sent.reload.source_id).to eq('RESERVED_2')
+    end
+
+    it 'still stores a message actually sent from the phone' do
+      conversation
+
+      expect do
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: echo_params('PHONE_MSG_1')).perform
+      end.to change(Message, :count).by(1)
+
+      message = Message.find_by(source_id: 'PHONE_MSG_1')
+      expect(message).to be_outgoing
+      expect(message.sender).to be_nil
+      expect(message.content_attributes['external_sender_name']).to eq('WhatsApp')
+    end
+  end
+
   describe 'membership request stub handling' do
     let(:group_jid) { '123456789123456789@g.us' }
     let(:requester_lid) { '12345678' }

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -954,6 +954,20 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       expect(conversation.reload.status).to eq('resolved')
     end
 
+    # Deleting a message whose send is still in flight leaves nobody holding its provider id, so the
+    # echo is the only chance to learn it — and to revoke the message on the contact's phone.
+    it 'revokes on the channel when the confirmed message was deleted meanwhile' do
+      sent = create(:message, inbox: inbox, conversation: conversation, message_type: :outgoing,
+                              content: 'Mensagem apagada', source_id: nil,
+                              content_attributes: { pending_source_id: 'RESERVED_4', deleted: true })
+
+      expect do
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: echo_params('RESERVED_4')).perform
+      end.to have_enqueued_job(Messages::DeleteOnChannelJob).with(sent.id)
+
+      expect(sent.reload.source_id).to eq('RESERVED_4')
+    end
+
     it 'keeps the source_id already confirmed by the send response' do
       sent = create(:message, inbox: inbox, conversation: conversation, message_type: :outgoing,
                               content: '**John** olá', source_id: 'RESERVED_2',

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -750,6 +750,18 @@ describe Whatsapp::Providers::WhatsappBaileysService do
         reserved = unsent_message.reload.pending_source_id
         expect(reserved).to match(/\A3EB0[0-9A-F]{18}\z/)
         expect(WebMock).to(have_requested(:post, request_path).with { |req| JSON.parse(req.body)['messageId'] == reserved })
+        # Stored so the echo handler's lookup can read it back out of the JSON column.
+        expect(Message.where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' = ?", reserved)).to exist
+      end
+
+      # The reservation is bookkeeping for a send that has not happened yet: it must not look like a
+      # message update to integrations, nor invalidate the idempotency key a retry has to reuse.
+      it 'does not touch updated_at when reserving' do
+        stub_request(:post, request_path)
+          .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: result_body.to_json)
+
+        expect { service.send_message(test_send_phone_number, unsent_message) }
+          .not_to(change { unsent_message.reload.updated_at })
       end
 
       it 'reuses the reserved id when the same message is sent again' do

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -2073,11 +2073,13 @@ describe Whatsapp::Providers::WhatsappBaileysService do
     }
   end
 
-  # The service reserves the WhatsApp message id before posting, which also settles `updated_at`.
-  # Reserving it here keeps the expected body (and the idempotency key built from `updated_at`)
-  # in sync with what the send actually posts.
+  # The service reserves the WhatsApp message id before posting, so reserve it here too or the
+  # expected body would carry a different `messageId`. The reload matters: the reservation runs
+  # under a row lock, which re-reads the row, so the service builds the idempotency key from the
+  # database `updated_at` (microseconds) rather than the in-memory one written by `update!`.
   def send_message_body(hash, msg = message)
     msg.update_under_lock!(pending_source_id: 'reserved_msg_id') if msg.pending_source_id.blank?
+    msg.reload
     hash.merge(chatwootMessageId: "#{msg.id}:#{msg.updated_at.to_f}", messageId: msg.pending_source_id).to_json
   end
 end

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -738,6 +738,33 @@ describe Whatsapp::Providers::WhatsappBaileysService do
       end
     end
 
+    context 'when reserving the WhatsApp message id' do
+      let(:unsent_message) { create(:message, inbox: whatsapp_channel.inbox, content: 'Hello') }
+
+      it 'sends under a reserved id and persists it before the request' do
+        stub_request(:post, request_path)
+          .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: result_body.to_json)
+
+        service.send_message(test_send_phone_number, unsent_message)
+
+        reserved = unsent_message.reload.pending_source_id
+        expect(reserved).to match(/\A3EB0[0-9A-F]{18}\z/)
+        expect(WebMock).to(have_requested(:post, request_path).with { |req| JSON.parse(req.body)['messageId'] == reserved })
+      end
+
+      it 'reuses the reserved id when the same message is sent again' do
+        stub_request(:post, request_path)
+          .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: result_body.to_json)
+
+        service.send_message(test_send_phone_number, unsent_message)
+        reserved = unsent_message.reload.pending_source_id
+        service.send_message(test_send_phone_number, unsent_message)
+
+        expect(unsent_message.reload.pending_source_id).to eq(reserved)
+        expect(WebMock).to(have_requested(:post, request_path).with { |req| JSON.parse(req.body)['messageId'] == reserved }.twice)
+      end
+    end
+
     context 'when request is unsuccessful' do
       it 'raises ProviderUnavailableError' do
         stub_request(:post, request_path)
@@ -2022,7 +2049,11 @@ describe Whatsapp::Providers::WhatsappBaileysService do
     }
   end
 
+  # The service reserves the WhatsApp message id before posting, which also settles `updated_at`.
+  # Reserving it here keeps the expected body (and the idempotency key built from `updated_at`)
+  # in sync with what the send actually posts.
   def send_message_body(hash, msg = message)
-    hash.merge(chatwootMessageId: "#{msg.id}:#{msg.updated_at.to_f}").to_json
+    msg.update_under_lock!(pending_source_id: 'reserved_msg_id') if msg.pending_source_id.blank?
+    hash.merge(chatwootMessageId: "#{msg.id}:#{msg.updated_at.to_f}", messageId: msg.pending_source_id).to_json
   end
 end

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -754,6 +754,18 @@ describe Whatsapp::Providers::WhatsappBaileysService do
         expect(Message.where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' = ?", reserved)).to exist
       end
 
+      # A send can sit behind the channel lock for minutes; the row may have been re-reserved (or
+      # cleared and re-reserved by a reaction toggle) since it was loaded.
+      it 'reads the reservation under the lock instead of the copy loaded before waiting' do
+        Message.find(unsent_message.id).update!(content_attributes: { pending_source_id: 'RESERVED_ELSEWHERE' })
+        stub_request(:post, request_path)
+          .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: result_body.to_json)
+
+        service.send_message(test_send_phone_number, unsent_message)
+
+        expect(WebMock).to(have_requested(:post, request_path).with { |req| JSON.parse(req.body)['messageId'] == 'RESERVED_ELSEWHERE' })
+      end
+
       # The reservation is bookkeeping for a send that has not happened yet: it must not look like a
       # message update to integrations, nor invalidate the idempotency key a retry has to reuse.
       it 'does not touch updated_at when reserving' do


### PR DESCRIPTION
Uma resposta enviada pelo agente às vezes aparecia duas vezes na conversa: a mensagem real, e segundos depois uma cópia sem remetente, estilizada como se alguém tivesse respondido pelo celular. Nada era enviado duas vezes ao contato; era só um registro fantasma no Chatwoot. Agora a mensagem enviada reserva o id do WhatsApp antes do envio, então o eco que o WhatsApp devolve é reconhecido como a própria mensagem e não vira um segundo registro.

## Closes

- Closes #338

## How to reproduce

1. Inbox de WhatsApp com `provider: baileys`.
2. Agente envia uma mensagem pelo dashboard.
3. Se a resposta do provider se perde (queda de socket, timeout, worker reiniciado) e o job é re-tentado, o eco do primeiro envio chega com um id que o Chatwoot nunca viu.
4. Antes: virava uma segunda mensagem outgoing sem `sender`, com `content_attributes.external_sender_name: "WhatsApp"`. Agora: é casada com a mensagem original, que só recebe o `source_id` que a resposta não entregou.

## What changed

- `reserve_source_id` no provider Baileys: gera o id do WhatsApp (`3EB0` + 18 hex, mesmo formato do `generateMessageIDV2`), persiste em `content_attributes.pending_source_id` e o envia como `messageId` antes do POST. Retentativas reutilizam o id reservado, então o WhatsApp continua vendo uma única mensagem.
- `confirm_reserved_outgoing_message` no handler de `messages.upsert`: um eco `fromMe` que não bate por `source_id` é casado pelo id reservado dentro da conversa, preenchendo o `source_id` ausente em vez de criar uma mensagem nova. Vale para conversa individual e grupo.
- Toggle de reação passa a descartar o `pending_source_id` junto com o `source_id`, já que aquela linha é reenviada e não pode reusar o id da reação anterior.

Depende de `fazer-ai/baileys-api#373` (suporte a `messageId` no `send-message`). Contra um provider mais antigo o campo é ignorado e o comportamento é o de hoje, então a ordem de deploy é provider primeiro, mas não há quebra se for ao contrário.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/362)
<!-- Reviewable:end -->

