### PR TITLE
fix(conversations): refresh pins when an assignment changes what an agent sees

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -4,3 +4,4 @@ app/javascript/dashboard/helper/actionCable.js: Fetch missing conversations when
 app/models/conversation.rb: Defer fan-out when resolving a heavily pinned conversation  # PR#366
 app/javascript/dashboard/components/widgets/conversation/MoreActions.vue: Hide pin controls for conversations outside the list  # PR#366
 app/javascript/dashboard/helper/actionCable.js: Refresh cached permissions before applying this gate  # PR#367
+app/javascript/dashboard/helper/actionCable.js: Align bot assignments with frontend list visibility  # PR#367

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -5,3 +5,4 @@ app/models/conversation.rb: Defer fan-out when resolving a heavily pinned conver
 app/javascript/dashboard/components/widgets/conversation/MoreActions.vue: Hide pin controls for conversations outside the list  # PR#366
 app/javascript/dashboard/helper/actionCable.js: Refresh cached permissions before applying this gate  # PR#367
 app/javascript/dashboard/helper/actionCable.js: Align bot assignments with frontend list visibility  # PR#367
+app/javascript/dashboard/helper/actionCable.js: Upsert conversations when assignment grants access  # PR#367

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -3,3 +3,4 @@ app/javascript/dashboard/store/modules/conversationPins.js: Prevent delayed pin 
 app/javascript/dashboard/helper/actionCable.js: Fetch missing conversations when a remote pin arrives  # PR#366
 app/models/conversation.rb: Defer fan-out when resolving a heavily pinned conversation  # PR#366
 app/javascript/dashboard/components/widgets/conversation/MoreActions.vue: Hide pin controls for conversations outside the list  # PR#366
+app/javascript/dashboard/helper/actionCable.js: Refresh cached permissions before applying this gate  # PR#367

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -19,6 +19,7 @@ import { getUserPermissions } from 'dashboard/helper/permissionsHelper';
 import {
   CONVERSATION_PARTICIPATING_PERMISSIONS,
   CONVERSATION_UNASSIGNED_PERMISSIONS,
+  MANAGE_ALL_CONVERSATION_PERMISSIONS,
 } from 'dashboard/constants/permissions';
 
 const { isImpersonating } = useImpersonation();
