### PR TITLE
feat(i18n): translate the fork's features into Spanish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ Practical checklist for any change impacting core logic or public APIs
 
 Upstream's locale files are byte-identical to the Chatwoot release we track. **Never add or edit a key inside `app/javascript/dashboard/i18n/locale/` or `config/locales/<locale>.yml`** — CI fails if you do, and the next upstream sync would conflict on every string we own.
 
-Everything the fork translates lives in two places:
+We ship our features in **en, pt_BR and es**; upstream keeps translating the other ~55 languages, and our keys fall back to `en` there. Everything the fork translates lives in two places:
 
 - Frontend → `app/javascript/dashboard/i18n/fazer-ai/locale/<locale>/*.json`
 - Backend → `config/locales/fazer_ai.<locale>.yml` (and `fazer_ai.mailers.<locale>.yml` for the Chatwoot mailer copy upstream hardcodes in ERB)

--- a/app/javascript/dashboard/helper/scheduleDateShortcutHelpers.js
+++ b/app/javascript/dashboard/helper/scheduleDateShortcutHelpers.js
@@ -115,15 +115,19 @@ export const getScheduleShortcuts = (now = new Date(), locale = 'en') => {
 };
 
 /**
- * Pre-process natural language input to normalize PT/EN time expressions
+ * Pre-process natural language input to normalize PT/ES/EN time expressions
  * before passing to chrono-node.
  */
 export const preProcessDateInput = text => {
   let result = text;
-  // PT: normalize common words typed without accents
+  // PT/ES: normalize common words typed without accents. The accent fixes are
+  // shared because the same spelling is correct in both languages.
   result = result.replace(/\bamanha\b/gi, 'amanhã');
+  result = result.replace(/\bmanana\b/gi, 'mañana');
   result = result.replace(/\bsabado\b/gi, 'sábado');
+  result = result.replace(/\bmiercoles\b/gi, 'miércoles');
   result = result.replace(/\bproxim([ao])\b/gi, 'próxim$1');
+  result = result.replace(/\bproxim([ao])s\b/gi, 'próxim$1s');
   // PT: normalize 'as' → 'às' before digits or time-of-day words
   result = result.replace(/\bas\s+(\d)/gi, 'às $1');
   result = result.replace(/\bas\s+(manh|tard|noit)/gi, 'às $1');
@@ -153,35 +157,37 @@ export const preProcessDateInput = text => {
     /(?:no per[ií]odo da|pela|de|à|às)\s+noite/gi,
     '18:00'
   );
+  // ES: time-of-day expressions (por la mañana, de la tarde, a la noche, etc.)
+  result = result.replace(/(?:por|de|a)\s+la\s+ma[ñn]ana/gi, '8:00');
+  result = result.replace(/(?:por|de|a)\s+la\s+tarde/gi, '13:00');
+  result = result.replace(/(?:por|de|a)\s+la\s+noche/gi, '18:00');
   return result;
 };
 
