### PR TITLE
fix(whatsapp): send a template's sample media by id instead of by link

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -1,0 +1,10 @@
+# Waived after adjudication. One entry per line: <repo-relative-path>: <finding title>
+
+# The swallow is Whatsapp::OneoffCampaignService's own pre-existing design ("continue processing
+# remaining contacts"), not something this branch introduced: `channel.send_template` failing on a
+# network blip was already skipped the same silent way, and before this branch a media-header campaign
+# failed for every recipient anyway, with 131053. Not raising is also the safer half of the trade:
+# the rescue is per recipient, so letting it through would fail the whole campaign job and Sidekiq
+# would re-run it, re-sending to everyone already delivered. Per-recipient retry is a mechanism the
+# campaign service does not have, and building it belongs in its own PR.
+app/services/whatsapp/template_processor_service.rb: Preserve retries for campaign sample uploads

--- a/app/services/whatsapp/populate_template_parameters_service.rb
+++ b/app/services/whatsapp/populate_template_parameters_service.rb
@@ -160,10 +160,12 @@ class Whatsapp::PopulateTemplateParametersService
   end
 
   # `%` joins the class so escapes already present survive untouched instead of being double-encoded.
+  # A `%` that does not start a valid escape is a literal one (`/100%.jpg`), and leaving it raw would
+  # make `URI.parse` reject the whole URL, so it is escaped first.
   def encode_uri_component(value, character_class)
     return value if value.nil?
 
-    Addressable::URI.encode_component(value, "#{character_class}%")
+    Addressable::URI.encode_component(value.gsub(/%(?![0-9A-Fa-f]{2})/, '%25'), "#{character_class}%")
   end
 
   def validate_url(url)

--- a/app/services/whatsapp/populate_template_parameters_service.rb
+++ b/app/services/whatsapp/populate_template_parameters_service.rb
@@ -34,16 +34,13 @@ class Whatsapp::PopulateTemplateParametersService
     end
   end
 
-  def build_media_parameter(url, media_type, media_name = nil)
-    return nil if url.blank?
+  # `source` is what the API should fetch the media by: either `{ link: url }` or `{ id: media_id }`.
+  def build_media_parameter(source, media_type, media_name = nil)
+    source = { link: source } if source.is_a?(String)
+    return nil if source[:link].blank? && source[:id].blank?
 
-    # A URL is not free text, so it never goes through `sanitize_parameter`: that helper strips
-    # characters and truncates at 1000 chars, which turns a long signed link into one that still
-    # looks valid but no longer resolves. The Cloud API only reports that back as a generic
-    # "131053 Media upload error", with no hint that we were the ones who broke the link.
-    normalized_url = normalize_url(url.to_s.strip)
-    validate_url(normalized_url)
-    build_media_type_parameter(normalized_url, media_type.downcase, media_name)
+    source = { link: prepare_url(source[:link]) } if source[:id].blank?
+    build_media_type_parameter(source, media_type.downcase, media_name)
   end
 
   def build_named_parameter(parameter_name, value)
@@ -97,32 +94,17 @@ class Whatsapp::PopulateTemplateParametersService
     }
   end
 
-  def build_media_type_parameter(sanitized_url, media_type, media_name = nil)
+  def build_media_type_parameter(source, media_type, media_name = nil)
     case media_type
     when 'image'
-      build_image_parameter(sanitized_url)
+      { type: 'image', image: source }
     when 'video'
-      build_video_parameter(sanitized_url)
+      { type: 'video', video: source }
     when 'document'
-      build_document_parameter(sanitized_url, media_name)
+      { type: 'document', document: media_name.present? ? source.merge(filename: media_name) : source }
     else
       raise ArgumentError, "Unsupported media type: #{media_type}"
     end
-  end
-
-  def build_image_parameter(url)
-    { type: 'image', image: { link: url } }
-  end
-
-  def build_video_parameter(url)
-    { type: 'video', video: { link: url } }
-  end
-
-  def build_document_parameter(url, media_name = nil)
-    document_params = { link: url }
-    document_params[:filename] = media_name if media_name.present?
-
-    { type: 'document', document: document_params }
   end
 
   def rich_formatting?(text)