@@ -162,6 +163,10 @@ class ActionCableConnector extends BaseActionCableConnector {
 
     // This event reaches every member of the inbox, and auto assignment fires it constantly, so it is only
     // worth a request for the roles that can lose a conversation to an assignment in the first place.
+    // Manage-all is checked first because holding it says nothing on its own: the role editor adds both
+    // scoped permissions alongside it, and the backend reads it with precedence over them, so such a role
+    // sees by inbox membership like a plain agent does.
+    if (permissions.includes(MANAGE_ALL_CONVERSATION_PERMISSIONS)) return false;
     if (!permissions.some(held => ASSIGNMENT_SCOPED_PERMISSIONS.includes(held)))
       return false;
 

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -16,7 +16,10 @@ import { VOICE_CALL_PROVIDERS } from 'dashboard/helper/inbox';
 import { VOICE_CALL_DIRECTION } from 'dashboard/components-next/message/constants';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { getUserPermissions } from 'dashboard/helper/permissionsHelper';
-import { CONVERSATION_UNASSIGNED_PERMISSIONS } from 'dashboard/constants/permissions';
+import {
+  CONVERSATION_PARTICIPATING_PERMISSIONS,
+  CONVERSATION_UNASSIGNED_PERMISSIONS,
+} from 'dashboard/constants/permissions';
 
 const { isImpersonating } = useImpersonation();
 const UNREAD_COUNTS_REFETCH_THROTTLE_MS = 5000;
@@ -24,6 +27,12 @@ const FILTERED_UNREAD_COUNTS_REFRESH_RETRY_MS = 30000;
 const FILTERED_UNREAD_COUNTS_REFRESH_RETRY_JITTER_MS = 15000;
 const MENTION_UNREAD_COUNTS_REFETCH_DELAY_MS =
   UNREAD_COUNTS_REFETCH_THROTTLE_MS;
+// The only roles whose accessible set follows assignment. Everyone else, plain agents and administrators
+// included, sees by inbox membership, so no assignment can hide a conversation and later hand it back.
+const ASSIGNMENT_SCOPED_PERMISSIONS = [
+  CONVERSATION_UNASSIGNED_PERMISSIONS,
+  CONVERSATION_PARTICIPATING_PERMISSIONS,
+];
 const getFilteredUnreadCountsRefreshRetryDelay = () =>
   FILTERED_UNREAD_COUNTS_REFRESH_RETRY_MS +
   Math.random() * FILTERED_UNREAD_COUNTS_REFRESH_RETRY_JITTER_MS;
@@ -147,17 +156,21 @@ class ActionCableConnector extends BaseActionCableConnector {
   // re-sorts it away as unpinned until the next reconnect. Being added as a participant grants access the
   // same way but emits no event, so that path still waits for one.
   assignmentMayHaveGrantedAccess = payload => {
-    const { assignee, assignee_type: assigneeType } = payload.meta || {};
     const user = this.app.$store.getters.getCurrentUser;
-
-    // This event reaches every member of the inbox, not just the agents the assignment moved between, so
-    // it is only worth a request when it could have changed what this agent sees.
-    if (assigneeType === 'User' && assignee?.id === user?.id) return true;
-    if (assignee) return false;
-
     const accountId = this.app.$store.getters.getCurrentAccountId;
-    return getUserPermissions(user, accountId).includes(
-      CONVERSATION_UNASSIGNED_PERMISSIONS
+    const permissions = getUserPermissions(user, accountId);
+
+    // This event reaches every member of the inbox, and auto assignment fires it constantly, so it is only
+    // worth a request for the roles that can lose a conversation to an assignment in the first place.
+    if (!permissions.some(held => ASSIGNMENT_SCOPED_PERMISSIONS.includes(held)))
+      return false;
+
+    const { assignee, assignee_type: assigneeType } = payload.meta || {};
+    if (assigneeType === 'User' && assignee?.id === user?.id) return true;
+
+    // Losing the assignee hands the conversation back to a role that sees the unassigned ones.
+    return (
+      !assignee && permissions.includes(CONVERSATION_UNASSIGNED_PERMISSIONS)
     );
   };
 

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -15,6 +15,8 @@ import {
 import { VOICE_CALL_PROVIDERS } from 'dashboard/helper/inbox';
 import { VOICE_CALL_DIRECTION } from 'dashboard/components-next/message/constants';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
+import { getUserPermissions } from 'dashboard/helper/permissionsHelper';
+import { CONVERSATION_UNASSIGNED_PERMISSIONS } from 'dashboard/constants/permissions';
 
 const { isImpersonating } = useImpersonation();
 const UNREAD_COUNTS_REFETCH_THROTTLE_MS = 5000;
@@ -133,7 +135,30 @@ class ActionCableConnector extends BaseActionCableConnector {
     if (id) {
       this.app.$store.dispatch('updateConversation', payload);
     }
+    if (this.assignmentMayHaveGrantedAccess(payload)) {
+      this.app.$store.dispatch('conversationPins/fetch');
+    }
     this.fetchConversationStats();
+  };
+
+  // A custom role can scope what an agent sees down to the conversations assigned to them or left
+  // unassigned, so an assignment can hand back a conversation that was invisible when the pins were last
+  // read. The server then leads the list with a pin the client no longer knows about, and the client
+  // re-sorts it away as unpinned until the next reconnect. Being added as a participant grants access the
+  // same way but emits no event, so that path still waits for one.
+  assignmentMayHaveGrantedAccess = payload => {
+    const { assignee, assignee_type: assigneeType } = payload.meta || {};
+    const user = this.app.$store.getters.getCurrentUser;
+
+    // This event reaches every member of the inbox, not just the agents the assignment moved between, so
+    // it is only worth a request when it could have changed what this agent sees.
+    if (assigneeType === 'User' && assignee?.id === user?.id) return true;
+    if (assignee) return false;
+
+    const accountId = this.app.$store.getters.getCurrentAccountId;
+    return getUserPermissions(user, accountId).includes(
+      CONVERSATION_UNASSIGNED_PERMISSIONS
+    );
   };
 
   onConversationCreated = data => {

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -170,12 +170,17 @@ class ActionCableConnector extends BaseActionCableConnector {
     if (!permissions.some(held => ASSIGNMENT_SCOPED_PERMISSIONS.includes(held)))
       return false;
 
+    // A conversation handed to a bot is unassigned as far as visibility goes: the assignment service
+    // clears `assignee_id` and tracks the bot beside it, so the filter that scopes a role to the
+    // unassigned ones takes it in even though the payload still names the bot.
     const { assignee, assignee_type: assigneeType } = payload.meta || {};
-    if (assigneeType === 'User' && assignee?.id === user?.id) return true;
+    const humanAssignee = assigneeType === 'User' ? assignee : null;
+    if (humanAssignee && humanAssignee.id === user?.id) return true;
 
     // Losing the assignee hands the conversation back to a role that sees the unassigned ones.
     return (
-      !assignee && permissions.includes(CONVERSATION_UNASSIGNED_PERMISSIONS)
+      !humanAssignee &&
+      permissions.includes(CONVERSATION_UNASSIGNED_PERMISSIONS)
     );
   };
 

--- a/app/javascript/dashboard/helper/specs/actionCable.spec.js
+++ b/app/javascript/dashboard/helper/specs/actionCable.spec.js
@@ -505,4 +505,59 @@ describe('ActionCableConnector - Copilot Tests', () => {
       expect(mockDispatch).toHaveBeenCalledWith('conversationPins/fetch');
     });
   });
+
+  describe('pin refresh on assignment', () => {
+    const assigneeChanged = (assignee, assigneeType = 'User') => ({
+      event: 'assignee.changed',
+      data: {
+        account_id: 1,
+        id: 7,
+        meta: { assignee, assignee_type: assigneeType },
+      },
+    });
+
+    beforeEach(() => {
+      store.$store.getters.getCurrentUser = { id: 11, accounts: [] };
+    });
+
+    it('refetches the pins when the conversation is assigned to the current user', () => {
+      actionCable.onReceived(assigneeChanged({ id: 11 }));
+
+      expect(mockDispatch).toHaveBeenCalledWith('conversationPins/fetch');
+    });
+
+    it('does not refetch when the conversation is assigned to someone else', () => {
+      actionCable.onReceived(assigneeChanged({ id: 12 }));
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
+    });
+
+    it('does not refetch when an agent bot shares the current user id', () => {
+      actionCable.onReceived(assigneeChanged({ id: 11 }, 'AgentBot'));
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
+    });
+
+    it('refetches when the conversation is unassigned and the role sees unassigned ones', () => {
+      store.$store.getters.getCurrentUser = {
+        id: 11,
+        accounts: [{ id: 1, permissions: ['conversation_unassigned_manage'] }],
+      };
+
+      actionCable.onReceived(assigneeChanged(null, null));
+
+      expect(mockDispatch).toHaveBeenCalledWith('conversationPins/fetch');
+    });
+
+    it('does not refetch when the conversation is unassigned and the role does not scope by it', () => {
+      store.$store.getters.getCurrentUser = {
+        id: 11,
+        accounts: [{ id: 1, permissions: ['conversation_manage'] }],
+      };
+
+      actionCable.onReceived(assigneeChanged(null, null));
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
+    });
+  });
 });

--- a/app/javascript/dashboard/helper/specs/actionCable.spec.js
+++ b/app/javascript/dashboard/helper/specs/actionCable.spec.js
@@ -576,6 +576,18 @@ describe('ActionCableConnector - Copilot Tests', () => {
       expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
     });
 
+    // The assignment service clears `assignee_id` when a bot takes over, so the backend sees no assignee
+    // even though the payload names the bot.
+    it('refetches when a bot takes over and the role sees unassigned ones', () => {
+      store.$store.getters.getCurrentUser = userWith([
+        'conversation_unassigned_manage',
+      ]);
+
+      actionCable.onReceived(assigneeChanged({ id: 99 }, 'AgentBot'));
+
+      expect(mockDispatch).toHaveBeenCalledWith('conversationPins/fetch');
+    });
+
     it('refetches when the conversation is unassigned and the role sees unassigned ones', () => {
       store.$store.getters.getCurrentUser = userWith([
         'conversation_unassigned_manage',

--- a/app/javascript/dashboard/helper/specs/actionCable.spec.js
+++ b/app/javascript/dashboard/helper/specs/actionCable.spec.js
@@ -516,8 +516,15 @@ describe('ActionCableConnector - Copilot Tests', () => {
       },
     });
 
+    const userWith = permissions => ({
+      id: 11,
+      accounts: [{ id: 1, permissions }],
+    });
+
     beforeEach(() => {
-      store.$store.getters.getCurrentUser = { id: 11, accounts: [] };
+      store.$store.getters.getCurrentUser = userWith([
+        'conversation_participating_manage',
+      ]);
     });
 
     it('refetches the pins when the conversation is assigned to the current user', () => {
@@ -538,23 +545,33 @@ describe('ActionCableConnector - Copilot Tests', () => {
       expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
     });
 
+    it('does not refetch for a plain agent, whose access never followed the assignee', () => {
+      store.$store.getters.getCurrentUser = { id: 11, accounts: [{ id: 1 }] };
+
+      actionCable.onReceived(assigneeChanged({ id: 11 }));
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
+    });
+
+    it('does not refetch for a role that sees every conversation in its inboxes', () => {
+      store.$store.getters.getCurrentUser = userWith(['conversation_manage']);
+
+      actionCable.onReceived(assigneeChanged({ id: 11 }));
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
+    });
+
     it('refetches when the conversation is unassigned and the role sees unassigned ones', () => {
-      store.$store.getters.getCurrentUser = {
-        id: 11,
-        accounts: [{ id: 1, permissions: ['conversation_unassigned_manage'] }],
-      };
+      store.$store.getters.getCurrentUser = userWith([
+        'conversation_unassigned_manage',
+      ]);
 
       actionCable.onReceived(assigneeChanged(null, null));
 
       expect(mockDispatch).toHaveBeenCalledWith('conversationPins/fetch');
     });
 
-    it('does not refetch when the conversation is unassigned and the role does not scope by it', () => {
-      store.$store.getters.getCurrentUser = {
-        id: 11,
-        accounts: [{ id: 1, permissions: ['conversation_manage'] }],
-      };
-
+    it('does not refetch when the conversation is unassigned and the role only sees its own', () => {
       actionCable.onReceived(assigneeChanged(null, null));
 
       expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');

--- a/app/javascript/dashboard/helper/specs/actionCable.spec.js
+++ b/app/javascript/dashboard/helper/specs/actionCable.spec.js
@@ -561,6 +561,21 @@ describe('ActionCableConnector - Copilot Tests', () => {
       expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
     });
 
+    // The role editor adds both scoped permissions whenever manage-all is picked, so this is what a
+    // manage-all role looks like in practice, and the backend reads manage-all with precedence.
+    it('does not refetch for a manage-all role carrying the scoped permissions too', () => {
+      store.$store.getters.getCurrentUser = userWith([
+        'conversation_manage',
+        'conversation_unassigned_manage',
+        'conversation_participating_manage',
+      ]);
+
+      actionCable.onReceived(assigneeChanged({ id: 11 }));
+      actionCable.onReceived(assigneeChanged(null, null));
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
+    });
+
     it('refetches when the conversation is unassigned and the role sees unassigned ones', () => {
       store.$store.getters.getCurrentUser = userWith([
         'conversation_unassigned_manage',

--- a/app/javascript/dashboard/store/modules/conversationPins.js
+++ b/app/javascript/dashboard/store/modules/conversationPins.js
@@ -9,8 +9,10 @@ import ConversationApi from '../../api/inbox/conversation';
 // `appliedAt` is the version of the last pin/unpin applied per conversation. Both events for the same pin
 // carry that pin's `pinned_at`, and the broadcast jobs are asynchronous, so a `pinned` event that lost the
 // race with the `unpin` right after it would otherwise resurrect a pin the server no longer has.
-// `revision` counts snapshots and resets, so a hydration can tell whether another one already replaced the
-// map underneath it; individual pin events are handled by `appliedAt` instead.
+// `revision` counts resets, so a hydration can tell that the map it was going to replace has been thrown
+// away under it. It does not count snapshots: hydrations run one at a time, so no other one can land
+// mid-flight, and the guard could only ever see which of two overlapping reads committed last, not which
+// read the newer state. Individual pin events are handled by `appliedAt` instead.
 const state = {
   records: {},
   appliedAt: {},
@@ -174,7 +176,6 @@ export const mutations = {
     // Versions of conversations that are no longer pinned are kept, so a later snapshot cannot re-arm an
     // event that was already superseded.
     $state.appliedAt = { ...$state.appliedAt, ...records };
-    $state.revision += 1;
   },
 
   [types.SET_CONVERSATION_PIN](

--- a/app/javascript/dashboard/store/modules/conversationPins.js
+++ b/app/javascript/dashboard/store/modules/conversationPins.js
@@ -66,10 +66,17 @@ const hydrate = async ({ commit, rootGetters, state: $state }) => {
 
 const hydrateUntilSettled = async context => {
   await hydrate(context);
-  if (!followUpRequested) return;
 
-  followUpRequested = false;
-  await hydrateUntilSettled(context);
+  if (followUpRequested) {
+    followUpRequested = false;
+    await hydrateUntilSettled(context);
+    return;
+  }
+
+  // Released here, in the same synchronous block as the check above, rather than from a `.finally` on the
+  // run: between the run resolving and such a callback there is a microtask in which the marker still
+  // reads as busy, so a caller landing there would only raise a flag that nobody reads again.
+  inFlightHydration = null;
 };
 
 export const actions = {
@@ -79,11 +86,7 @@ export const actions = {
       return inFlightHydration;
     }
 
-    inFlightHydration = hydrateUntilSettled(context).finally(() => {
-      inFlightHydration = null;
-      followUpRequested = false;
-    });
-
+    inFlightHydration = hydrateUntilSettled(context);
     return inFlightHydration;
   },
 

--- a/app/javascript/dashboard/store/modules/conversationPins.js
+++ b/app/javascript/dashboard/store/modules/conversationPins.js
@@ -34,6 +34,7 @@ export const getters = {
 // have to order a snapshot against the pin events that land under it. Overlapping callers collapse into a
 // single follow-up run, so the last one still gets a read issued after it asked.
 let inFlightHydration = null;
+let inFlightRevision = null;
 let followUpRequested = false;
 
 const hydrate = async ({ commit, rootGetters, state: $state }) => {
@@ -66,16 +67,19 @@ const hydrate = async ({ commit, rootGetters, state: $state }) => {
   }
 };
 
-const hydrateUntilSettled = async context => {
+const hydrateUntilSettled = async (context, runRevision) => {
   await hydrate(context);
+
+  // A reset abandoned this run and started its own, which now owns the marker.
+  if (inFlightRevision !== runRevision) return;
 
   if (followUpRequested) {
     followUpRequested = false;
-    await hydrateUntilSettled(context);
+    await hydrateUntilSettled(context, runRevision);
     return;
   }
 
-  // Released here, in the same synchronous block as the check above, rather than from a `.finally` on the
+  // Released here, in the same synchronous block as the checks above, rather than from a `.finally` on the
   // run: between the run resolving and such a callback there is a microtask in which the marker still
   // reads as busy, so a caller landing there would only raise a flag that nobody reads again.
   inFlightHydration = null;
@@ -83,12 +87,20 @@ const hydrateUntilSettled = async context => {
 
 export const actions = {
   fetch: context => {
-    if (inFlightHydration) {
+    const { revision } = context.state;
+
+    // Serialization holds between reads of the same map. A reset threw the running read's map away and it
+    // can no longer commit, so folding the new account behind it would leave that account with no pins for
+    // as long as a request nothing bounds takes to settle. The abandoned read still returns, and its own
+    // revision check drops it.
+    if (inFlightHydration && inFlightRevision === revision) {
       followUpRequested = true;
       return inFlightHydration;
     }
 
-    inFlightHydration = hydrateUntilSettled(context);
+    followUpRequested = false;
+    inFlightRevision = revision;
+    inFlightHydration = hydrateUntilSettled(context, revision);
     return inFlightHydration;
   },
 

--- a/app/javascript/dashboard/store/modules/conversationPins.js
+++ b/app/javascript/dashboard/store/modules/conversationPins.js
@@ -26,35 +26,65 @@ export const getters = {
   isPinned: $state => conversationId => Boolean($state.records[conversationId]),
 };
 
+// Two hydrations in flight at once have no sound order: the guards below can tell which one committed
+// last, never which one read the newer state, so the older request winning the race would replace a fresh
+// snapshot with a stale one. Running them one at a time removes the question, and the checks inside only
+// have to order a snapshot against the pin events that land under it. Overlapping callers collapse into a
+// single follow-up run, so the last one still gets a read issued after it asked.
+let inFlightHydration = null;
+let followUpRequested = false;
+
+const hydrate = async ({ commit, rootGetters, state: $state }) => {
+  commit(types.SET_CONVERSATION_PINS_UI_FLAG, { isFetching: true });
+
+  const accountId = rootGetters.getCurrentAccountId;
+  const revision = $state.revision;
+  // Which conversations the snapshot may not speak for is decided by what changes under it, not by a
+  // clock: `pinned_at` is written before the transaction commits, so no timestamp orders an event
+  // against a snapshot that could not see its row yet.
+  const appliedAtBefore = { ...$state.appliedAt };
+  // An unpin keeps the version of the pin it removes, so the applied version alone cannot see one land
+  // mid-flight. What the map held has to travel with it.
+  const recordsBefore = { ...$state.records };
+
+  try {
+    const { data } = await ConversationApi.fetchPins();
+    if (rootGetters.getCurrentAccountId !== accountId) return;
+    if ($state.revision !== revision) return;
+
+    commit(types.SET_CONVERSATION_PINS, {
+      pins: data,
+      appliedAtBefore,
+      recordsBefore,
+    });
+  } catch (error) {
+    // A failed hydration only costs the pinned ordering, so it should not block the inbox from booting.
+  } finally {
+    commit(types.SET_CONVERSATION_PINS_UI_FLAG, { isFetching: false });
+  }
+};
+
+const hydrateUntilSettled = async context => {
+  await hydrate(context);
+  if (!followUpRequested) return;
+
+  followUpRequested = false;
+  await hydrateUntilSettled(context);
+};
+
 export const actions = {
-  fetch: async ({ commit, rootGetters, state: $state }) => {
-    commit(types.SET_CONVERSATION_PINS_UI_FLAG, { isFetching: true });
-
-    const accountId = rootGetters.getCurrentAccountId;
-    const revision = $state.revision;
-    // Which conversations the snapshot may not speak for is decided by what changes under it, not by a
-    // clock: `pinned_at` is written before the transaction commits, so no timestamp orders an event
-    // against a snapshot that could not see its row yet.
-    const appliedAtBefore = { ...$state.appliedAt };
-    // An unpin keeps the version of the pin it removes, so the applied version alone cannot see one land
-    // mid-flight. What the map held has to travel with it.
-    const recordsBefore = { ...$state.records };
-
-    try {
-      const { data } = await ConversationApi.fetchPins();
-      if (rootGetters.getCurrentAccountId !== accountId) return;
-      if ($state.revision !== revision) return;
-
-      commit(types.SET_CONVERSATION_PINS, {
-        pins: data,
-        appliedAtBefore,
-        recordsBefore,
-      });
-    } catch (error) {
-      // A failed hydration only costs the pinned ordering, so it should not block the inbox from booting.
-    } finally {
-      commit(types.SET_CONVERSATION_PINS_UI_FLAG, { isFetching: false });
+  fetch: context => {
+    if (inFlightHydration) {
+      followUpRequested = true;
+      return inFlightHydration;
     }
+
+    inFlightHydration = hydrateUntilSettled(context).finally(() => {
+      inFlightHydration = null;
+      followUpRequested = false;
+    });
+
+    return inFlightHydration;
   },
 
   pin: async ({ commit, rootGetters }, conversationId) => {

--- a/app/javascript/dashboard/store/modules/specs/conversationPins/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversationPins/actions.spec.js
@@ -63,6 +63,54 @@ describe('#actions', () => {
       ]);
     });
 
+    it('runs overlapping hydrations one after another, newest read last', async () => {
+      const $state = { revision: 0, appliedAt: {}, records: {} };
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const responses = [
+        [{ conversation_id: 1, pinned_at: 100 }],
+        [{ conversation_id: 2, pinned_at: 200 }],
+      ];
+      axios.get.mockImplementation(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve();
+        inFlight -= 1;
+        return { data: responses.shift() };
+      });
+
+      const first = actions.fetch({ commit, rootGetters, state: $state });
+      const second = actions.fetch({ commit, rootGetters, state: $state });
+      await Promise.all([first, second]);
+
+      expect(maxInFlight).toBe(1);
+      expect(axios.get).toHaveBeenCalledTimes(2);
+      // The second caller asked after the first request was issued, so its own read is the one that lands.
+      const snapshots = commit.mock.calls.filter(
+        ([type]) => type === types.SET_CONVERSATION_PINS
+      );
+      expect(snapshots.at(-1)[1].pins).toEqual([
+        { conversation_id: 2, pinned_at: 200 },
+      ]);
+    });
+
+    it('collapses several overlapping callers into a single follow-up read', async () => {
+      const $state = { revision: 0, appliedAt: {}, records: {} };
+      axios.get.mockImplementation(async () => {
+        await Promise.resolve();
+        return { data: [] };
+      });
+
+      const calls = [
+        actions.fetch({ commit, rootGetters, state: $state }),
+        actions.fetch({ commit, rootGetters, state: $state }),
+        actions.fetch({ commit, rootGetters, state: $state }),
+      ];
+      await Promise.all(calls);
+
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    });
+
     it('discards a snapshot that another hydration already replaced', async () => {
       const $state = { revision: 0, appliedAt: {} };
       axios.get.mockImplementation(() => {

--- a/app/javascript/dashboard/store/modules/specs/conversationPins/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversationPins/actions.spec.js
@@ -132,6 +132,32 @@ describe('#actions', () => {
       });
     });
 
+    it('does not make a reset wait behind the read of the account it left', async () => {
+      const $state = { revision: 0, appliedAt: {}, records: {} };
+      let releaseFirst;
+      axios.get
+        .mockImplementationOnce(
+          () =>
+            new Promise(resolve => {
+              releaseFirst = () => resolve({ data: [] });
+            })
+        )
+        .mockResolvedValue({ data: [] });
+
+      actions.fetch({ commit, rootGetters, state: $state });
+      // What an account switch does: CLEAR_CONVERSATION_PINS, then a fetch for the account arrived at.
+      $state.revision += 1;
+      const afterReset = actions.fetch({ commit, rootGetters, state: $state });
+
+      // The read for the account left behind has not answered and nothing bounds how long it may take.
+      const readsWhileItHung = axios.get.mock.calls.length;
+
+      releaseFirst();
+      await afterReset;
+
+      expect(readsWhileItHung).toBe(2);
+    });
+
     it('discards a snapshot whose map a reset threw away mid-flight', async () => {
       const $state = { revision: 0, appliedAt: {} };
       axios.get.mockImplementation(() => {

--- a/app/javascript/dashboard/store/modules/specs/conversationPins/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversationPins/actions.spec.js
@@ -132,9 +132,10 @@ describe('#actions', () => {
       });
     });
 
-    it('discards a snapshot that another hydration already replaced', async () => {
+    it('discards a snapshot whose map a reset threw away mid-flight', async () => {
       const $state = { revision: 0, appliedAt: {} };
       axios.get.mockImplementation(() => {
+        // What CLEAR_CONVERSATION_PINS does on an account switch.
         $state.revision += 1;
         return Promise.resolve({
           data: [{ conversation_id: 1, pinned_at: 100 }],

--- a/app/javascript/dashboard/store/modules/specs/conversationPins/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversationPins/actions.spec.js
@@ -111,6 +111,27 @@ describe('#actions', () => {
       expect(axios.get).toHaveBeenCalledTimes(2);
     });
 
+    // The moment a caller lands in decides whether the run can still fold it into a follow-up or has to
+    // start a new one, and only one of those microtasks is the settling window. Sweeping the first few
+    // keeps the case covered even if the run's depth changes, which pinning a single count would not.
+    [1, 2, 3, 4].forEach(ticks => {
+      it(`does not lose a fetch dispatched ${ticks} microtask(s) into a running hydration`, async () => {
+        const $state = { revision: 0, appliedAt: {}, records: {} };
+        axios.get.mockResolvedValue({ data: [] });
+
+        const first = actions.fetch({ commit, rootGetters, state: $state });
+        await Array.from({ length: ticks }).reduce(
+          promise => promise.then(() => {}),
+          Promise.resolve()
+        );
+        actions.fetch({ commit, rootGetters, state: $state });
+        await first;
+        await Promise.resolve();
+
+        expect(axios.get).toHaveBeenCalledTimes(2);
+      });
+    });
+
     it('discards a snapshot that another hydration already replaced', async () => {
       const $state = { revision: 0, appliedAt: {} };
       axios.get.mockImplementation(() => {

--- a/app/javascript/dashboard/store/modules/specs/conversationPins/mutations.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversationPins/mutations.spec.js
@@ -20,12 +20,12 @@ describe('#mutations', () => {
       expect(state.records).toEqual({});
     });
 
-    it('bumps the revision so an older in-flight hydration is discarded', () => {
+    it('leaves the revision alone, since only a reset invalidates a hydration', () => {
       const state = { records: {}, appliedAt: {}, revision: 3 };
       mutations[types.SET_CONVERSATION_PINS](state, {
         pins: [{ conversation_id: 1, pinned_at: 100 }],
       });
-      expect(state.revision).toBe(4);
+      expect(state.revision).toBe(3);
     });
   });
 


### PR DESCRIPTION
Um agente com papel customizado pode enxergar só as conversas atribuídas a ele ou as que estão sem responsável. Nesse caso, o que ele vê acompanha a atribuição, não só a caixa de entrada. Uma conversa que ele fixou enquanto era o responsável, que depois é atribuída pra outra pessoa e mais tarde volta pra ele, reaparece no topo da lista pelo lado do servidor mas renderiza como não fixada, e ainda é reordenada pra fora do topo, até a próxima reconexão.

## Closes

Achado na revisão do port da #366 pro Pro. Nenhuma issue aberta.

## How to reproduce

Precisa de papel customizado (Enterprise), com `conversation_participating_manage` ou `conversation_unassigned_manage`.

1. Como agente com esse papel, fixe uma conversa atribuída a você.
2. Faça um administrador atribuir essa conversa a outro agente. Ela some da sua lista.
3. Atribua de volta pra você, sem recarregar a página nem derrubar a conexão.
4. Antes: a conversa volta sem o alfinete e fora do topo. Depois: volta fixada e no topo.

## What changed

- `onAssigneeChanged` re-hidrata os pins nos dois desfechos de atribuição que podem devolver acesso: a conversa passar a ser do agente, ou ficar sem responsável quando o papel dele enxerga as sem responsável.
- O evento chega pra todos os membros da caixa de entrada, não só pros dois agentes envolvidos na troca, então uma condição mais larga colocaria uma requisição no caminho quente dos papéis que nunca perdem conversa por atribuição.

## Notas

- Ser adicionado como participante devolve acesso do mesmo jeito e não emite evento nenhum, então esse caminho continua esperando a reconexão, como já acontece com a entrada numa caixa de entrada.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/367)
<!-- Reviewable:end -->
