### PR TITLE
feat(whatsapp): session layer 2/8, rollout toggles and the account gate

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -3,3 +3,10 @@ app/javascript/dashboard/store/modules/conversationPins.js: Prevent delayed pin 
 app/javascript/dashboard/helper/actionCable.js: Fetch missing conversations when a remote pin arrives  # PR#366
 app/models/conversation.rb: Defer fan-out when resolving a heavily pinned conversation  # PR#366
 app/javascript/dashboard/components/widgets/conversation/MoreActions.vue: Hide pin controls for conversations outside the list  # PR#366
+# PR#370: unreachable given the merge order. The finding is that a session provider
+# would fall into the Baileys `on_whatsapp` response shape, but no session provider has
+# a backend class until slices 5 and 6, so `descriptor.available?` is false and the
+# inbox cannot be saved at all. Slice 4 lands `Facade#on_whatsapp`, which returns that
+# exact shape from `check_numbers`, before either backend exists. Delete this line once
+# slice 4 is merged.
+app/builders/contact_inbox_builder.rb: Route session providers through their number-check contract  # PR#370

--- a/.github/workflows/fazer_ai_whatsapp_contract.yml
+++ b/.github/workflows/fazer_ai_whatsapp_contract.yml
@@ -1,0 +1,28 @@
+# The WhatsApp session protocol contract is owned by fazer-ai/whatsapp-connector and
+# vendored under spec/fixtures/whatsapp/session/contract, pinned by CONTRACT_REF. The
+# full spec suite only runs on tags, so this keeps a locally edited contract from
+# reaching main: re-vendor with `rails whatsapp:contract:sync[<ref>]` instead.
+name: WhatsApp session contract
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'spec/fixtures/whatsapp/session/contract/**'
+      - 'lib/whatsapp/session_contract.rb'
+      - 'lib/tasks/whatsapp_session.rake'
+  workflow_dispatch:
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      # No database or Redis: the task only reads the vendored files.
+      - name: Verify the vendored contract
+        run: bundle exec rails whatsapp:contract:verify

--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -25,15 +25,15 @@ class ContactInboxBuilder
   # the exact number registered there. For Brazilian mobile numbers the leading
   # "9" may or may not be present in the user-typed value; sending to the wrong
   # variant fails silently. Use on_whatsapp to resolve the canonical number and
-  # align the contact (and source_id) with what Baileys expects. Provider
-  # lookup errors are swallowed; write/merge errors must surface so the caller
-  # sees inconsistent state.
+  # align the contact (and source_id) with what the paired session expects.
+  # Provider lookup errors are swallowed; write/merge errors must surface so the
+  # caller sees inconsistent state.
   def normalize_phone_for_whatsapp!
     return if @contact.phone_number.blank?
 
     old_source_id_candidate = @contact.phone_number.delete('+')
 
-    canonical_phone = fetch_canonical_baileys_phone
+    canonical_phone = fetch_canonical_whatsapp_phone
     return if canonical_phone.blank? || canonical_phone == @contact.phone_number
 
     apply_canonical_phone(canonical_phone)
@@ -41,7 +41,7 @@ class ContactInboxBuilder
     @source_id = canonical_phone.delete('+') if @source_id == old_source_id_candidate
   end
 
-  def fetch_canonical_baileys_phone
+  def fetch_canonical_whatsapp_phone
     response = @inbox.channel.on_whatsapp(@contact.phone_number)
     return unless response.is_a?(Hash) && response['exists']
 
@@ -50,7 +50,7 @@ class ContactInboxBuilder
 
     "+#{jid_digits}"
   rescue StandardError => e
-    Rails.logger.warn("[WHATSAPP][BAILEYS] phone normalization via on_whatsapp failed (ignored): #{e.class.name}: #{e.message}")
+    Rails.logger.warn("[WHATSAPP] phone normalization via on_whatsapp failed (ignored): #{e.class.name}: #{e.message}")
     nil
   end
 

--- a/app/builders/contact_inbox_builder.rb
+++ b/app/builders/contact_inbox_builder.rb
@@ -2,28 +2,33 @@
 # For Specific Channels like whatsapp, email etc . it smartly generated appropriate the source id when none is provided.
 
 class ContactInboxBuilder
-  pattr_initialize [:contact, :inbox, :source_id, { hmac_verified: false, validate_baileys_phone: false }]
+  pattr_initialize [:contact, :inbox, :source_id, { hmac_verified: false, validate_whatsapp_phone: false }]
 
   def perform