@@ -144,6 +126,16 @@ class Whatsapp::PopulateTemplateParametersService
     sanitized = value.to_s.strip
     sanitized = sanitized.gsub(/[<>\"']/, '') # Remove potential HTML/JS chars
     sanitized[0...1000] # Limit length to prevent DoS
+  end
+
+  # A URL is not free text, so it never goes through `sanitize_parameter`: that helper strips characters
+  # and truncates at 1000 chars, which turns a long signed link into one that still looks valid but no
+  # longer resolves. The Cloud API only reports that back as a generic "131053 Media upload error", with
+  # no hint that we were the ones who broke the link.
+  def prepare_url(url)
+    normalized_url = normalize_url(url.to_s.strip)
+    validate_url(normalized_url)
+    normalized_url
   end
 
   def normalize_url(url)

--- a/app/services/whatsapp/populate_template_parameters_service.rb
+++ b/app/services/whatsapp/populate_template_parameters_service.rb
@@ -1,4 +1,8 @@
 class Whatsapp::PopulateTemplateParametersService
+  # Characters that may appear literally in a URI (RFC 3986 reserved + unreserved), plus `%` so
+  # escapes that are already in the URL are left alone.
+  URL_CHARACTER_CLASS = "#{Addressable::URI::CharacterClasses::RESERVED}#{Addressable::URI::CharacterClasses::UNRESERVED}%".freeze
+
   def build_parameter(value)
     case value
     when String
@@ -33,8 +37,11 @@ class Whatsapp::PopulateTemplateParametersService
   def build_media_parameter(url, media_type, media_name = nil)
     return nil if url.blank?
 
-    sanitized_url = sanitize_parameter(url)
-    normalized_url = normalize_url(sanitized_url)
+    # A URL is not free text, so it never goes through `sanitize_parameter`: that helper strips
+    # characters and truncates at 1000 chars, which turns a long signed link into one that still
+    # looks valid but no longer resolves. The Cloud API only reports that back as a generic
+    # "131053 Media upload error", with no hint that we were the ones who broke the link.
+    normalized_url = normalize_url(url.to_s.strip)
     validate_url(normalized_url)
     build_media_type_parameter(normalized_url, media_type.downcase, media_name)
   end
@@ -140,18 +147,16 @@ class Whatsapp::PopulateTemplateParametersService
   end
 
   def normalize_url(url)
-    # Use Addressable::URI for better URL normalization
-    # It handles spaces, special characters, and encoding automatically
-    Addressable::URI.parse(url).normalize.to_s
-  rescue Addressable::URI::InvalidURIError
-    # Fallback: simple space encoding if Addressable fails
-    url.gsub(' ', '%20')
+    # Percent-encode only what is illegal in a URI (spaces, non-ASCII), leaving existing escapes
+    # untouched. `Addressable::URI#normalize` can't be used here because it *decodes* escaped
+    # octets that map back to allowed characters (`%3F` becomes a literal `?`, splitting the query
+    # in two), which invalidates signed links such as the `header_handle` sample media that ships
+    # with a WhatsApp template.
+    Addressable::URI.encode_component(url, URL_CHARACTER_CLASS)
   end
 
   def validate_url(url)
     return if url.blank?
-
-    # url is already normalized by the caller
 
     uri = URI.parse(url)
     raise ArgumentError, "Invalid URL scheme: #{uri.scheme}. Only http and https are allowed" unless %w[http https].include?(uri.scheme)

--- a/app/services/whatsapp/populate_template_parameters_service.rb
+++ b/app/services/whatsapp/populate_template_parameters_service.rb
@@ -1,7 +1,5 @@
 class Whatsapp::PopulateTemplateParametersService
-  # Characters that may appear literally in a URI (RFC 3986 reserved + unreserved), plus `%` so
-  # escapes that are already in the URL are left alone.
-  URL_CHARACTER_CLASS = "#{Addressable::URI::CharacterClasses::RESERVED}#{Addressable::URI::CharacterClasses::UNRESERVED}%".freeze
+  CHARACTER_CLASSES = Addressable::URI::CharacterClasses
 
   def build_parameter(value)
     case value
@@ -138,13 +136,34 @@ class Whatsapp::PopulateTemplateParametersService
     normalized_url
   end
 
+  # Percent-encodes only what is illegal in each component, leaving existing escapes untouched.
+  #
+  # `Addressable::URI#normalize` can't be used here because it *decodes* escaped octets that map back
+  # to characters the component allows: `%3F` becomes a literal `?` that splits the query in two, which
+  # invalidates a signed link such as the `header_handle` sample media a WhatsApp template ships with.
+  # Encoding the URI as one string against the union of every reserved character is wrong in the other
+  # direction: it leaves a bracket in the path unescaped, which `URI.parse` then rejects, and turns an
+  # internationalized host into percent-encoded UTF-8 instead of punycode.
   def normalize_url(url)
-    # Percent-encode only what is illegal in a URI (spaces, non-ASCII), leaving existing escapes
-    # untouched. `Addressable::URI#normalize` can't be used here because it *decodes* escaped
-    # octets that map back to allowed characters (`%3F` becomes a literal `?`, splitting the query
-    # in two), which invalidates signed links such as the `header_handle` sample media that ships
-    # with a WhatsApp template.
-    Addressable::URI.encode_component(url, URL_CHARACTER_CLASS)
+    uri = Addressable::URI.parse(url)
+    Addressable::URI.new(
+      scheme: uri.scheme,
+      userinfo: uri.userinfo,
+      host: uri.normalized_host,
+      port: uri.port,
+      path: encode_uri_component(uri.path, CHARACTER_CLASSES::PATH),
+      query: encode_uri_component(uri.query, CHARACTER_CLASSES::QUERY),
+      fragment: encode_uri_component(uri.fragment, CHARACTER_CLASSES::FRAGMENT)
+    ).to_s
+  rescue Addressable::URI::InvalidURIError => e
+    raise ArgumentError, "Invalid URL format: #{e.message}. Please enter a valid URL like https://example.com/document.pdf"
+  end
+
+  # `%` joins the class so escapes already present survive untouched instead of being double-encoded.
+  def encode_uri_component(value, character_class)
+    return value if value.nil?
+
+    Addressable::URI.encode_component(value, "#{character_class}%")
   end
 
   def validate_url(url)

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -227,21 +227,30 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def parse_upload_response(response)
-    # A 429 or a 5xx is the API having a bad minute, not a file it refuses. Answering with
-    # MediaUploadError would be indistinguishable from a rejected file and would fail the message for
-    # good; letting these through keeps Sidekiq's retry.
-    response.value if response.code == '429' || response.is_a?(Net::HTTPServerError)
-
-    body = JSON.parse(response.body)
+    body = parse_json(response.body)
     return body['id'] if body['id'].present?
+
+    error = body['error'] || {}
+    # An API having a bad minute is not a file it refuses. Answering with MediaUploadError would be
+    # indistinguishable from a rejected file and would fail the message for good; letting these through
+    # keeps Sidekiq's retry. The HTTP status alone can't tell the two apart, because Graph reports
+    # throttling and other transient conditions inside a 400 envelope flagged `is_transient`.
+    response.value if transient_upload_error?(response, error)
 
     # The generic `error.message` for a rejected upload is just "(#100) Invalid parameter"; the reason
     # an agent can act on ("File Too Large", unsupported format) is in `error_data.details`.
-    error = body['error'] || {}
     raise CustomExceptions::Whatsapp::MediaUploadError,
-          "Media upload failed: #{error.dig('error_data', 'details') || error['message']}"
+          "Media upload failed: #{error.dig('error_data', 'details') || error['message'] || "HTTP #{response.code}"}"
+  end
+
+  def transient_upload_error?(response, error)
+    response.code == '429' || response.is_a?(Net::HTTPServerError) || error['is_transient'] == true
+  end
+
+  def parse_json(body)
+    JSON.parse(body.to_s)
   rescue JSON::ParserError
-    raise CustomExceptions::Whatsapp::MediaUploadError, "Media upload failed with HTTP #{response.code}"
+    {}
   end
 
   def voice_message?(type, attachment)

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -227,6 +227,11 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def parse_upload_response(response)
+    # A 429 or a 5xx is the API having a bad minute, not a file it refuses. Answering with
+    # MediaUploadError would be indistinguishable from a rejected file and would fail the message for
+    # good; letting these through keeps Sidekiq's retry.
+    response.value if response.code == '429' || response.is_a?(Net::HTTPServerError)
+
     body = JSON.parse(response.body)
     return body['id'] if body['id'].present?
 

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -95,6 +95,30 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     "#{api_base_path}/v13.0/#{media_id}"
   end
 
+  # Uploads a file to the WhatsApp media store and returns its id, which can then be used in place of a
+  # `link` anywhere the API takes media. Meta keeps the upload for 30 days.
+  # https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media#upload-media
+  #
+  # This is the one call that does not go through HTTParty: its multipart bodies are streamed with
+  # chunked encoding, and the Graph API answers "(#100) The parameter file is required" to those.
+  # Net::HTTP sends a Content-Length, which is what the endpoint expects.
+  def upload_media(file, content_type)
+    uri = URI.parse("#{phone_id_path('v24.0')}/media")
+    request = Net::HTTP::Post.new(uri)
+    request['Authorization'] = "Bearer #{whatsapp_channel.provider_config['api_key']}"
+    request.set_form(
+      [
+        %w[messaging_product whatsapp],
+        ['type', content_type],
+        ['file', file, { filename: File.basename(file.path), content_type: content_type }]
+      ],
+      'multipart/form-data'
+    )
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') { |http| http.request(request) }
+    parse_upload_response(response)
+  end
+
   def toggle_typing_status(typing_status, last_message:, **)
     return false unless [Events::Types::CONVERSATION_TYPING_ON, Events::Types::CONVERSATION_RECORDING].include?(typing_status)
 
@@ -200,6 +224,19 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   def error_message(response)
     # https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#sample-response
     response.parsed_response.dig('error', 'message') if response.parsed_response.is_a?(Hash)
+  end
+
+  def parse_upload_response(response)
+    body = JSON.parse(response.body)
+    return body['id'] if body['id'].present?
+
+    # The generic `error.message` for a rejected upload is just "(#100) Invalid parameter"; the reason
+    # an agent can act on ("File Too Large", unsupported format) is in `error_data.details`.
+    error = body['error'] || {}
+    raise CustomExceptions::Whatsapp::MediaUploadError,
+          "Media upload failed: #{error.dig('error_data', 'details') || error['message']}"
+  rescue JSON::ParserError
+    raise CustomExceptions::Whatsapp::MediaUploadError, "Media upload failed with HTTP #{response.code}"
   end
 
   def voice_message?(type, attachment)

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -38,9 +38,10 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
                                          parameters: processed_parameters
                                        }, message)
     persist_source_id(message_id)
