### PR TITLE
fix(calls): hide the Calls sidebar entry when voice is off

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/calls/routes.js
+++ b/app/javascript/dashboard/routes/dashboard/calls/routes.js
@@ -3,6 +3,7 @@ import {
   CONVERSATION_PERMISSIONS,
   ROLES,
 } from 'dashboard/constants/permissions';
+import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { frontendURL } from '../../../helper/URLHelper';
 import CallsIndex from './pages/CallsIndex.vue';
 
@@ -12,6 +13,10 @@ export const routes = [
     name: 'calls_dashboard_index',
     component: CallsIndex,
     meta: {
+      // The dashboard itself already requires channel_voice to render anything,
+      // so gate the sidebar entry (Policy reads this off the route meta) on the
+      // same flag instead of pointing accounts without voice at an empty page.
+      featureFlag: FEATURE_FLAGS.CHANNEL_VOICE,
       permissions: [...ROLES, ...CONVERSATION_PERMISSIONS],
       installationTypes: [
         INSTALLATION_TYPES.CLOUD,

--- a/app/javascript/dashboard/routes/dashboard/calls/specs/routes.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/calls/specs/routes.spec.js
@@ -1,0 +1,12 @@
+import { FEATURE_FLAGS } from 'dashboard/featureFlags';
+import { routes } from '../routes';
+
+describe('calls routes', () => {
+  it('gates the calls dashboard on the voice channel feature flag', () => {
+    const callsRoute = routes.find(
+      route => route.name === 'calls_dashboard_index'
+    );
+
+    expect(callsRoute.meta.featureFlag).toBe(FEATURE_FLAGS.CHANNEL_VOICE);
+  });
+});


### PR DESCRIPTION
The **Calls** entry showed up in the sidebar of every enterprise/cloud install, even for accounts that never enabled voice. Clicking it led to a dashboard that can only render an empty state, since the calls page already requires the `channel_voice` feature and at least one voice inbox. The entry now follows the same flag, so it stays hidden until an account actually has voice, and comes back on its own when someone enables WhatsApp Calling (which depends on the same feature).

## How to reproduce

1. On an enterprise (or cloud) install, open any account with `channel_voice` disabled — the default for every account.
2. Before this change: **Calls** sits in the sidebar between Captain and Contacts, and opening it shows an empty dashboard with nothing to do.
3. After this change: the entry is gone. Enable `channel_voice` for the account in super admin and it reappears.

## What changed

- `calls_dashboard_index` now declares `featureFlag: FEATURE_FLAGS.CHANNEL_VOICE` in its route meta. `SidebarGroup` wraps every entry in `<Policy>`, which reads that flag off the target route, so no sidebar code had to change. The search view and the go-to command palette read the same meta and stay consistent for free.
- The existing installation-type gate on the entry is untouched: it still hides Calls on community, which `<Policy>` does not cover here.
- Added a small spec pinning the flag on the route, mostly so a future upstream sync doesn't quietly revert it.

Note that the route itself is not blocked: the router's `beforeEach` only validates permissions, so navigating straight to `/accounts/:id/calls` still opens the page and its empty state. Gating navigation would mean touching the global guard for every flagged route, which is out of scope here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/371)
<!-- Reviewable:end -->