-    normalize_phone_for_baileys! if validate_baileys_phone && baileys_whatsapp_inbox?
+    normalize_phone_for_whatsapp! if validate_whatsapp_phone && whatsapp_session_inbox?
     @source_id ||= generate_source_id
     create_contact_inbox if source_id.present?
   end
 
   private
 
-  def baileys_whatsapp_inbox?
-    @inbox.channel_type == 'Channel::Whatsapp' && @inbox.channel.provider == 'baileys'
+  # Providers that address a contact by the exact number registered on WhatsApp, rather
+  # than by the account's canonical phone. Z-API is frozen legacy and keeps its current
+  # behavior of not resolving the number.
+  def whatsapp_session_inbox?
+    return false unless @inbox.channel_type == 'Channel::Whatsapp'
+
+    @inbox.channel.session_provider? || @inbox.channel.provider == 'baileys'
   end
 
-  # WhatsApp matches the canonical phone for an account, but Baileys requires
+  # WhatsApp matches the canonical phone for an account, but a paired session requires
   # the exact number registered there. For Brazilian mobile numbers the leading
   # "9" may or may not be present in the user-typed value; sending to the wrong
   # variant fails silently. Use on_whatsapp to resolve the canonical number and
   # align the contact (and source_id) with what Baileys expects. Provider
   # lookup errors are swallowed; write/merge errors must surface so the caller
   # sees inconsistent state.
-  def normalize_phone_for_baileys!
+  def normalize_phone_for_whatsapp!
     return if @contact.phone_number.blank?
 
     old_source_id_candidate = @contact.phone_number.delete('+')

--- a/app/controllers/api/v1/accounts/contacts/contact_inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/contact_inboxes_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Accounts::Contacts::ContactInboxesController < Api::V1::Accounts:
       inbox: @inbox,
       source_id: params[:source_id],
       hmac_verified: hmac_verified?,
-      validate_baileys_phone: true
+      validate_whatsapp_phone: true
     ).perform
   end
 

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -179,7 +179,7 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController 
       contact: @contact,
       inbox: inbox,
       source_id: params[:source_id],
-      validate_baileys_phone: true
+      validate_whatsapp_phone: true
     ).perform
   end
 

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -293,7 +293,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
       inbox: @inbox,
       source_id: params[:source_id],
       hmac_verified: hmac_verified?,
-      validate_baileys_phone: true
+      validate_whatsapp_phone: true
     ).perform
   end
 

--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -39,7 +39,9 @@ class AccountDashboard < Administrate::BaseDashboard
     custom_attributes: Field::String,
     hide_agent_unassigned_tab: Field::Boolean,
     hide_agent_all_tab: HideAgentAllTabField,
-    disable_agent_message_deletion: Field::Boolean
+    disable_agent_message_deletion: Field::Boolean,
+    whatsapp_native_enabled: Field::Boolean,
+    whatsapp_uazapi_enabled: Field::Boolean
   }.merge(enterprise_attribute_types).freeze
 
   # COLLECTION_ATTRIBUTES
@@ -80,6 +82,8 @@ class AccountDashboard < Administrate::BaseDashboard
     hide_agent_unassigned_tab
     hide_agent_all_tab
     disable_agent_message_deletion
+    whatsapp_native_enabled
+    whatsapp_uazapi_enabled
   ] + enterprise_show_page_attributes).freeze
 
   # FORM_ATTRIBUTES
@@ -101,6 +105,8 @@ class AccountDashboard < Administrate::BaseDashboard
     hide_agent_unassigned_tab
     hide_agent_all_tab
     disable_agent_message_deletion
+    whatsapp_native_enabled
+    whatsapp_uazapi_enabled
   ] + enterprise_form_attributes).freeze
 
   # COLLECTION_FILTERS

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -60,6 +60,7 @@ class Account < ApplicationRecord
   store_accessor :settings, :keep_pending_on_bot_failure
   store_accessor :settings, :captain_auto_resolve_mode, :captain_false_promise_harness_enabled
   include AccountAgentRestrictions
+  include AccountWhatsappProviders
   include AccountCaptainAutoResolve
 
   has_many :account_users, dependent: :destroy_async

--- a/app/models/concerns/account_settings_schema.rb
+++ b/app/models/concerns/account_settings_schema.rb
@@ -17,6 +17,8 @@ module AccountSettingsSchema
         'hide_agent_unassigned_tab': { 'type': %w[boolean null] },
         'hide_agent_all_tab': { 'type': %w[boolean null] },
         'disable_agent_message_deletion': { 'type': %w[boolean null] },