-  rescue ArgumentError => e
-    # Parameter validation (media URL, coupon code, media type) rejected the template. Retrying
-    # can't fix it, so surface the reason on the message instead of letting the job die silently.
+  rescue ArgumentError, CustomExceptions::Whatsapp::MediaUploadError => e
+    # Parameter validation (media URL, coupon code, media type) rejected the template, or its sample
+    # media could not be uploaded. Retrying can't fix either, so surface the reason on the message
+    # instead of letting the job die silently.
     message.update_under_lock!(status: :failed, external_error: e.message)
   end
 

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -38,6 +38,10 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
                                          parameters: processed_parameters
                                        }, message)
     persist_source_id(message_id)
+  rescue ArgumentError => e
+    # Parameter validation (media URL, coupon code, media type) rejected the template. Retrying
+    # can't fix it, so surface the reason on the message instead of letting the job die silently.
+    message.update_under_lock!(status: :failed, external_error: e.message)
   end
 
   def send_baileys_session_message

--- a/app/services/whatsapp/template_processor_service.rb
+++ b/app/services/whatsapp/template_processor_service.rb
@@ -41,7 +41,7 @@ class Whatsapp::TemplateProcessorService
     processed_params ||= template_params['processed_params']
     components = []
 
-    components.concat(process_header_components(processed_params))
+    components.concat(process_header_components(processed_params, template))
     components.concat(process_body_components(processed_params, template))
     components.concat(process_footer_components(processed_params))
     components.concat(process_button_components(processed_params))
@@ -49,27 +49,43 @@ class Whatsapp::TemplateProcessorService
     @template_params = components
   end
 
-  def process_header_components(processed_params)
+  def process_header_components(processed_params, template)
     return [] if processed_params['header'].blank?
 
-    header_params = build_header_params(processed_params['header'])
+    header_params = build_header_params(processed_params['header'], template)
     header_params.present? ? [{ type: 'header', parameters: header_params }] : []
   end
 
-  def build_header_params(header_data)
+  def build_header_params(header_data, template)
     header_params = []
     header_data.each do |key, value|
       next if value.blank?
 
       if media_url_with_type?(key, header_data)
         media_name = header_data['media_name']
-        media_param = parameter_builder.build_media_parameter(value, header_data['media_type'], media_name)
+        media_param = parameter_builder.build_media_parameter(media_source(value, template), header_data['media_type'], media_name)
         header_params << media_param if media_param
       elsif key != 'media_type' && key != 'media_name'
         header_params << parameter_builder.build_parameter(value)
       end
     end
     header_params
+  end
+
+  # Agents send the template's own sample media most of the time, and that URL can only be delivered as
+  # an uploaded media id, see Whatsapp::TemplateSampleMediaService. A URL the agent supplied is theirs
+  # to host, so it goes out as a plain link.
+  def media_source(media_url, template)
+    return { link: media_url } unless sample_media?(media_url, template)
+
+    { id: Whatsapp::TemplateSampleMediaService.new(channel: channel, url: media_url).media_id }
+  end
+
+  def sample_media?(media_url, template)
+    return false unless channel.provider == 'whatsapp_cloud'
+
+    header = Array(template['components']).find { |component| component['type'] == 'HEADER' }
+    Array(header&.dig('example', 'header_handle')).include?(media_url)
   end
 
   def media_url_with_type?(key, header_data)