+// chrono ships one parser per language; the bare export is the English one.
+const CHRONO_PARSERS = { pt: chrono.pt, es: chrono.es, en: chrono };
+
 /**
  * Parse a natural language date/time string using chrono-node.
- * Supports both PT and EN locales.
+ * Supports the languages in CHRONO_PARSERS; anything else parses as English.
  * Returns a Date object if successfully parsed, otherwise null.
  */
 export const parseNaturalDate = (text, locale = 'en', now = new Date()) => {
   if (!text || !text.trim()) return null;
   const processed = preProcessDateInput(text.trim());
   const opts = { forwardDate: true };
-  const isPt = locale.startsWith('pt');
-  const primaryResults = (isPt ? chrono.pt : chrono).parse(
-    processed,
-    now,
-    opts
+  const language = Object.keys(CHRONO_PARSERS).find(key =>
+    locale.startsWith(key)
   );
-  const fallbackResults = (isPt ? chrono : chrono.pt).parse(
-    processed,
-    now,
-    opts
-  );
+  const primary = CHRONO_PARSERS[language] ?? chrono;
+  // English is always tried as a fallback so that an agent typing "tomorrow"
+  // in a non-English dashboard still gets a date, as it did before.
+  const candidates = primary === chrono ? [chrono] : [primary, chrono];
   const matchLen = results => results.reduce((s, r) => s + r.text.length, 0);
   // Pick the parser that matched more of the input text
-  const best =
-    matchLen(primaryResults) >= matchLen(fallbackResults)
-      ? primaryResults
-      : fallbackResults;
+  const best = candidates
+    .map(parser => parser.parse(processed, now, opts))
+    .reduce((a, b) => (matchLen(a) >= matchLen(b) ? a : b));
   return best.length ? best[0].start.date() : null;
 };
 

--- a/app/javascript/dashboard/helper/scheduleDateShortcutHelpers.js
+++ b/app/javascript/dashboard/helper/scheduleDateShortcutHelpers.js
@@ -180,9 +180,11 @@ export const parseNaturalDate = (text, locale = 'en', now = new Date()) => {
     locale.startsWith(key)
   );
   const primary = CHRONO_PARSERS[language] ?? chrono;
-  // English is always tried as a fallback so that an agent typing "tomorrow"
-  // in a non-English dashboard still gets a date, as it did before.
-  const candidates = primary === chrono ? [chrono] : [primary, chrono];
+  // PT and EN are always tried as fallbacks, whatever the dashboard language:
+  // preProcessDateInput rewrites Portuguese expressions unconditionally, so
+  // dropping chrono.pt here would stop parsing input it just normalized.
+  // Deduplicated so the primary parser keeps its precedence on a tie.
+  const candidates = [...new Set([primary, chrono.pt, chrono])];
   const matchLen = results => results.reduce((s, r) => s + r.text.length, 0);
   // Pick the parser that matched more of the input text
   const best = candidates

--- a/app/javascript/dashboard/helper/specs/scheduleDateShortcutHelpers.spec.js
+++ b/app/javascript/dashboard/helper/specs/scheduleDateShortcutHelpers.spec.js
@@ -260,6 +260,46 @@ describe('#scheduleDateShortcutHelpers', () => {
     it('returns null for unrecognizable input', () => {
       expect(parseNaturalDate('xyz abc', 'en', now)).toBeNull();
     });
+
+    it('parses ES "mañana a las 8"', () => {
+      const result = parseNaturalDate('mañana a las 8', 'es', now);
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(15);
+      expect(result.getHours()).toBe(8);
+    });
+
+    it('parses ES "manana a las 19" (no accents) via preprocessing', () => {
+      const result = parseNaturalDate('manana a las 19', 'es', now);
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(15);
+      expect(result.getHours()).toBe(19);
+    });
+
+    it('parses ES "mañana por la tarde" via preprocessing', () => {
+      const result = parseNaturalDate('mañana por la tarde', 'es', now);
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(15);
+      expect(result.getHours()).toBe(13);
+    });
+
+    it('parses ES weekday names forward — "viernes"', () => {
+      const result = parseNaturalDate('viernes', 'es', now);
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(16);
+    });
+
+    it('still parses EN input on an ES dashboard', () => {
+      const result = parseNaturalDate('tomorrow at 8am', 'es', now);
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(15);
+      expect(result.getHours()).toBe(8);
+    });
+
+    it('falls back to EN for a language chrono does not cover', () => {
+      const result = parseNaturalDate('tomorrow at 8am', 'ta', now);
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(15);
+    });
   });
 
   describe('formatFullDateTime', () => {

--- a/app/javascript/dashboard/helper/specs/scheduleDateShortcutHelpers.spec.js
+++ b/app/javascript/dashboard/helper/specs/scheduleDateShortcutHelpers.spec.js
@@ -300,6 +300,29 @@ describe('#scheduleDateShortcutHelpers', () => {
       expect(result).toBeInstanceOf(Date);
       expect(result.getDate()).toBe(15);
     });
+
+    // preProcessDateInput normalizes PT regardless of locale, so the PT parser
+    // has to stay reachable from every dashboard language.
+    it('still parses PT input on an EN dashboard', () => {
+      const result = parseNaturalDate('amanhã às 19', 'en', now);
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(15);
+      expect(result.getHours()).toBe(19);
+    });
+
+    it('still parses a PT weekday on an EN dashboard', () => {
+      const result = parseNaturalDate('sexta às 10', 'en', now);
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(16);
+      expect(result.getHours()).toBe(10);
+    });
+
+    it('parses PT input on an ES dashboard', () => {
+      const result = parseNaturalDate('amanhã às 19', 'es', now);
+      expect(result).toBeInstanceOf(Date);
+      expect(result.getDate()).toBe(15);
+      expect(result.getHours()).toBe(19);
+    });
   });
 
   describe('formatFullDateTime', () => {

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/advancedFilters.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/advancedFilters.json
@@ -1,0 +1,29 @@
+{
+  "FILTER": {
+    "ATTRIBUTES": {
+      "GROUP_TYPE": "Tipo de conversación"
+    },
+    "CUSTOM_VIEWS": {
+      "EDIT": {
+        "API_FOLDERS": {
+          "ERROR_MESSAGE": "Error al actualizar la carpeta."
+        },
+        "API_SEGMENTS": {
+          "ERROR_MESSAGE": "Error al actualizar el segmento."
+        }
+      },
+      "VISIBILITY": {
+        "LABEL": "Visibilidad",
+        "GLOBAL": {
+          "LABEL": "Público",
+          "DESCRIPTION": "Disponible para todos los agentes de esta cuenta."
+        },
+        "PERSONAL": {
+          "LABEL": "Privado",
+          "DESCRIPTION": "Solo usted podrá ver y gestionar este filtro."
+        }
+      },
+      "READ_ONLY_TOOLTIP": "Carpeta pública. Pida a un administrador que la edite o la elimine."
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/automation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/automation.json
@@ -1,0 +1,14 @@
+{
+  "AUTOMATION": {
+    "ACTION": {
+      "SCHEDULED_MESSAGE_DELAY_LABEL": "Retraso",
+      "ATTACHMENT_ADD": "Añadir archivo adjunto",
+      "TEMPLATE_SELECT": "Usar plantilla",
+      "TEMPLATE_SELECTED": "Plantilla: {name}",
+      "TEMPLATE_USE": "Usar esta plantilla"
+    },
+    "ACTIONS": {
+      "CREATE_SCHEDULED_MESSAGE": "Crear mensaje programado"
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/chatlist.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/chatlist.json
@@ -1,0 +1,8 @@
+{
+  "CHAT_LIST": {
+    "TYPING": "escribiendo...",
+    "RECORDING": "grabando...",
+    "REACTED": "{sender} reaccionó {emoji}",
+    "REACTED_TO_SNIPPET": "{sender} reaccionó {emoji} a \"{snippet}\""
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/contact.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/contact.json
@@ -1,0 +1,36 @@
+{
+  "EDIT_CONTACT": {
+    "CONFIRM_DISCARD": {
+      "TITLE": "¿Descartar los cambios?",
+      "MESSAGE": "Tiene cambios sin guardar. ¿Seguro que desea descartarlos?",
+      "YES": "Descartar",
+      "NO": "Seguir editando"
+    }
+  },
+  "CONTACTS_LAYOUT": {
+    "HEADER": {
+      "ACTIONS": {
+        "FILTERS": {
+          "CREATE_SEGMENT": {
+            "VISIBILITY": {
+              "LABEL": "Visibilidad",
+              "GLOBAL": {
+                "LABEL": "Público",
+                "DESCRIPTION": "Disponible para todos los agentes de esta cuenta."
+              },
+              "PERSONAL": {
+                "LABEL": "Privado",
+                "DESCRIPTION": "Solo usted podrá ver y gestionar este segmento."
+              }
+            },
+            "READ_ONLY_TOOLTIP": "Segmento público. Pida a un administrador que lo edite o lo elimine."
+          }
+        }
+      }
+    }
+  },
+  "COMPOSE_NEW_CONVERSATION": {
+    "TAB_CONVERSATION": "Conversación",
+    "TAB_GROUP": "Grupo"
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
@@ -1,0 +1,82 @@
+{
+  "CONVERSATION": {
+    "ANNOUNCEMENT_MODE_BANNER": "Solo los administradores pueden enviar mensajes en este grupo",
+    "GROUP_LEFT_BANNER": "Ya no forma parte de este grupo y no puede enviar mensajes en él",
+    "GROUPS_DISABLED_BANNER": "Los mensajes de grupo están desactivados. Active la compatibilidad completa con grupos (gratis) para ver y enviar mensajes.",
+    "GROUPS_DISABLED_BANNER_NON_ADMIN": "Los mensajes de grupo están desactivados. Contacte a su administrador para activar la compatibilidad completa con grupos.",
+    "GROUPS_DISABLED_CTA": "Vea cómo activarla (gratis)",
+    "FOOTER": {
+      "SIGNATURE_LABEL_TOP": "↓ Firma",
+      "SIGNATURE_LABEL_TOP_TOOLTIP": "La firma se enviará al principio del mensaje",
+      "SIGNATURE_LABEL_BOTTOM": "↑ Firma",
+      "SIGNATURE_LABEL_BOTTOM_TOOLTIP": "La firma se enviará al final del mensaje",
+      "ANNOUNCEMENT_MODE_RESTRICTED": "Solo los administradores pueden enviar mensajes en este grupo",
+      "GROUP_LEFT_RESTRICTED": "Ya no forma parte de este grupo y no puede enviar mensajes en él",
+      "GROUPS_DISABLED_RESTRICTED": "Los mensajes de grupo están desactivados: actívelos gratis"
+    },
+    "REPLYBOX": {
+      "SCHEDULE_SEND": "Programar envío"
+    },
+    "ASSIGNMENT_CONFLICT": {
+      "TITLE": "La conversación ya está asignada",
+      "DESCRIPTION": "{agentName} ya está atendiendo esta conversación. Pídale que la libere o pida a un administrador que la reasigne.",
+      "DESCRIPTION_UNKNOWN_AGENT": "Otro agente ya está atendiendo esta conversación. Pídale que la libere o pida a un administrador que la reasigne.",
+      "CONFIRM": "Entendido"
+    },
+    "CHANGE_TEAM_FAILED": "No se pudo cambiar el equipo",
+    "MESSAGE_DELETED_BY_CONTACT": "Eliminado por el contacto",
+    "WHATSAPP": "WhatsApp",
+    "CONTEXT_MENU": {
+      "EDIT": {
+        "LABEL": "Editar",
+        "TITLE": "Editar mensaje",
+        "PLACEHOLDER": "Escriba el contenido del mensaje",
+        "SAVE": "Guardar",
+        "CANCEL": "Cancelar",
+        "SUCCESS": "Mensaje editado correctamente",
+        "ERROR": "No se pudo editar el mensaje",
+        "EMPTY_CONTENT": "El contenido del mensaje no puede estar vacío"
+      }
+    },
+    "REACTIONS": {
+      "ADD_REACTION": "Añadir reacción",
+      "MORE_EMOJIS": "Más emojis",
+      "FAILED": "No se pudo actualizar la reacción. Inténtelo de nuevo.",
+      "YOU": "Usted",
+      "CLICK_TO_REMOVE": "Haga clic para quitarla",
+      "QUICK": {
+        "THUMBS_UP": "Pulgar arriba",
+        "HEART": "Corazón",
+        "JOY": "Risa",
+        "SURPRISED": "Sorpresa",
+        "SAD": "Tristeza",
+        "PRAY": "Súplica",
+        "FIRE": "Fuego",
+        "PARTY": "Fiesta"
+      }
+    },
+    "INBOX": {
+      "WHATSAPP_PROVIDER_CONNECTION": {
+        "NOT_CONNECTED": "WhatsApp no está conectado. Vincule su dispositivo de nuevo.",
+        "NOT_CONNECTED_CONTACT_ADMIN": "WhatsApp no está conectado. Haga clic en este botón para intentar reconectar o contacte a su administrador para vincular el dispositivo de nuevo.",
+        "LINK_DEVICE": "Vincular dispositivo",
+        "RECONNECT_FAILED": "No se pudo reconectar. Contacte a su administrador para vincular el dispositivo de nuevo."
+      },
+      "WHATSAPP_REACHOUT_RESTRICTION": {
+        "RESTRICTED": "WhatsApp ha restringido temporalmente el inicio de conversaciones nuevas desde este número.",
+        "RESTRICTED_UNTIL": "WhatsApp ha restringido temporalmente el inicio de conversaciones nuevas desde este número hasta las {time}."
+      },
+      "WHATSAPP_NEW_CHAT_CAP": {
+        "WARNING": "Este número se está acercando a su límite de WhatsApp para iniciar conversaciones nuevas en este ciclo.",
+        "WARNING_WITH_QUOTA": "Este número ha iniciado {used} de {total} conversaciones nuevas permitidas por WhatsApp en este ciclo.",
+        "CAPPED": "Este número alcanzó su límite de WhatsApp para iniciar conversaciones nuevas en este ciclo.",
+        "CAPPED_WITH_QUOTA": "Este número alcanzó su límite de WhatsApp ({used} de {total}) para iniciar conversaciones nuevas en este ciclo."
+      }
+    }
+  },
+  "CONVERSATION_SIDEBAR": {
+    "ACCORDION": {
+      "SCHEDULED_MESSAGES": "Mensajes programados"
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/generalSettings.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/generalSettings.json
@@ -1,0 +1,11 @@
+{
+  "GENERAL_SETTINGS": {
+    "SUPER_ADMIN_ONLY_NOTICE": "Este mensaje solo es visible para los administradores del sistema."
+  },
+  "NOTIFICATIONS_PAGE": {
+    "TYPE_LABEL": {
+      "internal_chat_mention": "Mención",
+      "internal_chat_new_message": "Mensaje directo"
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/groups.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/groups.json
@@ -1,0 +1,127 @@
+{
+  "GROUP": {
+    "SIDEBAR_TITLE": "Grupo",
+    "INFO": {
+      "HEADER": "Información del grupo",
+      "MEMBER_COUNT": "{count} miembros",
+      "MEMBER_LIST_TITLE": "Miembros",
+      "ADMIN_BADGE": "Administrador",
+      "YOU_BADGE": "Usted",
+      "SYNC_BUTTON": "Sincronizar",
+      "SYNC_SUCCESS": "Miembros del grupo sincronizados correctamente.",
+      "SYNC_ERROR": "No se pudieron sincronizar los miembros del grupo. Inténtelo de nuevo.",
+      "EMPTY_STATE": "No se encontraron miembros."
+    },
+    "FILTER": {
+      "TYPE_LABEL": "Tipo",
+      "ALL": "Todas",
+      "INDIVIDUAL": "Individual",
+      "GROUP": "Grupo"
+    },
+    "CREATE": {
+      "TITLE": "Crear un grupo nuevo",
+      "INBOX_LABEL": "Bandeja de entrada:",
+      "INBOX_PLACEHOLDER": "Seleccione una bandeja de entrada",
+      "NAME_LABEL": "Nombre del grupo:",
+      "NAME_PLACEHOLDER": "Escriba el nombre del grupo",
+      "PARTICIPANTS_LABEL": "Participantes:",
+      "PARTICIPANTS_PLACEHOLDER": "Busque contactos para añadir",
+      "NAME_REQUIRED": "El nombre del grupo es obligatorio",
+      "PARTICIPANTS_REQUIRED": "Añada al menos un participante",
+      "SUBMIT_BUTTON": "Crear grupo",
+      "SUCCESS_MESSAGE": "Grupo creado correctamente.",
+      "ERROR_MESSAGE": "No se pudo crear el grupo. Inténtelo de nuevo.",
+      "GROUPS_DISABLED": "La creación de grupos está desactivada. Active la compatibilidad con grupos de WhatsApp (gratis) para crear grupos.",
+      "GROUPS_DISABLED_NON_ADMIN": "La creación de grupos está desactivada. Contacte a su administrador para activar la compatibilidad con grupos de WhatsApp.",
+      "GROUPS_DISABLED_CTA": "Vea cómo activarla (gratis)"
+    },
+    "METADATA": {
+      "EDIT_NAME_LABEL": "Nombre del grupo",
+      "EDIT_NAME_PLACEHOLDER": "Escriba el nombre del grupo",
+      "EDIT_DESCRIPTION_LABEL": "Descripción",
+      "EDIT_DESCRIPTION_PLACEHOLDER": "Escriba la descripción del grupo",
+      "EDIT_AVATAR_LABEL": "Foto del grupo",
+      "SAVE_SUCCESS": "Información del grupo actualizada correctamente.",
+      "SAVE_ERROR": "No se pudo actualizar la información del grupo. Inténtelo de nuevo."
+    },
+    "INVITE": {
+      "SECTION_TITLE": "Enlace de invitación",
+      "COPY_BUTTON": "Copiar el enlace",
+      "COPY_INVITE_LINK": "Copiar el enlace de invitación",
+      "COPY_SUCCESS": "Enlace de invitación copiado al portapapeles.",
+      "FETCH_ERROR": "No se pudo cargar el enlace de invitación."
+    },
+    "MEMBERS": {
+      "ADD_BUTTON": "Añadir miembro",
+      "ADDING": "Añadiendo el miembro...",
+      "ADD_SUCCESS": "Miembro añadido correctamente.",
+      "ADD_ERROR": "No se pudo añadir el miembro. Inténtelo de nuevo.",
+      "REMOVE_BUTTON": "Quitar",
+      "REMOVING": "Quitando el miembro...",
+      "REMOVE_SUCCESS": "Miembro eliminado correctamente.",
+      "REMOVE_ERROR": "No se pudo quitar el miembro. Inténtelo de nuevo.",
+      "PROMOTE_BUTTON": "Promover a administrador",
+      "PROMOTING": "Promoviendo el miembro...",
+      "PROMOTE_SUCCESS": "Miembro promovido a administrador.",
+      "PROMOTE_ERROR": "No se pudo promover el miembro. Inténtelo de nuevo.",
+      "DEMOTE_BUTTON": "Degradar a miembro",
+      "DEMOTING": "Degradando el miembro...",
+      "DEMOTE_SUCCESS": "Administrador degradado a miembro.",
+      "DEMOTE_ERROR": "No se pudo degradar el miembro. Inténtelo de nuevo.",
+      "GROUP_CREATOR_NOT_MODIFIABLE": "Este miembro creó el grupo, por lo que no se puede quitar ni degradar."
+    },
+    "JOIN_REQUESTS": {
+      "SECTION_TITLE": "Solicitudes pendientes",
+      "PENDING_COUNT": "{count} pendientes",
+      "APPROVE_BUTTON": "Aprobar",
+      "REJECT_BUTTON": "Rechazar",
+      "PROCESSING": "Procesando la solicitud...",
+      "APPROVE_SUCCESS": "Solicitud de ingreso aprobada.",
+      "REJECT_SUCCESS": "Solicitud de ingreso rechazada.",
+      "ACTION_ERROR": "No se pudo procesar la solicitud de ingreso. Inténtelo de nuevo."
+    },
+    "MENTION": {
+      "DROPDOWN_HEADER": "Miembros del grupo",
+      "EVERYONE": "Todos",
+      "EVERYONE_DESCRIPTION": "Notificar a todos los miembros"
+    },
+    "BAILEYS_OPTIONS": {
+      "MEMBERS_CAN": "Los miembros del grupo pueden:",
+      "ADMINS_CAN": "Los administradores del grupo pueden:",
+      "EDIT_GROUP_SETTINGS": "Editar la configuración del grupo",
+      "EDIT_GROUP_SETTINGS_DESCRIPTION": "Incluye el nombre del grupo, la imagen, la descripción, la duración de los mensajes temporales y la privacidad avanzada de la conversación, y permite fijar y guardar mensajes en la conversación o deshacer esa acción.",
+      "SEND_MESSAGES": "Enviar mensajes nuevos",
+      "ADD_MEMBERS": "Añadir miembros",
+      "RESET_INVITE_LINK": "Restablecer el enlace de invitación",
+      "RESET_INVITE_LINK_SUCCESS": "El enlace de invitación se restableció correctamente.",
+      "RESET_INVITE_LINK_ERROR": "No se pudo restablecer el enlace de invitación. Inténtelo de nuevo.",
+      "RESETTING_INVITE_LINK": "Restableciendo...",
+      "DISABLE_ADD_MEMBERS_CONFIRM_TITLE": "¿Restringir quién añade miembros?",
+      "DISABLE_ADD_MEMBERS_CONFIRM_DESCRIPTION": "Al desactivar esta opción, solo los administradores podrán añadir miembros y el enlace de invitación actual se restablecerá. ¿Desea continuar?",
+      "DISABLE_ADD_MEMBERS_CONFIRM_YES": "Confirmar",
+      "DISABLE_ADD_MEMBERS_CONFIRM_NO": "Cancelar",
+      "APPROVE_MEMBERS": "Aprobar los miembros nuevos",
+      "APPROVE_MEMBERS_DESCRIPTION": "Mientras esta opción esté activada, los administradores deberán aprobar a los miembros nuevos que se unan al grupo."
+    },
+    "SETTINGS": {
+      "SECTION_TITLE": "Configuración del grupo",
+      "ANNOUNCEMENT_MODE": "Modo de anuncios",
+      "ANNOUNCEMENT_MODE_DESCRIPTION": "Solo los administradores pueden enviar mensajes",
+      "LOCKED_MODE": "Modo bloqueado",
+      "LOCKED_MODE_DESCRIPTION": "Solo los administradores pueden editar la información del grupo",
+      "JOIN_APPROVAL": "Aprobación del administrador para unirse",
+      "JOIN_APPROVAL_DESCRIPTION": "Los administradores deben aprobar a los miembros nuevos",
+      "ADVANCED_OPTIONS": "Opciones avanzadas",
+      "GROUP_LEFT_BANNER": "Ya no es miembro de este grupo",
+      "LEAVE_GROUP": "Salir del grupo",
+      "LEAVING": "Saliendo del grupo...",
+      "LEAVE_CONFIRM": "¿Seguro que desea salir de este grupo?",
+      "LEAVE_CONFIRM_YES": "Salir",
+      "LEAVE_CONFIRM_NO": "Cancelar",
+      "LEAVE_SUCCESS": "Ha salido del grupo.",
+      "LEAVE_ERROR": "No se pudo salir del grupo. Inténtelo de nuevo.",
+      "UPDATE_SUCCESS": "Configuración del grupo actualizada correctamente.",
+      "UPDATE_ERROR": "No se pudo actualizar la configuración del grupo. Inténtelo de nuevo."
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/helpCenter.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/helpCenter.json
@@ -1,0 +1,24 @@
+{
+  "HELP_CENTER": {
+    "PORTAL_SETTINGS": {
+      "FORM": {
+        "SHOW_AUTHOR": {
+          "LABEL": "Mostrar los autores de los artículos",
+          "HELP_TEXT": "Muestra la información del autor en las páginas de categorías"
+        },
+        "CUSTOM_HEAD_HTML": {
+          "LABEL": "HTML personalizado en head",
+          "PLACEHOLDER": "Añada HTML personalizado a la sección <head> (por ejemplo, metaetiquetas, analítica, CSS personalizado)",
+          "HELP_TEXT": "Este código se insertará en el <head> de las páginas de su portal",
+          "ERROR": "El HTML personalizado de head debe tener menos de 15.000 caracteres"
+        },
+        "CUSTOM_BODY_HTML": {
+          "LABEL": "HTML personalizado en body",
+          "PLACEHOLDER": "Añada HTML personalizado antes de </body> (por ejemplo, scripts, píxeles de seguimiento, widgets)",
+          "HELP_TEXT": "Este código se insertará antes de la etiqueta de cierre </body> de las páginas de su portal",
+          "ERROR": "El HTML personalizado de body debe tener menos de 15.000 caracteres"
+        }
+      }
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inbox.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inbox.json
@@ -1,0 +1,8 @@
+{
+  "INBOX": {
+    "TYPES_NEXT": {
+      "INTERNAL_CHAT_MENTION": "Mencionado",
+      "INTERNAL_CHAT_NEW_MESSAGE": "Mensaje directo"
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -1,0 +1,145 @@
+{
+  "INBOX_MGMT": {
+    "ADD": {
+      "WHATSAPP": {
+        "PROVIDERS": {
+          "360_DIALOG_DESC": "Conectar con credenciales de 360Dialog",
+          "BAILEYS": "Baileys",
+          "BAILEYS_DESC": "Conectar mediante la API no oficial Baileys",
+          "ZAPI": "Z-API",
+          "ZAPI_DESC": "Conectar mediante la API no oficial Z-API"
+        },
+        "PROVIDER_URL": {
+          "LABEL": "URL del proveedor",
+          "PLACEHOLDER": "Si el proveedor no se ejecuta localmente, indique la URL",
+          "ERROR": "Introduzca una URL válida"
+        },
+        "MARK_AS_READ": {
+          "LABEL": "Enviar confirmaciones de lectura"
+        },
+        "PRESENCE_SUBSCRIBE": {
+          "LABEL": "Mostrar cuando el contacto está escribiendo"
+        },
+        "INSTANCE_ID": {
+          "LABEL": "ID de instancia",
+          "PLACEHOLDER": "Introduzca su ID de instancia",
+          "ERROR": "Este campo es obligatorio"
+        },
+        "TOKEN": {
+          "LABEL": "Token",
+          "PLACEHOLDER": "Introduzca el token de su instancia",
+          "ERROR": "Este campo es obligatorio"
+        },
+        "CLIENT_TOKEN": {
+          "LABEL": "Token de seguridad",
+          "PLACEHOLDER": "Introduzca su token de seguridad (vea la pestaña Security en el panel de Z-API)",
+          "ERROR": "Este campo es obligatorio"
+        },
+        "ADVANCED_OPTIONS": "Opciones avanzadas",
+        "EXTERNAL_PROVIDER": {
+          "SUBTITLE": "Haga clic abajo para configurar el canal de WhatsApp.",
+          "LINK_BUTTON": "Vincular dispositivo",
+          "LINK_DEVICE_MODAL": {
+            "TITLE": "Vincule su dispositivo",
+            "SUBTITLE": "Escanee el código QR para vincular su dispositivo. Verifique que el número de teléfono sea correcto antes de escanear.",
+            "LOADING_QRCODE": "Cargando el código QR...",
+            "RECONNECTING": "Conectando...",
+            "LINK_DEVICE": "Vincular dispositivo",
+            "DISCONNECT": "Desconectar",
+            "CONNECTED": "Su dispositivo se conectó correctamente. Ya puede empezar a enviar y recibir mensajes.",
+            "IMPORT_SESSION_TITLE": "¿El código QR no funciona?",
+            "IMPORT_SESSION_SHOW_MORE": "Ver más",
+            "IMPORT_SESSION_DESC": "WhatsApp ahora exige una clave de acceso al vincular algunas cuentas, lo que bloquea el código QR. Instale la extensión del navegador para importar una sesión que ya tenga iniciada en WhatsApp Web.",
+            "IMPORT_SESSION_INSTALL": "Instalar la extensión"
+          }
+        }
+      }
+    },
+    "CONVERT": {
+      "BUTTON": "Convertir",
+      "CONFIRM": {
+        "TITLE": "Convertir el proveedor de la bandeja de entrada",
+        "INTRO": "Está a punto de cambiar el proveedor de WhatsApp de '{inboxName}' (actualmente {currentProvider}). Antes de continuar, revise lo que va a suceder:",
+        "EFFECT_DISCONNECT": "La sesión actual con {currentProvider} se desconectará.",
+        "EFFECT_TEMPLATES": "Las plantillas de mensaje se borrarán y habrá que volver a sincronizarlas en el nuevo proveedor.",
+        "EFFECT_CONNECTION": "El estado de conexión del proveedor se restablecerá.",
+        "EFFECT_PRESERVED": "Se conservan las conversaciones, los mensajes, los contactos, las asignaciones de agentes y el historial.",
+        "EFFECT_IDENTITY": "El nombre de la bandeja de entrada y el número de teléfono no cambian.",
+        "CONFIRM_PROMPT": "Para confirmar, escriba abajo el nombre de la bandeja de entrada:",
+        "PLACE_HOLDER": "Escriba {inboxName} para continuar",
+        "CONTINUE": "Continuar con la conversión",
+        "CANCEL": "Cancelar"
+      },
+      "SELECT_PROVIDER_TITLE": "Seleccione el nuevo proveedor",
+      "SELECT_PROVIDER_DESCRIPTION": "Convirtiendo '{inboxName}' desde {currentProvider}.",
+      "SUBMIT_BUTTON": "Convertir la bandeja de entrada",
+      "API": {
+        "SUCCESS_MESSAGE": "Bandeja de entrada convertida correctamente",
+        "ERROR_MESSAGE": "No se pudo convertir la bandeja de entrada. Revise las credenciales e inténtelo de nuevo."
+      }
+    },
+    "SETTINGS_POPUP": {
+      "WHATSAPP_MANAGE_PROVIDER_CONNECTION_TITLE": "Gestionar la conexión del proveedor",
+      "WHATSAPP_MANAGE_PROVIDER_CONNECTION_SUBHEADER": "Vincule su dispositivo y gestione la conexión del proveedor.",
+      "WHATSAPP_MANAGE_PROVIDER_CONNECTION_BUTTON": "Gestionar la conexión",
+      "WHATSAPP_PROVIDER_URL_TITLE": "URL del proveedor",
+      "WHATSAPP_PROVIDER_URL_SUBHEADER": "Si el proveedor no se ejecuta localmente, indique la URL.",
+      "WHATSAPP_PROVIDER_URL_PLACEHOLDER": "Introduzca la URL del proveedor",
+      "WHATSAPP_PROVIDER_URL_ERROR": "Introduzca una URL válida",
+      "WHATSAPP_MARK_AS_READ_TITLE": "Confirmaciones de lectura",
+      "WHATSAPP_MARK_AS_READ_SUBHEADER": "Si está desactivado, cuando un mensaje se vea en Chatwoot no se enviará confirmación de lectura al remitente. Sus mensajes seguirán pudiendo recibir confirmaciones de lectura del remitente.",
+      "WHATSAPP_MARK_AS_READ_LABEL": "Enviar confirmaciones de lectura",
+      "WHATSAPP_PRESENCE_SUBSCRIBE_TITLE": "Indicador de escritura del contacto",
+      "WHATSAPP_PRESENCE_SUBSCRIBE_SUBHEADER": "Si está activado, verá en la conversación cuando un contacto de WhatsApp esté escribiendo o grabando audio. Es necesario reconectar el canal para que surta efecto.",
+      "WHATSAPP_PRESENCE_SUBSCRIBE_LABEL": "Mostrar cuando el contacto está escribiendo",
+      "WHATSAPP_INSTANCE_ID_TITLE": "ID de instancia",
+      "WHATSAPP_INSTANCE_ID_SUBHEADER": "Su ID de instancia de Z-API.",
+      "WHATSAPP_INSTANCE_ID_UPDATE_TITLE": "Actualizar el ID de instancia",
+      "WHATSAPP_INSTANCE_ID_UPDATE_SUBHEADER": "Introduzca aquí el nuevo ID de instancia",
+      "WHATSAPP_TOKEN_TITLE": "Token",
+      "WHATSAPP_TOKEN_SUBHEADER": "El token de su instancia de Z-API.",
+      "WHATSAPP_TOKEN_UPDATE_TITLE": "Actualizar el token",
+      "WHATSAPP_TOKEN_UPDATE_SUBHEADER": "Introduzca aquí el nuevo token de la instancia",
+      "WHATSAPP_CLIENT_TOKEN_TITLE": "Token de seguridad",
+      "WHATSAPP_CLIENT_TOKEN_SUBHEADER": "Su Client Token de Z-API (vea la pestaña Security en el panel de Z-API).",
+      "WHATSAPP_CLIENT_TOKEN_UPDATE_TITLE": "Actualizar el token de seguridad",
+      "WHATSAPP_CLIENT_TOKEN_UPDATE_SUBHEADER": "Introduzca aquí el nuevo token de seguridad"
+    },
+    "ASSIGNMENT": {
+      "PREVENT_TAKEOVER": "Impedir que otro agente tome la conversación",
+      "PREVENT_TAKEOVER_SUB_TEXT": "Cuando un agente toma una conversación, solo él o un administrador pueden cambiar quién la atiende. La asignación automática no se ve afectada."
+    },
+    "CSAT": {
+      "TEMPLATE_MODE": {
+        "LABEL": "Origen de la plantilla",
+        "CREATE_NEW": "Crear una plantilla nueva",
+        "USE_EXISTING": "Usar una plantilla existente"
+      },
+      "EXISTING_TEMPLATE": {
+        "LABEL": "Seleccionar plantilla",
+        "PLACEHOLDER": "Seleccione una plantilla aprobada",
+        "SYNC_BUTTON": "Sincronizar plantillas",
+        "SYNCING": "Sincronizando...",
+        "EMPTY_STATE": "No se encontraron plantillas compatibles. Las plantillas deben tener un botón de URL con un parámetro dinámico.",
+        "LINK_SUCCESS": "Plantilla vinculada correctamente",
+        "LINK_ERROR": "No se pudo vincular la plantilla",
+        "LOADING": "Cargando plantillas...",
+        "USING_LABEL": "Usando la plantilla existente: {name}",
+        "SYNC_ERROR": "No se pudieron sincronizar las plantillas. Inténtelo de nuevo."
+      },
+      "TEMPLATE_VARIABLES": {
+        "TITLE": "Variables de la plantilla",
+        "DESCRIPTION": "Defina los valores de las variables del cuerpo de la plantilla. Puede usar variables dinámicas como {'{{'} contact.name {'}}'}, que se resolverán al momento del envío.",
+        "VARIABLE_LABEL": "Variable {variable}",
+        "VARIABLE_PLACEHOLDER": "Introduzca el valor de {variable}",
+        "VARIABLE_REQUIRED": "Esta variable es obligatoria",
+        "VALIDATION_ERROR": "Defina todas las variables de la plantilla antes de guardar.",
+        "INSERT_VARIABLE": "Insertar variable"
+      }
+    },
+    "CHANNELS": {
+      "WHATSAPP_BAILEYS": "WhatsApp - Baileys",
+      "WHATSAPP_ZAPI": "WhatsApp - Z-API"
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/integrations.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/integrations.json
@@ -1,0 +1,35 @@
+{
+  "INTEGRATION_SETTINGS": {
+    "WEBHOOK": {
+      "FORM": {
+        "SUBSCRIPTIONS": {
+          "EVENTS": {
+            "MESSAGE_INCOMING": "Mensaje entrante",
+            "MESSAGE_OUTGOING": "Mensaje saliente",
+            "CONVERSATION_RECORDING": "Audio grabado de la conversación",
+            "PROVIDER_EVENT_RECEIVED": "Evento del proveedor recibido",
+            "INTERNAL_CHAT_MESSAGE_CREATED": "Mensaje de chat interno creado",
+            "INTERNAL_CHAT_MESSAGE_UPDATED": "Mensaje de chat interno actualizado",
+            "INTERNAL_CHAT_MESSAGE_DELETED": "Mensaje de chat interno eliminado",
+            "INTERNAL_CHAT_CHANNEL_UPDATED": "Canal de chat interno actualizado"
+          }
+        },
+        "INBOX": {
+          "LABEL": "Bandeja de entrada",
+          "TITLE": "Seleccione la bandeja de entrada",
+          "PLACEHOLDER": "Todas las bandejas de entrada",
+          "NO_RESULTS": "No se encontraron bandejas de entrada",
+          "INPUT_PLACEHOLDER": "Buscar bandeja de entrada"
+        }
+      }
+    },
+    "DASHBOARD_APPS": {
+      "VIEW": {
+        "NOT_FOUND": "No hemos encontrado esa aplicación de panel."
+      },
+      "FORM": {
+        "SHOW_ON_SIDEBAR_LABEL": "Mostrar en la barra lateral"
+      }
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/internalChat.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/internalChat.json
@@ -1,0 +1,210 @@
+{
+  "INTERNAL_CHAT": {
+    "TITLE": "Chat interno",
+    "BACK": "Volver a los canales",
+    "SIDEBAR": {
+      "EXPAND": "Expandir la lista de canales",
+      "COLLAPSE": "Contraer la lista de canales",
+      "RESIZE": "Redimensionar la lista de canales"
+    },
+    "REACTIONS": {
+      "THUMBS_UP": "Pulgar arriba",
+      "HEART": "Corazón",
+      "JOY": "Risa",
+      "SURPRISED": "Sorpresa",
+      "SAD": "Tristeza",
+      "PRAY": "Gracias",
+      "FIRE": "Fuego",
+      "PARTY": "Celebración"
+    },
+    "CHANNELS": "Canales",
+    "DIRECT_MESSAGES": "Mensajes directos",
+    "FAVORITES": "Favoritos",
+    "NEW_CHANNEL": "Canal nuevo",
+    "NEW_DM": "Mensaje nuevo",
+    "SEARCH_PLACEHOLDER": "Buscar en el chat...",
+    "SEARCH": {
+      "CHANNELS": "Canales",
+      "DIRECT_MESSAGES": "Mensajes directos",
+      "MESSAGES": "Mensajes",
+      "NO_RESULTS": "No se encontraron resultados",
+      "NO_RESULTS_SUBTITLE": "Pruebe con otro término de búsqueda o revise la ortografía.",
+      "LOAD_MORE": "Cargar más mensajes",
+      "SEARCHING": "Buscando...",
+      "MIN_CHARS_HINT": "Escriba al menos 3 caracteres para buscar."
+    },
+    "NO_CHANNELS": "No se encontraron canales",
+    "CHANNEL": {
+      "NAME": "Nombre del canal",
+      "DESCRIPTION": "Descripción",
+      "TYPE": "Tipo de canal",
+      "PUBLIC": "Público",
+      "PRIVATE": "Privado",
+      "MEMBERS": "Miembros",
+      "ARCHIVE": "Archivar el canal",
+      "UNARCHIVE": "Desarchivar el canal",
+      "DELETE": "Eliminar el canal",
+      "MUTE": "Silenciar el canal",
+      "UNMUTE": "Dejar de silenciar el canal",
+      "FAVORITE": "Añadir a favoritos",
+      "UNFAVORITE": "Quitar de favoritos",
+      "MARK_UNREAD": "Marcar como no leído",
+      "NO_MESSAGES": "Todavía no hay mensajes",
+      "NO_MESSAGES_SUBTITLE": "Sea el primero en escribir algo en este canal.",
+      "ARCHIVED": "Este canal está archivado",
+      "MEMBER_COUNT": "{count} miembro | {count} miembros",
+      "SETTINGS": "Configuración del canal",
+      "INFO": "Información del canal",
+      "CREATED_AT": "Creado",
+      "CONFIRM_DELETE": "¿Seguro que desea eliminar este canal?",
+      "ACTIONS": "Acciones",
+      "CREATED": "Canal creado correctamente",
+      "ADMIN": "Administrador",
+      "YOU": "(usted)",
+      "NO_MEMBERS": "Sin miembros",
+      "ADD_MEMBER": "Añadir miembro...",
+      "REMOVE_MEMBER": "Quitar miembro",
+      "EDIT_MEMBERS": "Editar los miembros",
+      "SAVE_MEMBERS": "Guardar",
+      "MEMBERS_UPDATED": "Miembros actualizados correctamente",
+      "ALL_AGENTS_NOTE": "Este canal será visible para todos los usuarios",
+      "CLOSE_DM": "Cerrar la conversación",
+      "SELECT_TEAMS": "Seleccionar equipos",
+      "SELECT_AGENTS": "Seleccionar agentes"
+    },
+    "MESSAGE": {
+      "PLACEHOLDER": "Escriba un mensaje...",
+      "EDIT": "Editar",
+      "DELETE": "Eliminar",
+      "REPLY": "Responder",
+      "REACT": "Reaccionar",
+      "EDITED": "(editado)",
+      "DELETED": "Este mensaje fue eliminado",
+      "SEND": "Enviar",
+      "UPLOAD_FILE": "Subir archivo",
+      "DRAG_DROP": "Suelte los archivos aquí para adjuntarlos",
+      "MENTION_USER": "Mencionar a un usuario",
+      "MENTION_CONVERSATION": "Mencionar una conversación",
+      "CONFIRM_DELETE": "¿Seguro que desea eliminar este mensaje?",
+      "EDITING": "Editando el mensaje",
+      "CANCEL_EDIT": "Cancelar la edición",
+      "BOLD": "Negrita",
+      "ITALIC": "Cursiva",
+      "CODE": "Código",
+      "MORE_ACTIONS": "Más acciones",
+      "COPY_LINK": "Copiar el enlace",
+      "LINK_COPIED": "Enlace del mensaje copiado al portapapeles",
+      "DELETED_USER": "Usuario eliminado"
+    },
+    "THREAD": {
+      "TITLE": "Hilo",
+      "CLOSE": "Cerrar el hilo",
+      "REPLIES": "{count} respuestas",
+      "REPLY_PLACEHOLDER": "Responder en el hilo...",
+      "ALSO_SEND_IN_CHANNEL": "Enviar también a la conversación"
+    },
+    "POLL": {
+      "CREATE": "Crear una encuesta",
+      "QUESTION": "Pregunta",
+      "OPTIONS": "Opciones",
+      "MULTIPLE_CHOICE": "Opción múltiple",
+      "DURATION": "Duración",
+      "DURATION_24H": "24 horas",
+      "DURATION_7D": "7 días",
+      "DURATION_14D": "14 días",
+      "DURATION_30D": "30 días",
+      "PUBLIC_RESULTS": "Resultados públicos",
+      "VOTE": "Votar",
+      "VOTES": "{count} votos",
+      "EXPIRED": "Finalizada",
+      "PIN": "Fijar la encuesta",
+      "ADD_OPTION": "Añadir opción",
+      "CANCEL": "Cancelar",
+      "PERCENTAGE": "{value}%",
+      "TIME_LEFT": {
+        "DAYS": "quedan {count} d",
+        "HOURS_MINUTES": "quedan {hours} h {minutes} min",
+        "MINUTES": "quedan {count} min"
+      },
+      "DISCARD_TITLE": "¿Descartar la encuesta?",
+      "DISCARD_DESCRIPTION": "Tiene cambios sin guardar. ¿Seguro que desea descartar esta encuesta?",
+      "DISCARD": "Descartar"
+    },
+    "DRAFT": {
+      "TITLE": "Borradores",
+      "LABEL": "Borrador",
+      "NO_DRAFTS": "Todavía no hay borradores",
+      "NO_DRAFTS_SUBTITLE": "Los borradores se guardan automáticamente cuando empieza a escribir en un canal.",
+      "DELETE": "Eliminar el borrador",
+      "SAVED_AGO": "Guardado hace {time}",
+      "CHANNEL_LABEL": "Canal n.º {channelId}"
+    },
+    "PIN": {
+      "PINNED_MESSAGE": "Mensaje fijado",
+      "PIN": "Fijar el mensaje",
+      "UNPIN": "Dejar de fijar el mensaje"
+    },
+    "TYPING": {
+      "SINGLE": "{name} está escribiendo...",
+      "MULTIPLE": "{names} están escribiendo..."
+    },
+    "DM": {
+      "NEW": "Mensaje directo nuevo",
+      "SELECT_AGENTS": "Seleccionar agentes"
+    },
+    "CATEGORY": {
+      "CREATE": "Crear una categoría",
+      "NAME": "Nombre de la categoría",
+      "NAME_PLACEHOLDER": "Escriba el nombre de la categoría",
+      "NONE": "Ninguna",
+      "CREATED": "Categoría creada correctamente",
+      "DELETE": "Eliminar la categoría",
+      "DELETE_DESCRIPTION": "Los canales de esta categoría pasarán a estar sin categoría."
+    },
+    "ERRORS": {
+      "FETCH_CHANNELS": "No se pudieron cargar los canales",
+      "FETCH_MESSAGES": "No se pudieron cargar los mensajes",
+      "SEND_MESSAGE": "No se pudo enviar el mensaje",
+      "CREATE_CHANNEL": "No se pudo crear el canal"
+    },
+    "DATE_SEPARATOR": {
+      "TODAY": "Hoy",
+      "YESTERDAY": "Ayer"
+    },
+    "SCROLL_TO_BOTTOM": "Ir al final",
+    "NEW_MESSAGES": "Mensajes nuevos",
+    "LOADING_MESSAGES": "Cargando los mensajes...",
+    "MENTION_BADGE": "{'@'}",
+    "EMPTY_STATE": {
+      "TITLE": "Bienvenido al chat interno",
+      "SUBTITLE": "Elija un canal o una conversación en la barra lateral para empezar."
+    },
+    "CONVERSATION_MENTION": {
+      "NO_RESULTS": "No se encontraron conversaciones",
+      "TYPE_TO_SEARCH": "Escriba el ID de una conversación o el nombre de un contacto",
+      "HEADER": "Conversaciones",
+      "PREFIX": "#",
+      "NO_ACCESS": "No tiene acceso a esta conversación",
+      "STATUS": {
+        "OPEN": "Abierta",
+        "RESOLVED": "Resuelta",
+        "PENDING": "Pendiente",
+        "SNOOZED": "Pospuesta"
+      }
+    },
+    "ARCHIVED": {
+      "TITLE": "Archivados",
+      "EMPTY": "No hay canales archivados"
+    },
+    "PRO": {
+      "TITLE": "Mejore su plan a Pro",
+      "POLLS_DESCRIPTION": "La creación de encuestas está disponible en la versión Pro.",
+      "PRIVATE_CHANNELS_DESCRIPTION": "Alcanzó el límite de {limit} canales privados. Mejore su plan a Pro para tener canales privados ilimitados.",
+      "SEARCH_DESCRIPTION": "La búsqueda se limita a los últimos {days} días. Mejore su plan a Pro para tener un historial de búsqueda ilimitado.",
+      "SEARCH_LIMITED_NOTE": "Resultados de los últimos {days} días",
+      "UPGRADE_NOW": "Mejorar plan",
+      "ADMIN_MESSAGE": "Esta función no está disponible en su plan actual. Contacte al administrador de la plataforma para mejorar el plan.",
+      "AGENT_MESSAGE": "Esta función no está disponible en su plan actual. Contacte a su administrador para mejorar el plan."
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/kanban.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/kanban.json
@@ -1,0 +1,11 @@
+{
+  "KANBAN": {
+    "PAYWALL": {
+      "TITLE": "Mejore su plan para usar Kanban",
+      "DESCRIPTION": "La función Kanban requiere una suscripción a Chatwoot Pro de fazer.ai.",
+      "UPGRADE_PROMPT": "Suscríbase a Chatwoot Pro de fazer.ai para acceder a los embudos Kanban, la gestión de tareas y la automatización de flujos de trabajo.",
+      "NON_ADMIN_MESSAGE": "La función Kanban no está disponible en su plan actual. Contacte a su administrador para mejorar el plan.",
+      "UPGRADE_NOW": "Mejorar plan"
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/overrides.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/overrides.json
@@ -1,0 +1,10 @@
+{
+  "CONVERSATION": {
+    "UNSUPPORTED_MESSAGE": "Este mensaje no es compatible. Puede verlo en la aplicación."
+  },
+  "INBOX_MGMT": {
+    "CSAT": {
+      "WHATSAPP_NOTE": "Nota: puede crear una plantilla nueva (que se enviará a WhatsApp para su aprobación como Utilidad, aunque Meta puede clasificarla como Marketing según el contenido) o usar una plantilla ya aprobada de su administrador de plantillas de Meta. Las encuestas se envían una sola vez por conversación, según la regla de la encuesta."
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/recording.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/recording.json
@@ -1,0 +1,7 @@
+{
+  "RECORDING": {
+    "ONE": "{user} está grabando audio",
+    "TWO": "{user} y {secondUser} están grabando audio",
+    "MULTIPLE": "{user} y {count} más están grabando audio"
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/scheduledMessages.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/scheduledMessages.json
@@ -1,0 +1,169 @@
+{
+  "SCHEDULED_MESSAGES": {
+    "NEW_BUTTON": "Programar mensaje",
+    "PAST_MESSAGES_SECTION": "Enviados",
+    "EMPTY_STATE": "Todavía no hay mensajes programados.",
+    "STATUS": {
+      "DRAFT": "Borrador",
+      "PENDING": "Pendiente",
+      "SENT": "Enviado",
+      "FAILED": "Fallido",
+      "HELD": "Retenido"
+    },
+    "HELD_SECTION": "Retenidos",
+    "ITEM": {
+      "SCHEDULED_FOR": "Programado para {time}",
+      "NO_SCHEDULE": "Sin programación",
+      "TEMPLATE_PREVIEW": "Plantilla: {name}",
+      "TEMPLATE_LABEL": "Plantilla: {name}",
+      "ATTACHMENT_PREVIEW": "Archivo adjunto: {filename}",
+      "ATTACHMENT_LABEL": "Archivo adjunto: {filename}",
+      "EMPTY_PREVIEW": "Sin contenido",
+      "EXPAND": "Expandir",
+      "COLLAPSE": "Contraer",
+      "GO_TO_MESSAGE": "Ir al mensaje",
+      "SEARCHING_MESSAGE": "Buscando el mensaje...",
+      "MESSAGE_NOT_FOUND": "No se encontró el mensaje vinculado. Es posible que se haya eliminado.",
+      "HELD_REASON": "Retenido porque el cliente respondió antes de que se enviara este mensaje."
+    },
+    "MODAL": {
+      "TITLE_NEW": "Programar un mensaje",
+      "TITLE_EDIT": "Editar el mensaje programado",
+      "MESSAGE_LABEL": "Mensaje",
+      "MESSAGE_PLACEHOLDER": "Escriba su mensaje...",
+      "DATETIME_LABEL": "Fecha y hora de envío",
+      "ATTACHMENT_LABEL": "Archivo adjunto",
+      "ATTACHMENT_ADD": "Adjuntar archivo",
+      "ATTACHMENT_CURRENT": "Archivo adjunto actual: {filename}",
+      "TEMPLATE_SELECT": "Usar plantilla",
+      "TEMPLATE_SELECTED": "Plantilla: {name}",
+      "TEMPLATE_ACTION": "Programar mensaje",
+      "CANCEL": "Cancelar",
+      "SAVE_DRAFT": "Guardar como borrador",
+      "SCHEDULE": "Programar",
+      "HOLD_ON_REPLY_LABEL": "Retener si el cliente responde antes",
+      "HOLD_ON_REPLY_DESCRIPTION": "Si el cliente envía un mensaje antes de que se envíe este, el mensaje se retendrá para revisión en lugar de enviarse automáticamente.",
+      "SHORTCUTS": {
+        "TOMORROW_MORNING": "Mañana por la mañana",
+        "TOMORROW_AFTERNOON": "Mañana por la tarde",
+        "MONDAY_MORNING": "El lunes por la mañana",
+        "CUSTOM": "Escriba una fecha y una hora"
+      },
+      "CUSTOM_INPUT_PLACEHOLDER": "p. ej. mañana a las 14, el viernes por la mañana",
+      "CUSTOM_INPUT_HINT": "Pruebe: mañana a las 15, el próximo lunes, en 2 horas",
+      "PARSED_DATE_IN_PAST": "Esta fecha ya pasó",
+      "DATEPICKER_TOOLTIP": "Elegir en el calendario",
+      "SCHEDULE_LABEL": "Programar envío"
+    },
+    "CONFIRM_CLOSE": {
+      "TITLE": "Cambios sin guardar",
+      "MESSAGE": "Tiene contenido sin guardar. ¿Desea descartar los cambios?",
+      "CONTINUE_EDITING": "Seguir editando",
+      "DISCARD": "Descartar",
+      "CANCEL": "Cancelar"
+    },
+    "CONFIRM_DELETE": {
+      "TITLE": "Eliminar el mensaje programado",
+      "MESSAGE": "¿Seguro que desea eliminar este mensaje programado? Esta acción no se puede deshacer.",
+      "CANCEL": "Cancelar",
+      "DELETE": "Eliminar"
+    },
+    "META": {
+      "TOOLTIP": "Programado a las {time} por {author}",
+      "YOU": "Usted",
+      "AUTHOR_YOU": "{name} (usted)",
+      "AUTOMATION": "Automatización",
+      "UNKNOWN_AUTHOR": "Desconocido"
+    },
+    "ERRORS": {
+      "CONTENT_REQUIRED": "Añada un mensaje, una plantilla o un archivo adjunto antes de guardar.",
+      "CONTENT_TOO_LONG": "El mensaje es demasiado largo. Se permiten {maxLength} caracteres como máximo.",
+      "DATETIME_REQUIRED": "Seleccione la fecha y la hora para programar el mensaje.",
+      "SCHEDULE_IN_PAST": "La hora programada debe ser futura.",
+      "SAVE_FAILED": "No se pudo guardar el mensaje programado. Inténtelo de nuevo.",
+      "DELETE_FAILED": "No se pudo eliminar el mensaje programado. Inténtelo de nuevo."
+    },
+    "RECURRENCE": {
+      "SECTION_TITLE": "Repeticiones",
+      "NO_REPEAT": "No se repite",
+      "DAILY": "Todos los días",
+      "WEEKLY": "Cada semana el {day}",
+      "MONTHLY_NTH": "Cada mes el {nth} {day}",
+      "MONTHLY_LAST": "Cada mes el último {day}",
+      "YEARLY": "Cada año el {dayNum} de {month}",
+      "WEEKDAYS": "Todos los días laborables (lun-vie)",
+      "CUSTOM": "Personalizada...",
+      "CUSTOM_MODAL": {
+        "TITLE": "Repetición personalizada",
+        "REPEAT_EVERY": "Repetir cada",
+        "FREQ_DAILY": "día(s)",
+        "FREQ_WEEKLY": "semana(s)",
+        "FREQ_MONTHLY": "mes(es)",
+        "FREQ_YEARLY": "año(s)",
+        "UNIT_DAY": "día | días",
+        "UNIT_WEEK": "semana | semanas",
+        "UNIT_MONTH": "mes | meses",
+        "UNIT_YEAR": "año | años",
+        "REPEAT_ON": "Repetir el",
+        "MONTHLY_ON_DAY": "Día del mes",
+        "MONTHLY_ON_WEEKDAY": "Día de la semana",
+        "ENDS": "Termina",
+        "ENDS_NEVER": "Nunca",
+        "ENDS_ON_DATE": "En la fecha",
+        "ENDS_AFTER": "Después de",
+        "ENDS_OCCURRENCES": "repeticiones",
+        "DONE": "Listo",
+        "CANCEL": "Cancelar"
+      },
+      "STATUS_ACTIVE": "Activa",
+      "STATUS_DRAFT": "Borrador",
+      "STATUS_COMPLETED": "Completada",
+      "STATUS_CANCELLED": "Cancelada",
+      "OCCURRENCES_SENT": "{count} enviados",
+      "NEXT_SEND": "Siguiente: {time}",
+      "EXPAND": "Ver el historial",
+      "COLLAPSE": "Ocultar el historial",
+      "STOP": "Detener la repetición",
+      "STOP_CONFIRM": {
+        "TITLE": "Detener la repetición",
+        "MESSAGE": "El mensaje pendiente se eliminará y la repetición se detendrá de forma permanente.",
+        "CONFIRM": "Detener",
+        "CANCEL": "Cancelar"
+      },
+      "EDIT": "Editar la repetición",
+      "EDIT_WARNING": "Siguiente envío: {oldDate} → {newDate}",
+      "WEEKDAYS_SHORT": {
+        "SUN": "D",
+        "MON": "L",
+        "TUE": "M",
+        "WED": "X",
+        "THU": "J",
+        "FRI": "V",
+        "SAT": "S"
+      },
+      "ORDINALS": {
+        "FIRST": "primer",
+        "SECOND": "segundo",
+        "THIRD": "tercer",
+        "FOURTH": "cuarto",
+        "FIFTH": "quinto",
+        "LAST": "último"
+      },
+      "DESCRIPTION": {
+        "DAILY_ONE": "Todos los días",
+        "DAILY_OTHER": "Cada {count} días",
+        "WEEKLY_ONE": "Cada semana",
+        "WEEKLY_OTHER": "Cada {count} semanas",
+        "WEEKLY_ON": "{prefix}: {days}",
+        "MONTHLY_ONE": "Cada mes",
+        "MONTHLY_OTHER": "Cada {count} meses",
+        "MONTHLY_ON_WEEKDAY": "{prefix} el {ordinal} {weekday}",
+        "YEARLY_ONE": "Cada año",
+        "YEARLY_OTHER": "Cada {count} años",
+        "UNTIL_DATE": "hasta el {date}",
+        "AFTER_COUNT": "{count} repeticiones"
+      },
+      "RESOLVED_WARNING": "Los mensajes programados no se enviarán mientras la conversación esté resuelta. Reabra la conversación para reanudar los envíos."
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/settings.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/settings.json
@@ -1,0 +1,56 @@
+{
+  "PROFILE_SETTINGS": {
+    "FORM": {
+      "MESSAGE_SIGNATURE_SECTION": {
+        "RESET_TO_DEFAULT": "Restablecer los valores predeterminados",
+        "RESET_SUCCESS": "Firma de la bandeja de entrada eliminada, se usará la firma predeterminada",
+        "INBOX_SELECTOR": {
+          "LABEL": "Bandeja de entrada",
+          "DEFAULT": "Predeterminada (todas las bandejas de entrada)",
+          "CUSTOM": "Personalizada"
+        },
+        "SIGNATURE_POSITION": {
+          "LABEL": "Posición de la firma",
+          "OPTIONS": {
+            "TOP": "Al principio del mensaje",
+            "BOTTOM": "Al final del mensaje"
+          }
+        },
+        "SIGNATURE_SEPARATOR": {
+          "LABEL": "Separador de la firma",
+          "OPTIONS": {
+            "BLANK": "Línea en blanco",
+            "HORIZONTAL_LINE": "Línea horizontal (--)"
+          }
+        },
+        "PREVIEW": {
+          "TITLE": "Vista previa de la firma",
+          "NOTE": "Así se verá su firma en los mensajes",
+          "EMPTY": "Escriba una firma arriba para ver la vista previa",
+          "SAMPLE_MESSAGE": "¡Hola! Gracias por contactarnos. ¿En qué puedo ayudarle hoy?"
+        }
+      },
+      "NOTIFICATIONS": {
+        "TYPES": {
+          "INTERNAL_CHAT_MENTION": "Le mencionan en el chat interno",
+          "INTERNAL_CHAT_NEW_MESSAGE": "Un nuevo mensaje directo en el chat interno"
+        }
+      }
+    }
+  },
+  "COMPONENTS": {
+    "REFERRAL_CARD": {
+      "AD_LABEL": "Desde un anuncio",
+      "VIEW_AD": "Ver anuncio"
+    },
+    "MEDIA": {
+      "AUDIO_UNAVAILABLE": "Este audio ya no está disponible.",
+      "VIDEO_UNAVAILABLE": "Este video ya no está disponible."
+    }
+  },
+  "SIDEBAR": {
+    "INTERNAL_CHAT": "Chat interno",
+    "KANBAN": "Kanban",
+    "APPS": "Apps"
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/specs/index.spec.js
+++ b/app/javascript/dashboard/i18n/fazer-ai/specs/index.spec.js
@@ -3,17 +3,27 @@ import messages from 'dashboard/i18n';
 import { forkMessages, withForkMessages } from 'dashboard/i18n/fazer-ai';
 import upstreamEn from 'dashboard/i18n/locale/en';
 import upstreamPtBr from 'dashboard/i18n/locale/pt_BR';
+import upstreamEs from 'dashboard/i18n/locale/es';
 import upstreamFr from 'dashboard/i18n/locale/fr';
 
 describe('fazer.ai translation overlay', () => {
   it('exposes a fork tree for every language we translate', () => {
-    expect(Object.keys(forkMessages).sort()).toEqual(['en', 'pt_BR']);
+    expect(Object.keys(forkMessages).sort()).toEqual(['en', 'es', 'pt_BR']);
   });
 
   it('adds namespaces that upstream does not ship', () => {
     expect(upstreamEn.INTERNAL_CHAT).toBeUndefined();
     expect(messages.en.INTERNAL_CHAT).toBeDefined();
     expect(messages.pt_BR.SCHEDULED_MESSAGES).toBeDefined();
+    expect(messages.es.SCHEDULED_MESSAGES).toBeDefined();
+  });
+
+  it('translates the fork keys rather than copying the en tree', () => {
+    expect(messages.es.INTERNAL_CHAT.TITLE).toBe('Chat interno');
+    expect(messages.es.GROUP.SETTINGS.LEAVE_GROUP).toBe('Salir del grupo');
+    expect(messages.es.INBOX_MGMT.CONVERT.BUTTON).not.toBe(
+      messages.en.INBOX_MGMT.CONVERT.BUTTON
+    );
   });
 
   it('adds fork keys inside an upstream namespace without dropping upstream keys', () => {
@@ -30,6 +40,9 @@ describe('fazer.ai translation overlay', () => {
     );
     expect(messages.pt_BR.CONVERSATION.UNSUPPORTED_MESSAGE).not.toBe(
       upstreamPtBr.CONVERSATION.UNSUPPORTED_MESSAGE
+    );
+    expect(messages.es.CONVERSATION.UNSUPPORTED_MESSAGE).not.toBe(
+      upstreamEs.CONVERSATION.UNSUPPORTED_MESSAGE
     );
   });
 

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -1,0 +1,101 @@
+# fazer.ai fork translations.
+#
+# Rails deep-merges every config/locales/*.yml, so these keys land on top of
+# upstream's <locale>.yml without touching it. Keys for our own features go
+# here; upstream copy we merely translate does not.
+#
+# Adding a language means adding fazer_ai.<locale>.yml. Nothing else changes.
+es:
+  internal_chat:
+    default_category_name: Canales
+    default_channel_name: General
+    messages:
+      deleted: Este mensaje fue eliminado
+  errors:
+    automation:
+      scheduled_message:
+        delay_out_of_range: El retraso debe estar entre 1 minuto y 999 días
+        content_attachment_or_template_required: El mensaje programado debe tener contenido, un archivo adjunto o una plantilla
+    scheduled_messages:
+      cannot_delete_processed: No se puede eliminar un mensaje programado que ya se envió o que falló
+    conversations:
+      already_assigned: "%{agent_name} ya está atendiendo esta conversación."
+    inboxes:
+      channel:
+        provider_connection:
+          wrong_phone_number: El número de teléfono que intenta vincular no es el mismo que tiene configurado. Verifique que el número sea correcto antes de escanear el código QR.
+          reconnect_loop_detected: No se pudo restablecer la conexión después de varios intentos. Los reintentos automáticos continúan a intervalos cada vez mayores. Si el problema persiste, desconecte la bandeja de entrada y vuelva a vincularla escaneando un código QR nuevo.
+  notifications:
+    notification_title:
+      internal_chat_mention: Le mencionaron en %{name}
+      internal_chat_new_message: Mensaje nuevo de %{name}
+  conversations:
+    activity:
+      group_participants:
+        add:
+          single: "%{author_name} añadió a %{contact_name} al grupo"
+          multiple: "%{author_name} añadió a %{contact_names} y %{last_contact_name} al grupo"
+        join: "%{contact_name} se unió mediante el enlace de invitación del grupo"
+        leave: "%{contact_name} salió del grupo"
+        remove:
+          single: "%{author_name} quitó a %{contact_name} del grupo"
+          multiple: "%{author_name} quitó a %{contact_names} y %{last_contact_name} del grupo"
+        promote:
+          single: "%{author_name} promovió a %{contact_name} a administrador"
+          multiple: "%{author_name} promovió a %{contact_names} y %{last_contact_name} a administradores"
+        demote:
+          single: "%{author_name} degradó a %{contact_name} a miembro"
+          multiple: "%{author_name} degradó a %{contact_names} y %{last_contact_name} a miembros"
+      groups_update:
+        subject_changed: '%{author_name} cambió el nombre del grupo a "%{value}"'
+        description_changed: "%{author_name} cambió la descripción del grupo"
+        description_removed: "%{author_name} eliminó la descripción del grupo"
+        restrict_enabled: "%{author_name} cambió la configuración para que solo los administradores puedan editar la configuración del grupo"
+        restrict_disabled: "%{author_name} cambió la configuración para que todos los miembros puedan editar la configuración del grupo"
+        announce_enabled: "%{author_name} cambió la configuración de este grupo para que solo los administradores puedan enviar mensajes"
+        announce_disabled: "%{author_name} cambió la configuración de este grupo para que todos los miembros puedan enviar mensajes"
+        member_add_mode_enabled: "%{author_name} cambió la configuración de este grupo para que todos los miembros puedan añadir a otras personas"
+        member_add_mode_disabled: "%{author_name} cambió la configuración de este grupo para que solo los administradores puedan añadir a otras personas"
+        join_approval_mode_enabled: "%{author_name} activó la aprobación del administrador para unirse a este grupo"
+        join_approval_mode_disabled: "%{author_name} desactivó la aprobación del administrador para unirse a este grupo"
+        invite_link_reset: "%{author_name} restableció el enlace de invitación de este grupo"
+        membership_request_created: "%{contact_name} quiere unirse al grupo"
+        membership_request_revoked: "%{contact_name} ya no quiere unirse al grupo"
+        icon_changed: "%{author_name} cambió la imagen del grupo"
+      recurring_message_failed: No se pudo enviar el mensaje programado recurrente. La siguiente repetición está programada para %{next_date}.
+      recurring_message_completed: La serie de mensajes programados recurrentes terminó después de %{count} repeticiones.
+      recurring_message_cancelled: "%{agent} detuvo el mensaje programado recurrente."
+      unknown_agent: Desconocido
+  contacts:
+    sync_group:
+      not_a_group: El contacto no es un grupo
+      no_identifier: El contacto no tiene un identificador de grupo
+      no_supported_inbox: No se encontró ninguna bandeja de entrada con soporte de sincronización de grupos para este contacto
+      metadata_unavailable: No se pudieron obtener los metadatos del grupo desde el proveedor
+  recurring_scheduled_messages:
+    description:
+      daily:
+        one: Todos los días
+        other: Cada %{count} días
+      weekly:
+        one: Cada semana
+        other: Cada %{count} semanas
+      weekly_on: "%{prefix} el %{days}"
+      monthly:
+        one: Cada mes
+        other: Cada %{count} meses
+      monthly_on_weekday: "%{prefix} el %{ordinal} %{weekday}"
+      yearly:
+        one: Cada año
+        other: Cada %{count} años
+      until_date: hasta el %{date}
+      after_count:
+        one: "%{count} repetición"
+        other: "%{count} repeticiones"
+      ordinals:
+        first: primer
+        second: segundo
+        third: tercer
+        fourth: cuarto
+        fifth: quinto
+        last: último

--- a/config/locales/fazer_ai.mailers.es.yml
+++ b/config/locales/fazer_ai.mailers.es.yml
@@ -1,0 +1,219 @@
+# fazer.ai fork translations for Chatwoot mailer templates.
+#
+# Upstream ships these templates with the copy hardcoded in ERB, so the fork
+# extracted them into i18n keys to translate them. They are not our features:
+# if upstream ever localizes its own mailers, this whole file goes away.
+es:
+  mailer:
+    common:
+      hi: Hola %{name}
+      hi_plain: Hola
+      hello: "Hola:"
+      hello_there: "Hola:"
+      click_here: Haga clic <a href="%{url}">aquí</a>
+      powered_by: Desarrollado por
+      sent_by_prefix: Este correo fue enviado por
+      you: Usted
+      attachment_click_to_view: Archivo adjunto [<a href="%{url}" target="_blank">Haga clic aquí para verlo</a>]
+      click_here_to_get_cracking: Haga clic <a href="%{url}">aquí</a> y manos a la obra.
+      the_chatwoot_team: El equipo de %{brand_name}
+    agent_notifications:
+      conversation_creation:
+        subject: "%{agent_name}: se creó una conversación nueva [ID - %{conversation_id}] en %{inbox_name}."
+        body: 'Se creó una conversación nueva (<a href="%{url}">#%{conversation_id}</a>) en %{inbox_name}. <strong>%{contact_name}</strong> escribió:'
+      conversation_assignment:
+        subject: "%{agent_name}: se le asignó una conversación nueva [ID - %{conversation_id}]."
+        body: Hora de salvar el mundo. Se le asignó una conversación nueva
+      conversation_mention:
+        subject: "%{agent_name}: le mencionaron en la conversación [ID - %{conversation_id}]"
+        body: 'Le mencionaron en una conversación. <b>%{sender_name}</b> escribió:'
+        previous_messages: 'Mensajes anteriores:'
+        view_message: Ver el mensaje
+      assigned_conversation_new_message:
+        subject: "%{agent_name}: mensaje nuevo en la conversación que tiene asignada [ID - %{conversation_id}]."
+        body: Recibió un mensaje nuevo en la conversación que tiene asignada.
+      participating_conversation_new_message:
+        subject: "%{agent_name}: mensaje nuevo en una conversación en la que participa [ID - %{conversation_id}]."
+        body: Recibió un mensaje nuevo en una conversación en la que participa.
+      sla_missed_first_response:
+        subject: La conversación [ID - %{conversation_id}] incumplió el SLA de primera respuesta
+        body: incumplió el SLA de primera respuesta según la política
+        full_body: 'La conversación #%{conversation_id} en %{inbox_name} incumplió el SLA de primera respuesta según la política %{sla_policy_name}.'
+        action: Atiéndala de inmediato.
+      sla_missed_next_response:
+        subject: La conversación [ID - %{conversation_id}] incumplió el SLA de la siguiente respuesta
+        body: incumplió el SLA de la siguiente respuesta según la política
+        full_body: 'La conversación #%{conversation_id} en %{inbox_name} incumplió el SLA de la siguiente respuesta según la política %{sla_policy_name}.'
+        action: Atiéndala de inmediato.
+      sla_missed_resolution:
+        subject: La conversación [ID - %{conversation_id}] incumplió el SLA de tiempo de resolución
+        body: incumplió el SLA de tiempo de resolución según la política
+        full_body: 'La conversación #%{conversation_id} en %{inbox_name} incumplió el SLA de tiempo de resolución según la política %{sla_policy_name}.'
+        action: Atiéndala de inmediato.
+    administrator_notifications:
+      channel_notifications:
+        whatsapp_disconnect:
+          subject: Su conexión con WhatsApp caducó
+          body: Su acceso a WhatsApp caducó.
+          action: Vuelva a conectar WhatsApp para seguir recibiendo mensajes.
+          click_to_reconnect: Haga clic <a href="%{url}">aquí</a> para volver a conectarlo.
+        facebook_disconnect:
+          subject: Su conexión con la página de Facebook caducó
+          body: Su acceso a la bandeja de entrada de Facebook caducó.
+          action: Vuelva a conectar la página de Facebook para seguir recibiendo mensajes.
+          click_to_reconnect: Haga clic <a href="%{url}">aquí</a> para volver a conectarla.
+        instagram_disconnect:
+          subject: Su conexión con Instagram caducó
+          body: Su acceso a la bandeja de entrada de Instagram caducó.
+          action: Vuelva a conectar Instagram para seguir recibiendo mensajes.
+          click_to_reconnect: Haga clic <a href="%{url}">aquí</a> para volver a conectarlo.
+        tiktok_disconnect:
+          subject: Su conexión con TikTok caducó
+          body: Su acceso a la bandeja de entrada de TikTok caducó.
+          action: Vuelva a conectar TikTok para seguir recibiendo mensajes.
+          click_to_reconnect: Haga clic <a href="%{url}">aquí</a> para volver a conectarlo.
+        email_disconnect:
+          subject: Su bandeja de entrada de correo se desconectó. Actualice las credenciales de SMTP/IMAP
+          body: Su bandeja de entrada de correo se desconectó por errores de configuración.
+          action: Actualícela para seguir recibiendo mensajes.
+          click_to_reconnect: Haga clic <a href="%{url}">aquí</a> para volver a conectarla.
+      account_notifications:
+        automation_rule_disabled:
+          subject: Regla de automatización desactivada por errores de validación.
+          body: La regla de automatización <b>%{rule_name}</b> se desactivó porque tiene condiciones no válidas.
+          explanation: Esto suele ocurrir cuando se elimina algún atributo personalizado que todavía se usa en las reglas de automatización.
+          action: Haga clic <a href="%{url}">aquí</a> para actualizar las condiciones.
+        contact_import_complete:
+          subject: Importación de contactos completada
+          body: Su importación de contactos se completó. Revise la pestaña de contactos para ver los contactos importados.
+          imported_records: 'Registros importados: %{count}'
+          failed_records: 'Registros fallidos: %{count}'
+          click_to_view_imported: Haga clic <a href="%{url}">aquí</a> para ver los contactos importados.
+          click_to_view_failed: Haga clic <a href="%{url}" target="_blank">aquí</a> para ver los registros fallidos.
+        contact_import_failed:
+          subject: Falló la importación de contactos
+          body: Su importación de contactos falló. Es posible que el archivo CSV que subió no sea válido. Le pedimos que revise el archivo y verifique que cumpla con el formato requerido.
+        contact_export_complete:
+          subject: El archivo de exportación de sus contactos está listo para descargar.
+          body: Su archivo de exportación de contactos está listo para descargar.
+          action: Haga clic <a href="%{url}">aquí</a> para descargar el archivo de exportación.
+        account_deletion_user_initiated:
+          subject: Se programó la eliminación de su cuenta de %{brand_name}
+          body: Un administrador de la cuenta solicitó la eliminación de la cuenta de %{brand_name} <strong>%{account_name}</strong>. La eliminación está programada para el <strong>%{deletion_date}</strong>.
+          what_happens_next: ¿Qué sucede a continuación?
+          remains_accessible: La cuenta seguirá accesible hasta la fecha de eliminación programada.
+          data_permanently_removed: Después de esa fecha se eliminarán de forma permanente todos los datos, incluidas las conversaciones, los contactos, las integraciones y la configuración.
+          cancel_request: Si cambia de opinión antes de la fecha de eliminación, puede <a href="%{url}">cancelar esta solicitud</a> desde la configuración de su cuenta.
+        account_deletion_for_inactivity:
+          subject: Su cuenta de %{brand_name} está programada para eliminarse por inactividad
+          body: Notamos que su cuenta de %{brand_name} <strong>%{account_name}</strong> lleva un tiempo inactiva. Por eso, su eliminación está programada para el <strong>%{deletion_date}</strong>.
+          how_to_keep: ¿Cómo conservo mi cuenta?
+          how_to_keep_body: Inicie sesión en su cuenta de %{brand_name} antes del <strong>%{deletion_date}</strong>. Desde la configuración de su cuenta puede <a href="%{url}">cancelar la eliminación</a> y seguir usándola.
+          what_if_no_cancel: ¿Qué pasa si no la cancelo?
+          what_if_no_cancel_body: Si no cancela la eliminación de la cuenta antes del <strong>%{deletion_date}</strong>, su cuenta y todos los datos asociados, incluidas las conversaciones, los contactos, los informes y la configuración, se eliminarán de forma permanente.
+          why_doing_this: ¿Por qué hacemos esto?
+          why_doing_this_body: Para mantener todo seguro y eficiente, eliminamos periódicamente las cuentas inactivas y así nuestros sistemas siguen optimizados para los equipos activos.
+          contact_us: Si tiene alguna pregunta, escríbanos a <a href="mailto:%{email}">%{email}</a>.
+      integrations_notifications:
+        slack_disconnect:
+          subject: Su integración con Slack caducó
+          body: Su integración con Slack caducó. Para seguir recibiendo mensajes en Slack, elimine la integración y vuelva a conectar su espacio de trabajo.
+          click_to_reconnect: Haga clic <a href="%{url}">aquí</a> para volver a conectarla.
+        dialogflow_disconnect:
+          subject: Su integración con Dialogflow se desconectó
+          body: Su integración con Dialogflow se desconectó por problemas de permisos. Para resolverlo, elimine la integración desde el panel de administración y vuelva a conectarla con credenciales nuevas.
+      account_compliance:
+        account_deleted:
+          subject: Aviso de eliminación de cuenta para %{account_id} - %{account_name}
+          body: Esta es una notificación para informarle de que se eliminó de forma permanente una cuenta de su instalación de %{brand_name}.
+          installation: "Instalación de %{brand_name}:"
+          account_id: 'ID de la cuenta:'
+          account_name: 'Nombre de la cuenta:'
+          deletion_due_at: 'Eliminación prevista para:'
+          deleted_at: 'Eliminada el:'
+          deletion_reason: 'Motivo de la eliminación:'
+          deleted_users: 'Usuarios eliminados (%{count}):'
+          deleted_users_none: 'Usuarios eliminados: ninguno'
+          user_id: 'ID de usuario:'
+          compliance_notice: Este correo sirve como registro para fines de cumplimiento.
+          thank_you: Gracias,
+          system_name: Sistema de %{brand_name}
+    team_notifications:
+      automation:
+        subject: Este correo se envió mediante acciones de una regla de automatización.
+        automation_system: Este es el correo del sistema de automatización
+    portal:
+      cname_instructions:
+        greeting: "Hola:"
+        intro: 'Para terminar de configurar su centro de ayuda, deberá actualizar la configuración DNS de su dominio personalizado: <strong>%{domain}</strong>.'
+        add_cname: 'Añada el siguiente registro CNAME en la configuración de su proveedor de DNS:'
+        steps_title: 'Instrucciones paso a paso:'
+        step_1: Inicie sesión en el panel de su proveedor de DNS
+        step_2: Vaya a la sección de gestión de DNS
+        step_3: Cree un registro CNAME nuevo con la información de arriba
+        step_4: Guarde los cambios y espere hasta 24 horas a que se propague el DNS
+        ssl_notice: Cuando el registro DNS esté activo, su dominio personalizado se protegerá automáticamente con un certificado SSL.
+        support_message: Si tiene preguntas o necesita ayuda, contacte a nuestro equipo de soporte. Estamos para ayudarle.
+    devise:
+      confirmation_instructions:
+        secure_link: este enlace seguro
+        button_fallback_html: Si el botón no funciona, abra %{link}.
+        labels:
+          invited_by: Invitado por
+          workspace: Espacio de trabajo
+          sign_in_method: Método de inicio de sesión
+          sign_in_method_value: Inicio de sesión único (SSO)
+          new_email: Correo nuevo
+        welcome:
+          eyebrow: Bienvenida
+          heading: Confirme su correo para empezar
+          intro_html: Le damos la bienvenida a %{brand_name}. Solo necesitamos verificar su dirección de correo antes de que empiece a usar su cuenta.
+          supporting_text: Toma solo un momento.
+          action_text: Confirmar mi cuenta
+        email_update:
+          eyebrow: Cambio de correo
+          heading: Confirme su dirección de correo nueva
+          intro_html: Recibimos una solicitud para cambiar la dirección de correo de su cuenta de %{brand_name}.
+          supporting_text: Confirme la dirección nueva abajo para completar el cambio.
+          action_text: Confirmar la dirección de correo
+        account_ready:
+          eyebrow: Cuenta lista
+          heading: Su cuenta está lista
+          intro_html: Su cuenta de %{brand_name} ya está activa.
+          supporting_text: Use el botón de abajo para iniciar sesión y continuar donde lo dejó.
+          action_text: Abrir mi cuenta
+        invitation:
+          eyebrow: Invitación al espacio de trabajo
+          heading_with_account: Le invitaron a unirse a %{account_name}
+          heading_default: Le invitaron a probar %{brand_name}
+          intro_with_account_html: "%{inviter_name} le invitó a unirse al espacio de trabajo %{account_name} en %{brand_name}."
+          intro_default_html: "%{inviter_name} le invitó a probar %{brand_name}."
+          supporting_text: Cree su cuenta para empezar a colaborar con su equipo.
+          action_text: Aceptar la invitación
+        sso_access_ready:
+          heading: Su acceso está listo
+          intro_html: Su acceso a %{brand_name} ya está configurado.
+          supporting_html: Use el portal de inicio de sesión único (SSO) de su organización para acceder a %{brand_name}.
+          info_title: Inicie sesión con el SSO de su organización
+          info_text_html: No necesitará una contraseña aparte para %{brand_name}. Empiece desde el portal del proveedor de identidad de su empresa.
+        sso_invitation:
+          intro_with_account_html: "%{inviter_name} le invitó a acceder al espacio de trabajo %{account_name} en %{brand_name}."
+          intro_default_html: "%{inviter_name} le invitó a acceder a %{brand_name}."
+          supporting_html: Su organización usa inicio de sesión único (SSO), así que no necesitará crear una contraseña aparte.
+          info_title: Use el portal SSO de su organización
+          info_text_html: Continúe desde el portal del proveedor de identidad de su empresa para acceder a %{brand_name}.
+      reset_password_instructions:
+        greeting_html: ¡Hola %{name}!
+        body_html: Alguien solicitó un enlace para cambiar su contraseña. Puede hacerlo con el enlace de abajo.
+        action: Cambiar mi contraseña
+        copy_paste_html: 'Copie y pegue la URL en su navegador si el enlace de arriba no funciona:'
+        ignore_html: Si no solicitó esto, ignore este correo.
+        no_change_html: Su contraseña no cambiará hasta que acceda al enlace de arriba y cree una nueva.
+      password_change:
+        greeting_html: ¡Hola %{name}!
+        body_html: Le escribimos para avisarle de que su contraseña se cambió.
+      unlock_instructions:
+        greeting_html: ¡Hola %{name}!
+        body_html: Su cuenta se bloqueó por un número excesivo de intentos fallidos de inicio de sesión.
+        action_prompt_html: 'Haga clic en el enlace de abajo para desbloquear su cuenta:'
+        unlock_account: Desbloquear mi cuenta


### PR DESCRIPTION
Chatwoot ships a Spanish dashboard, but everything this fork adds on top of it was English-only. A Spanish-speaking agent saw the UI switch to English exactly where our features begin: Kanban, internal chat, WhatsApp groups, scheduled messages, the Baileys and Z-API inbox setup, and the notification e-mails.

All 880 fork keys are now translated. Upstream's own Spanish files are untouched, so this is purely additive on top of the tree the base PR established.

> Stacked on #364. Review that one first; this PR targets its branch.

## What changed

`ruby scripts/i18n/fork_translations.rb scaffold es` created the tree, and every value was then translated. Register and terminology follow what upstream's `es` locale already uses, so our strings don't read as a different product: formal `usted`, `bandeja de entrada`, `plantilla`, `etiqueta`, `barra lateral`. Coverage is now `es 880/880` and `pt_BR 880/880`.

One change is code rather than strings. The scheduled-message date field accepts natural language ("tomorrow at 2pm"), and `parseNaturalDate` only ever built chrono's PT and EN parsers. Translating its placeholder and hint would have invited agents to type Spanish that silently failed to parse, leaving them with a field that rejects its own example. It now resolves a parser per language from chrono's own set, keeping English as a fallback, which also makes the next language a one-line change. Six specs cover the Spanish paths, including accent-less input (`manana a las 19`) and `por la tarde`.

## How to test

Switch the dashboard to Español and walk through our features: open a WhatsApp inbox's settings, create a group, schedule a message (including the "Escriba una fecha y una hora" field, try `mañana a las 15`), and open the internal chat. Nothing should read in English.

Then trigger a notification e-mail with the account in Spanish and confirm the body and subject are translated.

## Follow-up

Porting both PRs to `chatwoot-pro-main`, which adds roughly 670 more keys (Kanban, templates).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/365)
<!-- Reviewable:end -->