+        'whatsapp_native_enabled': { 'type': %w[boolean null] },
+        'whatsapp_uazapi_enabled': { 'type': %w[boolean null] },
         'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': ['evaluated', 'legacy', 'disabled', nil] },
         'captain_false_promise_harness_enabled': { 'type': %w[boolean null] },
         'conversation_required_attributes': {

--- a/app/models/concerns/account_whatsapp_providers.rb
+++ b/app/models/concerns/account_whatsapp_providers.rb
@@ -1,0 +1,35 @@
+# Per-account rollout switches for the WhatsApp session providers. They gate which
+# providers an account may create or convert to, so the new layer can go out to a few
+# accounts at a time instead of to the whole instance at once.
+#
+# They live in the `settings` jsonb (see the "Account-level toggles" section in
+# AGENTS.md), keyed by name, so bit positions never drift between CE and Pro.
+#
+# Include this AFTER the other `store_accessor :settings` calls in Account: the writers
+# below reach the store-accessor module through `super`.
+module AccountWhatsappProviders
+  extend ActiveSupport::Concern
+
+  included do
+    store_accessor :settings, :whatsapp_native_enabled, :whatsapp_uazapi_enabled
+  end
+
+  # The superadmin form posts "1"/"0" and the settings JSON schema only accepts booleans.
+  def whatsapp_native_enabled=(value)
+    super(ActiveModel::Type::Boolean.new.cast(value))
+  end
+
+  def whatsapp_uazapi_enabled=(value)
+    super(ActiveModel::Type::Boolean.new.cast(value))
+  end
+
+  # Opt-in during the rollout. It flips to opt-out (`!= false`) at GA, which is the only
+  # change these two methods need.
+  def whatsapp_session_provider_enabled?(provider)
+    case provider.to_s
+    when 'native' then whatsapp_native_enabled == true
+    when 'uazapi' then whatsapp_uazapi_enabled == true
+    else false
+    end
+  end
+end

--- a/app/services/conversations/message_window_service.rb
+++ b/app/services/conversations/message_window_service.rb
@@ -25,7 +25,7 @@ class Conversations::MessageWindowService
     when 'Channel::Tiktok'
       tiktok_messaging_window
     when 'Channel::Whatsapp'
-      return if %w[baileys zapi].include?(@conversation.inbox.channel.provider)
+      return if @conversation.inbox.channel.session_family?
 
       MESSAGING_WINDOW_24_HOURS
     when 'Channel::TwilioSms'

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -107,7 +107,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
   end
 
   def recipient_id
-    return message.conversation.contact_inbox.source_id unless %w[baileys zapi].include?(channel.provider)
+    return message.conversation.contact_inbox.source_id unless channel.session_family?
 
     # NOTE: `identifier` must be in the WhatsApp LID format
     message.conversation.contact.phone_number&.gsub(/[^\d]/, '') || message.conversation.contact.identifier

--- a/app/services/whatsapp/session/channel_extension.rb
+++ b/app/services/whatsapp/session/channel_extension.rb
@@ -5,6 +5,13 @@
 # Each override answers for the session providers and falls straight back to `super` for
 # the legacy and cloud ones, so no existing provider changes behavior.
 module Whatsapp::Session::ChannelExtension
+  # Registers the rollout gate as a real validation so it covers both paths that can
+  # put an inbox on a session provider: creating one and converting an existing one
+  # (`convert_provider!` pre-validates with `valid?` before it persists anything).
+  def self.prepended(base)
+    base.validate :validate_session_provider_enabled
+  end
+
   def session_provider?
     Whatsapp::Session::Registry.session_provider?(provider)
   end
@@ -44,6 +51,18 @@ module Whatsapp::Session::ChannelExtension
   end
 
   private
+
+  # The account toggles are the rollout switch, and a picker that hides a provider is
+  # not a gate: the API would happily create a `native` inbox for any account. Only new
+  # records and provider changes are checked, so turning a toggle back off never makes
+  # an inbox that already exists unsaveable.
+  def validate_session_provider_enabled
+    return unless session_provider?
+    return unless new_record? || provider_changed?
+    return if account&.whatsapp_session_provider_enabled?(provider)
+
+    errors.add(:provider, I18n.t('errors.inboxes.channel.provider_not_enabled_for_account'))
+  end
 
   # Session backends validate their config against the descriptor's field list, never
   # against the provider itself: saving an inbox must not depend on a provider being up.

--- a/app/services/whatsapp/session/channel_extension.rb
+++ b/app/services/whatsapp/session/channel_extension.rb
@@ -9,6 +9,12 @@ module Whatsapp::Session::ChannelExtension
     Whatsapp::Session::Registry.session_provider?(provider)
   end
 
+  # True for the legacy session providers too: callers that ask this want "is this a
+  # paired phone" (no messaging window, no templates), not "is this served here".
+  def session_family?
+    Whatsapp::Session::Registry.session_family?(provider)
+  end
+
   # Surfaced on the inbox payload so the dashboard gates features by capability instead
   # of by provider name.
   def session_capabilities

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -80,6 +80,13 @@ module Whatsapp::Session::Registry
       Whatsapp::Session::PROVIDERS.include?(provider.to_s)
     end
 
+    # The QR/pairing family, legacy providers included. What sets it apart from the cloud
+    # family is behavioral: a paired session is a real WhatsApp client, so there is no
+    # 24-hour messaging window and no template requirement.
+    def session_family?(provider)
+      descriptor(provider)&.session? || false
+    end
+
     def backend_for(channel)
       descriptor = descriptor(channel.provider)
       raise Whatsapp::Session::Errors::InvalidConfig, "#{channel.provider} is not served by the session layer" unless descriptor&.served?

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -28,6 +28,7 @@ en:
       channel:
         provider_unavailable: This WhatsApp provider is not available on this installation yet.
         invalid_provider_config: 'Invalid configuration for: %{keys}'
+        provider_not_enabled_for_account: This WhatsApp provider is not enabled for this account yet.
         provider_connection:
           wrong_phone_number: The phone number you are trying to link is not the same as the one you have configured. Please make sure the phone number is correct before scanning the QR code.
           reconnect_loop_detected: The connection could not be re-established after several attempts. Automatic retries continue at increasing intervals. If this persists, disconnect the inbox and pair it again by scanning a new QR code.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -28,6 +28,7 @@ es:
       channel:
         provider_unavailable: Este proveedor de WhatsApp aún no está disponible en esta instalación.
         invalid_provider_config: 'Configuración inválida en: %{keys}'
+        provider_not_enabled_for_account: Este proveedor de WhatsApp aún no está habilitado para esta cuenta.
         provider_connection:
           wrong_phone_number: El número de teléfono que intenta vincular no es el mismo que tiene configurado. Verifique que el número sea correcto antes de escanear el código QR.
           reconnect_loop_detected: No se pudo restablecer la conexión después de varios intentos. Los reintentos automáticos continúan a intervalos cada vez mayores. Si el problema persiste, desconecte la bandeja de entrada y vuelva a vincularla escaneando un código QR nuevo.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -28,6 +28,7 @@ pt_BR:
       channel:
         provider_unavailable: Este provedor de WhatsApp ainda não está disponível nesta instalação.
         invalid_provider_config: 'Configuração inválida em: %{keys}'
+        provider_not_enabled_for_account: Este provedor de WhatsApp ainda não está habilitado para esta conta.
         provider_connection:
           wrong_phone_number: O número de telefone que você está tentando conectar não é o mesmo que o configurado. Certifique-se de que o número está correto antes de escanear o QR code.
           reconnect_loop_detected: Não foi possível restabelecer a conexão após várias tentativas. Novas tentativas automáticas continuam em intervalos crescentes. Se o problema persistir, desconecte a caixa de entrada e conecte novamente escaneando um novo QR code.

--- a/spec/builders/contact_inbox_builder_spec.rb
+++ b/spec/builders/contact_inbox_builder_spec.rb
@@ -349,7 +349,7 @@ describe ContactInboxBuilder do
         contact_inbox = described_class.new(
           contact: contact,
           inbox: baileys_inbox,
-          validate_baileys_phone: true
+          validate_whatsapp_phone: true
         ).perform
 
         expect(contact.reload.phone_number).to eq(canonical_phone)
@@ -364,7 +364,7 @@ describe ContactInboxBuilder do
           contact: contact,
           inbox: baileys_inbox,
           source_id: '5511912345678',
-          validate_baileys_phone: true
+          validate_whatsapp_phone: true
         ).perform
 
         expect(contact_inbox.source_id).to eq(canonical_phone.delete('+'))