--- a/app/services/whatsapp/template_processor_service.rb
+++ b/app/services/whatsapp/template_processor_service.rb
@@ -76,16 +76,29 @@ class Whatsapp::TemplateProcessorService
   # an uploaded media id, see Whatsapp::TemplateSampleMediaService. A URL the agent supplied is theirs
   # to host, so it goes out as a plain link.
   def media_source(media_url, template)
-    return { link: media_url } unless sample_media?(media_url, template)
+    handle = sample_media_handle(media_url, template)
+    return { link: media_url } if handle.blank?
 
-    { id: Whatsapp::TemplateSampleMediaService.new(channel: channel, url: media_url).media_id }
+    { id: Whatsapp::TemplateSampleMediaService.new(channel: channel, url: handle).media_id }
   end
 
-  def sample_media?(media_url, template)
-    return false unless channel.provider == 'whatsapp_cloud'
+  # Returns the handle the template carries right now, which is not always the string that was stored.
+  # Meta re-signs the sample URL and the sync picks up the new signature every few hours, so a scheduled
+  # message or a campaign can carry a signature that has since rotated. The path identifies the file, so
+  # match on that and upload the current handle rather than the stale one.
+  def sample_media_handle(media_url, template)
+    return nil unless channel.provider == 'whatsapp_cloud'
 
     header = Array(template['components']).find { |component| component['type'] == 'HEADER' }
-    Array(header&.dig('example', 'header_handle')).include?(media_url)
+    Array(header&.dig('example', 'header_handle')).find { |handle| same_media?(handle, media_url) }
+  end
+
+  def same_media?(handle, media_url)
+    return true if handle == media_url
+
+    Addressable::URI.parse(handle).omit(:query, :fragment) == Addressable::URI.parse(media_url).omit(:query, :fragment)
+  rescue Addressable::URI::InvalidURIError
+    false
   end
 
   def media_url_with_type?(key, header_data)

--- a/app/services/whatsapp/template_sample_media_service.rb
+++ b/app/services/whatsapp/template_sample_media_service.rb
@@ -17,9 +17,13 @@ class Whatsapp::TemplateSampleMediaService
   # Keyed on the URL without its query, because Meta re-signs the handle on every template sync while
   # the file behind it stays the same. Keying on the full URL would re-upload the same media every time
   # the signature rotated.
+  #
+  # Scoped to the phone number rather than to the channel, because a media id belongs to the Cloud
+  # account that uploaded it: reauthorizing an inbox swaps the phone number id while keeping the channel
+  # record, and an id minted under the old account is not addressable by the new one.
   def cache_key
     path = Addressable::URI.parse(url).omit(:query, :fragment).to_s
-    "whatsapp_template_sample_media/#{channel.id}/#{Digest::SHA256.hexdigest(path)}"
+    "whatsapp_template_sample_media/#{channel.provider_config['phone_number_id']}/#{Digest::SHA256.hexdigest(path)}"
   end
 
   def upload

--- a/app/services/whatsapp/template_sample_media_service.rb
+++ b/app/services/whatsapp/template_sample_media_service.rb
@@ -1,0 +1,30 @@
+# The sample media a template ships with (`components[].example.header_handle[0]`) is hosted on Meta's
+# own CDN, which answers 403 to Meta's media fetcher. Passing it as a `link` therefore fails every send
+# with "131053 Media upload error", even though the very same URL downloads fine from anywhere else.
+# Uploading the file to the media store once and addressing it by id sidesteps the fetch entirely.
+class Whatsapp::TemplateSampleMediaService
+  # Meta keeps uploaded media for 30 days; expire a little early so an id is never used past its life.
+  CACHE_TTL = 25.days
+
+  pattr_initialize [:channel!, :url!]
+
+  def media_id
+    Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { upload }
+  end
+
+  private
+
+  def cache_key
+    "whatsapp_template_sample_media/#{channel.id}/#{Digest::SHA256.hexdigest(url)}"
+  end
+
+  def upload
+    file = Down.download(url)
+    channel.provider_service.upload_media(file, file.content_type)
+  rescue Down::Error => e
+    raise CustomExceptions::Whatsapp::MediaUploadError, "Could not download the template sample media: #{e.message}"
+  ensure
+    file&.close
+    file&.unlink
+  end
+end

--- a/app/services/whatsapp/template_sample_media_service.rb
+++ b/app/services/whatsapp/template_sample_media_service.rb
@@ -21,7 +21,10 @@ class Whatsapp::TemplateSampleMediaService
   def upload
     file = Down.download(url)
     channel.provider_service.upload_media(file, file.content_type)
-  rescue Down::Error => e
+  rescue Down::ClientError, Down::InvalidUrl => e
+    # Only a 4xx or a malformed URL is the media's own fault and worth failing the message over. A
+    # timeout, a refused connection or a 5xx is the CDN having a bad minute: those propagate so Sidekiq
+    # retries, instead of dropping the send for good over a blip.
     raise CustomExceptions::Whatsapp::MediaUploadError, "Could not download the template sample media: #{e.message}"
   ensure
     file&.close

--- a/app/services/whatsapp/template_sample_media_service.rb
+++ b/app/services/whatsapp/template_sample_media_service.rb
@@ -14,20 +14,30 @@ class Whatsapp::TemplateSampleMediaService
 
   private
 
+  # Keyed on the URL without its query, because Meta re-signs the handle on every template sync while
+  # the file behind it stays the same. Keying on the full URL would re-upload the same media every time
+  # the signature rotated.
   def cache_key
-    "whatsapp_template_sample_media/#{channel.id}/#{Digest::SHA256.hexdigest(url)}"
+    path = Addressable::URI.parse(url).omit(:query, :fragment).to_s
+    "whatsapp_template_sample_media/#{channel.id}/#{Digest::SHA256.hexdigest(path)}"
   end
 
   def upload
     file = Down.download(url)
     channel.provider_service.upload_media(file, file.content_type)
   rescue Down::ClientError, Down::InvalidUrl => e
-    # Only a 4xx or a malformed URL is the media's own fault and worth failing the message over. A
-    # timeout, a refused connection or a 5xx is the CDN having a bad minute: those propagate so Sidekiq
-    # retries, instead of dropping the send for good over a blip.
+    # Only a 4xx (bar a rate limit) or a malformed URL is the media's own fault and worth failing the
+    # message over. A 429, a timeout, a refused connection or a 5xx is the CDN having a bad minute:
+    # those propagate so Sidekiq retries, instead of dropping the send for good over a blip.
+    raise if rate_limited?(e)
+
     raise CustomExceptions::Whatsapp::MediaUploadError, "Could not download the template sample media: #{e.message}"
   ensure
     file&.close
     file&.unlink
+  end
+
+  def rate_limited?(error)
+    error.is_a?(Down::ResponseError) && error.response&.code.to_i == 429
   end
 end

--- a/lib/custom_exceptions/whatsapp/media_upload_error.rb
+++ b/lib/custom_exceptions/whatsapp/media_upload_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CustomExceptions::Whatsapp::MediaUploadError < CustomExceptions::Base
+  def message
+    @data
+  end
+end

--- a/spec/services/whatsapp/populate_template_parameters_service_spec.rb
+++ b/spec/services/whatsapp/populate_template_parameters_service_spec.rb
@@ -39,6 +39,26 @@ describe Whatsapp::PopulateTemplateParametersService do
 
       expect(normalized).to eq('https://example.com/image.jpg?caption=%22quoted%22%20%3Ctag%3E')
     end
+
+    # Brackets are legal in a host (IPv6) but not in a path, so the encoding has to be per component:
+    # left literal, URI.parse rejects the whole URL.
+    it 'escapes brackets in the path' do
+      normalized = service.send(:normalize_url, 'https://example.com/album[1]/image.jpg')
+
+      expect(normalized).to eq('https://example.com/album%5B1%5D/image.jpg')
+      expect { URI.parse(normalized) }.not_to raise_error
+    end
+
+    it 'converts an internationalized host to punycode rather than percent-encoding it' do
+      normalized = service.send(:normalize_url, 'https://exämple.com/image.jpg')
+
+      expect(normalized).to eq('https://xn--exmple-cua.com/image.jpg')
+    end
+
+    it 'raises on a value that is not a URL at all' do
+      expect { service.send(:normalize_url, '4::aW1hZ2UvcG5n:ARZopaque') }
+        .to raise_error(ArgumentError, /Invalid URL format/)
+    end
   end
 
   describe '#build_media_parameter' do

--- a/spec/services/whatsapp/populate_template_parameters_service_spec.rb
+++ b/spec/services/whatsapp/populate_template_parameters_service_spec.rb
@@ -55,6 +55,13 @@ describe Whatsapp::PopulateTemplateParametersService do
       expect(normalized).to eq('https://xn--exmple-cua.com/image.jpg')
     end
 
+    it 'escapes a literal percent sign without touching real escapes' do
+      normalized = service.send(:normalize_url, 'https://example.com/100%.jpg?caption=a%20b')
+
+      expect(normalized).to eq('https://example.com/100%25.jpg?caption=a%20b')
+      expect { URI.parse(normalized) }.not_to raise_error
+    end
+
     it 'raises on a value that is not a URL at all' do
       expect { service.send(:normalize_url, '4::aW1hZ2UvcG5n:ARZopaque') }
         .to raise_error(ArgumentError, /Invalid URL format/)

--- a/spec/services/whatsapp/populate_template_parameters_service_spec.rb
+++ b/spec/services/whatsapp/populate_template_parameters_service_spec.rb
@@ -25,6 +25,20 @@ describe Whatsapp::PopulateTemplateParametersService do
 
       expect(normalized).to eq(url)
     end
+
+    it 'leaves existing percent-escapes untouched' do
+      url = 'https://scontent.whatsapp.net/v/image.jpg?oh=AA%3FBB%2FCC%3DDD&oe=6AA7FF50'
+      normalized = service.send(:normalize_url, url)
+
+      expect(normalized).to eq(url)
+    end
+
+    it 'escapes characters that are illegal in a URL instead of dropping them' do
+      url = 'https://example.com/image.jpg?caption="quoted" <tag>'
+      normalized = service.send(:normalize_url, url)
+
+      expect(normalized).to eq('https://example.com/image.jpg?caption=%22quoted%22%20%3Ctag%3E')
+    end
   end
 
   describe '#build_media_parameter' do
@@ -56,6 +70,41 @@ describe Whatsapp::PopulateTemplateParametersService do
         expect(result[:type]).to eq('document')
         expect(result[:document][:link]).to eq(url)
         expect(result[:document][:filename]).to eq('test.pdf')