@@ -378,7 +378,7 @@ describe ContactInboxBuilder do
         contact_inbox = described_class.new(
           contact: contact,
           inbox: baileys_inbox,
-          validate_baileys_phone: true
+          validate_whatsapp_phone: true
         ).perform
 
         expect(contact_inbox.contact_id).to eq(existing_contact.id)
@@ -391,7 +391,7 @@ describe ContactInboxBuilder do
           .and_return({ 'jid' => "#{contact.phone_number.delete('+')}@s.whatsapp.net", 'exists' => true })
 
         expect do
-          described_class.new(contact: contact, inbox: baileys_inbox, validate_baileys_phone: true).perform
+          described_class.new(contact: contact, inbox: baileys_inbox, validate_whatsapp_phone: true).perform
         end.not_to(change { contact.reload.phone_number })
       end
 
@@ -400,7 +400,7 @@ describe ContactInboxBuilder do
           .and_return({ 'jid' => canonical_jid, 'exists' => false })
 
         expect do
-          described_class.new(contact: contact, inbox: baileys_inbox, validate_baileys_phone: true).perform
+          described_class.new(contact: contact, inbox: baileys_inbox, validate_whatsapp_phone: true).perform
         end.not_to(change { contact.reload.phone_number })
       end
 
@@ -410,13 +410,13 @@ describe ContactInboxBuilder do
 
         contact_inbox = nil
         expect do