+      end
+    end
+
+    context 'when URL is a signed CDN link' do
+      # The sample media WhatsApp ships with a media-header template (`example.header_handle[0]`)
+      # is a signed scontent.whatsapp.net URL. Altering a single character invalidates the
+      # signature and Meta rejects the send with "131053 Media upload error".
+      let(:signed_url) do
+        'https://scontent.whatsapp.net/v/t61.29466-34/687978337_1877819652904222_3947872441013628230_n.jpg' \
+          '?ccb=1-7&_nc_sid=8b1bef&_nc_ohc=_LhiCWLBrzYQ7kNvwFrXk8p&_nc_zt=28&_nc_ht=scontent.whatsapp.net' \
+          '&edm=AH51TzQEAAAA&_nc_gid=ysYExIrCDgUE4FDs3klCZw&oh=01_Q5Aa5QFGrQ4wUBzIasmARcne_Gf1Wsylopz0baO3TAZNrrZK2g&oe=6AA7FF50'
+      end
+
+      it 'sends the link byte for byte' do
+        result = service.build_media_parameter(signed_url, 'IMAGE')
+
+        expect(result[:image][:link]).to eq(signed_url)
+      end
+    end
+
+    context 'when URL is longer than a text parameter is allowed to be' do
+      it 'keeps the whole URL instead of truncating it' do
+        url = "https://example.com/image.jpg?signature=#{'a' * 1200}"
+        result = service.build_media_parameter(url, 'IMAGE')
+
+        expect(result[:image][:link]).to eq(url)
+      end
+    end
+
+    context 'when URL exceeds the maximum length' do
+      it 'raises instead of sending a truncated link' do
+        url = "https://example.com/image.jpg?signature=#{'a' * 2000}"
+
+        expect { service.build_media_parameter(url, 'IMAGE') }
+          .to raise_error(ArgumentError, 'URL too long (max 2000 characters)')
       end
     end
 

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -681,4 +681,33 @@ describe Whatsapp::Providers::WhatsappCloudService do
       expect(service.send_message('+123456789', message_with_reaction)).to eq 'message_id'
     end
   end
+
+  describe '#upload_media' do
+    let(:upload_url) { 'https://graph.facebook.com/v24.0/123456789/media' }
+    let(:file) { Tempfile.new(['sample', '.jpg']) }
+
+    after { file.close! }
+
+    it 'returns the media id' do
+      stub_request(:post, upload_url).to_return(status: 200, body: { id: '4565669250245108' }.to_json, headers: response_headers)
+
+      expect(service.upload_media(file, 'image/jpeg')).to eq '4565669250245108'
+    end
+
+    # `error.message` for a rejected upload is only "(#100) Invalid parameter"; the actionable reason
+    # (sample media above Meta's size limit, unsupported format) lives in `error_data.details`.
+    it 'raises with the detail Meta gives, not the generic message' do
+      body = {
+        error: {
+          message: '(#100) Invalid parameter',
+          code: 100,
+          error_data: { messaging_product: 'whatsapp', details: 'File Too Large: The file you uploaded is too large.' }
+        }
+      }
+      stub_request(:post, upload_url).to_return(status: 400, body: body.to_json, headers: response_headers)
+
+      expect { service.upload_media(file, 'video/mp4') }
+        .to raise_error(CustomExceptions::Whatsapp::MediaUploadError, /File Too Large/)
+    end
+  end
 end

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -709,5 +709,18 @@ describe Whatsapp::Providers::WhatsappCloudService do
       expect { service.upload_media(file, 'video/mp4') }
         .to raise_error(CustomExceptions::Whatsapp::MediaUploadError, /File Too Large/)
     end
+
+    # MediaUploadError fails the message for good, so a blip must not raise it.
+    it 'lets a server error propagate so the job can be retried' do
+      stub_request(:post, upload_url).to_return(status: 503, body: '', headers: response_headers)
+
+      expect { service.upload_media(file, 'image/jpeg') }.to raise_error(Net::HTTPFatalError)
+    end
+
+    it 'lets a rate limit propagate so the job can be retried' do
+      stub_request(:post, upload_url).to_return(status: 429, body: '', headers: response_headers)
+
+      expect { service.upload_media(file, 'image/jpeg') }.to raise_error(Net::HTTPClientException)
+    end
   end
 end

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -722,5 +722,14 @@ describe Whatsapp::Providers::WhatsappCloudService do
 
       expect { service.upload_media(file, 'image/jpeg') }.to raise_error(Net::HTTPClientException)
     end
+
+    # Graph reports throttling and other passing conditions inside a 400 envelope, so the status alone
+    # would read them as a rejected file.
+    it 'lets a transient error dressed as HTTP 400 propagate so the job can be retried' do
+      body = { error: { message: '(#4) Application request limit reached', code: 4, is_transient: true } }
+      stub_request(:post, upload_url).to_return(status: 400, body: body.to_json, headers: response_headers)
+
+      expect { service.upload_media(file, 'image/jpeg') }.to raise_error(Net::HTTPClientException)
+    end
   end
 end

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -325,6 +325,19 @@ describe Whatsapp::SendOnWhatsappService do
         expect { described_class.new(message: message).perform }.not_to raise_error
       end
 
+      it 'fails the message with the reason when a media parameter is rejected' do
+        processed_params = {
+          'body' => { '1' => '3' },
+          'header' => { 'media_url' => 'ftp://example.com/image.jpg', 'media_type' => 'image' }
+        }
+        rejected_template_params = build_sample_template_params(processed_params)
+        message = create_message_with_template('', rejected_template_params)
+
+        expect { described_class.new(message: message).perform }.not_to raise_error
+        expect(message.reload.status).to eq('failed')
+        expect(message.external_error).to eq('Invalid URL scheme: ftp. Only http and https are allowed')
+      end
+
       it 'processes template with rich text formatting' do
         processed_params = { 'body' => { '1' => '*Bold text* and _italic text_' } }
         rich_text_template_params = build_sample_template_params(processed_params)