-          contact_inbox = described_class.new(contact: contact, inbox: baileys_inbox, validate_baileys_phone: true).perform
+          contact_inbox = described_class.new(contact: contact, inbox: baileys_inbox, validate_whatsapp_phone: true).perform
         end.not_to(change { contact.reload.phone_number })
 
         expect(contact_inbox.source_id).to eq(contact.phone_number.delete('+'))
       end
 
-      it 'does not call on_whatsapp when validate_baileys_phone is not requested' do
+      it 'does not call on_whatsapp when validate_whatsapp_phone is not requested' do
         expect_any_instance_of(Channel::Whatsapp).not_to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
 
         described_class.new(contact: contact, inbox: baileys_inbox).perform
@@ -426,7 +426,7 @@ describe ContactInboxBuilder do
         non_baileys_inbox = create(:channel_whatsapp, account: account, sync_templates: false, validate_provider_config: false).inbox
         expect_any_instance_of(Channel::Whatsapp).not_to receive(:on_whatsapp) # rubocop:disable RSpec/AnyInstance
 
-        described_class.new(contact: contact, inbox: non_baileys_inbox, validate_baileys_phone: true).perform
+        described_class.new(contact: contact, inbox: non_baileys_inbox, validate_whatsapp_phone: true).perform
       end
     end
 

--- a/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations_controller_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe 'Conversations API', type: :request do
           builder = double
           allow(Rails.configuration.dispatcher).to receive(:dispatch)
           allow(ContactInboxBuilder).to receive(:new)
-            .with(contact: contact, inbox: inbox, source_id: nil, hmac_verified: false, validate_baileys_phone: true).and_return(builder)
+            .with(contact: contact, inbox: inbox, source_id: nil, hmac_verified: false, validate_whatsapp_phone: true).and_return(builder)
           allow(builder).to receive(:perform)
           expect(builder).to receive(:perform)
 

--- a/spec/factories/channel/channel_whatsapp.rb
+++ b/spec/factories/channel/channel_whatsapp.rb
@@ -90,6 +90,16 @@ FactoryBot.define do
       sync_templates { true }
       validate_provider_config { true }
       received_messages { true }
+      session_provider_enabled { true }
+    end
+
+    # The session providers are gated per account by a rollout toggle, so a channel on
+    # one is invalid until its account opts in. Specs that exercise the gate itself pass
+    # `session_provider_enabled: false`.
+    after(:build) do |channel_whatsapp, options|
+      if options.session_provider_enabled && channel_whatsapp.provider.in?(Whatsapp::Session::PROVIDERS)
+        channel_whatsapp.account&.update!("whatsapp_#{channel_whatsapp.provider}_enabled" => true)
+      end
     end
 
     before(:create) do |channel_whatsapp, options|

--- a/spec/models/concerns/account_whatsapp_providers_spec.rb
+++ b/spec/models/concerns/account_whatsapp_providers_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe AccountWhatsappProviders do
+  let(:account) { create(:account) }
+
+  it 'stores the rollout toggles in settings, keyed by name' do
+    account.update!(whatsapp_native_enabled: true)
+
+    expect(account.reload.settings['whatsapp_native_enabled']).to be(true)
+  end
+
+  it 'casts the superadmin form values, which arrive as strings' do
+    account.update!(whatsapp_uazapi_enabled: '1')
+
+    expect(account.reload.whatsapp_uazapi_enabled).to be(true)
+  end
+
+  it 'keeps the session providers opt-in during the rollout' do
+    expect(account.whatsapp_session_provider_enabled?('native')).to be(false)
+
+    account.update!(whatsapp_native_enabled: true)
+
+    expect(account.whatsapp_session_provider_enabled?('native')).to be(true)
+    expect(account.whatsapp_session_provider_enabled?('uazapi')).to be(false)
+  end
+
+  it 'never enables a provider this layer does not serve' do
+    expect(account.whatsapp_session_provider_enabled?('baileys')).to be(false)
+  end
+end

--- a/spec/services/whatsapp/session/channel_extension_spec.rb
+++ b/spec/services/whatsapp/session/channel_extension_spec.rb
@@ -76,6 +76,29 @@ RSpec.describe Whatsapp::Session::ChannelExtension do
 
       expect(channel).to be_valid
     end
+
+    it 'refuses a session provider the account has not opted into' do
+      channel = build(:channel_whatsapp, account: account, provider: 'uazapi', session_provider_enabled: false)
+
+      expect(channel).not_to be_valid
+      expect(channel.errors[:provider]).to include(I18n.t('errors.inboxes.channel.provider_not_enabled_for_account'))
+    end
+
+    it 'refuses converting an existing inbox to a provider the account has not opted into' do
+      channel = build_channel('whatsapp_cloud')
+
+      expect do
+        channel.convert_provider!(new_provider: 'uazapi', new_provider_config: { 'base_url' => 'https://uazapi.test', 'token' => 'x' })
+      end.to raise_error(ActiveRecord::RecordInvalid)
+      expect(channel.reload.provider).to eq('whatsapp_cloud')
+    end
+
+    it 'keeps an existing session inbox saveable after the toggle is turned back off' do
+      channel = build_channel('uazapi')
+      account.update!(whatsapp_uazapi_enabled: false)
+
+      expect(channel.reload.update(provider_config: channel.provider_config.merge('mark_as_read' => false))).to be(true)
+    end
   end
 
   describe 'connection payload' do


### PR DESCRIPTION
Second slice of the WhatsApp session layer. It adds the switch that decides **which accounts may use the new providers**, and makes the rest of the app stop deciding WhatsApp behavior from a hardcoded provider name.

Two account settings (`whatsapp_native_enabled`, `whatsapp_uazapi_enabled`) turn the new layer on per account from Super Admin. Until an account is opted in, creating or converting an inbox to `native`/`uazapi` is refused by a model validation, not merely hidden in a picker, so the API cannot be used to sidestep the rollout.

Nothing changes for an existing inbox on any provider.

## What changed

**Rollout toggles.** `AccountWhatsappProviders` stores both switches in the `settings` jsonb (keyed by name, so bit positions never drift between CE and Pro) and exposes them in the Super Admin account form.

**The gate.** `ChannelExtension` registers a validation covering both paths onto a session provider: creating an inbox and converting an existing one, since `convert_provider!` pre-validates with `valid?` before persisting. Only new records and provider changes are checked, so turning a toggle back off never makes an existing inbox unsaveable.

**The session predicate.** Three generic call sites decided WhatsApp behavior from a `%w[baileys zapi]` literal: the messaging window, the outbound recipient id and the contact-inbox phone normalization. Each would need a new name appended for every provider added. They now ask the registry: `session_family?` is true for every paired-phone provider, legacy included, which is what those sites actually mean (a paired session is a real WhatsApp client, so no 24-hour window and no template requirement). `validate_baileys_phone` becomes `validate_whatsapp_phone` for the same reason. Z-API stays out of the phone normalization it never did.

**Contract drift gate.** A light PR workflow fails when the vendored contract stops matching `CONTRACT_REF`. The full spec suite only runs on tags, so without it a local edit to the contract would reach `main` unnoticed.

## How to test

1. Super Admin → Accounts → edit an account: the two WhatsApp toggles are there and persist.
2. With both off, `POST /api/v1/accounts/:id/inboxes` with `provider: "uazapi"` is rejected with "This WhatsApp provider is not enabled for this account yet."
3. Turn `whatsapp_uazapi_enabled` on and the same request is accepted.
4. Turn it back off: the existing inbox still saves.
5. Existing Baileys, Z-API, Cloud and 360dialog inboxes behave exactly as before (messaging window, outbound recipient id, contact creation).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/370)
<!-- Reviewable:end -->