--- a/spec/services/whatsapp/template_processor_service_spec.rb
+++ b/spec/services/whatsapp/template_processor_service_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe Whatsapp::TemplateProcessorService do
+  subject(:processed_parameters) { described_class.new(channel: channel, template_params: template_params).call.last }
+
+  let(:sample_url) { 'https://scontent.whatsapp.net/v/t61.29466-34/sample_n.jpg?ccb=1-7&oh=01_Q5Aa&oe=6AA7FF50' }
+  let(:template) do
+    {
+      'name' => 'promo',
+      'status' => 'APPROVED',
+      'language' => 'pt_BR',
+      'category' => 'MARKETING',
+      'components' => [
+        { 'type' => 'HEADER', 'format' => 'IMAGE', 'example' => { 'header_handle' => [sample_url] } },
+        { 'text' => 'Olá {{1}}', 'type' => 'BODY' }
+      ]
+    }
+  end
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'whatsapp_cloud', message_templates: [template], validate_provider_config: false, sync_templates: false)
+  end
+  let(:template_params) do
+    {
+      'name' => 'promo',
+      'language' => 'pt_BR',
+      'processed_params' => {
+        'body' => { '1' => 'Ana' },
+        'header' => { 'media_url' => media_url, 'media_type' => 'image' }
+      }
+    }
+  end
+
+  context "when the agent sends the template's own sample media" do
+    let(:media_url) { sample_url }
+
+    # That URL is hosted on Meta's CDN, which answers 403 to Meta's own media fetcher, so it can only
+    # be delivered as an uploaded media id.
+    it 'uploads it and addresses it by id' do
+      allow(Whatsapp::TemplateSampleMediaService).to receive(:new)
+        .with(channel: channel, url: sample_url)
+        .and_return(instance_double(Whatsapp::TemplateSampleMediaService, media_id: 'uploaded_id'))
+
+      expect(processed_parameters).to include(
+        { type: 'header', parameters: [{ type: 'image', image: { id: 'uploaded_id' } }] }
+      )
+    end
+  end
+
+  context 'when the agent supplies their own URL' do
+    let(:media_url) { 'https://cdn.example.com/promo.jpg' }
+
+    it 'sends it as a link' do
+      expect(Whatsapp::TemplateSampleMediaService).not_to receive(:new)
+
+      expect(processed_parameters).to include(
+        { type: 'header', parameters: [{ type: 'image', image: { link: media_url } }] }
+      )
+    end
+  end
+
+  context 'when the provider is not whatsapp_cloud' do
+    let(:media_url) { sample_url }
+    let(:channel) { create(:channel_whatsapp, message_templates: [template], validate_provider_config: false, sync_templates: false) }
+
+    it 'sends the sample media as a link, since only the Cloud API exposes a media store' do
+      expect(Whatsapp::TemplateSampleMediaService).not_to receive(:new)
+
+      expect(processed_parameters).to include(
+        { type: 'header', parameters: [{ type: 'image', image: { link: sample_url } }] }
+      )
+    end
+  end
+end

--- a/spec/services/whatsapp/template_processor_service_spec.rb
+++ b/spec/services/whatsapp/template_processor_service_spec.rb
@@ -46,6 +46,23 @@ describe Whatsapp::TemplateProcessorService do
     end
   end
 
+  # A scheduled message or a campaign stores the sample URL at compose time. By the time it fires, the
+  # sync has refreshed the template and Meta has re-signed the handle, so the stored string no longer
+  # matches character for character.
+  context 'when the stored sample URL carries a signature that has since rotated' do
+    let(:media_url) { 'https://scontent.whatsapp.net/v/t61.29466-34/sample_n.jpg?ccb=1-7&oh=00_OldSig&oe=6A000000' }
+
+    it 'uploads the handle the template carries now' do
+      allow(Whatsapp::TemplateSampleMediaService).to receive(:new)
+        .with(channel: channel, url: sample_url)
+        .and_return(instance_double(Whatsapp::TemplateSampleMediaService, media_id: 'uploaded_id'))
+
+      expect(processed_parameters).to include(
+        { type: 'header', parameters: [{ type: 'image', image: { id: 'uploaded_id' } }] }
+      )
+    end
+  end
+
   context 'when the agent supplies their own URL' do
     let(:media_url) { 'https://cdn.example.com/promo.jpg' }
 

--- a/spec/services/whatsapp/template_sample_media_service_spec.rb
+++ b/spec/services/whatsapp/template_sample_media_service_spec.rb
@@ -52,6 +52,17 @@ describe Whatsapp::TemplateSampleMediaService do
     expect { service.media_id }.to raise_error(Down::ClientError)
   end
 
+  # Reauthorizing an inbox swaps the phone number id while keeping the channel record. A media id minted
+  # under the old Cloud account is not addressable by the new one, so it must not be served from cache.
+  it 'uploads again after the inbox is reauthorized onto another Cloud account' do
+    service.media_id
+    channel.provider_config = channel.provider_config.merge('phone_number_id' => 'reauthorized_id')
+
+    described_class.new(channel: channel, url: url).media_id
+
+    expect(provider).to have_received(:upload_media).twice
+  end
+
   # Meta re-signs the handle on every template sync. The file behind it does not change, so a rotated
   # signature must not cost a second upload.
   it 'reuses the upload when only the signature rotated' do

--- a/spec/services/whatsapp/template_sample_media_service_spec.rb
+++ b/spec/services/whatsapp/template_sample_media_service_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe Whatsapp::TemplateSampleMediaService do
+  subject(:service) { described_class.new(channel: channel, url: url) }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'whatsapp_cloud', validate_provider_config: false, sync_templates: false) }
+  let(:provider) { instance_double(Whatsapp::Providers::WhatsappCloudService) }
+  let(:url) { 'https://scontent.whatsapp.net/v/t61.29466-34/sample_n.jpg?oh=01_Q5Aa&oe=6AA7FF50' }
+
+  before do
+    stub_request(:get, url).to_return(status: 200, body: 'image data', headers: { 'Content-Type' => 'image/jpeg' })
+    allow(channel).to receive(:provider_service).and_return(provider)
+    allow(provider).to receive(:upload_media).and_return('media_id')
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+  end
+
+  it 'uploads the downloaded file and returns the media id' do
+    expect(service.media_id).to eq('media_id')
+    expect(provider).to have_received(:upload_media).with(anything, 'image/jpeg')
+  end
+
+  # A campaign sends the same template to every contact; re-uploading it each time would be pure waste.
+  it 'uploads only once for repeated sends of the same media' do
+    2.times { described_class.new(channel: channel, url: url).media_id }
+
+    expect(provider).to have_received(:upload_media).once
+  end
+
+  it 'raises with a readable reason when the download fails' do
+    stub_request(:get, url).to_return(status: 404)
+
+    expect { service.media_id }.to raise_error(CustomExceptions::Whatsapp::MediaUploadError, /Could not download/)
+  end
+end

--- a/spec/services/whatsapp/template_sample_media_service_spec.rb
+++ b/spec/services/whatsapp/template_sample_media_service_spec.rb
@@ -26,9 +26,23 @@ describe Whatsapp::TemplateSampleMediaService do
     expect(provider).to have_received(:upload_media).once
   end
 
-  it 'raises with a readable reason when the download fails' do
+  it 'raises with a readable reason when the media itself is gone' do
     stub_request(:get, url).to_return(status: 404)
 
     expect { service.media_id }.to raise_error(CustomExceptions::Whatsapp::MediaUploadError, /Could not download/)
+  end
+
+  # A blip must stay retryable: MediaUploadError fails the message for good, so only a deterministic
+  # rejection may raise it.
+  it 'lets a CDN outage propagate so the job can be retried' do
+    stub_request(:get, url).to_return(status: 503)
+
+    expect { service.media_id }.to raise_error(Down::ServerError)
+  end
+
+  it 'lets a connection timeout propagate so the job can be retried' do
+    stub_request(:get, url).to_timeout
+
+    expect { service.media_id }.to raise_error(Down::TimeoutError)
   end
 end

--- a/spec/services/whatsapp/template_sample_media_service_spec.rb
+++ b/spec/services/whatsapp/template_sample_media_service_spec.rb
@@ -45,4 +45,22 @@ describe Whatsapp::TemplateSampleMediaService do
 
     expect { service.media_id }.to raise_error(Down::TimeoutError)
   end
+
+  it 'lets a CDN rate limit propagate so the job can be retried' do
+    stub_request(:get, url).to_return(status: 429)
+
+    expect { service.media_id }.to raise_error(Down::ClientError)
+  end
+
+  # Meta re-signs the handle on every template sync. The file behind it does not change, so a rotated
+  # signature must not cost a second upload.
+  it 'reuses the upload when only the signature rotated' do
+    rotated = 'https://scontent.whatsapp.net/v/t61.29466-34/sample_n.jpg?oh=02_XyZz&oe=6BB80061'
+    stub_request(:get, rotated).to_return(status: 200, body: 'image data', headers: { 'Content-Type' => 'image/jpeg' })
+
+    service.media_id
+    described_class.new(channel: channel, url: rotated).media_id
+
+    expect(provider).to have_received(:upload_media).once
+  end
 end


### PR DESCRIPTION
Enviar um template de WhatsApp com header de mídia usando a arte de exemplo que o próprio template carrega passa a funcionar. Antes, o envio falhava sempre com `131053 Media upload error`, e a atendente não tinha como saber por quê: o campo do picker abre pré-preenchido com a URL de exemplo, parece pronto, e a mensagem morre do lado da Meta.

A causa é que essa URL (`components[].example.header_handle[0]`) fica hospedada no CDN da própria Meta, e esse CDN responde **403 ao fetcher de mídia da Meta**. A mesma URL baixa normalmente de qualquer outro lugar: `curl` pega 206 de um laptop e do servidor. Só quem precisa buscá-la é recusado.

Reproduzido contra a Cloud API três vezes antes de escrever o código: v13.0 e v24.0 a partir de uma WABA, e v24.0 a partir da WABA que emitiu a URL. As três voltaram 403. O detalhe que faz isso ser difícil de diagnosticar é que o POST responde **HTTP 200 em todos os casos**; o `131053` só aparece depois, no webhook de status.

Closes #349

## How to reproduce

1. Canal WhatsApp Cloud com um template MARKETING de header de imagem aprovado.
2. Abrir o picker de templates numa conversa e escolher esse template.
3. Enviar sem mexer no campo "Cabeçalho Image", que já vem preenchido com a URL de exemplo.
4. Antes: a mensagem falha com `131053 Media upload error`. Depois: entrega.

## How to test

Com o mesmo template, enviar uma vez usando o valor pré-preenchido e outra colando uma URL própria. As duas devem entregar. Se a arte de exemplo passar do limite de tamanho da Meta (16 MB para vídeo, 5 MB para imagem), a mensagem falha com "File Too Large: The file you uploaded is too large." em vez do `131053` mudo.

## What changed

- Quando a atendente envia a mídia de exemplo do próprio template, o arquivo é subido para o media store da Meta e endereçado por `id`. Uma URL que ela mesma colou continua saindo como `link`.
- A detecção compara com o `header_handle` do template, não com o domínio da URL, para não depender de adivinhar em qual CDN a Meta hospeda cada tipo de mídia.
- O `media_id` é cacheado por canal e URL por 25 dias (a Meta guarda por 30), então uma campanha faz um upload, não um por contato.
- O upload é a única chamada do provider fora do HTTParty: a versão 0.24 monta multipart em streaming, com chunked encoding e sem `Content-Length`, e a Graph API recusa isso com `(#100) The parameter file is required`. `Net::HTTP#set_form` manda `Content-Length`.
- A URL de mídia deixou de passar pelo `sanitize_parameter`, que é escrito para texto de variável: ele remove `<>"'` e trunca em 1000 caracteres, corrompendo em silêncio uma URL assinada longa. Sem o truncamento, o guard de `max 2000 characters` volta a ser alcançável, que era código morto.
- `normalize_url` trocou `Addressable::URI#normalize` por `encode_component`. O `normalize` *decodifica* escapes: `%2F` vira `/`, `%3D` vira `=`, `%3F` vira um `?` literal que parte a query em duas. Qualquer um desses invalida uma assinatura.
- Erros de parâmetro e de upload passam a falhar a mensagem com o motivo visível, em vez de morrerem no job. O motivo vem de `error_data.details`, porque o `error.message` da Meta é só `(#100) Invalid parameter`.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/363)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhatsApp Cloud API template messages can now upload sample media and use the resulting media IDs.
  * Media templates support both links and media IDs, with document filenames preserved where applicable.
  * Sample media uploads are cached to reduce repeated processing.

* **Bug Fixes**
  * Preserved valid signed and percent-encoded URLs while validating unsupported or oversized links.
  * Invalid media parameters now mark messages as failed with a clear error message instead of stopping silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
