### PR TITLE
feat(whatsapp): session layer 3/8, the provider-neutral inbound pipeline

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -10,3 +10,9 @@ app/javascript/dashboard/components/widgets/conversation/MoreActions.vue: Hide p
 # exact shape from `check_numbers`, before either backend exists. Delete this line once
 # slice 4 is merged.
 app/builders/contact_inbox_builder.rb: Route session providers through their number-check contract  # PR#370
+# PR#372: the same cross-slice gap as the number-check finding above. Slice 4 lands
+# `Facade::Groups#sync_group`, which calls this syncer, and `provider_service` only
+# becomes the facade there; until then `Channel::Whatsapp#sync_group` finds no such
+# method on the backend and returns. No session provider has a backend class before
+# slices 5 and 6, so no inbox can reach this. Delete this line once slice 4 is merged.
+app/services/whatsapp/session/groups/syncer.rb: Wire scheduled and manual syncs to the session syncer  # PR#372

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -21,3 +21,9 @@ app/services/whatsapp/session/groups/syncer.rb: Wire scheduled and manual syncs 
 # The note in event_job.rb sits where the fix belongs; this line only stops the review
 # from reporting it every round. Removing this waiver does not close the issue.
 app/jobs/whatsapp/session/event_job.rb: Preserve HTTP event order before dispatch  # PR#372
+# PR#372: real, tracked in fazer-ai/chatwoot#374, and inherited rather than introduced.
+# `group_left` is stored on the account-level group Contact, which is exactly where the
+# Baileys layer writes it and where three dashboard components read it. Scoping it per
+# inbox means changing that contract in the frozen legacy layer as well, so it is its
+# own change, not a slice of this one. Removing this waiver does not close the issue.
+app/services/whatsapp/session/inbound/handlers/group_updated.rb: Scope the group-left state to the originating inbox  # PR#372

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -27,3 +27,9 @@ app/jobs/whatsapp/session/event_job.rb: Preserve HTTP event order before dispatc
 # inbox means changing that contract in the frozen legacy layer as well, so it is its
 # own change, not a slice of this one. Removing this waiver does not close the issue.
 app/services/whatsapp/session/inbound/handlers/group_updated.rb: Scope the group-left state to the originating inbox  # PR#372
+# PR#372: real, tracked in fazer-ai/chatwoot#375, and not specific to this layer. The
+# window belongs to `Avatar::AvatarFromUrlJob`, which is handed a URL with no notion of
+# how fresh it is; the Baileys avatar paths have the same one. Closing it means giving
+# that shared job a freshness check, which is its own change. Removing this waiver does
+# not close the issue.
+app/jobs/whatsapp/session/update_contact_avatar_job.rb: Prevent stale avatar jobs from restoring removed photos  # PR#372

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -38,3 +38,9 @@ app/jobs/whatsapp/session/update_contact_avatar_job.rb: Prevent stale avatar job
 # yet, and the claim mechanism depends on what the provider payloads carry. The note in
 # event_job.rb sits where the fix belongs. Removing this waiver does not close the issue.
 app/services/whatsapp/session/inbound/dispatcher.rb: Deduplicate events before invoking non-idempotent handlers  # PR#372
+# PR#372: real, tracked in fazer-ai/chatwoot#376, and not answerable in this layer. The
+# snapshot cannot say "this group has no photo": `Serializable.from_h` reads an absent
+# key and an explicit null the same way, so the syncer cannot tell a removal from a
+# field the snapshot did not mention. Fixing it is a contract change, decided with the
+# payloads captured in the Uazapi slice. Removing this waiver does not close the issue.
+app/services/whatsapp/session/groups/syncer.rb: Remove avatars absent from rejoin snapshots  # PR#372

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -16,3 +16,8 @@ app/builders/contact_inbox_builder.rb: Route session providers through their num
 # method on the backend and returns. No session provider has a backend class before
 # slices 5 and 6, so no inbox can reach this. Delete this line once slice 4 is merged.
 app/services/whatsapp/session/groups/syncer.rb: Wire scheduled and manual syncs to the session syncer  # PR#372
+# PR#372: real, tracked in fazer-ai/chatwoot#373, and deliberately not answered here.
+# The mechanism depends on payloads captured from a live Uazapi instance in slice 6.
+# The note in event_job.rb sits where the fix belongs; this line only stops the review
+# from reporting it every round. Removing this waiver does not close the issue.
+app/jobs/whatsapp/session/event_job.rb: Preserve HTTP event order before dispatch  # PR#372

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -33,3 +33,8 @@ app/services/whatsapp/session/inbound/handlers/group_updated.rb: Scope the group
 # that shared job a freshness check, which is its own change. Removing this waiver does
 # not close the issue.
 app/jobs/whatsapp/session/update_contact_avatar_job.rb: Prevent stale avatar jobs from restoring removed photos  # PR#372
+# PR#372: the redelivery half of fazer-ai/chatwoot#373, deliberately not answered here.
+# No session provider has a backend until slices 5 and 6, so nothing can replay an event
+# yet, and the claim mechanism depends on what the provider payloads carry. The note in
+# event_job.rb sits where the fix belongs. Removing this waiver does not close the issue.
+app/services/whatsapp/session/inbound/dispatcher.rb: Deduplicate events before invoking non-idempotent handlers  # PR#372

--- a/app/jobs/contacts/sync_group_job.rb
+++ b/app/jobs/contacts/sync_group_job.rb
@@ -3,10 +3,14 @@ class Contacts::SyncGroupJob < ApplicationJob
 
   SYNC_COOLDOWN = 15.minutes
 
-  def perform(contact, force: false, soft: false)
+  # `channel` is the inbox the sync was asked for. Without it the service falls back to
+  # `Contact#group_channel`, which picks the group contact's first contact_inbox: an
+  # arbitrary choice as soon as the same WhatsApp group is in two inboxes of one
+  # account, and the sync can then run through a session that is not even connected.
+  def perform(contact, force: false, soft: false, channel: nil)
     return if !force && recently_synced?(contact)
 
-    Contacts::SyncGroupService.new(contact: contact, soft: soft).perform
+    Contacts::SyncGroupService.new(contact: contact, soft: soft, channel: channel).perform
   rescue Whatsapp::Session::Errors::ProviderUnavailable => e
     Rails.logger.error "SyncGroupJob failed for contact #{contact.id}: #{e.message}"
   end

--- a/app/jobs/whatsapp/session/event_job.rb
+++ b/app/jobs/whatsapp/session/event_job.rb
@@ -4,6 +4,14 @@
 # payload into canonical events and enqueues one job per event). The connector's own
 # events are dispatched inline by the stream consumer, which is what preserves their
 # order.
+#
+# UNORDERED, ON PURPOSE, FOR NOW (fazer-ai/chatwoot#373). One job per event means two
+# events of the same chat can run in either order, so a revoke, an edit or a reaction
+# can execute before the `message.received` that stores its target, find nothing, and be
+# dropped for good. The guard belongs here, and what it can be depends on whether the
+# provider's webhook carries a sequence or a usable timestamp: that is captured from a
+# live instance in the Uazapi slice, and the mechanism is chosen then. Do not delete this
+# note without closing the issue.
 class Whatsapp::Session::EventJob < ApplicationJob
   queue_as :high
 

--- a/app/jobs/whatsapp/session/event_job.rb
+++ b/app/jobs/whatsapp/session/event_job.rb
@@ -10,14 +10,20 @@
 # can execute before the `message.received` that stores its target, find nothing, and be
 # dropped for good. The guard belongs here, and what it can be depends on whether the
 # provider's webhook carries a sequence or a usable timestamp: that is captured from a
-# live instance in the Uazapi slice, and the mechanism is chosen then. Do not delete this
-# note without closing the issue.
+# live instance in the Uazapi slice, and the mechanism is chosen then.
+#
+# The same issue covers the other half, redelivery: nothing claims `Event#id` before the
+# dispatcher runs a handler, so a stream replay or a webhook retry writes a second
+# activity row for a group change and re-fires `PROVIDER_EVENT_RECEIVED`. One mechanism
+# (a per-session cursor, or an event-id claim) answers both, which is why they are
+# decided together. Do not delete this note without closing the issue.
 class Whatsapp::Session::EventJob < ApplicationJob
   queue_as :high
 
-  # Another worker holds the chat: retried rather than waited on, so a Sidekiq thread
-  # is never parked on Redis.
-  retry_on Whatsapp::Session::Inbound::Locks::Busy, wait: 2.seconds, attempts: 5
+  # Another worker holds the chat or the message: retried rather than waited on, so a
+  # Sidekiq thread is never parked on Redis. The backoff has to outlast a marker left
+  # behind by a killed worker, which is why it grows instead of staying at two seconds.
+  retry_on Whatsapp::Session::Inbound::Locks::Busy, wait: :polynomially_longer, attempts: 6
 
   # `frame` is a decoded event frame (Model::Event#to_frame).
   def perform(channel, frame)

--- a/app/jobs/whatsapp/session/event_job.rb
+++ b/app/jobs/whatsapp/session/event_job.rb
@@ -1,0 +1,23 @@
+# Runs one inbound event through the dispatcher.
+#
+# This is the path for providers that deliver over HTTP (a webhook translates its
+# payload into canonical events and enqueues one job per event). The connector's own
+# events are dispatched inline by the stream consumer, which is what preserves their
+# order.
+class Whatsapp::Session::EventJob < ApplicationJob
+  queue_as :high
+
+  # Another worker holds the chat: retried rather than waited on, so a Sidekiq thread
+  # is never parked on Redis.
+  retry_on Whatsapp::Session::Inbound::Locks::Busy, wait: 2.seconds, attempts: 5
+
+  # `frame` is a decoded event frame (Model::Event#to_frame).
+  def perform(channel, frame)
+    event = Whatsapp::Session::Model::Event.from_frame(frame)
+    Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+  rescue Whatsapp::Session::Errors::InvalidEvent, Whatsapp::Session::Errors::InvalidPayload => e
+    # A payload this version cannot read is a provider or contract problem, not
+    # something a retry fixes.
+    Rails.logger.error("[WHATSAPP SESSION] invalid event on inbox #{channel.inbox&.id}: #{e.message}")
+  end
+end

--- a/app/jobs/whatsapp/session/logout_job.rb
+++ b/app/jobs/whatsapp/session/logout_job.rb
@@ -1,0 +1,21 @@
+# Drops a session Chatwoot refuses to keep, retrying until the provider takes the order.
+#
+# The one caller is the wrong-number rejection, where a swallowed failure is the worst
+# outcome available: the state is already written, so the handler will report every
+# repeat of it as unchanged and never reach the logout again, and the wrong WhatsApp
+# account stays connected with nobody asking it to stop.
+class Whatsapp::Session::LogoutJob < ApplicationJob
+  queue_as :high
+
+  retry_on Whatsapp::Session::Errors::ProviderUnavailable, wait: :polynomially_longer, attempts: 6
+  retry_on Whatsapp::Session::Errors::RateLimited, wait: :polynomially_longer, attempts: 6
+
+  def perform(channel)
+    channel.provider_service.logout
+  rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
+    raise
+  rescue Whatsapp::Session::Errors::Error => e
+    # Nothing a retry fixes: the session is already gone, or the backend cannot be asked.
+    Rails.logger.warn("[WHATSAPP SESSION] logout failed for inbox #{channel.inbox&.id}: #{e.message}")
+  end
+end

--- a/app/jobs/whatsapp/session/media_fetch_job.rb
+++ b/app/jobs/whatsapp/session/media_fetch_job.rb
@@ -27,7 +27,9 @@ class Whatsapp::Session::MediaFetchJob < ApplicationJob
     # The provider no longer has the bytes: nothing to retry, and the agent needs to
     # see that the attachment is gone rather than perpetually loading.
     Rails.logger.warn("[WHATSAPP SESSION] media unavailable for message #{message.id}: #{e.message}")
-    message.update!(is_unsupported: true)
+    # Under lock and off a reloaded row: `is_unsupported` is a content_attributes flag,
+    # and a revoke that landed during the download would be rewritten away by this.
+    message.update_under_lock!(is_unsupported: true)
   end
 
   private

--- a/app/jobs/whatsapp/session/media_fetch_job.rb
+++ b/app/jobs/whatsapp/session/media_fetch_job.rb
@@ -1,0 +1,46 @@
+# Downloads the bytes of an inbound media message and attaches them.
+#
+# Separate from the message row on purpose: the connector's consumer thread keeps a
+# session's events in order, and a multi-megabyte download must not hold it. The
+# message is created first and gains its attachment seconds later.
+class Whatsapp::Session::MediaFetchJob < ApplicationJob
+  queue_as :medium
+
+  retry_on Down::Error, wait: :polynomially_longer, attempts: 3
+  retry_on Whatsapp::Session::Errors::ProviderUnavailable, wait: :polynomially_longer, attempts: 3
+
+  # `content` is a serialized Model::Content::Media.
+  def perform(message, content)
+    return if message.attachments.any?
+
+    media = Whatsapp::Session::Model::Content.from_h(content)
+    payload = message.inbox.channel.provider_service.download_media(media.ref)
+    attach(message, media, payload)
+  rescue Whatsapp::Session::Errors::MediaUnavailable, Whatsapp::Session::Errors::NotSupported => e
+    # The provider no longer has the bytes: nothing to retry, and the agent needs to
+    # see that the attachment is gone rather than perpetually loading.
+    Rails.logger.warn("[WHATSAPP SESSION] media unavailable for message #{message.id}: #{e.message}")
+    message.update!(is_unsupported: true)
+  end
+
+  private
+
+  def attach(message, media, payload)
+    attachment = message.attachments.build(
+      account_id: message.account_id,
+      file_type: media.attachment_file_type,
+      file: { io: payload.io, filename: filename(media, payload, message), content_type: payload.mime || media.mime }
+    )
+    attachment.meta = { is_recorded_audio: true } if media.voice_note
+    message.save!
+  end
+
+  def filename(media, payload, message)
+    return media.filename if media.filename.present?
+    return payload.filename if payload.filename.present?
+
+    mime = (payload.mime || media.mime).to_s
+    extension = ".#{mime.split(';').first.split('/').last}" if mime.present?
+    "#{media.kind}_#{message.source_id}_#{Time.current.strftime('%Y%m%d')}#{extension}"
+  end
+end

--- a/app/jobs/whatsapp/session/media_fetch_job.rb
+++ b/app/jobs/whatsapp/session/media_fetch_job.rb
@@ -22,10 +22,16 @@ class Whatsapp::Session::MediaFetchJob < ApplicationJob
       next if message.reload.deleted? || message.attachments.any?
 
       attach(message, media, payload)
+      # `MESSAGE_UPDATED` only reaches the open thread, so the conversation card in the
+      # list keeps its "no content" preview for a media-only message until something else
+      # touches that conversation.
+      Whatsapp::Session::Inbound::ChatList.refresh(message.conversation)
     end
-  rescue Whatsapp::Session::Errors::MediaUnavailable, Whatsapp::Session::Errors::NotSupported => e
-    # The provider no longer has the bytes: nothing to retry, and the agent needs to
-    # see that the attachment is gone rather than perpetually loading.
+  rescue Whatsapp::Session::Errors::MediaUnavailable, Whatsapp::Session::Errors::NotSupported,
+         Whatsapp::Session::Errors::MediaTooLarge => e
+    # The provider will not hand over these bytes, now or on a retry: it no longer has
+    # them, it cannot serve them, or the file is past its size cap. The agent needs to
+    # see that the attachment is not coming rather than an bubble that loads forever.
     Rails.logger.warn("[WHATSAPP SESSION] media unavailable for message #{message.id}: #{e.message}")
     # Under lock and off a reloaded row: `is_unsupported` is a content_attributes flag,
     # and a revoke that landed during the download would be rewritten away by this.

--- a/app/jobs/whatsapp/session/media_fetch_job.rb
+++ b/app/jobs/whatsapp/session/media_fetch_job.rb
@@ -41,6 +41,13 @@ class Whatsapp::Session::MediaFetchJob < ApplicationJob
       file: { io: payload.io, filename: filename(media, payload, message), content_type: payload.mime || media.mime }
     )
     attachment.meta = { is_recorded_audio: true } if media.voice_note
+    # Adding an attachment changes no column on the message, and
+    # `Message#dispatch_update_event` returns early on an empty `previous_changes`, so
+    # nothing would tell the open dashboards that the bubble finally has its file: the
+    # agent would keep seeing the empty bubble until a reload. Stamping `updated_at` in
+    # the same save is what makes the row dirty enough to broadcast, once, with the
+    # attachment already committed.
+    message.updated_at = Time.current
     message.save!
   end
 

--- a/app/jobs/whatsapp/session/media_fetch_job.rb
+++ b/app/jobs/whatsapp/session/media_fetch_job.rb
@@ -15,7 +15,14 @@ class Whatsapp::Session::MediaFetchJob < ApplicationJob
 
     media = Whatsapp::Session::Model::Content.from_h(content)
     payload = message.inbox.channel.provider_service.download_media(media.ref)
-    attach(message, media, payload)
+    # Re-read under lock, after the download: a deletion that landed while this job was
+    # queued or running destroyed the attachments, and attaching now would put the
+    # supposedly deleted media back into storage and back on the API.
+    message.with_lock do
+      next if message.reload.deleted? || message.attachments.any?
+
+      attach(message, media, payload)
+    end
   rescue Whatsapp::Session::Errors::MediaUnavailable, Whatsapp::Session::Errors::NotSupported => e
     # The provider no longer has the bytes: nothing to retry, and the agent needs to
     # see that the attachment is gone rather than perpetually loading.

--- a/app/jobs/whatsapp/session/update_contact_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_contact_avatar_job.rb
@@ -19,6 +19,12 @@ class Whatsapp::Session::UpdateContactAvatarJob < ApplicationJob
     url = channel.provider_service.profile_picture_url(
       Whatsapp::Session::Model::Commands::ContactProfilePicture.new(party: address)
     )
+    # RACE, TRACKED (fazer-ai/chatwoot#375). A picture-removed event that purges the
+    # avatar after this is queued does not stop it: the download lands afterwards and
+    # puts the deleted picture back until the next picture event. The freshness check
+    # belongs in `Avatar::AvatarFromUrlJob`, which is shared well outside WhatsApp and
+    # has the same window on the Baileys paths. Do not delete this note without closing
+    # the issue.
     ::Avatar::AvatarFromUrlJob.perform_later(contact, url) if url.present?
   rescue Whatsapp::Session::Errors::Error => e
     Rails.logger.warn("[WHATSAPP SESSION] profile picture failed for contact #{contact.id}: #{e.message}")

--- a/app/jobs/whatsapp/session/update_contact_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_contact_avatar_job.rb
@@ -32,6 +32,10 @@ class Whatsapp::Session::UpdateContactAvatarJob < ApplicationJob
     # has the same window on the Baileys paths. Do not delete this note without closing
     # the issue.
     ::Avatar::AvatarFromUrlJob.perform_later(contact, url) if url.present?
+  rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
+    # Raised on so the `retry_on` above can see it: a rescue in this method catches the
+    # error first, and the retry declaration never runs.
+    raise
   rescue Whatsapp::Session::Errors::Error => e
     # What is left here cannot be retried into working: the backend does not support the
     # lookup, the credentials are wrong, or the party has no picture to give.

--- a/app/jobs/whatsapp/session/update_contact_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_contact_avatar_job.rb
@@ -11,8 +11,12 @@ class Whatsapp::Session::UpdateContactAvatarJob < ApplicationJob
     channel = inbox.channel
     return unless channel.session_capabilities.include?('profile_picture')
 
+    # The command declares an Address, and building it with `new` runs no coercion, so
+    # handing it a Party would put the wrong shape on the wire and break every backend
+    # that reads the address.
+    address = Whatsapp::Session::Model::Party.from_h(party).address
     url = channel.provider_service.profile_picture_url(
-      Whatsapp::Session::Model::Commands::ContactProfilePicture.new(party: Whatsapp::Session::Model::Party.from_h(party))
+      Whatsapp::Session::Model::Commands::ContactProfilePicture.new(party: address)
     )
     ::Avatar::AvatarFromUrlJob.perform_later(contact, url) if url.present?
   rescue Whatsapp::Session::Errors::Error => e

--- a/app/jobs/whatsapp/session/update_contact_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_contact_avatar_job.rb
@@ -4,9 +4,10 @@
 class Whatsapp::Session::UpdateContactAvatarJob < ApplicationJob
   queue_as :low
 
-  # `party` is a serialized Model::Party.
-  def perform(contact, inbox, party)
-    return if contact.avatar.attached?
+  # `party` is a serialized Model::Party. `force` is the picture-changed event, which
+  # knows the stored avatar is out of date and must refetch over it.
+  def perform(contact, inbox, party, force: false)
+    return if contact.avatar.attached? && !force
 
     channel = inbox.channel
     return unless channel.session_capabilities.include?('profile_picture')

--- a/app/jobs/whatsapp/session/update_contact_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_contact_avatar_job.rb
@@ -1,0 +1,21 @@
+# Fetches a contact's WhatsApp profile picture. Enqueued whenever a contact is seen
+# without an avatar, so the dashboard fills in over time instead of blocking the
+# message that introduced the contact.
+class Whatsapp::Session::UpdateContactAvatarJob < ApplicationJob
+  queue_as :low
+
+  # `party` is a serialized Model::Party.
+  def perform(contact, inbox, party)
+    return if contact.avatar.attached?
+
+    channel = inbox.channel
+    return unless channel.session_capabilities.include?('profile_picture')
+
+    url = channel.provider_service.profile_picture_url(
+      Whatsapp::Session::Model::Commands::ContactProfilePicture.new(party: Whatsapp::Session::Model::Party.from_h(party))
+    )
+    ::Avatar::AvatarFromUrlJob.perform_later(contact, url) if url.present?
+  rescue Whatsapp::Session::Errors::Error => e
+    Rails.logger.warn("[WHATSAPP SESSION] profile picture failed for contact #{contact.id}: #{e.message}")
+  end
+end

--- a/app/jobs/whatsapp/session/update_contact_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_contact_avatar_job.rb
@@ -4,6 +4,12 @@
 class Whatsapp::Session::UpdateContactAvatarJob < ApplicationJob
   queue_as :low
 
+  # A session that is down or throttled will answer later. Swallowing that leaves the
+  # stored avatar in place, and the ordinary message path will not ask again while an
+  # avatar is attached, so a forced refresh dropped here is stale forever.
+  retry_on Whatsapp::Session::Errors::ProviderUnavailable, wait: :polynomially_longer, attempts: 4
+  retry_on Whatsapp::Session::Errors::RateLimited, wait: :polynomially_longer, attempts: 4
+
   # `party` is a serialized Model::Party. `force` is the picture-changed event, which
   # knows the stored avatar is out of date and must refetch over it.
   def perform(contact, inbox, party, force: false)
@@ -27,6 +33,8 @@ class Whatsapp::Session::UpdateContactAvatarJob < ApplicationJob
     # the issue.
     ::Avatar::AvatarFromUrlJob.perform_later(contact, url) if url.present?
   rescue Whatsapp::Session::Errors::Error => e
+    # What is left here cannot be retried into working: the backend does not support the
+    # lookup, the credentials are wrong, or the party has no picture to give.
     Rails.logger.warn("[WHATSAPP SESSION] profile picture failed for contact #{contact.id}: #{e.message}")
   end
 end

--- a/app/jobs/whatsapp/session/update_group_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_group_avatar_job.rb
@@ -1,5 +1,5 @@
-# Refetches a group photo. `force` drops the stored one first, which is what a
-# picture-changed event needs: the avatar is attached, but it is the old one.
+# Refetches a group photo. `force` is what a picture-changed event needs: the avatar is
+# attached, but it is the old one.
 class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
   queue_as :low
 
@@ -16,7 +16,7 @@ class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
     info = fetch_info(channel, group_contact)
     return if info&.picture_url.blank?
 
-    group_contact.avatar.purge if group_contact.avatar.attached?
+    reset_sync_markers(group_contact) if force
     ::Avatar::AvatarFromUrlJob.perform_later(group_contact, info.picture_url)
   end
 
@@ -24,6 +24,17 @@ class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
 
   def refetch?(group_contact, force)
     force || !group_contact.avatar.attached?
+  end
+
+  # A group contact is a Contact, so `Avatar::AvatarFromUrlJob` applies its rate limit
+  # and its URL hash to it, skips a group synced in the last minute, and stamps both
+  # markers even on the run it skipped. Without this the forced refresh is dropped and
+  # the next attempt with the same URL is dropped as a duplicate. The stored avatar is
+  # not purged: the attach replaces it, and purging first loses the picture whenever the
+  # download does not happen. Same reset the Baileys path does before its own refetch.
+  def reset_sync_markers(group_contact)
+    attributes = (group_contact.additional_attributes || {}).except('last_avatar_sync_at', 'avatar_url_hash')
+    group_contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def fetch_info(channel, group_contact)

--- a/app/jobs/whatsapp/session/update_group_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_group_avatar_job.rb
@@ -3,6 +3,11 @@
 class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
   queue_as :low
 
+  # Same reason as the contact job: a forced refresh dropped because the session was
+  # momentarily down leaves the old picture, and nothing asks again while it is attached.
+  retry_on Whatsapp::Session::Errors::ProviderUnavailable, wait: :polynomially_longer, attempts: 4
+  retry_on Whatsapp::Session::Errors::RateLimited, wait: :polynomially_longer, attempts: 4
+
   # `channel` is the inbox the event came from. Falling back to `group_channel` picks
   # the group contact's first contact_inbox, which is an arbitrary choice as soon as the
   # same WhatsApp group is in two inboxes of one account: the picture could then be
@@ -16,7 +21,8 @@ class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
     info = fetch_info(channel, group_contact)
     return if info&.picture_url.blank?
 
-    reset_sync_markers(group_contact) if force
+    return Whatsapp::Session::AvatarSync.refetch(group_contact, info.picture_url) if force
+
     ::Avatar::AvatarFromUrlJob.perform_later(group_contact, info.picture_url)
   end
 
@@ -26,22 +32,15 @@ class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
     force || !group_contact.avatar.attached?
   end
 
-  # A group contact is a Contact, so `Avatar::AvatarFromUrlJob` applies its rate limit
-  # and its URL hash to it, skips a group synced in the last minute, and stamps both
-  # markers even on the run it skipped. Without this the forced refresh is dropped and
-  # the next attempt with the same URL is dropped as a duplicate. The stored avatar is
-  # not purged: the attach replaces it, and purging first loses the picture whenever the
-  # download does not happen. Same reset the Baileys path does before its own refetch.
-  def reset_sync_markers(group_contact)
-    attributes = (group_contact.additional_attributes || {}).except('last_avatar_sync_at', 'avatar_url_hash')
-    group_contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
-  end
-
   def fetch_info(channel, group_contact)
     address = Whatsapp::Session::Model::Address.parse(group_contact.identifier)
     return if address.blank?
 
     channel.provider_service.group_info(Whatsapp::Session::Model::Commands::GroupInfo.new(group: address))
+  rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
+    # Raised on, not swallowed: the job retries and the retry is what keeps a forced
+    # refresh from leaving the old picture attached for good.
+    raise
   rescue Whatsapp::Session::Errors::Error => e
     Rails.logger.warn("[WHATSAPP SESSION] group photo failed for contact #{group_contact.id}: #{e.message}")
     nil

--- a/app/jobs/whatsapp/session/update_group_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_group_avatar_job.rb
@@ -3,10 +3,15 @@
 class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
   queue_as :low
 
-  def perform(group_contact, force: false)
-    channel = group_contact.group_channel
+  # `channel` is the inbox the event came from. Falling back to `group_channel` picks
+  # the group contact's first contact_inbox, which is an arbitrary choice as soon as the
+  # same WhatsApp group is in two inboxes of one account: the picture could then be
+  # asked of a provider that is not even connected.
+  def perform(group_contact, force: false, channel: nil)
+    return unless refetch?(group_contact, force)
+
+    channel ||= group_contact.group_channel
     return if channel.blank?
-    return if group_contact.avatar.attached? && !force
 
     info = fetch_info(channel, group_contact)
     return if info&.picture_url.blank?
@@ -16,6 +21,10 @@ class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
   end
 
   private
+
+  def refetch?(group_contact, force)
+    force || !group_contact.avatar.attached?
+  end
 
   def fetch_info(channel, group_contact)
     address = Whatsapp::Session::Model::Address.parse(group_contact.identifier)

--- a/app/jobs/whatsapp/session/update_group_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_group_avatar_job.rb
@@ -1,0 +1,29 @@
+# Refetches a group photo. `force` drops the stored one first, which is what a
+# picture-changed event needs: the avatar is attached, but it is the old one.
+class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
+  queue_as :low
+
+  def perform(group_contact, force: false)
+    channel = group_contact.group_channel
+    return if channel.blank?
+    return if group_contact.avatar.attached? && !force
+
+    info = fetch_info(channel, group_contact)
+    return if info&.picture_url.blank?
+
+    group_contact.avatar.purge if group_contact.avatar.attached?
+    ::Avatar::AvatarFromUrlJob.perform_later(group_contact, info.picture_url)
+  end
+
+  private
+
+  def fetch_info(channel, group_contact)
+    address = Whatsapp::Session::Model::Address.parse(group_contact.identifier)
+    return if address.blank?
+
+    channel.provider_service.group_info(Whatsapp::Session::Model::Commands::GroupInfo.new(group: address))
+  rescue Whatsapp::Session::Errors::Error => e
+    Rails.logger.warn("[WHATSAPP SESSION] group photo failed for contact #{group_contact.id}: #{e.message}")
+    nil
+  end
+end

--- a/app/services/contacts/sync_group_service.rb
+++ b/app/services/contacts/sync_group_service.rb
@@ -7,7 +7,7 @@ class Contacts::SyncGroupService
     channel = self.channel || contact.group_channel
     raise ActionController::BadRequest, I18n.t('contacts.sync_group.no_supported_inbox') if channel.blank? || !channel.respond_to?(:sync_group)
 
-    conversation = find_or_create_sync_conversation
+    conversation = find_or_create_sync_conversation(channel)
     raise ActionController::BadRequest, I18n.t('contacts.sync_group.no_supported_inbox') if conversation.blank?
 
     channel.sync_group(conversation, soft: soft)
@@ -19,13 +19,23 @@ class Contacts::SyncGroupService
 
   private
 
-  def find_or_create_sync_conversation
-    contact_inbox = contact.contact_inboxes.first
+  def find_or_create_sync_conversation(channel)
+    contact_inbox = sync_contact_inbox(channel)
     return nil if contact_inbox.blank?
 
     contact_inbox.conversations.where(status: %i[open pending]).last ||
       contact_inbox.conversations.order(created_at: :desc).first ||
       create_group_conversation(contact_inbox)
+  end
+
+  # A caller that supplied a channel means "sync this group as that inbox sees it", so
+  # the thread has to come from that inbox too. Taking the contact's first contact_inbox
+  # would drive the supplied channel with a conversation belonging to another one, and
+  # write the result into whichever inbox happened to be first.
+  def sync_contact_inbox(channel)
+    return contact.contact_inboxes.first if self.channel.blank?
+
+    contact.contact_inboxes.find_by(inbox: channel.inbox)
   end
 
   def create_group_conversation(contact_inbox)

--- a/app/services/contacts/sync_group_service.rb
+++ b/app/services/contacts/sync_group_service.rb
@@ -1,10 +1,10 @@
 class Contacts::SyncGroupService
-  pattr_initialize [:contact!, { soft: false }]
+  pattr_initialize [:contact!, { soft: false, channel: nil }]
 
   def perform
     validate_group_contact!
 
-    channel = contact.group_channel
+    channel = self.channel || contact.group_channel
     raise ActionController::BadRequest, I18n.t('contacts.sync_group.no_supported_inbox') if channel.blank? || !channel.respond_to?(:sync_group)
 
     conversation = find_or_create_sync_conversation

--- a/app/services/whatsapp/session/avatar_sync.rb
+++ b/app/services/whatsapp/session/avatar_sync.rb
@@ -11,13 +11,19 @@ module Whatsapp::Session::AvatarSync
 
   module_function
 
+  # Read and written under the row lock. `additional_attributes` is one JSON column that
+  # also carries the group's description, its settings and `group_left`, and the caller
+  # is often a job that fetched group info first: writing the whole hash it read before
+  # that round trip would throw away whatever landed in the meantime.
   def reset(contact)
     return if contact.blank?
 
-    attributes = (contact.additional_attributes || {}).except(*MARKERS)
-    return if attributes == contact.additional_attributes
+    contact.with_lock do
+      attributes = (contact.additional_attributes || {}).except(*MARKERS)
+      next if attributes == contact.additional_attributes
 
-    contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
+      contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
+    end
   end
 
   # Clears the markers and asks for the picture at `url`, which the caller already has.

--- a/app/services/whatsapp/session/avatar_sync.rb
+++ b/app/services/whatsapp/session/avatar_sync.rb
@@ -1,0 +1,30 @@
+# The two markers `Avatar::AvatarFromUrlJob` keeps on a Contact to avoid refetching the
+# same picture: the last sync time (a one minute rate limit) and a hash of the URL it
+# already fetched. That job stamps both even on the run it skipped, so anything that
+# knows the stored avatar is out of date has to clear them first or its refresh is
+# dropped, and so is every later attempt at the same URL.
+#
+# Three callers know that: the contact picture-changed event, the forced group photo
+# refresh, and the group rejoin snapshot.
+module Whatsapp::Session::AvatarSync
+  MARKERS = %w[last_avatar_sync_at avatar_url_hash].freeze
+
+  module_function
+
+  def reset(contact)
+    return if contact.blank?
+
+    attributes = (contact.additional_attributes || {}).except(*MARKERS)
+    return if attributes == contact.additional_attributes
+
+    contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  # Clears the markers and asks for the picture at `url`, which the caller already has.
+  def refetch(contact, url)
+    return if contact.blank? || url.blank?
+
+    reset(contact)
+    ::Avatar::AvatarFromUrlJob.perform_later(contact, url)
+  end
+end

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -36,7 +36,14 @@ class Whatsapp::Session::ConnectionStateWriter
 
   def merge(state, persisted)
     payload = state.to_h
-    payload['error'] = translate(payload['error']) if payload['error'].present?
+    # The sentence is what the dashboard renders, and the key is what code compares
+    # against: the sentence depends on the locale in force when it was written and on
+    # the translation not having been reworded since, so a guard reading it would fail
+    # open without anybody noticing.
+    if payload['error'].present?
+      payload['error_code'] = payload['error']
+      payload['error'] = translate(payload['error'])
+    end
     payload['connection'] ||= persisted['connection']
     payload['epoch'] ||= persisted['epoch']
     STICKY_KEYS.each do |key|

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -12,6 +12,16 @@
 class Whatsapp::Session::ConnectionStateWriter
   STICKY_KEYS = Whatsapp::Session::Model::ConnectionState::STICKY_KEYS
 
+  # The session was paired with a number this inbox is not configured for. Written here,
+  # read by everything that has to keep the wrong account's chats out until the logout
+  # succeeds, so the three places that used to spell it out cannot drift apart.
+  WRONG_PHONE_ERROR = 'wrong_phone_number'.freeze
+
+  # Quarantined: the connection belongs to somebody else's WhatsApp account.
+  def self.disowned?(channel)
+    channel.provider_connection.to_h['error_code'] == WRONG_PHONE_ERROR
+  end
+
   attr_reader :channel
 
   def initialize(channel)

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -108,8 +108,13 @@ class Whatsapp::Session::Groups::Syncer
     end
   end
 
+  # `skip_avatar` on a soft sync, exactly as the Baileys path passes `skip_avatars: soft`:
+  # an activity hint on a large group would otherwise enqueue one provider profile
+  # lookup per member without an avatar, which is the expensive half a hint does not
+  # justify paying for.
   def upsert_member(participant)
-    contact = Whatsapp::Session::Inbound::ContactResolver.new(inbox: inbox, party: participant.party)&.perform&.contact
+    contact = Whatsapp::Session::Inbound::ContactResolver
+              .new(inbox: inbox, party: participant.party, skip_avatar: soft)&.perform&.contact
     return if contact.blank?
 
     member = GroupMember.find_or_initialize_by(group_contact: group_contact, contact: contact)

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -1,0 +1,97 @@
+# Brings a group contact in line with what WhatsApp says about the group: its name,
+# description, settings, invite code and member list.
+#
+# It runs from two places, which is why the metadata can be passed in: an event that
+# already carries the group (group.joined) supplies it directly, while a scheduled or
+# manual sync fetches it through the backend.
+class Whatsapp::Session::Groups::Syncer
+  Model = Whatsapp::Session::Model
+
+  # Group settings, as WhatsApp names them on the wire and as the dashboard reads them
+  # from additional_attributes (the keys the Baileys layer already writes).
+  SETTINGS = { announce: 'announce', locked: 'restrict',
+               join_approval: 'join_approval_mode', member_add_mode: 'member_add_mode' }.freeze
+
+  attr_reader :channel, :group_contact, :soft
+
+  # `soft` skips the member list: it is the expensive half, and an activity ping only
+  # means "something happened in this group", not "the roster changed".
+  def initialize(channel:, group_contact:, info: nil, soft: false)
+    @channel = channel
+    @group_contact = group_contact
+    @info = info
+    @soft = soft
+  end
+
+  def perform
+    info = @info || fetch_info
+    return if info.blank?
+
+    update_contact(info)
+    sync_members(info) unless soft
+    update_avatar(info)
+    group_contact
+  end
+
+  private
+
+  def inbox = channel.inbox
+
+  def fetch_info
+    address = Model::Address.parse(group_contact.identifier)
+    return if address.blank? || !address.group?
+
+    channel.provider_service.group_info(Model::Commands::GroupInfo.new(group: address))
+  rescue Whatsapp::Session::Errors::Error => e
+    Rails.logger.error("[WHATSAPP SESSION] group info failed for #{group_contact.identifier}: #{e.message}")
+    nil
+  end
+
+  def update_contact(info)
+    params = {}
+    params[:name] = info.subject if info.subject.present? && group_contact.name != info.subject
+
+    attributes = (group_contact.additional_attributes || {}).merge(synced_attributes(info))
+    params[:additional_attributes] = attributes if attributes != group_contact.additional_attributes
+    group_contact.update!(params) if params.present?
+  end
+
+  def synced_attributes(info)
+    attributes = {
+      'description' => info.description.presence,
+      'owner' => info.owner&.identifier || info.owner&.phone,
+      'owner_pn' => info.owner&.phone,
+      'invite_code' => info.invite_code.presence,
+      'group_last_synced_at' => Time.current.to_i,
+      'group_left' => false
+    }.compact
+    SETTINGS.each { |member, key| attributes[key] = info.public_send(member) unless info.public_send(member).nil? }
+    attributes
+  end
+
+  def sync_members(info)
+    return if info.participants.blank?
+
+    member_ids = info.participants.filter_map { |participant| upsert_member(participant) }
+    group_contact.group_memberships.active.where.not(contact_id: member_ids).find_each do |membership|
+      membership.update!(is_active: false)
+    end
+  end
+
+  def upsert_member(participant)
+    contact = Whatsapp::Session::Inbound::ContactResolver.new(inbox: inbox, party: participant.party)&.perform&.contact
+    return if contact.blank?
+
+    member = GroupMember.find_or_initialize_by(group_contact: group_contact, contact: contact)
+    member.assign_attributes(role: participant.admin? ? :admin : :member, is_active: true)
+    member.save! if member.changed?
+    contact.id
+  end
+
+  def update_avatar(info)
+    return if info.picture_url.blank?
+    return if group_contact.avatar.attached?
+
+    ::Avatar::AvatarFromUrlJob.perform_later(group_contact, info.picture_url)
+  end
+end

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -123,8 +123,13 @@ class Whatsapp::Session::Groups::Syncer
     contact.id
   end
 
+  # An event that carried the group is a snapshot of it right now, so its picture wins
+  # over the stored one: nothing replays the picture-change events from while the session
+  # was out of the group, and the guard below would otherwise keep the old image for as
+  # long as the avatar stays attached, which is forever.
   def update_avatar(info)
     return if info.picture_url.blank?
+    return Whatsapp::Session::AvatarSync.refetch(group_contact, info.picture_url) if @info.present?
     return if group_contact.avatar.attached?
 
     ::Avatar::AvatarFromUrlJob.perform_later(group_contact, info.picture_url)

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -78,7 +78,11 @@ class Whatsapp::Session::Groups::Syncer
       'owner_pn' => info.owner&.phone,
       'invite_code' => info.invite_code.presence,
       'group_last_synced_at' => Time.current.to_i,
-      'group_left' => false
+      # Only rejoining clears this, and only `group.joined` knows that happened. A
+      # scheduled sync can still read cached metadata for a group the session left, and
+      # clearing the flag there would put the group actions back in the dashboard for a
+      # thread that can no longer send anything.
+      'group_left' => (false if @info.present?)
     }.compact
     attributes['description'] = info.description.presence unless info.description.nil?
     attributes.merge(setting_attributes(info))

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -72,7 +72,13 @@ class Whatsapp::Session::Groups::Syncer
     return if address.blank?
 
     channel.provider_service.group_info(Model::Commands::GroupInfo.new(group: address))
+  rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
+    # Raised on. Swallowing it here returns nil, and the caller reads that as "nothing to
+    # apply" and goes on to dispatch CONTACT_GROUP_SYNCED and hand back the untouched
+    # contact: a sync that never happened, reported as one that did.
+    raise
   rescue Whatsapp::Session::Errors::Error => e
+    # What is left says the group cannot be read at all, which no retry changes.
     Rails.logger.error("[WHATSAPP SESSION] group info failed for #{group_contact.identifier}: #{e.message}")
     nil
   end
@@ -144,6 +150,11 @@ class Whatsapp::Session::Groups::Syncer
   # was out of the group, and the guard below would otherwise keep the old image for as
   # long as the avatar stays attached, which is forever.
   def update_avatar(info)
+    # A NULL PICTURE IS AMBIGUOUS, TRACKED (fazer-ai/chatwoot#376). A snapshot reporting
+    # no picture reads exactly like one that does not mention the picture, so a photo
+    # removed while the session was out of the group keeps the stored avatar. Telling the
+    # two apart is a contract change, decided with the Uazapi payloads. Do not delete
+    # this note without closing the issue.
     return if info.picture_url.blank?
     return Whatsapp::Session::AvatarSync.refetch(group_contact, info.picture_url) if @info.present?
     return if group_contact.avatar.attached?

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -12,6 +12,16 @@ class Whatsapp::Session::Groups::Syncer
   SETTINGS = { announce: 'announce', locked: 'restrict',
                join_approval: 'join_approval_mode', member_add_mode: 'member_add_mode' }.freeze
 
+  # Three of the four settings arrive as booleans and one as the wire enum, but the
+  # dashboard reads all four out of additional_attributes as booleans, and reads
+  # member_add_mode as "may every member add people". Storing `admin_add` raw would be
+  # read as true, showing the exact opposite of the setting the group has.
+  def self.setting_value(member, raw)
+    return raw unless member == :member_add_mode
+
+    raw.to_s == 'all_member_add'
+  end
+
   attr_reader :channel, :group_contact, :soft
 
   # `soft` skips the member list: it is the expensive half, and an activity ping only
@@ -56,17 +66,29 @@ class Whatsapp::Session::Groups::Syncer
     group_contact.update!(params) if params.present?
   end
 
+  # A snapshot describes the group as it is now, so a description the group removed has
+  # to overwrite the one stored: it arrives as an empty value, and dropping it would
+  # leave the old text on screen forever. An *absent* field is a different thing and is
+  # left alone, because `invite_code` is only readable by an admin and `owner` is not
+  # always reported, so treating either absence as a removal would throw away what we
+  # legitimately have.
   def synced_attributes(info)
     attributes = {
-      'description' => info.description.presence,
       'owner' => info.owner&.identifier || info.owner&.phone,
       'owner_pn' => info.owner&.phone,
       'invite_code' => info.invite_code.presence,
       'group_last_synced_at' => Time.current.to_i,
       'group_left' => false
     }.compact
-    SETTINGS.each { |member, key| attributes[key] = info.public_send(member) unless info.public_send(member).nil? }
-    attributes
+    attributes['description'] = info.description.presence unless info.description.nil?
+    attributes.merge(setting_attributes(info))
+  end
+
+  def setting_attributes(info)
+    SETTINGS.filter_map do |member, key|
+      raw = info.public_send(member)
+      [key, self.class.setting_value(member, raw)] unless raw.nil?
+    end.to_h
   end
 
   def sync_members(info)

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -24,8 +24,12 @@ class Whatsapp::Session::Groups::Syncer
 
   attr_reader :channel, :group_contact, :soft
 
-  # `soft` skips the member list: it is the expensive half, and an activity ping only
-  # means "something happened in this group", not "the roster changed".
+  # `soft` is the activity ping: something happened in this group, but not what. The
+  # roster is read anyway, exactly as the Baileys path does, because `group_last_synced_at`
+  # is advanced either way and `Contacts::SyncGroupJob` reads it as a 15 minute cooldown
+  # for every sync that is not forced, the manual one from the dashboard included.
+  # Skipping the members while stamping the group as synced would leave a stale roster
+  # that nothing can refresh for the next quarter of an hour. Only the avatar is skipped.
   def initialize(channel:, group_contact:, info: nil, soft: false)
     @channel = channel
     @group_contact = group_contact
@@ -38,8 +42,8 @@ class Whatsapp::Session::Groups::Syncer
     return if info.blank?
 
     update_contact(info)
-    sync_members(info) unless soft
-    update_avatar(info)
+    sync_members(info)
+    update_avatar(info) unless soft
     group_contact
   end
 

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -38,7 +38,22 @@ class Whatsapp::Session::Groups::Syncer
   end
 
   def perform
-    info = @info || fetch_info
+    # A snapshot handed in came with an event the caller already serialized, so this only
+    # takes the lock when it fetches one: a scheduled or manual sync otherwise races the
+    # group's own events and can apply metadata older than what just landed, reviving
+    # members that left or overwriting `group_left`.
+    return apply(@info) if @info.present?
+
+    Whatsapp::Session::Inbound::Locks.with_chat_lock(
+      inbox, group_address&.id, ttl: Whatsapp::Session::Inbound::Locks::GROUP_SYNC_LOCK_TTL
+    ) { apply(fetch_info) }
+  end
+
+  private
+
+  def inbox = channel.inbox
+
+  def apply(info)
     return if info.blank?
 
     update_contact(info)
@@ -47,13 +62,14 @@ class Whatsapp::Session::Groups::Syncer
     group_contact
   end
 
-  private
-
-  def inbox = channel.inbox
+  def group_address
+    address = Model::Address.parse(group_contact.identifier)
+    address if address.present? && address.group?
+  end
 
   def fetch_info
-    address = Model::Address.parse(group_contact.identifier)
-    return if address.blank? || !address.group?
+    address = group_address
+    return if address.blank?
 
     channel.provider_service.group_info(Model::Commands::GroupInfo.new(group: address))
   rescue Whatsapp::Session::Errors::Error => e

--- a/app/services/whatsapp/session/inbound/chat_list.rb
+++ b/app/services/whatsapp/session/inbound/chat_list.rb
@@ -1,0 +1,17 @@
+# The chat list is not refreshed by a message update.
+#
+# `MESSAGE_UPDATED` only reaches the open thread, so a message mutated in place (an
+# edit, a reaction swapped for another, a message deleted from the phone) leaves the
+# conversation card in the list showing what it used to say until something else
+# updates that conversation. Touching `updated_at` alongside the event is what also
+# lets the frontend drop cables that arrive out of order.
+module Whatsapp::Session::Inbound::ChatList
+  module_function
+
+  def refresh(conversation)
+    return if conversation.blank?
+
+    conversation.update_columns(updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+    conversation.dispatch_conversation_updated_event
+  end
+end

--- a/app/services/whatsapp/session/inbound/contact_lookup.rb
+++ b/app/services/whatsapp/session/inbound/contact_lookup.rb
@@ -1,0 +1,41 @@
+# Finds the contact_inbox a Party already has, and never creates one.
+#
+# Three keys can hold the same person and only one of them may exist: the source_id the
+# event names, the other ninth-digit form of that number, and the phone stored on the
+# contact itself, which is all that is left to match on once consolidation re-keyed the
+# row to a LID. Presence, picture changes and group activity all ask this same question
+# about a party they must not invent, so it is answered here instead of three times.
+module Whatsapp::Session::Inbound::ContactLookup
+  module_function
+
+  def find(inbox:, party:)
+    return if party.blank?
+
+    by_source_id(inbox, party) || by_variant_source_id(inbox, party) || by_contact_phone(inbox, party)
+  end
+
+  def contact(inbox:, party:)
+    find(inbox: inbox, party: party)&.contact
+  end
+
+  def by_source_id(inbox, party)
+    keys = [party.lid, party.phone].compact_blank
+    return if keys.empty?
+
+    inbox.contact_inboxes.find_by(source_id: keys)
+  end
+
+  def by_variant_source_id(inbox, party)
+    variants = Whatsapp::Session::PhoneMatch.variants(party.phone) - [party.phone.to_s]
+    return if variants.empty?
+
+    inbox.contact_inboxes.find_by(source_id: variants)
+  end
+
+  def by_contact_phone(inbox, party)
+    numbers = Whatsapp::Session::PhoneMatch.variants(party.phone).map { |variant| "+#{variant}" }
+    return if numbers.empty?
+
+    inbox.contact_inboxes.joins(:contact).find_by(contact: { phone_number: numbers })
+  end
+end

--- a/app/services/whatsapp/session/inbound/contact_lookup.rb
+++ b/app/services/whatsapp/session/inbound/contact_lookup.rb
@@ -18,11 +18,13 @@ module Whatsapp::Session::Inbound::ContactLookup
     find(inbox: inbox, party: party)&.contact
   end
 
+  # In priority order, never as one `IN`: while both keys still have a row, which is the
+  # window before consolidation merges them, an unordered match can answer with the
+  # phone-keyed copy that is on its way out, and the event would update that one.
+  # `Party#source_id` makes the LID the canonical key, so it is asked for first.
   def by_source_id(inbox, party)
     keys = [party.lid, party.phone].compact_blank
-    return if keys.empty?
-
-    inbox.contact_inboxes.find_by(source_id: keys)
+    keys.lazy.filter_map { |key| inbox.contact_inboxes.find_by(source_id: key) }.first
   end
 
   def by_variant_source_id(inbox, party)

--- a/app/services/whatsapp/session/inbound/contact_resolver.rb
+++ b/app/services/whatsapp/session/inbound/contact_resolver.rb
@@ -9,12 +9,13 @@
 # its own phone and identifier, while a group participant is described partially and
 # may only fill in what is still blank.
 class Whatsapp::Session::Inbound::ContactResolver
-  attr_reader :inbox, :party, :overwrite
+  attr_reader :inbox, :party, :overwrite, :skip_avatar
 
-  def initialize(inbox:, party:, overwrite: false)
+  def initialize(inbox:, party:, overwrite: false, skip_avatar: false)
     @inbox = inbox
     @party = party
     @overwrite = overwrite
+    @skip_avatar = skip_avatar
   end
 
   def perform
@@ -121,6 +122,7 @@ class Whatsapp::Session::Inbound::ContactResolver
   end
 
   def enqueue_avatar(contact)
+    return if skip_avatar
     return if contact.avatar.attached?
     return unless inbox.channel.session_capabilities.include?('profile_picture')
 

--- a/app/services/whatsapp/session/inbound/contact_resolver.rb
+++ b/app/services/whatsapp/session/inbound/contact_resolver.rb
@@ -22,7 +22,7 @@ class Whatsapp::Session::Inbound::ContactResolver
 
     consolidate
     contact_inbox = ::ContactInboxWithContactBuilder.new(
-      source_id: party.source_id, inbox: inbox, contact_attributes: contact_attributes
+      source_id: source_id, inbox: inbox, contact_attributes: contact_attributes
     ).perform
 
     update_contact(contact_inbox.contact)
@@ -31,6 +31,24 @@ class Whatsapp::Session::Inbound::ContactResolver
   end
 
   private
+
+  # The key the contact is already filed under, when that is one of this number's other
+  # ninth-digit forms. Consolidation cannot help here: it needs a phone *and* a LID, and
+  # a phone-only party has no LID to consolidate towards. Without this the builder does
+  # an exact match, misses the row, and files the same person twice, with a second
+  # conversation to go with it.
+  def source_id
+    @source_id ||= existing_variant_source_id || party.source_id
+  end
+
+  def existing_variant_source_id
+    return if party.lid.present? || party.phone.blank?
+
+    variants = Whatsapp::Session::PhoneMatch.variants(party.phone)
+    return if variants.size <= 1
+
+    inbox.contact_inboxes.where(source_id: variants).pick(:source_id)
+  end
 
   # A contact created from a phone-keyed message keeps its own contact_inbox; when the
   # LID for the same person shows up later, this merges the two before the builder can

--- a/app/services/whatsapp/session/inbound/contact_resolver.rb
+++ b/app/services/whatsapp/session/inbound/contact_resolver.rb
@@ -1,0 +1,114 @@
+# Turns a canonical Party into the ContactInbox that holds it.
+#
+# WhatsApp addresses the same person by LID in some chats and by phone number in
+# others, and a contact can already exist under either. Every inbound path goes
+# through here so that consolidation (merging a phone-keyed contact into its LID) and
+# the "is this name a placeholder?" rule are decided in exactly one place.
+#
+# `overwrite` separates the two callers: the peer of a 1:1 chat is authoritative about
+# its own phone and identifier, while a group participant is described partially and
+# may only fill in what is still blank.
+class Whatsapp::Session::Inbound::ContactResolver
+  attr_reader :inbox, :party, :overwrite
+
+  def initialize(inbox:, party:, overwrite: false)
+    @inbox = inbox
+    @party = party
+    @overwrite = overwrite
+  end
+
+  def perform
+    return if party.blank? || party.source_id.blank?
+
+    consolidate
+    contact_inbox = ::ContactInboxWithContactBuilder.new(
+      source_id: party.source_id, inbox: inbox, contact_attributes: contact_attributes
+    ).perform
+
+    update_contact(contact_inbox.contact)
+    enqueue_avatar(contact_inbox.contact)
+    contact_inbox
+  end
+
+  private
+
+  # A contact created from a phone-keyed message keeps its own contact_inbox; when the
+  # LID for the same person shows up later, this merges the two before the builder can
+  # create a second contact.
+  def consolidate
+    return if party.phone.blank? && party.lid.blank?
+
+    Whatsapp::ContactInboxConsolidationService.new(
+      inbox: inbox, phone: party.phone, lid: party.lid, identifier: party.identifier
+    ).perform
+  end
+
+  def contact_attributes
+    {
+      name: party.name.presence || party.phone.presence || party.lid,
+      phone_number: party.phone_e164,
+      identifier: party.identifier
+    }.compact
+  end
+
+  def update_contact(contact)
+    params = {
+      phone_number: (party.phone_e164 if update_phone?(contact)),
+      identifier: (party.identifier if update_identifier?(contact)),
+      name: (party.name if update_name?(contact))
+    }.compact
+    contact.update!(params) if params.present?
+    contact
+  end
+
+  def update_phone?(contact)
+    return false if party.phone.blank?
+
+    overwrite ? contact.phone_number != party.phone_e164 : contact.phone_number.blank?
+  end
+
+  def update_identifier?(contact)
+    return false if party.identifier.blank?
+
+    overwrite ? contact.identifier != party.identifier : contact.identifier.blank?
+  end
+
+  def update_name?(contact)
+    party.name.present? && placeholder_name?(contact.name)
+  end
+
+  # A name equal to the contact's phone (in any normalized "9"-variant), to its LID or
+  # to the "<lid>@lid" identifier was auto-generated, not typed by a human, so the push
+  # name may replace it. Comparing normalized variants is what rescues a contact whose
+  # name was stranded by phone normalization.
+  def placeholder_name?(name)
+    return true if name.blank?
+    return true if name == party.identifier
+
+    digits = name.delete('+')
+    return false unless digits.match?(/\A\d+\z/)
+    return true if digits.in?([party.phone, party.lid].compact)
+
+    party.phone.present? && same_whatsapp_number?(digits, party.phone)
+  end
+
+  def same_whatsapp_number?(left, right)
+    normalizer = phone_normalizer_for(left) || phone_normalizer_for(right)
+    return false unless normalizer
+
+    normalizer.normalize(left) == normalizer.normalize(right)
+  end
+
+  def phone_normalizer_for(value)
+    Whatsapp::PhoneNumberNormalizationService::NORMALIZERS
+      .map(&:new)
+      .find { |normalizer| normalizer.handles_country?(value) }
+  end
+
+  def enqueue_avatar(contact)
+    return if contact.avatar.attached?
+    return unless inbox.channel.session_capabilities.include?('profile_picture')
+
+    Whatsapp::Session::UpdateContactAvatarJob.perform_later(contact, inbox, party.to_h)
+  end
+end

--- a/app/services/whatsapp/session/inbound/contact_resolver.rb
+++ b/app/services/whatsapp/session/inbound/contact_resolver.rb
@@ -89,20 +89,7 @@ class Whatsapp::Session::Inbound::ContactResolver
     return false unless digits.match?(/\A\d+\z/)
     return true if digits.in?([party.phone, party.lid].compact)
 
-    party.phone.present? && same_whatsapp_number?(digits, party.phone)
-  end
-
-  def same_whatsapp_number?(left, right)
-    normalizer = phone_normalizer_for(left) || phone_normalizer_for(right)
-    return false unless normalizer
-
-    normalizer.normalize(left) == normalizer.normalize(right)
-  end
-
-  def phone_normalizer_for(value)
-    Whatsapp::PhoneNumberNormalizationService::NORMALIZERS
-      .map(&:new)
-      .find { |normalizer| normalizer.handles_country?(value) }
+    party.phone.present? && Whatsapp::Session::PhoneMatch.same_number?(digits, party.phone)
   end
 
   def enqueue_avatar(contact)

--- a/app/services/whatsapp/session/inbound/contact_resolver.rb
+++ b/app/services/whatsapp/session/inbound/contact_resolver.rb
@@ -41,11 +41,16 @@ class Whatsapp::Session::Inbound::ContactResolver
     @source_id ||= existing_variant_source_id || party.source_id
   end
 
+  # The number as reported wins whenever it is already filed: an unordered `IN` over
+  # both ninth-digit forms can hand back the other row, which files the message under
+  # the wrong contact and then, with `overwrite`, tries to move the exact number onto a
+  # contact that does not own it and fails the uniqueness check, losing the message.
   def existing_variant_source_id
     return if party.lid.present? || party.phone.blank?
 
-    variants = Whatsapp::Session::PhoneMatch.variants(party.phone)
-    return if variants.size <= 1
+    variants = Whatsapp::Session::PhoneMatch.variants(party.phone) - [party.phone]
+    return if variants.blank?
+    return if inbox.contact_inboxes.exists?(source_id: party.phone)
 
     inbox.contact_inboxes.where(source_id: variants).pick(:source_id)
   end

--- a/app/services/whatsapp/session/inbound/contact_resolver.rb
+++ b/app/services/whatsapp/session/inbound/contact_resolver.rb
@@ -107,9 +107,14 @@ class Whatsapp::Session::Inbound::ContactResolver
   def placeholder_name?(name)
     return true if name.blank?
     return true if name == party.identifier
+    # Nothing but a number and the punctuation a number is written with. Stripping the
+    # separators first would read "Ana 2" as the digit 2; requiring the whole name to
+    # look like a phone keeps a real name out, while still catching the formatted forms
+    # ("+55 41 99999-0000") a conversion or an import leaves behind.
+    return false unless name.match?(/\A\+?[\d\s().-]+\z/)
 
-    digits = name.delete('+')
-    return false unless digits.match?(/\A\d+\z/)
+    digits = Whatsapp::Session::PhoneMatch.digits(name)
+    return false if digits.blank?
     return true if digits.in?([party.phone, party.lid].compact)
 
     party.phone.present? && Whatsapp::Session::PhoneMatch.same_number?(digits, party.phone)

--- a/app/services/whatsapp/session/inbound/conversation_finder.rb
+++ b/app/services/whatsapp/session/inbound/conversation_finder.rb
@@ -1,0 +1,67 @@
+# Picks the conversation an inbound message belongs to, or opens one.
+#
+# Lifted from Whatsapp::IncomingMessageBaseService so the session layer does not have
+# to touch that file (it is one of the three the upstream sync keeps rewriting). The
+# rules are the upstream ones: a reaction lands in the thread holding its target, and
+# everything else follows the inbox reopen policy.
+class Whatsapp::Session::Inbound::ConversationFinder
+  attr_reader :inbox, :contact, :contact_inbox, :attribution, :reaction_target_id
+
+  # `attribution` is the first-touch payload ({ 'referral' =>, 'entry_point' => }) the
+  # message carried, already compacted by the handler.
+  def initialize(inbox:, contact:, contact_inbox:, attribution: {}, reaction_target_id: nil)
+    @inbox = inbox
+    @contact = contact
+    @contact_inbox = contact_inbox
+    @attribution = attribution.presence || {}
+    @reaction_target_id = reaction_target_id
+  end
+
+  def perform
+    conversation = conversation_for_reaction || conversation_by_inbox_config
+    return backfill_first_touch(conversation) if conversation
+
+    ::Conversation.create!(conversation_params)
+  end
+
+  private
+
+  # A reaction annotates a message that already exists, so it must land in that
+  # message's thread rather than follow the reopen policy: reacting to a message in a
+  # resolved conversation would otherwise open a stray blank one.
+  def conversation_for_reaction
+    return if reaction_target_id.blank?
+
+    inbox.messages.find_by(source_id: reaction_target_id)&.conversation
+  end
+
+  def conversation_by_inbox_config
+    # Scoped to the contact across all its contact_inboxes: one person can hold several
+    # source_ids in the same inbox (phone and LID), and reopen must see all of them.
+    conversations = contact.conversations.where(inbox_id: inbox.id)
+    return conversations.last if inbox.lock_to_single_conversation
+
+    conversations.where.not(status: :resolved).last
+  end
+
+  def conversation_params
+    params = {
+      account_id: inbox.account_id, inbox_id: inbox.id,
+      contact_id: contact.id, contact_inbox_id: contact_inbox.id
+    }
+    params[:additional_attributes] = attribution if attribution.present?
+    params
+  end
+
+  # When the message reuses an existing thread, what conversation_params would have
+  # persisted on create never lands. Backfill only the keys still missing, so a genuine
+  # first touch is never overwritten by a later one.
+  def backfill_first_touch(conversation)
+    return conversation if attribution.blank?
+
+    existing = conversation.additional_attributes || {}
+    missing = attribution.reject { |key, _| existing.key?(key) }
+    conversation.update!(additional_attributes: existing.merge(missing)) if missing.present?
+    conversation
+  end
+end

--- a/app/services/whatsapp/session/inbound/conversation_finder.rb
+++ b/app/services/whatsapp/session/inbound/conversation_finder.rb
@@ -19,7 +19,7 @@ class Whatsapp::Session::Inbound::ConversationFinder
 
   def perform
     conversation = conversation_for_reaction || conversation_by_inbox_config
-    return backfill_first_touch(conversation) if conversation
+    return backfill_first_touch(mark_as_group(conversation)) if conversation
 
     ::Conversation.create!(conversation_params)
   end
@@ -50,7 +50,19 @@ class Whatsapp::Session::Inbound::ConversationFinder
       contact_id: contact.id, contact_inbox_id: contact_inbox.id
     }
     params[:additional_attributes] = attribution if attribution.present?
+    params[:group_type] = :group if group?
     params
+  end
+
+  # Asked of the contact rather than passed in: the group contact is the one thing that
+  # already knows, and a caller that forgot the flag would open an ordinary thread for a
+  # group. A thread that predates the group being recognised as one is repaired here,
+  # which is what GroupConversationHandler also does when it reuses a conversation.
+  def group? = contact.group_type_group?
+
+  def mark_as_group(conversation)
+    conversation.update!(group_type: :group) if group? && !conversation.group_type_group?
+    conversation
   end
 
   # When the message reuses an existing thread, what conversation_params would have

--- a/app/services/whatsapp/session/inbound/dispatcher.rb
+++ b/app/services/whatsapp/session/inbound/dispatcher.rb
@@ -1,0 +1,76 @@
+# The single entry point for everything that arrives from a session provider.
+#
+# The table is explicit on purpose: a type absent from it is ignored, never guessed at
+# by name. That is what lets an older Chatwoot keep running against a newer connector,
+# and what keeps the Uazapi translator honest about what it can actually produce.
+class Whatsapp::Session::Inbound::Dispatcher
+  Handlers = Whatsapp::Session::Inbound::Handlers
+
+  HANDLERS = {
+    'session.state' => Handlers::ConnectionState,
+    'session.logged_out' => Handlers::ConnectionState,
+    'session.stream_replaced' => Handlers::ConnectionState,
+    'session.temporary_ban' => Handlers::ConnectionState,
+    'session.client_outdated' => Handlers::ConnectionState,
+    'session.connect_failure' => Handlers::ConnectionState,
+    'pairing.qr' => Handlers::ConnectionState,
+    'pairing.code' => Handlers::ConnectionState,
+    'pairing.success' => Handlers::ConnectionState,
+    'pairing.error' => Handlers::ConnectionState,
+    'message.received' => Handlers::MessageReceived,
+    'message.receipt' => Handlers::MessageReceipt,
+    'message.edited' => Handlers::MessageEdited,
+    'message.revoked' => Handlers::MessageRevoked,
+    'message.reaction' => Handlers::MessageReaction,
+    'media.download_failed' => Handlers::MediaDownloadFailed,
+    'command.failed' => Handlers::CommandFailed,
+    'chat.presence' => Handlers::Presence,
+    'presence.update' => Handlers::Presence,
+    'contact.picture_changed' => Handlers::ContactPictureChanged,
+    'group.joined' => Handlers::GroupJoined,
+    'group.updated' => Handlers::GroupUpdated,
+    'group.picture_changed' => Handlers::GroupPictureChanged,
+    'group.activity' => Handlers::GroupActivity,
+    'account.reachout_timelock' => Handlers::AccountLimits,
+    'account.new_chat_cap' => Handlers::AccountLimits,
+    'raw' => Handlers::Raw
+  }.freeze
+
+  # Types the catalog defines and this layer deliberately drops. Listed so that a type
+  # missing from both tables shows up as a gap instead of as silence.
+  IGNORED = %w[
+    pairing.passkey_request pairing.passkey_confirmation contact.identity_changed
+    call.offer call.terminate history.sync
+  ].freeze
+
+  attr_reader :channel, :event
+
+  # Returns :handled, :ignored or :duplicate. Raises Locks::Busy when another worker
+  # holds the chat, which the caller answers by retrying the job.
+  def self.dispatch(channel, event)
+    new(channel, event).perform
+  end
+
+  def initialize(channel, event)
+    @channel = channel
+    @event = event
+  end
+
+  def perform
+    return skip('unknown payload') unless event.known?
+
+    handler = HANDLERS[event.type]
+    return skip('no handler') if handler.nil?
+
+    handler.new(channel: channel, event: event).perform
+  end
+
+  private
+
+  def skip(reason)
+    Rails.logger.debug { "[WHATSAPP SESSION] #{event.type} skipped on inbox #{channel.inbox&.id}: #{reason}" }
+    :ignored
+  end
+end
+
+Whatsapp::Session::Inbound::Dispatcher.prepend_mod_with('Whatsapp::Session::Inbound::Dispatcher')

--- a/app/services/whatsapp/session/inbound/dispatcher.rb
+++ b/app/services/whatsapp/session/inbound/dispatcher.rb
@@ -4,36 +4,38 @@
 # by name. That is what lets an older Chatwoot keep running against a newer connector,
 # and what keeps the Uazapi translator honest about what it can actually produce.
 class Whatsapp::Session::Inbound::Dispatcher
-  Handlers = Whatsapp::Session::Inbound::Handlers
-
+  # Handler names, not handler classes. A class object stored here is captured from
+  # another file, and a reload leaves this table pointing at the previous generation,
+  # whose own namespace aliases are stale in turn. Resolving the name when the event
+  # arrives costs nothing and cannot go out of date.
   HANDLERS = {
-    'session.state' => Handlers::ConnectionState,
-    'session.logged_out' => Handlers::ConnectionState,
-    'session.stream_replaced' => Handlers::ConnectionState,
-    'session.temporary_ban' => Handlers::ConnectionState,
-    'session.client_outdated' => Handlers::ConnectionState,
-    'session.connect_failure' => Handlers::ConnectionState,
-    'pairing.qr' => Handlers::ConnectionState,
-    'pairing.code' => Handlers::ConnectionState,
-    'pairing.success' => Handlers::ConnectionState,
-    'pairing.error' => Handlers::ConnectionState,
-    'message.received' => Handlers::MessageReceived,
-    'message.receipt' => Handlers::MessageReceipt,
-    'message.edited' => Handlers::MessageEdited,
-    'message.revoked' => Handlers::MessageRevoked,
-    'message.reaction' => Handlers::MessageReaction,
-    'media.download_failed' => Handlers::MediaDownloadFailed,
-    'command.failed' => Handlers::CommandFailed,
-    'chat.presence' => Handlers::Presence,
-    'presence.update' => Handlers::Presence,
-    'contact.picture_changed' => Handlers::ContactPictureChanged,
-    'group.joined' => Handlers::GroupJoined,
-    'group.updated' => Handlers::GroupUpdated,
-    'group.picture_changed' => Handlers::GroupPictureChanged,
-    'group.activity' => Handlers::GroupActivity,
-    'account.reachout_timelock' => Handlers::AccountLimits,
-    'account.new_chat_cap' => Handlers::AccountLimits,
-    'raw' => Handlers::Raw
+    'session.state' => 'ConnectionState',
+    'session.logged_out' => 'ConnectionState',
+    'session.stream_replaced' => 'ConnectionState',
+    'session.temporary_ban' => 'ConnectionState',
+    'session.client_outdated' => 'ConnectionState',
+    'session.connect_failure' => 'ConnectionState',
+    'pairing.qr' => 'ConnectionState',
+    'pairing.code' => 'ConnectionState',
+    'pairing.success' => 'ConnectionState',
+    'pairing.error' => 'ConnectionState',
+    'message.received' => 'MessageReceived',
+    'message.receipt' => 'MessageReceipt',
+    'message.edited' => 'MessageEdited',
+    'message.revoked' => 'MessageRevoked',
+    'message.reaction' => 'MessageReaction',
+    'media.download_failed' => 'MediaDownloadFailed',
+    'command.failed' => 'CommandFailed',
+    'chat.presence' => 'Presence',
+    'presence.update' => 'Presence',
+    'contact.picture_changed' => 'ContactPictureChanged',
+    'group.joined' => 'GroupJoined',
+    'group.updated' => 'GroupUpdated',
+    'group.picture_changed' => 'GroupPictureChanged',
+    'group.activity' => 'GroupActivity',
+    'account.reachout_timelock' => 'AccountLimits',
+    'account.new_chat_cap' => 'AccountLimits',
+    'raw' => 'Raw'
   }.freeze
 
   # Types the catalog defines and this layer deliberately drops. Listed so that a type
@@ -62,7 +64,7 @@ class Whatsapp::Session::Inbound::Dispatcher
     handler = HANDLERS[event.type]
     return skip('no handler') if handler.nil?
 
-    handler.new(channel: channel, event: event).perform
+    "Whatsapp::Session::Inbound::Handlers::#{handler}".constantize.new(channel: channel, event: event).perform
   end
 
   private

--- a/app/services/whatsapp/session/inbound/dispatcher.rb
+++ b/app/services/whatsapp/session/inbound/dispatcher.rb
@@ -78,7 +78,7 @@ class Whatsapp::Session::Inbound::Dispatcher
   def allowed_while_disowned?(handler)
     return true if handler == 'ConnectionState'
 
-    channel.provider_connection['error'] != I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
+    channel.provider_connection['error_code'] != 'wrong_phone_number'
   end
 
   def skip(reason)

--- a/app/services/whatsapp/session/inbound/dispatcher.rb
+++ b/app/services/whatsapp/session/inbound/dispatcher.rb
@@ -78,7 +78,7 @@ class Whatsapp::Session::Inbound::Dispatcher
   def allowed_while_disowned?(handler)
     return true if handler == 'ConnectionState'
 
-    channel.provider_connection['error_code'] != 'wrong_phone_number'
+    !Whatsapp::Session::ConnectionStateWriter.disowned?(channel)
   end
 
   def skip(reason)

--- a/app/services/whatsapp/session/inbound/dispatcher.rb
+++ b/app/services/whatsapp/session/inbound/dispatcher.rb
@@ -63,11 +63,23 @@ class Whatsapp::Session::Inbound::Dispatcher
 
     handler = HANDLERS[event.type]
     return skip('no handler') if handler.nil?
+    return skip('inbox disowned its session') unless allowed_while_disowned?(handler)
 
     "Whatsapp::Session::Inbound::Handlers::#{handler}".constantize.new(channel: channel, event: event).perform
   end
 
   private
+
+  # A session paired with a number this inbox is not configured for is somebody else's
+  # WhatsApp account, and its chats must not be filed here. The logout that removes it is
+  # asynchronous and can be retried for a while, so this is what keeps the wrong account's
+  # messages out in the meantime. Connection events still run, because they are how the
+  # inbox reports the problem and how a correct pairing clears it.
+  def allowed_while_disowned?(handler)
+    return true if handler == 'ConnectionState'
+
+    channel.provider_connection['error'] != I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
+  end
 
   def skip(reason)
     Rails.logger.debug { "[WHATSAPP SESSION] #{event.type} skipped on inbox #{channel.inbox&.id}: #{reason}" }

--- a/app/services/whatsapp/session/inbound/echo_matcher.rb
+++ b/app/services/whatsapp/session/inbound/echo_matcher.rb
@@ -8,22 +8,19 @@
 # so the echo is matched on that reservation instead, and the id the response never
 # delivered is filled in here.
 class Whatsapp::Session::Inbound::EchoMatcher
-  attr_reader :inbox, :contact, :message_id, :client_ref
+  attr_reader :inbox, :message_id, :client_ref
 
   # `client_ref` is the correlation token for a provider that assigns its own message
   # id and cannot take ours: the echo then comes back under an id Chatwoot has never
   # seen, and this token is the only thing tying it to the message that was sent.
-  def initialize(inbox:, contact:, message_id:, client_ref: nil)
+  def initialize(inbox:, message_id:, client_ref: nil)
     @inbox = inbox
-    @contact = contact
     @message_id = message_id
     @client_ref = client_ref
   end
 
   # Returns the already-stored message this echo belongs to, or nil.
   def perform
-    return if contact.blank?
-
     reserved = reserved_message
     return if reserved.nil?
 
@@ -33,16 +30,18 @@ class Whatsapp::Session::Inbound::EchoMatcher
 
   private
 
-  # Spans every conversation the contact has in this inbox: the sent message can be in
-  # any of them, and the answer is the conversation actually holding it.
+  # The whole inbox, not the peer's conversations. A reservation is a WhatsApp message
+  # id this session generated, so it identifies the message on its own, and scoping the
+  # lookup to a contact only means the echo of a chat addressed by a key that contact is
+  # not filed under yet misses its own reservation and is stored a second time.
   def reserved_message
     references = [message_id, client_ref].compact_blank
     return if references.empty?
 
-    Message.where(conversation_id: contact.conversations.where(inbox_id: inbox.id).select(:id))
-           .where(message_type: :outgoing)
-           .where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' IN (?)", references)
-           .first
+    inbox.messages
+         .where(message_type: :outgoing)
+         .where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' IN (?)", references)
+         .first
   end
 
   # The id the send never got to store is what a revoke needs, so a message deleted

--- a/app/services/whatsapp/session/inbound/echo_matcher.rb
+++ b/app/services/whatsapp/session/inbound/echo_matcher.rb
@@ -1,0 +1,48 @@
+# WhatsApp echoes back every message the session sends, including the ones Chatwoot
+# itself dispatched. Those echoes are normally recognized by `source_id`, which is
+# written from the send response, but when that response is lost and the job retries,
+# the echo carries an id Chatwoot never stored: it would land as a new sender-less
+# outgoing message, rendered as if an agent had replied from the phone.
+#
+# Session sends reserve their WhatsApp id before the request (Outbound::SourceIdReservation),
+# so the echo is matched on that reservation instead, and the id the response never
+# delivered is filled in here.
+class Whatsapp::Session::Inbound::EchoMatcher
+  attr_reader :inbox, :contact, :message_id
+
+  def initialize(inbox:, contact:, message_id:)
+    @inbox = inbox
+    @contact = contact
+    @message_id = message_id
+  end
+
+  # Returns the already-stored message this echo belongs to, or nil.
+  def perform
+    return if message_id.blank? || contact.blank?
+
+    reserved = reserved_message
+    return if reserved.nil?
+
+    confirm_source_id(reserved) if reserved.source_id.blank?
+    reserved
+  end
+
+  private
+
+  # Spans every conversation the contact has in this inbox: the sent message can be in
+  # any of them, and the answer is the conversation actually holding it.
+  def reserved_message
+    Message.where(conversation_id: contact.conversations.where(inbox_id: inbox.id).select(:id))
+           .where(message_type: :outgoing)
+           .where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' = ?", message_id)
+           .first
+  end
+
+  # The id the send never got to store is what a revoke needs, so a message deleted
+  # while that send was in flight can only be taken off the contact's phone once this
+  # echo supplies it.
+  def confirm_source_id(reserved)
+    reserved.update_under_lock!(source_id: message_id)
+    ::Messages::DeleteOnChannelJob.perform_later(reserved.id) if reserved.deleted?
+  end
+end

--- a/app/services/whatsapp/session/inbound/echo_matcher.rb
+++ b/app/services/whatsapp/session/inbound/echo_matcher.rb
@@ -8,17 +8,21 @@
 # so the echo is matched on that reservation instead, and the id the response never
 # delivered is filled in here.
 class Whatsapp::Session::Inbound::EchoMatcher
-  attr_reader :inbox, :contact, :message_id
+  attr_reader :inbox, :contact, :message_id, :client_ref
 
-  def initialize(inbox:, contact:, message_id:)
+  # `client_ref` is the correlation token for a provider that assigns its own message
+  # id and cannot take ours: the echo then comes back under an id Chatwoot has never
+  # seen, and this token is the only thing tying it to the message that was sent.
+  def initialize(inbox:, contact:, message_id:, client_ref: nil)
     @inbox = inbox
     @contact = contact
     @message_id = message_id
+    @client_ref = client_ref
   end
 
   # Returns the already-stored message this echo belongs to, or nil.
   def perform
-    return if message_id.blank? || contact.blank?
+    return if contact.blank?
 
     reserved = reserved_message
     return if reserved.nil?
@@ -32,9 +36,12 @@ class Whatsapp::Session::Inbound::EchoMatcher
   # Spans every conversation the contact has in this inbox: the sent message can be in
   # any of them, and the answer is the conversation actually holding it.
   def reserved_message
+    references = [message_id, client_ref].compact_blank
+    return if references.empty?
+
     Message.where(conversation_id: contact.conversations.where(inbox_id: inbox.id).select(:id))
            .where(message_type: :outgoing)
-           .where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' = ?", message_id)
+           .where("(content_attributes#>>'{}')::jsonb->>'pending_source_id' IN (?)", references)
            .first
   end
 
@@ -42,6 +49,8 @@ class Whatsapp::Session::Inbound::EchoMatcher
   # while that send was in flight can only be taken off the contact's phone once this
   # echo supplies it.
   def confirm_source_id(reserved)
+    return if message_id.blank?
+
     reserved.update_under_lock!(source_id: message_id)
     ::Messages::DeleteOnChannelJob.perform_later(reserved.id) if reserved.deleted?
   end

--- a/app/services/whatsapp/session/inbound/group_activity_writer.rb
+++ b/app/services/whatsapp/session/inbound/group_activity_writer.rb
@@ -42,21 +42,11 @@ class Whatsapp::Session::Inbound::GroupActivityWriter
 
   def inbox = conversation.inbox
 
-  # Same lookup order the rest of the inbound path uses: what the event reported first,
-  # then the other ninth-digit form. A group event that names its author only by the
-  # alternate form would otherwise miss the contact and print the raw number in an
-  # activity line that has the person's name available.
+  # A group event names its author by whichever key WhatsApp felt like using, which is
+  # often not the one the contact_inbox is filed under: an exact match prints the raw
+  # number in an activity line that has the person's name available.
   def actor_contact
-    keys = [actor.lid, actor.phone].compact_blank
-    contact = inbox.contact_inboxes.find_by(source_id: keys)&.contact if keys.present?
-    contact || variant_actor_contact
-  end
-
-  def variant_actor_contact
-    variants = Whatsapp::Session::PhoneMatch.variants(actor.phone) - [actor.phone]
-    return if variants.blank?
-
-    inbox.contact_inboxes.find_by(source_id: variants)&.contact
+    Whatsapp::Session::Inbound::ContactLookup.contact(inbox: inbox, party: actor)
   end
 
   def participant_content(action, names)

--- a/app/services/whatsapp/session/inbound/group_activity_writer.rb
+++ b/app/services/whatsapp/session/inbound/group_activity_writer.rb
@@ -34,13 +34,30 @@ class Whatsapp::Session::Inbound::GroupActivityWriter
   def author_name
     return translate('groups_update.unknown_author') if actor.blank?
 
-    contact = inbox.contact_inboxes.find_by(source_id: [actor.lid, actor.phone].compact)&.contact
+    contact = actor_contact
     contact&.name.presence || contact&.phone_number.presence || actor.name.presence || actor.source_id
   end
 
   private
 
   def inbox = conversation.inbox
+
+  # Same lookup order the rest of the inbound path uses: what the event reported first,
+  # then the other ninth-digit form. A group event that names its author only by the
+  # alternate form would otherwise miss the contact and print the raw number in an
+  # activity line that has the person's name available.
+  def actor_contact
+    keys = [actor.lid, actor.phone].compact_blank
+    contact = inbox.contact_inboxes.find_by(source_id: keys)&.contact if keys.present?
+    contact || variant_actor_contact
+  end
+
+  def variant_actor_contact
+    variants = Whatsapp::Session::PhoneMatch.variants(actor.phone) - [actor.phone]
+    return if variants.blank?
+
+    inbox.contact_inboxes.find_by(source_id: variants)&.contact
+  end
 
   def participant_content(action, names)
     return translate("group_participants.#{action}", contact_name: names.first) if action.in?(%w[join leave])

--- a/app/services/whatsapp/session/inbound/group_activity_writer.rb
+++ b/app/services/whatsapp/session/inbound/group_activity_writer.rb
@@ -1,0 +1,60 @@
+# The activity messages a group thread shows ("X changed the group name to Y").
+#
+# The i18n keys are the ones the Baileys layer already writes, so a converted inbox
+# keeps rendering its history and its new events the same way.
+class Whatsapp::Session::Inbound::GroupActivityWriter
+  attr_reader :conversation, :actor
+
+  def initialize(conversation:, actor: nil)
+    @conversation = conversation
+    @actor = actor
+  end
+
+  def write(key, **params)
+    conversation.messages.create!(
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      message_type: :activity,
+      content: translate("groups_update.#{key}", author_name: author_name, **params)
+    )
+  end
+
+  def write_participants(action, contacts)
+    names = contacts.map { |contact| contact.name.presence || contact.phone_number || contact.identifier }
+    conversation.messages.create!(
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      message_type: :activity,
+      content: participant_content(action, names)
+    )
+  end
+
+  # The name to blame for a change. A group event names its author by LID, which may
+  # not be a contact yet: the raw id is a better answer than an empty sentence.
+  def author_name
+    return translate('groups_update.unknown_author') if actor.blank?
+
+    contact = inbox.contact_inboxes.find_by(source_id: [actor.lid, actor.phone].compact)&.contact
+    contact&.name.presence || contact&.phone_number.presence || actor.name.presence || actor.source_id
+  end
+
+  private
+
+  def inbox = conversation.inbox
+
+  def participant_content(action, names)
+    return translate("group_participants.#{action}", contact_name: names.first) if action.in?(%w[join leave])
+
+    if names.one?
+      translate("group_participants.#{action}.single", author_name: author_name, contact_name: names.first)
+    else
+      translate("group_participants.#{action}.multiple", author_name: author_name,
+                                                         contact_names: names[..-2].join(', '), last_contact_name: names.last)
+    end
+  end
+
+  def translate(key, **params)
+    locale = conversation.account.locale || I18n.default_locale
+    I18n.with_locale(locale) { I18n.t("conversations.activity.#{key}", **params) }
+  end
+end

--- a/app/services/whatsapp/session/inbound/group_resolver.rb
+++ b/app/services/whatsapp/session/inbound/group_resolver.rb
@@ -28,8 +28,16 @@ class Whatsapp::Session::Inbound::GroupResolver
   end
 
   # The thread of the group, honouring the same reopen rules as a 1:1 conversation.
+  #
+  # Not `find_or_create_group_conversation`: that one only reuses open and pending rows,
+  # so a group whose thread was snoozed, or resolved under `lock_to_single_conversation`,
+  # would get a second conversation and split the group in two. It lives in the concern
+  # the frozen Baileys layer also uses, so the policy is applied here instead of changed
+  # there.
   def conversation_for(group_contact_inbox)
-    find_or_create_group_conversation(group_contact_inbox)
+    Whatsapp::Session::Inbound::ConversationFinder.new(
+      inbox: inbox, contact: group_contact_inbox.contact, contact_inbox: group_contact_inbox
+    ).perform
   end
 
   # Membership writes live in GroupConversationHandler, which keeps them private

--- a/app/services/whatsapp/session/inbound/group_resolver.rb
+++ b/app/services/whatsapp/session/inbound/group_resolver.rb
@@ -22,7 +22,7 @@ class Whatsapp::Session::Inbound::GroupResolver
   def perform
     group_contact_inbox, group_contact = find_or_create_group_contact
     sender_contact = resolve_sender
-    add_group_member(group_contact, sender_contact) if sender_contact
+    track_membership(group_contact, sender_contact) if sender_contact
 
     Result.new(group_contact_inbox: group_contact_inbox, group_contact: group_contact, sender_contact: sender_contact)
   end
@@ -56,6 +56,20 @@ class Whatsapp::Session::Inbound::GroupResolver
   end
 
   private
+
+  # A message proves that whoever wrote it is in the group; it says nothing about what
+  # they are in it. `add_group_member` writes the role it is handed, so calling it here
+  # with the default would demote back to member, on every message they send, anyone a
+  # roster sync or a `promote` event recorded as an administrator, including our own
+  # number on the echo of our own sends. `inbox_admin?` reads exactly that row to decide
+  # whether this inbox may post in an announce-only group.
+  def track_membership(group_contact, contact)
+    member = GroupMember.find_by(group_contact: group_contact, contact: contact)
+    return add_group_member(group_contact, contact) if member.nil?
+
+    member.update!(is_active: true) unless member.is_active?
+    member
+  end
 
   def resolve_sender
     return if sender.blank?

--- a/app/services/whatsapp/session/inbound/group_resolver.rb
+++ b/app/services/whatsapp/session/inbound/group_resolver.rb
@@ -1,0 +1,67 @@
+# Resolves the three records a group message needs: the contact that stands for the
+# group, the contact of whoever wrote the message, and the membership between them.
+#
+# The heavy lifting is GroupConversationHandler, the concern every channel shares. It
+# is written against abstract extractors, which is what this class supplies from the
+# canonical event.
+class Whatsapp::Session::Inbound::GroupResolver
+  include GroupConversationHandler
+
+  # What a group message handler needs to write the message.
+  Result = Data.define(:group_contact_inbox, :group_contact, :sender_contact)
+
+  attr_reader :inbox, :group, :sender, :subject
+
+  def initialize(inbox:, group:, sender: nil, subject: nil)
+    @inbox = inbox
+    @group = group
+    @sender = sender
+    @subject = subject
+  end
+
+  def perform
+    group_contact_inbox, group_contact = find_or_create_group_contact
+    sender_contact = resolve_sender
+    add_group_member(group_contact, sender_contact) if sender_contact
+
+    Result.new(group_contact_inbox: group_contact_inbox, group_contact: group_contact, sender_contact: sender_contact)
+  end
+
+  # The thread of the group, honouring the same reopen rules as a 1:1 conversation.
+  def conversation_for(group_contact_inbox)
+    find_or_create_group_conversation(group_contact_inbox)
+  end
+
+  # Membership writes live in GroupConversationHandler, which keeps them private
+  # because most channels only reach them from their own handler. Group events change
+  # membership without a message, so they are exposed here.
+  def add_member(group_contact, contact, role: :member)
+    add_group_member(group_contact, contact, role: role)
+  end
+
+  def remove_member(group_contact, contact)
+    remove_group_member(group_contact, contact)
+  end
+
+  def update_member_role(group_contact, contact, role)
+    update_group_member_role(group_contact, contact, role)
+  end
+
+  private
+
+  def resolve_sender
+    return if sender.blank?
+
+    Whatsapp::Session::Inbound::ContactResolver.new(inbox: inbox, party: sender)&.perform&.contact
+  end
+
+  # Matches what the Baileys layer persists, so a converted inbox keeps addressing the
+  # same group contact instead of creating a second one.
+  def extract_group_identifier = group.to_jid
+  def extract_group_source_id = group.id
+  def extract_group_name = subject
+  def extract_sender_identifier = sender&.identifier
+  def extract_sender_source_id = sender&.source_id
+  def extract_sender_name = sender&.name || sender&.phone || sender&.lid
+  def extract_sender_phone = sender&.phone_e164
+end

--- a/app/services/whatsapp/session/inbound/handlers/account_limits.rb
+++ b/app/services/whatsapp/session/inbound/handlers/account_limits.rb
@@ -1,0 +1,30 @@
+# WhatsApp's own limits on the account behind the session: the wait before it may
+# start new conversations, and how many it may start. They arrive out of band and stay
+# on the connection record until the provider says otherwise.
+class Whatsapp::Session::Inbound::Handlers::AccountLimits < Whatsapp::Session::Inbound::Handlers::Base
+  Events = Whatsapp::Session::Model::Events
+
+  def perform
+    case payload
+    when Events::AccountReachoutTimelock then write('reachout_time_lock', payload.reachout_time_lock)
+    when Events::AccountNewChatCap then write('new_chat_cap', payload.new_chat_cap)
+    else :ignored
+    end
+  end
+
+  private
+
+  # Written straight to the connection record rather than through ConnectionStateWriter:
+  # these are the sticky keys, and they must not carry a connection state with them.
+  def write(key, value)
+    return :ignored if value.nil?
+
+    channel.with_lock do
+      connection = (channel.provider_connection.presence || {}).merge(key => value)
+      next :ignored if connection == channel.provider_connection
+
+      channel.update_provider_connection!(connection)
+      :handled
+    end
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/base.rb
+++ b/app/services/whatsapp/session/inbound/handlers/base.rb
@@ -1,0 +1,43 @@
+# Common ground for every inbound handler: what the event is about, and the three
+# answers a handler may give.
+#
+#   :handled   the event changed something
+#   :ignored   the event is not actionable here (disabled capability, unknown chat...)
+#   :duplicate the event had already been processed
+class Whatsapp::Session::Inbound::Handlers::Base
+  Model = Whatsapp::Session::Model
+  Inbound = Whatsapp::Session::Inbound
+
+  attr_reader :channel, :event
+
+  def initialize(channel:, event:)
+    @channel = channel
+    @event = event
+  end
+
+  def perform
+    raise NotImplementedError, "#{self.class} must implement #perform"
+  end
+
+  private
+
+  def payload = event.payload
+  def inbox = channel.inbox
+  def account = inbox.account
+
+  def capability?(capability)
+    channel.session_capabilities.include?(capability.to_s)
+  end
+
+  # Chats Chatwoot has no representation for. The connector already drops most of them,
+  # but a hosted API forwards everything its instance sees.
+  def ignorable_chat?(address)
+    address.blank? || address.ignorable?
+  end
+
+  def find_message(source_id)
+    return if source_id.blank?
+
+    inbox.messages.find_by(source_id: source_id)
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/base.rb
+++ b/app/services/whatsapp/session/inbound/handlers/base.rb
@@ -35,9 +35,15 @@ class Whatsapp::Session::Inbound::Handlers::Base
     address.blank? || address.ignorable?
   end
 
-  def find_message(source_id)
-    return if source_id.blank?
+  def find_message(source_id) = find_messages(source_id).first
 
-    inbox.messages.find_by(source_id: source_id)
+  # A shared-contact payload is stored as one row per card, all carrying the provider's
+  # single id, which is how the Baileys layer and the Cloud provider store it too.
+  # Anything mutating a message by that id therefore has to reach every row, or a revoke
+  # takes one card off the screen and leaves the rest of the share behind.
+  def find_messages(source_id)
+    return Message.none if source_id.blank?
+
+    inbox.messages.where(source_id: source_id).order(:id)
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/base.rb
+++ b/app/services/whatsapp/session/inbound/handlers/base.rb
@@ -5,9 +5,6 @@
 #   :ignored   the event is not actionable here (disabled capability, unknown chat...)
 #   :duplicate the event had already been processed
 class Whatsapp::Session::Inbound::Handlers::Base
-  Model = Whatsapp::Session::Model
-  Inbound = Whatsapp::Session::Inbound
-
   attr_reader :channel, :event
 
   def initialize(channel:, event:)
@@ -20,6 +17,14 @@ class Whatsapp::Session::Inbound::Handlers::Base
   end
 
   private
+
+  # Resolved on every call, never held in a constant. Both are implicit namespaces (no
+  # `model.rb`, no `inbound.rb`), so a constant here captures a module object that a
+  # reload strips of its autoloads, and every handler inheriting it then raises
+  # `uninitialized constant` on the first lookup through it. Asking for the full path
+  # each time is what makes the tree survive a reload.
+  def model = Whatsapp::Session::Model
+  def inbound = Whatsapp::Session::Inbound
 
   def payload = event.payload
   def inbox = channel.inbox

--- a/app/services/whatsapp/session/inbound/handlers/command_failed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/command_failed.rb
@@ -8,7 +8,7 @@ class Whatsapp::Session::Inbound::Handlers::CommandFailed < Whatsapp::Session::I
     message = pending_message
     return :ignored if message.nil?
 
-    Inbound::StatusTransition.apply(message, 'failed', error: payload.error) ? :handled : :ignored
+    inbound::StatusTransition.apply(message, 'failed', error: payload.error) ? :handled : :ignored
   end
 
   private

--- a/app/services/whatsapp/session/inbound/handlers/command_failed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/command_failed.rb
@@ -1,0 +1,25 @@
+# A fire-and-forget command could not be executed. The only one with something to show
+# for it is a send: its message is marked failed so the agent sees it did not go out.
+class Whatsapp::Session::Inbound::Handlers::CommandFailed < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    Rails.logger.warn(
+      "[WHATSAPP SESSION] command #{payload.command_type} failed on inbox #{inbox.id}: #{payload.error&.code}"
+    )
+    message = pending_message
+    return :ignored if message.nil?
+
+    Inbound::StatusTransition.apply(message, 'failed', error: payload.error) ? :handled : :ignored
+  end
+
+  private
+
+  # The send reserved its WhatsApp id before dispatching, so the failed command points
+  # at a message that may not carry that id as source_id yet.
+  def pending_message
+    return if payload.message_id.blank?
+
+    find_message(payload.message_id) || inbox.messages.where(
+      "(content_attributes#>>'{}')::jsonb->>'pending_source_id' = ?", payload.message_id
+    ).first
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -56,7 +56,7 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
   def connecting(**attributes) = state('connecting', **attributes)
 
   def state(connection, **attributes)
-    Model::ConnectionState.new(connection: connection, epoch: epoch, **attributes)
+    model::ConnectionState.new(connection: connection, epoch: epoch, **attributes)
   end
 
   # Uazapi has no ownership model and sends no epoch; only the connector's epoch is a

--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -68,10 +68,14 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
   # The operator scanned the QR with a different number than the inbox is configured
   # for. Keeping that session would file the wrong contacts under this inbox, so it is
   # dropped and the inbox says why.
+  #
+  # Compared through the normalizers, never as raw digits: a Brazilian line is reported
+  # by WhatsApp with or without the ninth digit depending on when it was registered, so
+  # a textual comparison would reject the very number the operator configured.
   def wrong_phone?
-    configured = channel.phone_number.to_s.delete('+')
-    paired = payload.phone.to_s.delete('+')
-    configured.present? && paired.present? && configured != paired
+    configured = channel.phone_number.to_s
+    paired = payload.phone.to_s
+    configured.present? && paired.present? && !Whatsapp::Session::PhoneMatch.same_number?(configured, paired)
   end
 
   def after_write(state)

--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -1,0 +1,86 @@
+# Everything that changes what the inbox reports about its WhatsApp connection: the
+# state itself, the pairing steps, and the ways a session dies.
+#
+# One handler for all of them because they write the same record, through the only
+# writer allowed to touch it. The i18n key in `error` is what the dashboard renders;
+# a provider message never reaches the UI.
+class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session::Inbound::Handlers::Base
+  Events = Whatsapp::Session::Model::Events
+
+  def perform
+    state = build_state
+    return :ignored if state.nil?
+
+    result = Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state)
+    after_write(state) if result == :written
+    result == :stale ? :ignored : :handled
+  end
+
+  private
+
+  # Every event that only means "the session closed, and here is why" maps straight to
+  # its i18n key; the rest need a little more than that.
+  CLOSING_ERRORS = {
+    Events::SessionLoggedOut => 'logged_out',
+    Events::SessionStreamReplaced => 'stream_replaced',
+    Events::SessionTemporaryBan => 'temporary_ban',
+    Events::SessionClientOutdated => 'client_outdated',
+    Events::SessionConnectFailure => 'connect_failure',
+    Events::PairingError => 'connect_failure'
+  }.freeze
+
+  def build_state
+    error = CLOSING_ERRORS[payload.class]
+    return closed(error, ban: payload.try(:ban)) if error
+
+    case payload
+    when Events::SessionState then session_state
+    when Events::PairingQr then connecting(qr_data_url: payload.png_data_url)
+    when Events::PairingCode then connecting(pairing_code: payload.code)
+    when Events::PairingSuccess then pairing_success
+    end
+  end
+
+  def session_state
+    state(payload.state, error: payload.reason, phone_number: payload.phone, lid: payload.lid,
+                         quarantine: payload.quarantine, ban: payload.ban)
+  end
+
+  def pairing_success
+    return closed('wrong_phone_number') if wrong_phone?
+
+    connecting(phone_number: payload.phone, lid: payload.lid)
+  end
+
+  def closed(error, **attributes) = state('close', error: error, **attributes)
+  def connecting(**attributes) = state('connecting', **attributes)
+
+  def state(connection, **attributes)
+    Model::ConnectionState.new(connection: connection, epoch: epoch, **attributes)
+  end
+
+  # Uazapi has no ownership model and sends no epoch; only the connector's epoch is a
+  # real fencing token, and it starts at 1.
+  def epoch
+    event.epoch.to_i.positive? ? event.epoch.to_i : nil
+  end
+
+  # The operator scanned the QR with a different number than the inbox is configured
+  # for. Keeping that session would file the wrong contacts under this inbox, so it is
+  # dropped and the inbox says why.
+  def wrong_phone?
+    configured = channel.phone_number.to_s.delete('+')
+    paired = payload.phone.to_s.delete('+')
+    configured.present? && paired.present? && configured != paired
+  end
+
+  def after_write(state)
+    logout_wrong_number if state.error == 'wrong_phone_number'
+  end
+
+  def logout_wrong_number
+    channel.provider_service.logout
+  rescue Whatsapp::Session::Errors::Error => e
+    Rails.logger.warn("[WHATSAPP SESSION] logout after wrong number failed for inbox #{inbox.id}: #{e.message}")
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -41,7 +41,13 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
     end
   end
 
+  # The same check pairing does, and for the same reason. `pairing.success` is not the
+  # only event that names the paired number: a `session.state` already queued behind it,
+  # or one arriving because the logout below failed, would otherwise be accepted on its
+  # own and put the inbox back to work on somebody else's WhatsApp account.
   def session_state
+    return closed('wrong_phone_number') if wrong_phone?
+
     state(payload.state, error: payload.reason, phone_number: payload.phone, lid: payload.lid,
                          quarantine: payload.quarantine, ban: payload.ban)
   end

--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -46,16 +46,26 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
   # or one arriving because the logout below failed, would otherwise be accepted on its
   # own and put the inbox back to work on somebody else's WhatsApp account.
   def session_state
-    return closed('wrong_phone_number') if wrong_phone?
+    return closed(wrong_phone_error) if wrong_phone? || unidentified_while_disowned?
 
     state(payload.state, error: payload.reason, phone_number: payload.phone, lid: payload.lid,
                          quarantine: payload.quarantine, ban: payload.ban)
   end
 
   def pairing_success
-    return closed('wrong_phone_number') if wrong_phone?
+    return closed(wrong_phone_error) if wrong_phone?
 
     connecting(phone_number: payload.phone, lid: payload.lid)
+  end
+
+  # `session.state` only requires `state`: the contract's own `connecting` fixture carries
+  # nothing else, and an `open` can arrive the same way. Such a state says nothing about
+  # whose account is connected, and writing it would clear the quarantine below while the
+  # logout that removes the wrong account is still being retried, so the dispatcher would
+  # start filing that account's chats here again. The quarantine is lifted only by a state
+  # that names a number, and names the right one.
+  def unidentified_while_disowned?
+    payload.phone.blank? && Whatsapp::Session::ConnectionStateWriter.disowned?(channel)
   end
 
   def closed(error, **attributes) = state('close', error: error, **attributes)
@@ -89,6 +99,8 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
   # logout that failed once inline would never be attempted a second time, and the wrong
   # WhatsApp account would stay connected.
   def after_write(state)
-    Whatsapp::Session::LogoutJob.perform_later(channel) if state.error == 'wrong_phone_number'
+    Whatsapp::Session::LogoutJob.perform_later(channel) if state.error == wrong_phone_error
   end
+
+  def wrong_phone_error = Whatsapp::Session::ConnectionStateWriter::WRONG_PHONE_ERROR
 end

--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -84,13 +84,11 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
     configured.present? && paired.present? && !Whatsapp::Session::PhoneMatch.same_number?(configured, paired)
   end
 
+  # Through a job, not inline. The state has already been written by the time this runs,
+  # so a repeat of the same event is reported as unchanged and never gets here again: a
+  # logout that failed once inline would never be attempted a second time, and the wrong
+  # WhatsApp account would stay connected.
   def after_write(state)
-    logout_wrong_number if state.error == 'wrong_phone_number'
-  end
-
-  def logout_wrong_number
-    channel.provider_service.logout
-  rescue Whatsapp::Session::Errors::Error => e
-    Rails.logger.warn("[WHATSAPP SESSION] logout after wrong number failed for inbox #{inbox.id}: #{e.message}")
+    Whatsapp::Session::LogoutJob.perform_later(channel) if state.error == 'wrong_phone_number'
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
@@ -1,43 +1,32 @@
-# The contact changed their profile photo. The bytes are not in the event, so the
-# stored avatar is dropped and refetched.
+# The contact changed their profile photo. The bytes are not in the event, so the stored
+# avatar is refetched.
 class Whatsapp::Session::Inbound::Handlers::ContactPictureChanged < Whatsapp::Session::Inbound::Handlers::Base
   def perform
     return :ignored unless capability?(:profile_picture)
 
-    contact = find_contact
+    contact = Inbound::ContactLookup.contact(inbox: inbox, party: payload.party)
     return :ignored if contact.nil?
 
-    contact.avatar.purge if contact.avatar.attached?
-    return :handled if payload.removed
-
-    Whatsapp::Session::UpdateContactAvatarJob.perform_later(contact, inbox, payload.party.to_h)
+    payload.removed ? remove_avatar(contact) : refresh_avatar(contact)
     :handled
   end
 
   private
 
-  def find_contact
-    return if payload.party.blank?
-
-    by_source_id || by_phone
+  def remove_avatar(contact)
+    contact.avatar.purge if contact.avatar.attached?
   end
 
-  def by_source_id
-    source_ids = [payload.party.lid, payload.party.phone].compact_blank
-    return if source_ids.empty?
-
-    inbox.contact_inboxes.find_by(source_id: source_ids)&.contact
-  end
-
-  # A contact inbox keyed by LID is invisible to a lookup holding only the phone, which
-  # is what this event carries for a contact that was created before the inbox moved
-  # provider. Every ninth-digit form is tried, because the contact may well be stored
-  # under the other one. Matched on the contact itself and never created: a photo
-  # changing is no reason to invent somebody.
-  def by_phone
-    numbers = Whatsapp::Session::PhoneMatch.variants(payload.party.phone).map { |variant| "+#{variant}" }
-    return if numbers.empty?
-
-    inbox.contact_inboxes.joins(:contact).find_by(contact: { phone_number: numbers })&.contact
+  # The stored avatar stays until its replacement is attached, and the two sync markers
+  # are cleared first. Purging up front loses the picture for good whenever the download
+  # does not happen, which is common: `Avatar::AvatarFromUrlJob` skips a contact synced
+  # in the last minute or handed a URL it already fetched, and its `ensure` stamps both
+  # markers even on the skipped run, so the next attempt with that URL is skipped as a
+  # duplicate too. The markers exist to stop the same picture being fetched over and
+  # over, not to suppress the event announcing that the picture changed.
+  def refresh_avatar(contact)
+    attributes = (contact.additional_attributes || {}).except('last_avatar_sync_at', 'avatar_url_hash')
+    contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
+    Whatsapp::Session::UpdateContactAvatarJob.perform_later(contact, inbox, payload.party.to_h, force: true)
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
@@ -19,6 +19,24 @@ class Whatsapp::Session::Inbound::Handlers::ContactPictureChanged < Whatsapp::Se
   def find_contact
     return if payload.party.blank?
 
-    inbox.contact_inboxes.find_by(source_id: [payload.party.lid, payload.party.phone].compact)&.contact
+    by_source_id || by_phone
+  end
+
+  def by_source_id
+    source_ids = [payload.party.lid, payload.party.phone].compact_blank
+    return if source_ids.empty?
+
+    inbox.contact_inboxes.find_by(source_id: source_ids)&.contact
+  end
+
+  # A contact inbox keyed by LID is invisible to a lookup holding only the phone, which
+  # is what this event carries for a contact that was created before the inbox moved
+  # provider. Matched on the contact itself and never created: a photo changing is no
+  # reason to invent somebody.
+  def by_phone
+    phone = payload.party.phone_e164
+    return if phone.blank?
+
+    inbox.contact_inboxes.joins(:contact).find_by(contact: { phone_number: phone })&.contact
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
@@ -1,0 +1,24 @@
+# The contact changed their profile photo. The bytes are not in the event, so the
+# stored avatar is dropped and refetched.
+class Whatsapp::Session::Inbound::Handlers::ContactPictureChanged < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    return :ignored unless capability?(:profile_picture)
+
+    contact = find_contact
+    return :ignored if contact.nil?
+
+    contact.avatar.purge if contact.avatar.attached?
+    return :handled if payload.removed
+
+    Whatsapp::Session::UpdateContactAvatarJob.perform_later(contact, inbox, payload.party.to_h)
+    :handled
+  end
+
+  private
+
+  def find_contact
+    return if payload.party.blank?
+
+    inbox.contact_inboxes.find_by(source_id: [payload.party.lid, payload.party.phone].compact)&.contact
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
@@ -31,12 +31,13 @@ class Whatsapp::Session::Inbound::Handlers::ContactPictureChanged < Whatsapp::Se
 
   # A contact inbox keyed by LID is invisible to a lookup holding only the phone, which
   # is what this event carries for a contact that was created before the inbox moved
-  # provider. Matched on the contact itself and never created: a photo changing is no
-  # reason to invent somebody.
+  # provider. Every ninth-digit form is tried, because the contact may well be stored
+  # under the other one. Matched on the contact itself and never created: a photo
+  # changing is no reason to invent somebody.
   def by_phone
-    phone = payload.party.phone_e164
-    return if phone.blank?
+    numbers = Whatsapp::Session::PhoneMatch.variants(payload.party.phone).map { |variant| "+#{variant}" }
+    return if numbers.empty?
 
-    inbox.contact_inboxes.joins(:contact).find_by(contact: { phone_number: phone })&.contact
+    inbox.contact_inboxes.joins(:contact).find_by(contact: { phone_number: numbers })&.contact
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
@@ -4,7 +4,7 @@ class Whatsapp::Session::Inbound::Handlers::ContactPictureChanged < Whatsapp::Se
   def perform
     return :ignored unless capability?(:profile_picture)
 
-    contact = Inbound::ContactLookup.contact(inbox: inbox, party: payload.party)
+    contact = inbound::ContactLookup.contact(inbox: inbox, party: payload.party)
     return :ignored if contact.nil?
 
     payload.removed ? remove_avatar(contact) : refresh_avatar(contact)

--- a/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
@@ -25,8 +25,7 @@ class Whatsapp::Session::Inbound::Handlers::ContactPictureChanged < Whatsapp::Se
   # duplicate too. The markers exist to stop the same picture being fetched over and
   # over, not to suppress the event announcing that the picture changed.
   def refresh_avatar(contact)
-    attributes = (contact.additional_attributes || {}).except('last_avatar_sync_at', 'avatar_url_hash')
-    contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
+    Whatsapp::Session::AvatarSync.reset(contact)
     Whatsapp::Session::UpdateContactAvatarJob.perform_later(contact, inbox, payload.party.to_h, force: true)
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/group_activity.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_activity.rb
@@ -14,12 +14,12 @@ class Whatsapp::Session::Inbound::Handlers::GroupActivity < Whatsapp::Session::I
   private
 
   def refresh(group)
-    Inbound::Locks.with_chat_lock(inbox, group.id) do
-      resolver = Inbound::GroupResolver.new(inbox: inbox, group: group)
+    inbound::Locks.with_chat_lock(inbox, group.id) do
+      resolver = inbound::GroupResolver.new(inbox: inbox, group: group)
       result = resolver.perform
       conversation = resolver.conversation_for(result.group_contact_inbox)
 
-      Contacts::SyncGroupJob.perform_later(result.group_contact, soft: true)
+      Contacts::SyncGroupJob.perform_later(result.group_contact, soft: true, channel: channel)
       conversation.update_columns(last_activity_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
       conversation.dispatch_conversation_updated_event
     end

--- a/app/services/whatsapp/session/inbound/handlers/group_activity.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_activity.rb
@@ -1,0 +1,27 @@
+# A hint that these groups have been active. It carries no detail, so it only refreshes
+# the chat list order and asks for a soft sync, which is throttled by the sync job.
+class Whatsapp::Session::Inbound::Handlers::GroupActivity < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    return :ignored unless capability?(:groups)
+
+    groups = Array(payload.groups).reject { |group| ignorable_chat?(group) }
+    return :ignored if groups.empty?
+
+    groups.each { |group| refresh(group) }
+    :handled
+  end
+
+  private
+
+  def refresh(group)
+    Inbound::Locks.with_chat_lock(inbox, group.id) do
+      resolver = Inbound::GroupResolver.new(inbox: inbox, group: group)
+      result = resolver.perform
+      conversation = resolver.conversation_for(result.group_contact_inbox)
+
+      Contacts::SyncGroupJob.perform_later(result.group_contact, soft: true)
+      conversation.update_columns(last_activity_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      conversation.dispatch_conversation_updated_event
+    end
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/group_joined.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_joined.rb
@@ -6,7 +6,8 @@ class Whatsapp::Session::Inbound::Handlers::GroupJoined < Whatsapp::Session::Inb
     return :ignored unless capability?(:groups)
     return :ignored if payload.info.blank?
 
-    inbound::Locks.with_chat_lock(inbox, payload.info.group.id) { sync }
+    # The long lease: this syncs the whole roster from the snapshot the event carried.
+    inbound::Locks.with_chat_lock(inbox, payload.info.group.id, ttl: inbound::Locks::GROUP_SYNC_LOCK_TTL) { sync }
   end
 
   private
@@ -26,8 +27,11 @@ class Whatsapp::Session::Inbound::Handlers::GroupJoined < Whatsapp::Session::Inb
     :handled
   end
 
+  # Snoozed counts as closed here: this event creates no message, so nothing triggers the
+  # reopen a message would, and the restored group would stay hidden until the old snooze
+  # happened to expire.
   def reopen(conversation)
-    conversation.open! if conversation.resolved?
+    conversation.open! if conversation.resolved? || conversation.snoozed?
     conversation
   end
 

--- a/app/services/whatsapp/session/inbound/handlers/group_joined.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_joined.rb
@@ -6,24 +6,28 @@ class Whatsapp::Session::Inbound::Handlers::GroupJoined < Whatsapp::Session::Inb
     return :ignored unless capability?(:groups)
     return :ignored if payload.info.blank?
 
-    Inbound::Locks.with_chat_lock(inbox, payload.info.group.id) { sync }
+    inbound::Locks.with_chat_lock(inbox, payload.info.group.id) { sync }
   end
 
   private
 
   def sync
-    resolver = Inbound::GroupResolver.new(inbox: inbox, group: payload.info.group, subject: payload.info.subject)
+    resolver = inbound::GroupResolver.new(inbox: inbox, group: payload.info.group, subject: payload.info.subject)
     result = resolver.perform
     # Opened right away so the group shows up in the chat list with its history, the
     # same as a group whose first message just arrived.
     resolver.conversation_for(result.group_contact_inbox)
 
     Whatsapp::Session::Groups::Syncer.new(channel: channel, group_contact: result.group_contact, info: payload.info).perform
-    # The roster changed, and an ordinary contact update does not carry `group_members`,
-    # so without this an open dashboard keeps showing the members (and the admin rights)
-    # the group had before, until a reload or the next participant event.
-    result.group_contact.reload
-    Rails.configuration.dispatcher.dispatch(Events::Types::CONTACT_GROUP_SYNCED, Time.zone.now, contact: result.group_contact)
+    broadcast_roster(result.group_contact)
     :handled
+  end
+
+  # The roster changed, and an ordinary contact update does not carry `group_members`,
+  # so without this an open dashboard keeps showing the members (and the admin rights)
+  # the group had before, until a reload or the next participant event.
+  def broadcast_roster(group_contact)
+    group_contact.reload
+    Rails.configuration.dispatcher.dispatch(Events::Types::CONTACT_GROUP_SYNCED, Time.zone.now, contact: group_contact)
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/group_joined.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_joined.rb
@@ -1,0 +1,24 @@
+# The session was added to a group (or created one). The event carries the whole group,
+# so the contact, its settings and its members are written without asking the provider
+# anything.
+class Whatsapp::Session::Inbound::Handlers::GroupJoined < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    return :ignored unless capability?(:groups)
+    return :ignored if payload.info.blank?
+
+    Inbound::Locks.with_chat_lock(inbox, payload.info.group.id) { sync }
+  end
+
+  private
+
+  def sync
+    resolver = Inbound::GroupResolver.new(inbox: inbox, group: payload.info.group, subject: payload.info.subject)
+    result = resolver.perform
+    # Opened right away so the group shows up in the chat list with its history, the
+    # same as a group whose first message just arrived.
+    resolver.conversation_for(result.group_contact_inbox)
+
+    Whatsapp::Session::Groups::Syncer.new(channel: channel, group_contact: result.group_contact, info: payload.info).perform
+    :handled
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/group_joined.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_joined.rb
@@ -19,6 +19,11 @@ class Whatsapp::Session::Inbound::Handlers::GroupJoined < Whatsapp::Session::Inb
     resolver.conversation_for(result.group_contact_inbox)
 
     Whatsapp::Session::Groups::Syncer.new(channel: channel, group_contact: result.group_contact, info: payload.info).perform
+    # The roster changed, and an ordinary contact update does not carry `group_members`,
+    # so without this an open dashboard keeps showing the members (and the admin rights)
+    # the group had before, until a reload or the next participant event.
+    result.group_contact.reload
+    Rails.configuration.dispatcher.dispatch(Events::Types::CONTACT_GROUP_SYNCED, Time.zone.now, contact: result.group_contact)
     :handled
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/group_joined.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_joined.rb
@@ -15,12 +15,20 @@ class Whatsapp::Session::Inbound::Handlers::GroupJoined < Whatsapp::Session::Inb
     resolver = inbound::GroupResolver.new(inbox: inbox, group: payload.info.group, subject: payload.info.subject)
     result = resolver.perform
     # Opened right away so the group shows up in the chat list with its history, the
-    # same as a group whose first message just arrived.
-    resolver.conversation_for(result.group_contact_inbox)
+    # same as a group whose first message just arrived. Reopened explicitly, because this
+    # event creates no message: an inbox that locks to a single conversation hands back
+    # the resolved thread of the group it was in before, and nothing else would move it
+    # off resolved until somebody happens to write there.
+    reopen(resolver.conversation_for(result.group_contact_inbox))
 
     Whatsapp::Session::Groups::Syncer.new(channel: channel, group_contact: result.group_contact, info: payload.info).perform
     broadcast_roster(result.group_contact)
     :handled
+  end
+
+  def reopen(conversation)
+    conversation.open! if conversation.resolved?
+    conversation
   end
 
   # The roster changed, and an ordinary contact update does not carry `group_members`,

--- a/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
@@ -4,12 +4,12 @@ class Whatsapp::Session::Inbound::Handlers::GroupPictureChanged < Whatsapp::Sess
   def perform
     return :ignored unless capability?(:groups)
 
-    Inbound::Locks.with_chat_lock(inbox, payload.group.id) do
-      resolver = Inbound::GroupResolver.new(inbox: inbox, group: payload.group)
+    inbound::Locks.with_chat_lock(inbox, payload.group.id) do
+      resolver = inbound::GroupResolver.new(inbox: inbox, group: payload.group)
       result = resolver.perform
       conversation = resolver.conversation_for(result.group_contact_inbox)
 
-      Inbound::GroupActivityWriter.new(conversation: conversation, actor: payload.actor).write('icon_changed')
+      inbound::GroupActivityWriter.new(conversation: conversation, actor: payload.actor).write('icon_changed')
       refresh_avatar(result.group_contact)
       :handled
     end

--- a/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
@@ -10,8 +10,19 @@ class Whatsapp::Session::Inbound::Handlers::GroupPictureChanged < Whatsapp::Sess
       conversation = resolver.conversation_for(result.group_contact_inbox)
 
       Inbound::GroupActivityWriter.new(conversation: conversation, actor: payload.actor).write('icon_changed')
-      Whatsapp::Session::UpdateGroupAvatarJob.perform_later(result.group_contact, force: true)
+      refresh_avatar(result.group_contact)
       :handled
     end
+  end
+
+  private
+
+  # A removal has nothing to refetch, and the job returns before purging when the group
+  # reports no photo, so asking it to refresh would leave the old image attached for
+  # good.
+  def refresh_avatar(group_contact)
+    return Whatsapp::Session::UpdateGroupAvatarJob.perform_later(group_contact, force: true) unless payload.removed
+
+    group_contact.avatar.purge if group_contact.avatar.attached?
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
@@ -1,0 +1,17 @@
+# The group photo changed. The new bytes are not in the event, so the avatar is
+# refetched and the thread records who changed it.
+class Whatsapp::Session::Inbound::Handlers::GroupPictureChanged < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    return :ignored unless capability?(:groups)
+
+    Inbound::Locks.with_chat_lock(inbox, payload.group.id) do
+      resolver = Inbound::GroupResolver.new(inbox: inbox, group: payload.group)
+      result = resolver.perform
+      conversation = resolver.conversation_for(result.group_contact_inbox)
+
+      Inbound::GroupActivityWriter.new(conversation: conversation, actor: payload.actor).write('icon_changed')
+      Whatsapp::Session::UpdateGroupAvatarJob.perform_later(result.group_contact, force: true)
+      :handled
+    end
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
@@ -21,7 +21,7 @@ class Whatsapp::Session::Inbound::Handlers::GroupPictureChanged < Whatsapp::Sess
   # reports no photo, so asking it to refresh would leave the old image attached for
   # good.
   def refresh_avatar(group_contact)
-    return Whatsapp::Session::UpdateGroupAvatarJob.perform_later(group_contact, force: true) unless payload.removed
+    return Whatsapp::Session::UpdateGroupAvatarJob.perform_later(group_contact, force: true, channel: channel) unless payload.removed
 
     group_contact.avatar.purge if group_contact.avatar.attached?
   end

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -107,10 +107,17 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
     return unless action == 'leave'
     return unless contacts.any? { |contact| session_owner?(contact) }
 
+    # ACCOUNT-WIDE, ON PURPOSE, FOR NOW (fazer-ai/chatwoot#374). The group contact is
+    # shared by every inbox of the account that is in this WhatsApp group, so this marks
+    # the group as left for all of them, and nothing on the inboxes that stayed will
+    # clear it. The flag lives here because that is where the Baileys layer writes it and
+    # where three dashboard components read it; scoping it per inbox means changing that
+    # contract in the frozen legacy layer too. Do not delete this note without closing
+    # the issue.
     merge_attributes('group_left' => true)
-    # Only this inbox's threads. The group contact is shared by every inbox of the
-    # account that is in the same WhatsApp group, and closing their conversations
-    # because *this* session left would end a thread another number can still use.
+    # Only this inbox's threads, which the flag above cannot manage. Closing another
+    # number's conversations because *this* session left would end a thread it can
+    # still use.
     @group_contact_inbox.conversations.where(status: %i[open pending]).find_each { |thread| thread.update!(status: :resolved) }
   end
 

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -6,7 +6,7 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
 
   def perform
     return :ignored unless capability?(:groups)
-    return :ignored if changes.blank?
+    return :ignored unless changes.respond_to?(:any?) && changes.any?
 
     inbound::Locks.with_chat_lock(inbox, payload.group.id) do
       apply

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -1,0 +1,123 @@
+# Something changed in a group: its name, its description, one of its settings, or who
+# is in it. Each change becomes an activity message in the group thread and, where the
+# dashboard reads it, an attribute on the group contact.
+class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::Inbound::Handlers::Base
+  SETTINGS = Whatsapp::Session::Groups::Syncer::SETTINGS
+
+  def perform
+    return :ignored unless capability?(:groups)
+    return :ignored if changes.blank?
+
+    Inbound::Locks.with_chat_lock(inbox, payload.group.id) do
+      apply
+      :handled
+    end
+  end
+
+  private
+
+  def changes = payload.changes
+
+  def apply
+    @resolver = Inbound::GroupResolver.new(inbox: inbox, group: payload.group)
+    result = @resolver.perform
+    @group_contact = result.group_contact
+    @conversation = @resolver.conversation_for(result.group_contact_inbox)
+    @activity = Inbound::GroupActivityWriter.new(conversation: @conversation, actor: payload.actor)
+
+    apply_subject
+    apply_description
+    apply_settings
+    apply_participants
+    dispatch_group_synced
+  end
+
+  def apply_subject
+    return if changes.subject.blank?
+
+    @group_contact.update!(name: changes.subject)
+    @activity.write('subject_changed', value: changes.subject)
+  end
+
+  # An empty (not absent) description is the group removing it.
+  def apply_description
+    return if changes.description.nil?
+
+    merge_attributes('description' => changes.description.presence)
+    @activity.write(changes.description.present? ? 'description_changed' : 'description_removed')
+  end
+
+  def apply_settings
+    SETTINGS.each do |member, key|
+      value = changes.public_send(member)
+      next if value.nil?
+
+      merge_attributes(key => value)
+      @activity.write("#{key}_#{value ? 'enabled' : 'disabled'}")
+    end
+  end
+
+  def apply_participants
+    %w[join leave promote demote].each do |action|
+      parties = Array(changes.public_send(action))
+      next if parties.blank?
+
+      contacts = parties.filter_map { |party| resolve_participant(party) }
+      next if contacts.empty?
+
+      contacts.each { |contact| apply_membership(action, contact) }
+      @activity.write_participants(activity_action(action, parties), contacts)
+      resolve_conversations_if_left(action, contacts)
+    end
+  end
+
+  def resolve_participant(party)
+    Inbound::ContactResolver.new(inbox: inbox, party: party)&.perform&.contact
+  end
+
+  def apply_membership(action, contact)
+    case action
+    when 'join' then @resolver.add_member(@group_contact, contact)
+    when 'leave' then @resolver.remove_member(@group_contact, contact)
+    when 'promote' then @resolver.update_member_role(@group_contact, contact, :admin)
+    when 'demote' then @resolver.update_member_role(@group_contact, contact, :member)
+    end
+  end
+
+  # WhatsApp reports "someone was added" and "someone joined by link" the same way; the
+  # difference is whether an actor did it.
+  def activity_action(action, parties)
+    case action
+    when 'join' then payload.actor.blank? ? 'join' : 'add'
+    when 'leave' then leaving_by_self?(parties) ? 'leave' : 'remove'
+    else action
+    end
+  end
+
+  def leaving_by_self?(parties)
+    return true if payload.actor.blank?
+
+    parties.any? { |party| party.source_id == payload.actor.source_id }
+  end
+
+  # The session's own number left the group: nothing more will arrive in that thread.
+  def resolve_conversations_if_left(action, contacts)
+    return unless action == 'leave'
+    return unless contacts.any? { |contact| contact.phone_number&.delete('+') == channel.phone_number&.delete('+') }
+
+    merge_attributes('group_left' => true)
+    @group_contact.contact_inboxes.each do |contact_inbox|
+      contact_inbox.conversations.where(status: %i[open pending]).find_each { |thread| thread.update!(status: :resolved) }
+    end
+  end
+
+  def merge_attributes(attributes)
+    merged = (@group_contact.additional_attributes || {}).merge(attributes)
+    @group_contact.update!(additional_attributes: merged) if merged != @group_contact.additional_attributes
+  end
+
+  def dispatch_group_synced
+    @group_contact.reload
+    Rails.configuration.dispatcher.dispatch(Events::Types::CONTACT_GROUP_SYNCED, Time.zone.now, contact: @group_contact)
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -8,7 +8,7 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
     return :ignored unless capability?(:groups)
     return :ignored if changes.blank?
 
-    Inbound::Locks.with_chat_lock(inbox, payload.group.id) do
+    inbound::Locks.with_chat_lock(inbox, payload.group.id) do
       apply
       :handled
     end
@@ -19,12 +19,12 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
   def changes = payload.changes
 
   def apply
-    @resolver = Inbound::GroupResolver.new(inbox: inbox, group: payload.group)
+    @resolver = inbound::GroupResolver.new(inbox: inbox, group: payload.group)
     result = @resolver.perform
     @group_contact = result.group_contact
     @group_contact_inbox = result.group_contact_inbox
     @conversation = @resolver.conversation_for(@group_contact_inbox)
-    @activity = Inbound::GroupActivityWriter.new(conversation: @conversation, actor: payload.actor)
+    @activity = inbound::GroupActivityWriter.new(conversation: @conversation, actor: payload.actor)
 
     apply_subject
     apply_description
@@ -74,15 +74,21 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
   end
 
   def resolve_participant(party)
-    Inbound::ContactResolver.new(inbox: inbox, party: party)&.perform&.contact
+    inbound::ContactResolver.new(inbox: inbox, party: party)&.perform&.contact
   end
 
+  # A promote or a demote is the first thing seen about a participant often enough: the
+  # roster sync may never have run for this group, or the person joined before the inbox
+  # existed. `update_member_role` only updates a membership that is already there and
+  # says nothing otherwise, so the roster would keep omitting somebody the event just
+  # confirmed is in the group. Adding with the reported role writes the same row and
+  # creates it when it is missing.
   def apply_membership(action, contact)
     case action
     when 'join' then @resolver.add_member(@group_contact, contact)
     when 'leave' then @resolver.remove_member(@group_contact, contact)
-    when 'promote' then @resolver.update_member_role(@group_contact, contact, :admin)
-    when 'demote' then @resolver.update_member_role(@group_contact, contact, :member)
+    when 'promote' then @resolver.add_member(@group_contact, contact, role: :admin)
+    when 'demote' then @resolver.add_member(@group_contact, contact, role: :member)
     end
   end
 

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -49,9 +49,10 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
 
   def apply_settings
     SETTINGS.each do |member, key|
-      value = changes.public_send(member)
-      next if value.nil?
+      raw = changes.public_send(member)
+      next if raw.nil?
 
+      value = Whatsapp::Session::Groups::Syncer.setting_value(member, raw)
       merge_attributes(key => value)
       @activity.write("#{key}_#{value ? 'enabled' : 'disabled'}")
     end
@@ -103,7 +104,7 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
   # The session's own number left the group: nothing more will arrive in that thread.
   def resolve_conversations_if_left(action, contacts)
     return unless action == 'leave'
-    return unless contacts.any? { |contact| contact.phone_number&.delete('+') == channel.phone_number&.delete('+') }
+    return unless contacts.any? { |contact| Whatsapp::Session::PhoneMatch.same_number?(contact.phone_number, channel.phone_number) }
 
     merge_attributes('group_left' => true)
     @group_contact.contact_inboxes.each do |contact_inbox|

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -124,7 +124,10 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
     # Only this inbox's threads, which the flag above cannot manage. Closing another
     # number's conversations because *this* session left would end a thread it can
     # still use.
-    @group_contact_inbox.conversations.where(status: %i[open pending]).find_each { |thread| thread.update!(status: :resolved) }
+    # Snoozed as well: the snooze job reopens on its own schedule, and a thread reopened
+    # for a group this inbox has left can no longer send anything.
+    @group_contact_inbox.conversations.where(status: %i[open pending snoozed])
+                        .find_each { |thread| thread.update!(status: :resolved) }
   end
 
   # WhatsApp may describe the session's own participant by LID alone, in which case the

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -22,7 +22,8 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
     @resolver = Inbound::GroupResolver.new(inbox: inbox, group: payload.group)
     result = @resolver.perform
     @group_contact = result.group_contact
-    @conversation = @resolver.conversation_for(result.group_contact_inbox)
+    @group_contact_inbox = result.group_contact_inbox
+    @conversation = @resolver.conversation_for(@group_contact_inbox)
     @activity = Inbound::GroupActivityWriter.new(conversation: @conversation, actor: payload.actor)
 
     apply_subject
@@ -107,9 +108,10 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
     return unless contacts.any? { |contact| session_owner?(contact) }
 
     merge_attributes('group_left' => true)
-    @group_contact.contact_inboxes.each do |contact_inbox|
-      contact_inbox.conversations.where(status: %i[open pending]).find_each { |thread| thread.update!(status: :resolved) }
-    end
+    # Only this inbox's threads. The group contact is shared by every inbox of the
+    # account that is in the same WhatsApp group, and closing their conversations
+    # because *this* session left would end a thread another number can still use.
+    @group_contact_inbox.conversations.where(status: %i[open pending]).find_each { |thread| thread.update!(status: :resolved) }
   end
 
   # WhatsApp may describe the session's own participant by LID alone, in which case the

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -104,12 +104,23 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
   # The session's own number left the group: nothing more will arrive in that thread.
   def resolve_conversations_if_left(action, contacts)
     return unless action == 'leave'
-    return unless contacts.any? { |contact| Whatsapp::Session::PhoneMatch.same_number?(contact.phone_number, channel.phone_number) }
+    return unless contacts.any? { |contact| session_owner?(contact) }
 
     merge_attributes('group_left' => true)
     @group_contact.contact_inboxes.each do |contact_inbox|
       contact_inbox.conversations.where(status: %i[open pending]).find_each { |thread| thread.update!(status: :resolved) }
     end
+  end
+
+  # WhatsApp may describe the session's own participant by LID alone, in which case the
+  # resolved contact has no phone at all and comparing numbers can only answer no. The
+  # LID the session paired under is on the connection record, so both identities are
+  # checked.
+  def session_owner?(contact)
+    return true if Whatsapp::Session::PhoneMatch.same_number?(contact.phone_number, channel.phone_number)
+
+    lid = channel.provider_connection['lid'].presence
+    lid.present? && contact.identifier == "#{lid}@lid"
   end
 
   def merge_attributes(attributes)

--- a/app/services/whatsapp/session/inbound/handlers/media_download_failed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/media_download_failed.rb
@@ -1,0 +1,14 @@
+# The provider could not decrypt or download the media of a message it already
+# delivered. The message stays, flagged so the agent knows the attachment is gone
+# rather than still loading.
+class Whatsapp::Session::Inbound::Handlers::MediaDownloadFailed < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    message = find_message(payload.message_id)
+    return :ignored if message.nil?
+    return :ignored if message.attachments.any?
+
+    message.update!(is_unsupported: true)
+    Rails.logger.warn("[WHATSAPP SESSION] media download failed for #{payload.message_id}: #{payload.reason}")
+    :handled
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/media_download_failed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/media_download_failed.rb
@@ -7,7 +7,10 @@ class Whatsapp::Session::Inbound::Handlers::MediaDownloadFailed < Whatsapp::Sess
     return :ignored if message.nil?
     return :ignored if message.attachments.any?
 
-    message.update!(is_unsupported: true)
+    # `is_unsupported` lives in the content_attributes JSON, so writing it off the
+    # instance loaded before a revoke landed would rewrite the whole hash and undelete
+    # the message.
+    message.update_under_lock!(is_unsupported: true)
     Rails.logger.warn("[WHATSAPP SESSION] media download failed for #{payload.message_id}: #{payload.reason}")
     :handled
   end

--- a/app/services/whatsapp/session/inbound/handlers/message_edited.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_edited.rb
@@ -15,7 +15,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::I
     # not overwrite the original.
     previous = target.is_edited ? target.previous_content : target.content
     target.update!(content: content, is_edited: true, previous_content: previous)
-    Inbound::ChatList.refresh(target.conversation)
+    inbound::ChatList.refresh(target.conversation)
     :handled
   end
 

--- a/app/services/whatsapp/session/inbound/handlers/message_edited.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_edited.rb
@@ -15,6 +15,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::I
     # not overwrite the original.
     previous = target.is_edited ? target.previous_content : target.content
     target.update!(content: content, is_edited: true, previous_content: previous)
+    Inbound::ChatList.refresh(target.conversation)
     :handled
   end
 

--- a/app/services/whatsapp/session/inbound/handlers/message_edited.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_edited.rb
@@ -7,7 +7,9 @@ class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::I
     return :ignored if target.nil?
 
     content = edited_content
-    return :ignored if content.blank?
+    # nil is a content type this layer cannot render as text; an empty string is a real
+    # edit that removed the caption, and dropping it would leave the old one on screen.
+    return :ignored if content.nil?
 
     # The first edit is what the reader wants to compare against, so a second edit does
     # not overwrite the original.
@@ -20,9 +22,9 @@ class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::I
 
   def edited_content
     case payload.content
-    when Content::Text then payload.content.body
-    when Content::Media then payload.content.caption
-    when Content::Rich then payload.content.preview_text
+    when Content::Text then payload.content.body.to_s
+    when Content::Media then payload.content.caption.to_s
+    when Content::Rich then payload.content.preview_text.to_s
     end
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_edited.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_edited.rb
@@ -1,0 +1,28 @@
+# The contact (or the connected phone) edited a message that is already stored.
+class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::Inbound::Handlers::Base
+  Content = Whatsapp::Session::Model::Content
+
+  def perform
+    target = find_message(payload.message_id)
+    return :ignored if target.nil?
+
+    content = edited_content
+    return :ignored if content.blank?
+
+    # The first edit is what the reader wants to compare against, so a second edit does
+    # not overwrite the original.
+    previous = target.is_edited ? target.previous_content : target.content
+    target.update!(content: content, is_edited: true, previous_content: previous)
+    :handled
+  end
+
+  private
+
+  def edited_content
+    case payload.content
+    when Content::Text then payload.content.body
+    when Content::Media then payload.content.caption
+    when Content::Rich then payload.content.preview_text
+    end
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/message_edited.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_edited.rb
@@ -11,15 +11,26 @@ class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::I
     # edit that removed the caption, and dropping it would leave the old one on screen.
     return :ignored if content.nil?
 
-    # The first edit is what the reader wants to compare against, so a second edit does
-    # not overwrite the original.
-    previous = target.is_edited ? target.previous_content : target.content
-    target.update!(content: content, is_edited: true, previous_content: previous)
+    apply(target, content)
     inbound::ChatList.refresh(target.conversation)
     :handled
   end
 
   private
+
+  # Both the read and the write happen under the row lock: `is_edited` and
+  # `previous_content` live in the content_attributes JSON, so an edit applied off an
+  # instance loaded before a concurrent revoke would serialize the pre-revoke hash and
+  # bring a deleted message back, and the "what did it say before" read has to see the
+  # same row it is about to write.
+  def apply(target, content)
+    target.with_lock do
+      # The first edit is what the reader wants to compare against, so a second edit
+      # does not overwrite the original.
+      previous = target.is_edited ? target.previous_content : target.content
+      target.update!(content: content, is_edited: true, previous_content: previous)
+    end
+  end
 
   def edited_content
     case payload.content

--- a/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
@@ -1,0 +1,74 @@
+# Someone reacted to a message, or took their reaction back.
+class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    return :ignored unless actionable?
+
+    Inbound::Locks.with_chat_lock(inbox, payload.chat.id) do
+      payload.removal? ? remove : add
+    end
+  end
+
+  private
+
+  def actionable?
+    return false if ignorable_chat?(payload.chat)
+    return capability?(:groups) if payload.chat.group?
+
+    true
+  end
+
+  def remove
+    store(sender_contact).remove ? :handled : :ignored
+  end
+
+  def add
+    return :duplicate if find_message(payload.id)
+
+    contact_inbox = resolve_contact_inbox
+    return :ignored if contact_inbox.nil?
+
+    conversation = conversation_for(contact_inbox)
+    return :ignored if conversation.nil?
+
+    store(payload.chat.group? ? sender_contact : contact_inbox.contact).write(conversation)
+    :handled
+  end
+
+  def store(sender)
+    Inbound::ReactionStore.new(inbox: inbox, reaction: payload, sender: sender)
+  end
+
+  # The reaction belongs in the thread holding the message it annotates. Without a
+  # stored target there is nothing to annotate, so the reaction is dropped rather than
+  # opening a thread of its own.
+  def conversation_for(contact_inbox)
+    target = find_message(payload.target_id)
+    return target.conversation if target
+
+    return nil if payload.chat.group?
+
+    Inbound::ConversationFinder.new(inbox: inbox, contact: contact_inbox.contact, contact_inbox: contact_inbox).perform
+  end
+
+  def resolve_contact_inbox
+    return group_result&.group_contact_inbox if payload.chat.group?
+
+    Inbound::ContactResolver.new(inbox: inbox, party: peer_party, overwrite: true).perform
+  end
+
+  def sender_contact
+    return nil if payload.from_me
+
+    payload.chat.group? ? group_result&.sender_contact : resolve_contact_inbox&.contact
+  end
+
+  def group_result
+    @group_result ||= Inbound::GroupResolver.new(inbox: inbox, group: payload.chat, sender: payload.sender).perform
+  end
+
+  def peer_party
+    return payload.sender if !payload.from_me && payload.sender.present?
+
+    Model::Party.from_address(payload.chat)
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
@@ -17,7 +17,12 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
     true
   end
 
+  # Checked before the sender is resolved: resolving creates a Contact, a ContactInbox
+  # and an avatar job, and a removal aimed at a message nobody here reacted to has
+  # nothing to remove. Without this, every stray removal leaves a contact behind.
   def remove
+    return :ignored unless Inbound::ReactionStore.active?(inbox: inbox, target_id: payload.target_id)
+
     store(sender_contact).remove ? :handled : :ignored
   end
 
@@ -26,6 +31,13 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
 
     contact_inbox = resolve_contact_inbox
     return :ignored if contact_inbox.nil?
+
+    # A reaction Chatwoot sent reserves its id like any other message, so a lost send
+    # response makes the echo arrive under an id we never stored. The reservation is
+    # what identifies it; writing again would leave two reactions on the same bubble.
+    return :handled if Inbound::EchoMatcher.new(
+      inbox: inbox, contact: contact_inbox.contact, message_id: payload.id
+    ).perform
 
     conversation = conversation_for(contact_inbox)
     return :ignored if conversation.nil?

--- a/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
@@ -3,7 +3,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
   def perform
     return :ignored unless actionable?
 
-    inbound::Locks.with_chat_lock(inbox, payload.chat.id) do
+    inbound::Locks.with_chat_lock(inbox, chat_lock_ids) do
       payload.removal? ? remove : add
     end
   end
@@ -73,5 +73,13 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
     return payload.sender if !payload.from_me && payload.sender.present?
 
     model::Party.from_address(payload.chat)
+  end
+
+  # Same aliasing as an inbound message: the peer is named by phone in one event and by
+  # LID in the next, and both have to serialize against each other.
+  def chat_lock_ids
+    return [payload.chat.id] if payload.chat.group?
+
+    [payload.chat.id, peer_party&.phone, peer_party&.lid]
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
@@ -18,10 +18,14 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
   end
 
   # Checked before the sender is resolved: resolving creates a Contact, a ContactInbox
-  # and an avatar job, and a removal aimed at a message nobody here reacted to has
-  # nothing to remove. Without this, every stray removal leaves a contact behind.
+  # and an avatar job, and a removal aimed at a reaction this sender never made has
+  # nothing to remove. Without this, every stray removal leaves a contact behind, which
+  # is why the lookup here is the non-creating one.
   def remove
-    return :ignored unless inbound::ReactionStore.active?(inbox: inbox, target_id: payload.target_id)
+    known = payload.from_me ? nil : inbound::ContactLookup.contact(inbox: inbox, party: peer_party)
+    return :ignored if known.nil? && !payload.from_me
+    return :ignored unless inbound::ReactionStore.active?(inbox: inbox, target_id: payload.target_id,
+                                                          sender: known, from_me: payload.from_me)
 
     store(sender_contact).remove ? :handled : :ignored
   end
@@ -80,6 +84,9 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
   def chat_lock_ids
     return [payload.chat.id] if payload.chat.group?
 
-    [payload.chat.id, peer_party&.phone, peer_party&.lid]
+    # Every ninth-digit form as well: WhatsApp reports a Brazilian or Argentinian line
+    # with or without the extra digit, `ContactResolver` files both under one contact,
+    # and two keys differing by that digit would not serialize against each other.
+    [payload.chat.id, peer_party&.lid, *Whatsapp::Session::PhoneMatch.variants(peer_party&.phone)]
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
@@ -3,7 +3,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
   def perform
     return :ignored unless actionable?
 
-    Inbound::Locks.with_chat_lock(inbox, payload.chat.id) do
+    inbound::Locks.with_chat_lock(inbox, payload.chat.id) do
       payload.removal? ? remove : add
     end
   end
@@ -21,7 +21,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
   # and an avatar job, and a removal aimed at a message nobody here reacted to has
   # nothing to remove. Without this, every stray removal leaves a contact behind.
   def remove
-    return :ignored unless Inbound::ReactionStore.active?(inbox: inbox, target_id: payload.target_id)
+    return :ignored unless inbound::ReactionStore.active?(inbox: inbox, target_id: payload.target_id)
 
     store(sender_contact).remove ? :handled : :ignored
   end
@@ -33,7 +33,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
     # response makes the echo arrive under an id we never stored. The reservation is
     # what identifies it, on its own and before any contact is resolved; writing again
     # would leave two reactions on the same bubble.
-    return :handled if Inbound::EchoMatcher.new(inbox: inbox, message_id: payload.id).perform
+    return :handled if inbound::EchoMatcher.new(inbox: inbox, message_id: payload.id).perform
 
     contact_inbox = resolve_contact_inbox
     return :ignored if contact_inbox.nil?
@@ -46,7 +46,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
   end
 
   def store(sender)
-    Inbound::ReactionStore.new(inbox: inbox, reaction: payload, sender: sender)
+    inbound::ReactionStore.new(inbox: inbox, reaction: payload, sender: sender)
   end
 
   # The reaction belongs in the thread holding the message it annotates. Without a
@@ -58,13 +58,13 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
 
     return nil if payload.chat.group?
 
-    Inbound::ConversationFinder.new(inbox: inbox, contact: contact_inbox.contact, contact_inbox: contact_inbox).perform
+    inbound::ConversationFinder.new(inbox: inbox, contact: contact_inbox.contact, contact_inbox: contact_inbox).perform
   end
 
   def resolve_contact_inbox
     return group_result&.group_contact_inbox if payload.chat.group?
 
-    Inbound::ContactResolver.new(inbox: inbox, party: peer_party, overwrite: true).perform
+    inbound::ContactResolver.new(inbox: inbox, party: peer_party, overwrite: true).perform
   end
 
   def sender_contact
@@ -74,12 +74,12 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
   end
 
   def group_result
-    @group_result ||= Inbound::GroupResolver.new(inbox: inbox, group: payload.chat, sender: payload.sender).perform
+    @group_result ||= inbound::GroupResolver.new(inbox: inbox, group: payload.chat, sender: payload.sender).perform
   end
 
   def peer_party
     return payload.sender if !payload.from_me && payload.sender.present?
 
-    Model::Party.from_address(payload.chat)
+    model::Party.from_address(payload.chat)
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
@@ -29,15 +29,14 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
   def add
     return :duplicate if find_message(payload.id)
 
-    contact_inbox = resolve_contact_inbox
-    return :ignored if contact_inbox.nil?
-
     # A reaction Chatwoot sent reserves its id like any other message, so a lost send
     # response makes the echo arrive under an id we never stored. The reservation is
-    # what identifies it; writing again would leave two reactions on the same bubble.
-    return :handled if Inbound::EchoMatcher.new(
-      inbox: inbox, contact: contact_inbox.contact, message_id: payload.id
-    ).perform
+    # what identifies it, on its own and before any contact is resolved; writing again
+    # would leave two reactions on the same bubble.
+    return :handled if Inbound::EchoMatcher.new(inbox: inbox, message_id: payload.id).perform
+
+    contact_inbox = resolve_contact_inbox
+    return :ignored if contact_inbox.nil?
 
     conversation = conversation_for(contact_inbox)
     return :ignored if conversation.nil?

--- a/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
@@ -35,30 +35,22 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
     # would leave two reactions on the same bubble.
     return :handled if inbound::EchoMatcher.new(inbox: inbox, message_id: payload.id).perform
 
+    # The reaction belongs in the thread holding the message it annotates, and that is
+    # checked before anybody is resolved: resolving creates a Contact, a ContactInbox and
+    # an avatar job, and a reaction whose target was never stored has nothing to annotate.
+    # It is dropped rather than opening a thread of its own to hold it.
+    target = find_message(payload.target_id)
+    return :ignored if target.nil?
+
     contact_inbox = resolve_contact_inbox
     return :ignored if contact_inbox.nil?
 
-    conversation = conversation_for(contact_inbox)
-    return :ignored if conversation.nil?
-
-    store(payload.chat.group? ? sender_contact : contact_inbox.contact).write(conversation)
+    store(payload.chat.group? ? sender_contact : contact_inbox.contact).write(target.conversation)
     :handled
   end
 
   def store(sender)
     inbound::ReactionStore.new(inbox: inbox, reaction: payload, sender: sender)
-  end
-
-  # The reaction belongs in the thread holding the message it annotates. Without a
-  # stored target there is nothing to annotate, so the reaction is dropped rather than
-  # opening a thread of its own.
-  def conversation_for(contact_inbox)
-    target = find_message(payload.target_id)
-    return target.conversation if target
-
-    return nil if payload.chat.group?
-
-    inbound::ConversationFinder.new(inbox: inbox, contact: contact_inbox.contact, contact_inbox: contact_inbox).perform
   end
 
   def resolve_contact_inbox

--- a/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
@@ -12,7 +12,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceipt < Whatsapp::Session::
 
   def apply(message)
     seen = mark_conversation_seen(message) if read_on_our_side?(message)
-    changed = Inbound::StatusTransition.apply(message, payload.type, error: payload.error)
+    changed = inbound::StatusTransition.apply(message, payload.type, error: payload.error)
     changed || seen.present?
   end
 

--- a/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
@@ -32,12 +32,19 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceipt < Whatsapp::Session::
   def mark_conversation_seen(message)
     conversation = message.conversation
     seen_at = read_at(message)
-    return false if conversation.agent_last_seen_at.present? && conversation.agent_last_seen_at >= seen_at
 
-    attributes = { agent_last_seen_at: seen_at }
-    attributes[:assignee_last_seen_at] = seen_at if conversation.assignee_id.present?
-    conversation.update_columns(attributes) # rubocop:disable Rails/SkipsModelValidations
-    true
+    # Compared and written under the row lock. Two read receipts for one conversation can
+    # be processed at once, and comparing outside the lock lets both pass against the old
+    # value, after which the older receipt can land last and walk the marker backwards,
+    # making messages that were already seen show up unread again.
+    conversation.with_lock do
+      next false if conversation.agent_last_seen_at.present? && conversation.agent_last_seen_at >= seen_at
+
+      attributes = { agent_last_seen_at: seen_at }
+      attributes[:assignee_last_seen_at] = seen_at if conversation.assignee_id.present?
+      conversation.update_columns(attributes) # rubocop:disable Rails/SkipsModelValidations
+      true
+    end
   end
 
   # The receipt's own time when the provider reports one, otherwise the message it names:

--- a/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
@@ -1,0 +1,27 @@
+# Delivery receipts for messages this session sent, and read marks the contact made.
+class Whatsapp::Session::Inbound::Handlers::MessageReceipt < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    messages = Array(payload.message_ids).filter_map { |id| find_message(id) }
+    return :ignored if messages.empty?
+
+    updated = messages.count { |message| apply(message) }
+    updated.positive? ? :handled : :ignored
+  end
+
+  private
+
+  def apply(message)
+    changed = Inbound::StatusTransition.apply(message, payload.type, error: payload.error)
+    mark_conversation_seen(message) if changed && payload.type == 'read'
+    changed
+  end
+
+  # The contact read what the agent sent, so the unread badge on the agent's side has
+  # nothing left to report.
+  def mark_conversation_seen(message)
+    conversation = message.conversation
+    attributes = { agent_last_seen_at: Time.current }
+    attributes[:assignee_last_seen_at] = Time.current if conversation.assignee_id.present?
+    conversation.update_columns(attributes) # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
@@ -11,17 +11,26 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceipt < Whatsapp::Session::
   private
 
   def apply(message)
+    seen = mark_conversation_seen(message) if read_on_our_side?(message)
     changed = Inbound::StatusTransition.apply(message, payload.type, error: payload.error)
-    mark_conversation_seen(message) if changed && payload.type == 'read'
-    changed
+    changed || seen.present?
   end
 
-  # The contact read what the agent sent, so the unread badge on the agent's side has
-  # nothing left to report.
+  # A read receipt for an *incoming* message is one of this account's own devices
+  # marking the chat read, so somebody here saw it. A read receipt for an outgoing
+  # message is the contact reading us, which says nothing about what we have seen:
+  # counting it would clear the unread badge for incoming messages nobody here opened.
+  def read_on_our_side?(message)
+    payload.type == 'read' && message.incoming?
+  end
+
+  # Independent of whether the status moved: a chat marked read twice is still read, and
+  # the seen timestamps have to follow the second mark as well.
   def mark_conversation_seen(message)
     conversation = message.conversation
     attributes = { agent_last_seen_at: Time.current }
     attributes[:assignee_last_seen_at] = Time.current if conversation.assignee_id.present?
     conversation.update_columns(attributes) # rubocop:disable Rails/SkipsModelValidations
+    true
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
@@ -24,13 +24,27 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceipt < Whatsapp::Session::
     payload.type == 'read' && message.incoming?
   end
 
-  # Independent of whether the status moved: a chat marked read twice is still read, and
-  # the seen timestamps have to follow the second mark as well.
+  # The receipt says the chat was read *at that moment*, not now. Unread counts compare
+  # a message's creation time against these markers, so stamping `Time.current` marks
+  # every incoming message that arrived since as seen too: a read receipt delivered late,
+  # or an HTTP event job running out of order, would clear the badge for messages nobody
+  # here has opened. The markers only ever move forward.
   def mark_conversation_seen(message)
     conversation = message.conversation
-    attributes = { agent_last_seen_at: Time.current }
-    attributes[:assignee_last_seen_at] = Time.current if conversation.assignee_id.present?
+    seen_at = read_at(message)
+    return false if conversation.agent_last_seen_at.present? && conversation.agent_last_seen_at >= seen_at
+
+    attributes = { agent_last_seen_at: seen_at }
+    attributes[:assignee_last_seen_at] = seen_at if conversation.assignee_id.present?
     conversation.update_columns(attributes) # rubocop:disable Rails/SkipsModelValidations
     true
+  end
+
+  # The receipt's own time when the provider reports one, otherwise the message it names:
+  # reading a message cannot have happened before that message existed.
+  def read_at(message)
+    return Time.zone.at(payload.timestamp / 1000) if payload.timestamp.present?
+
+    message.created_at
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
@@ -1,7 +1,7 @@
 # Delivery receipts for messages this session sent, and read marks the contact made.
 class Whatsapp::Session::Inbound::Handlers::MessageReceipt < Whatsapp::Session::Inbound::Handlers::Base
   def perform
-    messages = Array(payload.message_ids).filter_map { |id| find_message(id) }
+    messages = Array(payload.message_ids).flat_map { |id| find_messages(id).to_a }
     return :ignored if messages.empty?
 
     updated = messages.count { |message| apply(message) }

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -7,7 +7,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
     inbound::Locks.with_message_lock(inbox, message.id) do
       next :duplicate if find_message(message.id)
 
-      inbound::Locks.with_chat_lock(inbox, message.chat.id) do
+      inbound::Locks.with_chat_lock(inbox, chat_lock_ids) do
         # Re-checked under the chat lock: an agent's send can be slow enough for the
         # echo to arrive before its source_id is stored.
         next :duplicate if find_message(message.id)
@@ -70,6 +70,16 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
     return false if message.incoming?
 
     inbound::EchoMatcher.new(inbox: inbox, message_id: message.id, client_ref: message.client_ref).perform.present?
+  end
+
+  # Every id this chat can be addressed by. WhatsApp names the same 1:1 peer by phone in
+  # one event and by LID in the next, and both resolve to one contact: locking only the
+  # id this event carries lets a worker holding the other alias run alongside, and each
+  # opens a conversation of its own.
+  def chat_lock_ids
+    return [message.chat.id] if message.group?
+
+    [message.chat.id, peer_party&.phone, peer_party&.lid]
   end
 
   # In a 1:1 chat the other side is the chat itself; `sender` is the author, which is

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -4,10 +4,10 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   def perform
     return :ignored unless actionable?
 
-    Inbound::Locks.with_message_lock(inbox, message.id) do
+    inbound::Locks.with_message_lock(inbox, message.id) do
       next :duplicate if find_message(message.id)
 
-      Inbound::Locks.with_chat_lock(inbox, message.chat.id) do
+      inbound::Locks.with_chat_lock(inbox, message.chat.id) do
         # Re-checked under the chat lock: an agent's send can be slow enough for the
         # echo to arrive before its source_id is stored.
         next :duplicate if find_message(message.id)
@@ -36,13 +36,13 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   end
 
   def handle_individual
-    contact_inbox = Inbound::ContactResolver.new(inbox: inbox, party: peer_party, overwrite: true).perform
+    contact_inbox = inbound::ContactResolver.new(inbox: inbox, party: peer_party, overwrite: true).perform
     return :ignored if contact_inbox.nil?
 
     contact = contact_inbox.contact
     return :ignored if silenced?(contact)
 
-    conversation = Inbound::ConversationFinder.new(
+    conversation = inbound::ConversationFinder.new(
       inbox: inbox, contact: contact, contact_inbox: contact_inbox, attribution: attribution
     ).perform
 
@@ -52,7 +52,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   end
 
   def handle_group
-    resolver = Inbound::GroupResolver.new(inbox: inbox, group: message.chat, sender: message.sender)
+    resolver = inbound::GroupResolver.new(inbox: inbox, group: message.chat, sender: message.sender)
     group = resolver.perform
 
     write(resolver.conversation_for(group.group_contact_inbox), group.sender_contact)
@@ -60,7 +60,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   end
 
   def write(conversation, sender)
-    Inbound::MessageWriter.new(conversation: conversation, inbound: message, sender: sender).perform
+    inbound::MessageWriter.new(conversation: conversation, inbound: message, sender: sender).perform
   end
 
   # Only what the connected phone sent can be the echo of one of our own sends, and
@@ -69,7 +69,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   def echo_matched?
     return false if message.incoming?
 
-    Inbound::EchoMatcher.new(inbox: inbox, message_id: message.id, client_ref: message.client_ref).perform.present?
+    inbound::EchoMatcher.new(inbox: inbox, message_id: message.id, client_ref: message.client_ref).perform.present?
   end
 
   # In a 1:1 chat the other side is the chat itself; `sender` is the author, which is
@@ -78,7 +78,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   def peer_party
     return message.sender if message.incoming? && message.sender.present?
 
-    Model::Party.from_address(message.chat)
+    model::Party.from_address(message.chat)
   end
 
   # The same rule the Cloud path applies (`IncomingMessageBaseService#contact_processable?`):

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -38,7 +38,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
     # The echo of a message Chatwoot sent under a reserved id is already stored;
     # matching it before a conversation is picked keeps it from reopening (or opening)
     # a thread just to hold a message that is already there.
-    return :handled if Inbound::EchoMatcher.new(inbox: inbox, contact: contact, message_id: message.id).perform
+    return :handled if echo_matched?(contact)
 
     conversation = Inbound::ConversationFinder.new(
       inbox: inbox, contact: contact, contact_inbox: contact_inbox, attribution: attribution
@@ -52,7 +52,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   def handle_group
     resolver = Inbound::GroupResolver.new(inbox: inbox, group: message.chat, sender: message.sender)
     group = resolver.perform
-    return :handled if Inbound::EchoMatcher.new(inbox: inbox, contact: group.group_contact, message_id: message.id).perform
+    return :handled if echo_matched?(group.group_contact)
 
     write(resolver.conversation_for(group.group_contact_inbox), group.sender_contact)
     :handled
@@ -60,6 +60,12 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
 
   def write(conversation, sender)
     Inbound::MessageWriter.new(conversation: conversation, inbound: message, sender: sender).perform
+  end
+
+  def echo_matched?(contact)
+    Inbound::EchoMatcher.new(
+      inbox: inbox, contact: contact, message_id: message.id, client_ref: message.client_ref
+    ).perform
   end
 
   # In a 1:1 chat the other side is the chat itself; `sender` is the author, which is

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -1,0 +1,85 @@
+# A message arrived on the session: from the contact, or from the connected phone (the
+# echo of something an agent typed there, or of what Chatwoot itself sent).
+class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    return :ignored unless actionable?
+
+    Inbound::Locks.with_message_lock(inbox, message.id) do
+      next :duplicate if find_message(message.id)
+
+      Inbound::Locks.with_chat_lock(inbox, message.chat.id) do
+        # Re-checked under the chat lock: an agent's send can be slow enough for the
+        # echo to arrive before its source_id is stored.
+        next :duplicate if find_message(message.id)
+
+        message.group? ? handle_group : handle_individual
+      end
+    end
+  end
+
+  private
+
+  def message = payload.message
+
+  def actionable?
+    return false if message.blank? || ignorable_chat?(message.chat)
+    return capability?(:groups) if message.group?
+
+    true
+  end
+
+  def handle_individual
+    contact_inbox = Inbound::ContactResolver.new(inbox: inbox, party: peer_party, overwrite: true).perform
+    return :ignored if contact_inbox.nil?
+
+    contact = contact_inbox.contact
+    # The echo of a message Chatwoot sent under a reserved id is already stored;
+    # matching it before a conversation is picked keeps it from reopening (or opening)
+    # a thread just to hold a message that is already there.
+    return :handled if Inbound::EchoMatcher.new(inbox: inbox, contact: contact, message_id: message.id).perform
+
+    conversation = Inbound::ConversationFinder.new(
+      inbox: inbox, contact: contact, contact_inbox: contact_inbox, attribution: attribution
+    ).perform
+
+    write(conversation, contact)
+    dispatch_typing_off(conversation, contact)
+    :handled
+  end
+
+  def handle_group
+    resolver = Inbound::GroupResolver.new(inbox: inbox, group: message.chat, sender: message.sender)
+    group = resolver.perform
+    return :handled if Inbound::EchoMatcher.new(inbox: inbox, contact: group.group_contact, message_id: message.id).perform
+
+    write(resolver.conversation_for(group.group_contact_inbox), group.sender_contact)
+    :handled
+  end
+
+  def write(conversation, sender)
+    Inbound::MessageWriter.new(conversation: conversation, inbound: message, sender: sender).perform
+  end
+
+  # In a 1:1 chat the other side is the chat itself; `sender` is the author, which is
+  # the session owner on an echo and therefore not who the conversation belongs to.
+  # An incoming message carries the richer Party (phone and LID together), so it wins.
+  def peer_party
+    return message.sender if message.incoming? && message.sender.present?
+
+    Model::Party.from_address(message.chat)
+  end
+
+  def attribution
+    { 'referral' => message.referral, 'entry_point' => message.entry_point }.compact
+  end
+
+  # The contact stopped typing by definition once the message landed.
+  def dispatch_typing_off(conversation, contact)
+    return unless message.incoming?
+
+    Rails.configuration.dispatcher.dispatch(
+      Events::Types::CONVERSATION_TYPING_OFF, Time.zone.now,
+      conversation: conversation, user: contact, is_private: false
+    )
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -79,7 +79,10 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   def chat_lock_ids
     return [message.chat.id] if message.group?
 
-    [message.chat.id, peer_party&.phone, peer_party&.lid]
+    # Every ninth-digit form as well: WhatsApp reports a Brazilian or Argentinian line
+    # with or without the extra digit, `ContactResolver` files both under one contact,
+    # and two keys differing by that digit would not serialize against each other.
+    [message.chat.id, peer_party&.lid, *Whatsapp::Session::PhoneMatch.variants(peer_party&.phone)]
   end
 
   # In a 1:1 chat the other side is the chat itself; `sender` is the author, which is

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -12,6 +12,13 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
         # echo to arrive before its source_id is stored.
         next :duplicate if find_message(message.id)
 
+        # The echo of a message Chatwoot sent under a reserved id is already stored, and
+        # it is matched before anything is resolved: the echo may address the chat by a
+        # LID the peer has no contact under yet, and resolving that first would file the
+        # person a second time and then look for the reservation on the wrong contact,
+        # storing the echo again in a conversation of its own.
+        next :handled if echo_matched?
+
         message.group? ? handle_group : handle_individual
       end
     end
@@ -35,11 +42,6 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
     contact = contact_inbox.contact
     return :ignored if silenced?(contact)
 
-    # The echo of a message Chatwoot sent under a reserved id is already stored;
-    # matching it before a conversation is picked keeps it from reopening (or opening)
-    # a thread just to hold a message that is already there.
-    return :handled if echo_matched?(contact)
-
     conversation = Inbound::ConversationFinder.new(
       inbox: inbox, contact: contact, contact_inbox: contact_inbox, attribution: attribution
     ).perform
@@ -52,7 +54,6 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   def handle_group
     resolver = Inbound::GroupResolver.new(inbox: inbox, group: message.chat, sender: message.sender)
     group = resolver.perform
-    return :handled if echo_matched?(group.group_contact)
 
     write(resolver.conversation_for(group.group_contact_inbox), group.sender_contact)
     :handled
@@ -62,10 +63,13 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
     Inbound::MessageWriter.new(conversation: conversation, inbound: message, sender: sender).perform
   end
 
-  def echo_matched?(contact)
-    Inbound::EchoMatcher.new(
-      inbox: inbox, contact: contact, message_id: message.id, client_ref: message.client_ref
-    ).perform
+  # Only what the connected phone sent can be the echo of one of our own sends, and
+  # skipping the query for everything else keeps it off the path every inbound message
+  # takes.
+  def echo_matched?
+    return false if message.incoming?
+
+    Inbound::EchoMatcher.new(inbox: inbox, message_id: message.id, client_ref: message.client_ref).perform.present?
   end
 
   # In a 1:1 chat the other side is the chat itself; `sender` is the author, which is

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -33,6 +33,8 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
     return :ignored if contact_inbox.nil?
 
     contact = contact_inbox.contact
+    return :ignored if silenced?(contact)
+
     # The echo of a message Chatwoot sent under a reserved id is already stored;
     # matching it before a conversation is picked keeps it from reopening (or opening)
     # a thread just to hold a message that is already there.
@@ -67,6 +69,14 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
     return message.sender if message.incoming? && message.sender.present?
 
     Model::Party.from_address(message.chat)
+  end
+
+  # The same rule the Cloud path applies (`IncomingMessageBaseService#contact_processable?`):
+  # a blocked contact stops generating messages and notifications, but the echo of a
+  # reply typed on the connected phone is still stored, or the agent's own answer would
+  # go missing from the thread.
+  def silenced?(contact)
+    contact.blocked? && message.incoming?
   end
 
   def attribution

--- a/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
@@ -24,6 +24,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::
     attributes = { 'deleted' => true, 'pending_source_id' => target.pending_source_id }.compact
     target.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: attributes)
     target.attachments.destroy_all
+    Inbound::ChatList.refresh(target.conversation)
     :handled
   end
 
@@ -33,6 +34,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::
     return :ignored if target.deleted_by_contact
 
     target.update!(deleted_by_contact: true)
+    Inbound::ChatList.refresh(target.conversation)
     :handled
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
@@ -14,11 +14,16 @@ class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::
   private
 
   # Deleted from the connected phone: same outcome as deleting it from Chatwoot, which
-  # is also what the echo of a Chatwoot deletion looks like (hence the guard).
+  # is also what the echo of a Chatwoot deletion looks like (hence the guard). Same
+  # outcome means the same as the messages controller produces, attachments included:
+  # leaving the files behind would keep the deleted media readable through the API and
+  # in storage. The reserved id survives, so a send still in flight stays matchable.
   def revoke_by_self(target)
     return :ignored if target.deleted?
 
-    target.update!(content: '', content_attributes: target.content_attributes.merge('deleted' => true))
+    attributes = { 'deleted' => true, 'pending_source_id' => target.pending_source_id }.compact
+    target.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: attributes)
+    target.attachments.destroy_all
     :handled
   end
 

--- a/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
@@ -5,10 +5,14 @@
 # rare and accepted; persisting pending revokes would need its own state.
 class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::Inbound::Handlers::Base
   def perform
-    target = find_message(payload.message_id)
-    return :ignored if target.nil?
+    targets = find_messages(payload.message_id).to_a
+    return :ignored if targets.empty?
 
-    payload.by_self? ? revoke_by_self(target) : revoke_by_contact(target)
+    results = targets.map { |target| payload.by_self? ? revoke_by_self(target) : revoke_by_contact(target) }
+    return :ignored unless results.include?(:handled)
+
+    Inbound::ChatList.refresh(targets.first.conversation)
+    :handled
   end
 
   private
@@ -24,7 +28,6 @@ class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::
     attributes = { 'deleted' => true, 'pending_source_id' => target.pending_source_id }.compact
     target.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: attributes)
     target.attachments.destroy_all
-    Inbound::ChatList.refresh(target.conversation)
     :handled
   end
 
@@ -34,7 +37,6 @@ class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::
     return :ignored if target.deleted_by_contact
 
     target.update!(deleted_by_contact: true)
-    Inbound::ChatList.refresh(target.conversation)
     :handled
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
@@ -1,0 +1,33 @@
+# A message was deleted for everyone: by the contact, or from the connected phone.
+#
+# If the revoke somehow arrives before the message it points at, this is a no-op and
+# the message is later stored without the flag. WhatsApp delivers in order, so that is
+# rare and accepted; persisting pending revokes would need its own state.
+class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    target = find_message(payload.message_id)
+    return :ignored if target.nil?
+
+    payload.by_self? ? revoke_by_self(target) : revoke_by_contact(target)
+  end
+
+  private
+
+  # Deleted from the connected phone: same outcome as deleting it from Chatwoot, which
+  # is also what the echo of a Chatwoot deletion looks like (hence the guard).
+  def revoke_by_self(target)
+    return :ignored if target.deleted?
+
+    target.update!(content: '', content_attributes: target.content_attributes.merge('deleted' => true))
+    :handled
+  end
+
+  # The contact deleted it: keep the stored content and only flag it, so the agent can
+  # still read what was said while the UI marks it as deleted.
+  def revoke_by_contact(target)
+    return :ignored if target.deleted_by_contact
+
+    target.update!(deleted_by_contact: true)
+    :handled
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
@@ -25,10 +25,18 @@ class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::
   def revoke_by_self(target)
     return :ignored if target.deleted?
 
-    attributes = { 'deleted' => true, 'pending_source_id' => target.pending_source_id }.compact
-    target.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text, content_attributes: attributes)
-    target.attachments.destroy_all
-    :handled
+    # Under the row lock: the reserved id is read out of the hash that is about to be
+    # replaced, so an echo confirming a send in between would otherwise be thrown away
+    # and the message could never be taken off the contact's phone.
+    target.with_lock do
+      next :ignored if target.deleted?
+
+      attributes = { 'deleted' => true, 'pending_source_id' => target.pending_source_id }.compact
+      target.update!(content: I18n.t('conversations.messages.deleted'), content_type: :text,
+                     content_attributes: attributes)
+      target.attachments.destroy_all
+      :handled
+    end
   end
 
   # The contact deleted it: keep the stored content and only flag it, so the agent can
@@ -36,7 +44,9 @@ class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::
   def revoke_by_contact(target)
     return :ignored if target.deleted_by_contact
 
-    target.update!(deleted_by_contact: true)
+    # `deleted_by_contact` lives in the content_attributes JSON, so writing it off a
+    # stale instance rewrites the whole hash.
+    target.update_under_lock!(deleted_by_contact: true)
     :handled
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
@@ -11,7 +11,7 @@ class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::
     results = targets.map { |target| payload.by_self? ? revoke_by_self(target) : revoke_by_contact(target) }
     return :ignored unless results.include?(:handled)
 
-    Inbound::ChatList.refresh(targets.first.conversation)
+    inbound::ChatList.refresh(targets.first.conversation)
     :handled
   end
 

--- a/app/services/whatsapp/session/inbound/handlers/presence.rb
+++ b/app/services/whatsapp/session/inbound/handlers/presence.rb
@@ -28,7 +28,7 @@ class Whatsapp::Session::Inbound::Handlers::Presence < Whatsapp::Session::Inboun
 
   private
 
-  def chat_presence? = payload.is_a?(Model::Events::ChatPresence)
+  def chat_presence? = payload.is_a?(model::Events::ChatPresence)
 
   def subscribed?
     channel.provider_config&.dig('presence_subscribe').present?
@@ -50,7 +50,7 @@ class Whatsapp::Session::Inbound::Handlers::Presence < Whatsapp::Session::Inboun
   # The party is addressed by LID in one event and by phone in the next, and only one
   # of them may have a contact_inbox yet.
   def find_contact_inbox
-    party = chat_presence? ? (payload.sender || Model::Party.from_address(payload.chat)) : payload.party
-    Inbound::ContactLookup.find(inbox: inbox, party: party)
+    party = chat_presence? ? (payload.sender || model::Party.from_address(payload.chat)) : payload.party
+    inbound::ContactLookup.find(inbox: inbox, party: party)
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/presence.rb
+++ b/app/services/whatsapp/session/inbound/handlers/presence.rb
@@ -57,10 +57,14 @@ class Whatsapp::Session::Inbound::Handlers::Presence < Whatsapp::Session::Inboun
     contact_inbox || find_by_phone(party)
   end
 
+  # Every ninth-digit form, for the same reason the contact and picture resolvers try
+  # them: the event carries whichever form WhatsApp uses and the contact is stored under
+  # whichever one reached us first. An exact match drops the typing indicator silently.
   def find_by_phone(party)
-    return if party.phone.blank?
+    numbers = Whatsapp::Session::PhoneMatch.variants(party.phone).map { |variant| "+#{variant}" }
+    return if numbers.empty?
 
-    contact = inbox.contacts.find_by(phone_number: party.phone_e164)
+    contact = inbox.contacts.find_by(phone_number: numbers)
     inbox.contact_inboxes.find_by(contact_id: contact.id) if contact
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/presence.rb
+++ b/app/services/whatsapp/session/inbound/handlers/presence.rb
@@ -51,20 +51,6 @@ class Whatsapp::Session::Inbound::Handlers::Presence < Whatsapp::Session::Inboun
   # of them may have a contact_inbox yet.
   def find_contact_inbox
     party = chat_presence? ? (payload.sender || Model::Party.from_address(payload.chat)) : payload.party
-    return if party.blank?
-
-    contact_inbox = inbox.contact_inboxes.find_by(source_id: [party.lid, party.phone].compact)
-    contact_inbox || find_by_phone(party)
-  end
-
-  # Every ninth-digit form, for the same reason the contact and picture resolvers try
-  # them: the event carries whichever form WhatsApp uses and the contact is stored under
-  # whichever one reached us first. An exact match drops the typing indicator silently.
-  def find_by_phone(party)
-    numbers = Whatsapp::Session::PhoneMatch.variants(party.phone).map { |variant| "+#{variant}" }
-    return if numbers.empty?
-
-    contact = inbox.contacts.find_by(phone_number: numbers)
-    inbox.contact_inboxes.find_by(contact_id: contact.id) if contact
+    Inbound::ContactLookup.find(inbox: inbox, party: party)
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/presence.rb
+++ b/app/services/whatsapp/session/inbound/handlers/presence.rb
@@ -1,0 +1,66 @@
+# Typing and recording indicators, and the online/offline signal that turns them off.
+#
+# Both are gated by `presence_subscribe`: subscribing to a contact's presence is what
+# makes WhatsApp send these at all, and an operator who did not opt in should not have
+# the dashboard reacting to them either.
+class Whatsapp::Session::Inbound::Handlers::Presence < Whatsapp::Session::Inbound::Handlers::Base
+  include Events::Types
+
+  STATES = {
+    'composing' => CONVERSATION_TYPING_ON,
+    'recording' => CONVERSATION_RECORDING,
+    'paused' => CONVERSATION_TYPING_OFF,
+    'available' => CONVERSATION_TYPING_OFF,
+    'unavailable' => CONVERSATION_TYPING_OFF
+  }.freeze
+
+  def perform
+    return :ignored unless subscribed?
+
+    event_name = STATES[payload.state]
+    return :ignored if event_name.blank?
+    return :ignored if chat_presence? && ignorable_chat?(payload.chat)
+    # A group types on behalf of one participant; Chatwoot's indicator is per contact.
+    return :ignored if chat_presence? && payload.chat.group?
+
+    dispatch(event_name)
+  end
+
+  private
+
+  def chat_presence? = payload.is_a?(Model::Events::ChatPresence)
+
+  def subscribed?
+    channel.provider_config&.dig('presence_subscribe').present?
+  end
+
+  def dispatch(event_name)
+    contact_inbox = find_contact_inbox
+    return :ignored if contact_inbox.nil?
+
+    conversation = inbox.conversations.where(contact_id: contact_inbox.contact_id).where.not(status: :resolved).last
+    return :ignored if conversation.nil?
+
+    Rails.configuration.dispatcher.dispatch(
+      event_name, Time.zone.now, conversation: conversation, user: contact_inbox.contact, is_private: false
+    )
+    :handled
+  end
+
+  # The party is addressed by LID in one event and by phone in the next, and only one
+  # of them may have a contact_inbox yet.
+  def find_contact_inbox
+    party = chat_presence? ? (payload.sender || Model::Party.from_address(payload.chat)) : payload.party
+    return if party.blank?
+
+    contact_inbox = inbox.contact_inboxes.find_by(source_id: [party.lid, party.phone].compact)
+    contact_inbox || find_by_phone(party)
+  end
+
+  def find_by_phone(party)
+    return if party.phone.blank?
+
+    contact = inbox.contacts.find_by(phone_number: party.phone_e164)
+    inbox.contact_inboxes.find_by(contact_id: contact.id) if contact
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/raw.rb
+++ b/app/services/whatsapp/session/inbound/handlers/raw.rb
@@ -1,0 +1,11 @@
+# A provider event with no canonical meaning. It is not stored; it only reaches the
+# webhooks that subscribe to raw provider traffic.
+class Whatsapp::Session::Inbound::Handlers::Raw < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    Rails.configuration.dispatcher.dispatch(
+      Events::Types::PROVIDER_EVENT_RECEIVED, Time.zone.now,
+      inbox: inbox, event: payload.provider_event, payload: payload.data
+    )
+    :handled
+  end
+end

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -45,22 +45,31 @@ module Whatsapp::Session::Inbound::Locks
   # Serializes everything that resolves a contact or picks a conversation for one chat,
   # so two messages of the same chat cannot each create their own conversation.
   #
-  # Released by token, not by key. `Redis::LockManager#unlock` deletes unconditionally,
-  # so an operation that outran the TTL (syncing a large group roster is the realistic
-  # one) would delete the lock a second worker had already taken, and from there the two
-  # interleave their conversation, membership and activity writes.
-  def with_chat_lock(inbox, chat)
-    return yield if chat.blank?
+  # Takes every id the chat can be addressed by, because WhatsApp names the same 1:1 peer
+  # by phone in one event and by LID in the next: locking only the one an event happens
+  # to carry lets two workers each find no conversation and open one. The ids are locked
+  # in a fixed order, so two workers holding different aliases cannot deadlock, and each
+  # is released by token: `Redis::LockManager#unlock` deletes unconditionally, so an
+  # operation that outran the TTL (syncing a large group roster is the realistic one)
+  # would delete a lock a second worker had already taken.
+  def with_chat_lock(inbox, *chats)
+    keys = chats.flatten.compact_blank.uniq.sort.map { |chat| chat_key(inbox, chat) }
+    return yield if keys.empty?
 
-    key = chat_key(inbox, chat)
-    token = SecureRandom.uuid
-    raise Busy, "chat #{chat} of inbox #{inbox.id} is locked" unless Redis::Alfred.set(key, token, nx: true, ex: CHAT_LOCK_TTL)
-
+    held = {}
     begin
+      keys.each { |key| held[key] = claim(key, inbox) }
       yield
     ensure
-      Redis::Alfred.delete_if_equals(key, token)
+      held.each { |key, token| Redis::Alfred.delete_if_equals(key, token) }
     end
+  end
+
+  def claim(key, inbox)
+    token = SecureRandom.uuid
+    raise Busy, "#{key} of inbox #{inbox.id} is locked" unless Redis::Alfred.set(key, token, nx: true, ex: CHAT_LOCK_TTL)
+
+    token
   end
 
   def processing?(inbox, message_id)

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -10,19 +10,26 @@ module Whatsapp::Session::Inbound::Locks
   class Busy < StandardError; end
 
   CHAT_LOCK_TTL = 30.seconds
-  MESSAGE_LOCK_TTL = 1.day
+  # Long enough to cover one processing pass, short enough that a marker orphaned by a
+  # killed worker heals on its own within the job's retry budget.
+  MESSAGE_LOCK_TTL = 30.seconds
 
   module_function
 
-  # Marks a provider message id as being processed. A redelivery of the same id while
-  # the first pass is still running answers :duplicate instead of writing a second row.
-  # The marker is released at the end: what makes a *finished* message a duplicate is
-  # its stored source_id, not this key.
+  # Marks a provider message id as being processed, so a redelivery arriving while the
+  # first pass is still running retries instead of racing it into a second row.
+  #
+  # Holding the marker answers `Busy`, never :duplicate. What makes a *finished* message
+  # a duplicate is its stored source_id, and the caller checks that inside; a worker
+  # killed between taking the marker and writing the row would otherwise have its own
+  # retry answered ":duplicate", which acknowledges the event and loses the message.
   def with_message_lock(inbox, message_id)
     return yield if message_id.blank?
 
     key = message_key(inbox, message_id)
-    return :duplicate unless Redis::Alfred.set(key, true, nx: true, ex: MESSAGE_LOCK_TTL)
+    unless Redis::Alfred.set(key, true, nx: true, ex: MESSAGE_LOCK_TTL)
+      raise Busy, "message #{message_id} of inbox #{inbox.id} is already being processed"
+    end
 
     begin
       yield

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -40,17 +40,22 @@ module Whatsapp::Session::Inbound::Locks
 
   # Serializes everything that resolves a contact or picks a conversation for one chat,
   # so two messages of the same chat cannot each create their own conversation.
+  #
+  # Released by token, not by key. `Redis::LockManager#unlock` deletes unconditionally,
+  # so an operation that outran the TTL (syncing a large group roster is the realistic
+  # one) would delete the lock a second worker had already taken, and from there the two
+  # interleave their conversation, membership and activity writes.
   def with_chat_lock(inbox, chat)
     return yield if chat.blank?
 
     key = chat_key(inbox, chat)
-    lock_manager = Redis::LockManager.new
-    raise Busy, "chat #{chat} of inbox #{inbox.id} is locked" unless lock_manager.lock(key, CHAT_LOCK_TTL)
+    token = SecureRandom.uuid
+    raise Busy, "chat #{chat} of inbox #{inbox.id} is locked" unless Redis::Alfred.set(key, token, nx: true, ex: CHAT_LOCK_TTL)
 
     begin
       yield
     ensure
-      lock_manager.unlock(key)
+      Redis::Alfred.delete_if_equals(key, token)
     end
   end
 

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -27,14 +27,18 @@ module Whatsapp::Session::Inbound::Locks
     return yield if message_id.blank?
 
     key = message_key(inbox, message_id)
-    unless Redis::Alfred.set(key, true, nx: true, ex: MESSAGE_LOCK_TTL)
+    token = SecureRandom.uuid
+    unless Redis::Alfred.set(key, token, nx: true, ex: MESSAGE_LOCK_TTL)
       raise Busy, "message #{message_id} of inbox #{inbox.id} is already being processed"
     end
 
     begin
       yield
     ensure
-      Redis::Alfred.delete(key)
+      # By token, for the same reason the chat lock is: a pass that outran the TTL would
+      # otherwise delete the marker a redelivery had already taken, and a third delivery
+      # could then run alongside it and write a second row.
+      Redis::Alfred.delete_if_equals(key, token)
     end
   end
 

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -1,0 +1,61 @@
+# The two guards the inbound path needs, in one place.
+#
+# The `native` backend already delivers a session's events in order on a single
+# consumer thread, so nothing there can race. Uazapi arrives as HTTP webhooks fanned
+# out over Sidekiq, where two messages of the same chat can land at once, so both
+# guards have to hold for the family as a whole.
+module Whatsapp::Session::Inbound::Locks
+  # Raised when another worker holds the chat: the caller retries the job instead of
+  # spinning, so a Sidekiq thread is never parked waiting on Redis.
+  class Busy < StandardError; end
+
+  CHAT_LOCK_TTL = 30.seconds
+  MESSAGE_LOCK_TTL = 1.day
+
+  module_function
+
+  # Marks a provider message id as being processed. A redelivery of the same id while
+  # the first pass is still running answers :duplicate instead of writing a second row.
+  # The marker is released at the end: what makes a *finished* message a duplicate is
+  # its stored source_id, not this key.
+  def with_message_lock(inbox, message_id)
+    return yield if message_id.blank?
+
+    key = message_key(inbox, message_id)
+    return :duplicate unless Redis::Alfred.set(key, true, nx: true, ex: MESSAGE_LOCK_TTL)
+
+    begin
+      yield
+    ensure
+      Redis::Alfred.delete(key)
+    end
+  end
+
+  # Serializes everything that resolves a contact or picks a conversation for one chat,
+  # so two messages of the same chat cannot each create their own conversation.
+  def with_chat_lock(inbox, chat)
+    return yield if chat.blank?
+
+    key = chat_key(inbox, chat)
+    lock_manager = Redis::LockManager.new
+    raise Busy, "chat #{chat} of inbox #{inbox.id} is locked" unless lock_manager.lock(key, CHAT_LOCK_TTL)
+
+    begin
+      yield
+    ensure
+      lock_manager.unlock(key)
+    end
+  end
+
+  def processing?(inbox, message_id)
+    Redis::Alfred.get(message_key(inbox, message_id)).present?
+  end
+
+  def message_key(inbox, message_id)
+    format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: "#{inbox.id}_#{message_id}")
+  end
+
+  def chat_key(inbox, chat)
+    "WHATSAPP::CONTACT_LOCK::#{inbox.id}_#{chat}"
+  end
+end

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -10,6 +10,12 @@ module Whatsapp::Session::Inbound::Locks
   class Busy < StandardError; end
 
   CHAT_LOCK_TTL = 30.seconds
+  # Reading a group's whole roster is the one guarded operation that can run for minutes:
+  # each participant is resolved, and a large group has hundreds. A lease that expires
+  # mid-way is not a lock at all, because a second worker takes the key and the two
+  # interleave their membership writes, and releasing by token only stops the first from
+  # deleting the second's lease.
+  GROUP_SYNC_LOCK_TTL = 2.minutes
   # Long enough to cover one processing pass, short enough that a marker orphaned by a
   # killed worker heals on its own within the job's retry budget.
   MESSAGE_LOCK_TTL = 30.seconds
@@ -52,22 +58,22 @@ module Whatsapp::Session::Inbound::Locks
   # is released by token: `Redis::LockManager#unlock` deletes unconditionally, so an
   # operation that outran the TTL (syncing a large group roster is the realistic one)
   # would delete a lock a second worker had already taken.
-  def with_chat_lock(inbox, *chats)
+  def with_chat_lock(inbox, *chats, ttl: CHAT_LOCK_TTL)
     keys = chats.flatten.compact_blank.uniq.sort.map { |chat| chat_key(inbox, chat) }
     return yield if keys.empty?
 
     held = {}
     begin
-      keys.each { |key| held[key] = claim(key, inbox) }
+      keys.each { |key| held[key] = claim(key, inbox, ttl) }
       yield
     ensure
       held.each { |key, token| Redis::Alfred.delete_if_equals(key, token) }
     end
   end
 
-  def claim(key, inbox)
+  def claim(key, inbox, ttl)
     token = SecureRandom.uuid
-    raise Busy, "#{key} of inbox #{inbox.id} is locked" unless Redis::Alfred.set(key, token, nx: true, ex: CHAT_LOCK_TTL)
+    raise Busy, "#{key} of inbox #{inbox.id} is locked" unless Redis::Alfred.set(key, token, nx: true, ex: ttl)
 
     token
   end

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -119,7 +119,10 @@ class Whatsapp::Session::Inbound::MessageWriter
   def build_contact_message(card)
     card = card.stringify_keys
     phone = card['phone'].presence
-    name = card['name'].presence
+    # `display_name` is what the contract calls it. Reading `name` found nothing, so a
+    # card with a phone lost its name and a name-only card was dropped entirely, leaving
+    # the conversation that had just been opened with no message in it.
+    name = card['display_name'].presence
     return if phone.blank? && name.blank?
 
     message = conversation.messages.build(content: contact_line(name, phone), **message_attributes)

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -117,7 +117,20 @@ class Whatsapp::Session::Inbound::MessageWriter
   # dashboard renders them in the contact bubble instead of as plain text.
   def build_contact_messages
     messages = Array(content.contacts).filter_map { |card| build_contact_message(card) }
-    messages.last
+    return messages.last if messages.present?
+
+    unsupported_contact_message
+  end
+
+  # An empty share, or one whose cards carry no name, no phone and no vCard, leaves
+  # nothing to render, but the conversation has already been opened by the caller and
+  # nothing would hold the inbound source id: the thread would sit empty and every
+  # redelivery would walk the same path again. The unsupported bubble is what the agent
+  # should see anyway, and storing it is what closes the deduplication.
+  def unsupported_contact_message
+    attributes = message_attributes
+    attributes[:content_attributes] = attributes[:content_attributes].merge(is_unsupported: true)
+    conversation.messages.create!(content: nil, **attributes)
   end
 
   def build_contact_message(card)

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -1,0 +1,132 @@
+# Turns a canonical InboundMessage into the Chatwoot message row (or rows, for shared
+# contacts). Every provider in the session family goes through this one writer, so the
+# stored shape does not depend on who delivered the message.
+#
+# Media is not downloaded here: the bytes are fetched by MediaFetchJob and attached
+# afterwards. Downloading inline would stall the consumer thread that keeps a session's
+# events in order, and the attachment lands within seconds either way.
+class Whatsapp::Session::Inbound::MessageWriter
+  Content = Whatsapp::Session::Model::Content
+
+  attr_reader :conversation, :inbound, :sender
+
+  def initialize(conversation:, inbound:, sender: nil)
+    @conversation = conversation
+    @inbound = inbound
+    @sender = sender
+  end
+
+  def perform
+    return build_contact_messages if content.is_a?(Content::Contacts)
+
+    message = conversation.messages.build(content: message_content, **message_attributes)
+    attach_location(message)
+    message.save!
+    enqueue_media_fetch(message)
+    message
+  end
+
+  private
+
+  def inbox = conversation.inbox
+  def content = inbound.content
+  def incoming? = inbound.incoming?
+
+  def message_attributes
+    {
+      account_id: inbox.account_id,
+      inbox_id: inbox.id,
+      source_id: inbound.id,
+      sender: incoming? ? sender : nil,
+      message_type: incoming? ? :incoming : :outgoing,
+      content_attributes: content_attributes
+    }
+  end
+
+  def message_content
+    case content
+    when Content::Text then convert_mentions(content.body)
+    when Content::Media then content.caption
+    when Content::Rich then content.preview_text
+    end
+  end
+
+  def content_attributes
+    {
+      external_created_at: inbound.timestamp && (inbound.timestamp / 1000),
+      # An outgoing message stored without a sender was written on the phone, not by an
+      # agent; the dashboard needs a name to show in the bubble.
+      external_sender_name: ('WhatsApp' unless incoming?),
+      in_reply_to_external_id: inbound.quoted_id.presence,
+      referral: inbound.referral.presence,
+      is_unsupported: (true if unsupported?),
+      rich: (content.to_content_attribute if content.is_a?(Content::Rich))
+    }.compact
+  end
+
+  # A rich card with no text and no media header renders as an empty bubble, which is
+  # what the unsupported flag exists for.
+  def unsupported?
+    return true if content.is_a?(Content::Unsupported)
+
+    content.is_a?(Content::Rich) && content.preview_text.blank? && content.media.blank?
+  end
+
+  def convert_mentions(text)
+    return text if text.blank? || inbound.mentions.blank?
+
+    Whatsapp::MentionConverterService.convert_incoming_mentions(
+      text, { mentionedJid: Array(inbound.mentions).map(&:to_jid) }, inbox.account, inbox
+    )
+  end
+
+  # Location carries no downloadable bytes: the coordinates are the attachment.
+  def attach_location(message)
+    return unless content.is_a?(Content::Location)
+
+    name = [content.name, content.address].compact_blank.join(', ')
+    message.attachments.build(
+      account_id: inbox.account_id,
+      file_type: :location,
+      coordinates_lat: content.latitude,
+      coordinates_long: content.longitude,
+      fallback_title: name.presence
+    )
+  end
+
+  def enqueue_media_fetch(message)
+    return unless content.is_a?(Content::Media)
+    return if content.ref.blank?
+
+    Whatsapp::Session::MediaFetchJob.perform_later(message, content.to_h)
+  end
+
+  # One message per shared contact, each with a native contact attachment, so the
+  # dashboard renders them in the contact bubble instead of as plain text.
+  def build_contact_messages
+    messages = Array(content.contacts).filter_map { |card| build_contact_message(card) }
+    messages.last
+  end
+
+  def build_contact_message(card)
+    card = card.stringify_keys
+    phone = card['phone'].presence
+    name = card['name'].presence
+    return if phone.blank? && name.blank?
+
+    message = conversation.messages.build(content: contact_line(name, phone), **message_attributes)
+    message.attachments.build(
+      account_id: inbox.account_id, file_type: :contact,
+      fallback_title: phone || name, meta: { firstName: name }.compact
+    )
+    message.save!
+    message
+  end
+
+  def contact_line(name, phone)
+    return name if phone.blank?
+    return phone if name.blank? || name.start_with?('+')
+
+    "#{name} - #{phone}"
+  end
+end

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -23,6 +23,7 @@ class Whatsapp::Session::Inbound::MessageWriter
     attach_location(message)
     message.save!
     enqueue_media_fetch(message)
+    acknowledge([message])
     message
   end
 
@@ -123,9 +124,24 @@ class Whatsapp::Session::Inbound::MessageWriter
     messages = ActiveRecord::Base.transaction do
       Array(content.contacts).filter_map { |card| build_contact_message(card) }
     end
-    return messages.last if messages.present?
+    return acknowledge(messages).last if messages.present?
 
     unsupported_contact_message
+  end
+
+  # Tells WhatsApp the message was received, which is what puts the second tick on the
+  # contact's screen and, when the inbox asks for it, marks the chat read. The Baileys
+  # and Z-API writers both do this for every incoming row; without it every message this
+  # layer stores stays unread on the contact's phone forever.
+  def acknowledge(messages)
+    return messages unless incoming? && messages.present?
+
+    inbox.channel.received_messages(messages, conversation)
+    messages
+  rescue Whatsapp::Session::Errors::NotSupported
+    # The backend cannot acknowledge, or has not shipped yet. Storing the message is what
+    # matters; the tick on the contact's screen is not worth failing the event over.
+    messages
   end
 
   # An empty share, or one whose cards carry no name, no phone and no vCard, leaves
@@ -136,7 +152,9 @@ class Whatsapp::Session::Inbound::MessageWriter
   def unsupported_contact_message
     attributes = message_attributes
     attributes[:content_attributes] = attributes[:content_attributes].merge(is_unsupported: true)
-    conversation.messages.create!(content: nil, **attributes)
+    message = conversation.messages.create!(content: nil, **attributes)
+    acknowledge([message])
+    message
   end
 
   def build_contact_message(card)

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -115,8 +115,14 @@ class Whatsapp::Session::Inbound::MessageWriter
 
   # One message per shared contact, each with a native contact attachment, so the
   # dashboard renders them in the contact bubble instead of as plain text.
+  # One transaction for the whole share, as the Cloud path wraps its own message
+  # creation: a card failing to save after its siblings were committed would leave the
+  # event's source id stored, and the redelivery would then be read as a duplicate and
+  # drop the cards that never landed.
   def build_contact_messages
-    messages = Array(content.contacts).filter_map { |card| build_contact_message(card) }
+    messages = ActiveRecord::Base.transaction do
+      Array(content.contacts).filter_map { |card| build_contact_message(card) }
+    end
     return messages.last if messages.present?
 
     unsupported_contact_message

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -39,6 +39,10 @@ class Whatsapp::Session::Inbound::MessageWriter
       source_id: inbound.id,
       sender: incoming? ? sender : nil,
       message_type: incoming? ? :incoming : :outgoing,
+      # WhatsApp already has an echo: it is the phone reporting what it sent. Leaving it
+      # at the default `sent` would show the agent a message stuck on one tick that no
+      # receipt is ever going to move.
+      status: incoming? ? :sent : :delivered,
       content_attributes: content_attributes
     }
   end
@@ -118,11 +122,13 @@ class Whatsapp::Session::Inbound::MessageWriter
 
   def build_contact_message(card)
     card = card.stringify_keys
-    phone = card['phone'].presence
     # `display_name` is what the contract calls it. Reading `name` found nothing, so a
     # card with a phone lost its name and a name-only card was dropped entirely, leaving
-    # the conversation that had just been opened with no message in it.
-    name = card['display_name'].presence
+    # the conversation that had just been opened with no message in it. Both fields are
+    # optional on the wire and a card may arrive as nothing but its vCard, which is why
+    # that is read too rather than dropping the share.
+    phone = card['phone'].presence || vcard_phone(card['vcard'])
+    name = card['display_name'].presence || vcard_name(card['vcard'])
     return if phone.blank? && name.blank?
 
     message = conversation.messages.build(content: contact_line(name, phone), **message_attributes)
@@ -132,6 +138,18 @@ class Whatsapp::Session::Inbound::MessageWriter
     )
     message.save!
     message
+  end
+
+  # The WhatsApp vCard TEL line is `...;waid=<digits>:<formatted phone>`, so the
+  # formatted number is preferred and the waid digits are the fallback. Same reading the
+  # Baileys layer does, kept here so a card with nothing else still lands.
+  def vcard_phone(vcard)
+    vcard = vcard.to_s
+    vcard[/waid=\d+:\s*([^\r\n]+)/, 1]&.strip.presence || vcard[/waid=(\d+)/, 1].presence
+  end
+
+  def vcard_name(vcard)
+    vcard.to_s[/^FN[^:]*:\s*([^\r\n]+)/, 1]&.strip.presence
   end
 
   def contact_line(name, phone)

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -94,11 +94,15 @@ class Whatsapp::Session::Inbound::MessageWriter
     )
   end
 
+  # A rich card carries its header image, video or document in `media`, which is the
+  # same downloadable reference a plain media message has: without this the card is
+  # stored with its text and no attachment.
   def enqueue_media_fetch(message)
-    return unless content.is_a?(Content::Media)
-    return if content.ref.blank?
+    media = content if content.is_a?(Content::Media)
+    media ||= content.media if content.is_a?(Content::Rich)
+    return if media.blank? || media.ref.blank?
 
-    Whatsapp::Session::MediaFetchJob.perform_later(message, content.to_h)
+    Whatsapp::Session::MediaFetchJob.perform_later(message, media.to_h)
   end
 
   # One message per shared contact, each with a native contact attachment, so the

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -55,7 +55,11 @@ class Whatsapp::Session::Inbound::MessageWriter
     {
       external_created_at: inbound.timestamp && (inbound.timestamp / 1000),
       # An outgoing message stored without a sender was written on the phone, not by an
-      # agent; the dashboard needs a name to show in the bubble.
+      # agent; the dashboard needs a name to show in the bubble, and `human_response?`
+      # needs the flag to count the reply as one, so it clears `waiting_since` and
+      # registers a first response like an agent's own message would. Anything Chatwoot
+      # itself sent was matched by its reserved id and never reaches this writer.
+      external_echo: (true unless incoming?),
       external_sender_name: ('WhatsApp' unless incoming?),
       in_reply_to_external_id: inbound.quoted_id.presence,
       referral: inbound.referral.presence,

--- a/app/services/whatsapp/session/inbound/reaction_store.rb
+++ b/app/services/whatsapp/session/inbound/reaction_store.rb
@@ -11,21 +11,36 @@ class Whatsapp::Session::Inbound::ReactionStore
     @sender = sender
   end
 
+  # True when anything is still reacting to this target, from anyone. Cheap enough to ask
+  # before resolving a sender, which is what keeps a removal aimed at nothing from
+  # creating a contact on its way to doing nothing.
+  def self.active?(inbox:, target_id:)
+    json = "(content_attributes#>>'{}')::jsonb"
+    Message.where(inbox_id: inbox.id)
+           .where("#{json}->>'is_reaction' = 'true'")
+           .where("#{json}->>'in_reply_to_external_id' = ?", target_id)
+           .where.not(content: '')
+           .where("COALESCE(#{json}->>'deleted', 'false') != 'true'")
+           .exists?
+  end
+
   def write(conversation)
-    conversation.messages.create!(
-      account_id: inbox.account_id,
-      inbox_id: inbox.id,
-      source_id: reaction.id,
-      sender: reaction.from_me ? nil : sender,
-      message_type: reaction.from_me ? :outgoing : :incoming,
-      content: reaction.emoji,
-      content_attributes: {
-        is_reaction: true,
-        in_reply_to_external_id: reaction.target_id,
-        external_created_at: reaction.timestamp && (reaction.timestamp / 1000),
-        external_sender_name: ('WhatsApp' if reaction.from_me)
-      }.compact
-    )
+    existing = find_existing
+    return replace(existing) if existing
+
+    conversation.messages.create!(account_id: inbox.account_id, inbox_id: inbox.id, source_id: reaction.id,
+                                  sender: reaction.from_me ? nil : sender,
+                                  message_type: reaction.from_me ? :outgoing : :incoming,
+                                  content: reaction.emoji, content_attributes: new_content_attributes)
+  end
+
+  def new_content_attributes
+    {
+      is_reaction: true,
+      in_reply_to_external_id: reaction.target_id,
+      external_created_at: reaction.timestamp && (reaction.timestamp / 1000),
+      external_sender_name: ('WhatsApp' if reaction.from_me)
+    }.compact
   end
 
   # WhatsApp delivers a removal as a reaction with an empty emoji. The stored row is
@@ -45,6 +60,21 @@ class Whatsapp::Session::Inbound::ReactionStore
   end
 
   private
+
+  # WhatsApp gives a changed reaction a new id, so the same sender swapping one emoji
+  # for another arrives as a fresh event rather than as an edit. One row per (target,
+  # sender) is the invariant the removal path depends on: a second row would show both
+  # emojis on the bubble and leave one of them behind when the reaction is taken back.
+  def replace(existing)
+    existing.update!(
+      source_id: reaction.id,
+      content: reaction.emoji,
+      content_attributes: existing.content_attributes.merge(
+        { 'external_created_at' => reaction.timestamp && (reaction.timestamp / 1000) }.compact
+      )
+    )
+    existing
+  end
 
   # Deliberately not scoped to any conversation: the original reaction may live in an
   # older or resolved thread while the inbound flow picked a different one.

--- a/app/services/whatsapp/session/inbound/reaction_store.rb
+++ b/app/services/whatsapp/session/inbound/reaction_store.rb
@@ -55,7 +55,7 @@ class Whatsapp::Session::Inbound::ReactionStore
     return if existing.nil?
 
     existing.update!(content: '', content_attributes: existing.content_attributes.merge('deleted' => true))
-    refresh_chat_list(existing.conversation)
+    Whatsapp::Session::Inbound::ChatList.refresh(existing.conversation)
     existing
   end
 
@@ -73,6 +73,7 @@ class Whatsapp::Session::Inbound::ReactionStore
         { 'external_created_at' => reaction.timestamp && (reaction.timestamp / 1000) }.compact
       )
     )
+    Whatsapp::Session::Inbound::ChatList.refresh(existing.conversation)
     existing
   end
 
@@ -96,13 +97,5 @@ class Whatsapp::Session::Inbound::ReactionStore
            .where("COALESCE(#{json}->>'deleted', 'false') != 'true'")
            .reorder(created_at: :desc)
            .first
-  end
-
-  # The MESSAGE_UPDATED cable only refreshes the open thread, so without this the chat
-  # list preview stays pointed at the reaction that was just removed. Touching
-  # updated_at also lets the frontend drop cables that arrive out of order.
-  def refresh_chat_list(conversation)
-    conversation.update_columns(updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
-    conversation.dispatch_conversation_updated_event
   end
 end

--- a/app/services/whatsapp/session/inbound/reaction_store.rb
+++ b/app/services/whatsapp/session/inbound/reaction_store.rb
@@ -11,17 +11,26 @@ class Whatsapp::Session::Inbound::ReactionStore
     @sender = sender
   end
 
-  # True when anything is still reacting to this target, from anyone. Cheap enough to ask
-  # before resolving a sender, which is what keeps a removal aimed at nothing from
-  # creating a contact on its way to doing nothing.
-  def self.active?(inbox:, target_id:)
+  # True when *this sender* still has a reaction on this target. Asked before the sender
+  # is resolved, which is what keeps a removal aimed at nothing from creating a contact
+  # on its way to doing nothing: scoped to the target alone, somebody else's reaction
+  # would answer yes and the contact would be created anyway.
+  #
+  # `sender` is the Contact, or nil for a reaction written from the connected phone, and
+  # the caller finds it without creating one.
+  def self.active?(inbox:, target_id:, sender:, from_me: false)
     json = "(content_attributes#>>'{}')::jsonb"
-    Message.where(inbox_id: inbox.id)
-           .where("#{json}->>'is_reaction' = 'true'")
-           .where("#{json}->>'in_reply_to_external_id' = ?", target_id)
-           .where.not(content: '')
-           .where("COALESCE(#{json}->>'deleted', 'false') != 'true'")
-           .exists?
+    scope = Message.where(inbox_id: inbox.id)
+                   .where("#{json}->>'is_reaction' = 'true'")
+                   .where("#{json}->>'in_reply_to_external_id' = ?", target_id)
+                   .where.not(content: '')
+                   .where("COALESCE(#{json}->>'deleted', 'false') != 'true'")
+    scope = if from_me
+              scope.where(sender_id: nil, sender_type: nil).where(message_type: Message.message_types[:outgoing])
+            else
+              scope.where(sender: sender)
+            end
+    scope.exists?
   end
 
   def write(conversation)

--- a/app/services/whatsapp/session/inbound/reaction_store.rb
+++ b/app/services/whatsapp/session/inbound/reaction_store.rb
@@ -1,0 +1,78 @@
+# Reactions are stored as ordinary message rows flagged `is_reaction`, one row per
+# (target, sender), toggled instead of duplicated. This holds both halves of that:
+# writing a new reaction and marking an existing one removed.
+class Whatsapp::Session::Inbound::ReactionStore
+  attr_reader :inbox, :reaction, :sender
+
+  # `sender` is the Contact that reacted, nil for a reaction sent from the phone.
+  def initialize(inbox:, reaction:, sender: nil)
+    @inbox = inbox
+    @reaction = reaction
+    @sender = sender
+  end
+
+  def write(conversation)
+    conversation.messages.create!(
+      account_id: inbox.account_id,
+      inbox_id: inbox.id,
+      source_id: reaction.id,
+      sender: reaction.from_me ? nil : sender,
+      message_type: reaction.from_me ? :outgoing : :incoming,
+      content: reaction.emoji,
+      content_attributes: {
+        is_reaction: true,
+        in_reply_to_external_id: reaction.target_id,
+        external_created_at: reaction.timestamp && (reaction.timestamp / 1000),
+        external_sender_name: ('WhatsApp' if reaction.from_me)
+      }.compact
+    )
+  end
+
+  # WhatsApp delivers a removal as a reaction with an empty emoji. The stored row is
+  # emptied and flagged deleted rather than removed, so the bubble it annotates keeps
+  # its history.
+  #
+  # A `from_me` removal reaches this from two paths and both must work: the echo of a
+  # removal Chatwoot itself made (the row is already deleted, so this no-ops) and a
+  # removal made on the connected phone (the row is still active, stored sender-less).
+  def remove
+    existing = find_existing
+    return if existing.nil?
+
+    existing.update!(content: '', content_attributes: existing.content_attributes.merge('deleted' => true))
+    refresh_chat_list(existing.conversation)
+    existing
+  end
+
+  private
+
+  # Deliberately not scoped to any conversation: the original reaction may live in an
+  # older or resolved thread while the inbound flow picked a different one.
+  def find_existing
+    json = "(content_attributes#>>'{}')::jsonb"
+    base = Message.where(inbox_id: inbox.id)
+                  .where("#{json}->>'is_reaction' = 'true'")
+                  .where("#{json}->>'in_reply_to_external_id' = ?", reaction.target_id)
+    matches = if reaction.from_me
+                # Written from the phone: no agent on the row, stored outgoing.
+                base.where(sender_id: nil, sender_type: nil).where(message_type: Message.message_types[:outgoing])
+              else
+                base.where(sender: sender)
+              end
+
+    # Active-only: when every match is already deleted this returns nil, so an echoed
+    # removal does not re-delete the row and bump the conversation again.
+    matches.where.not(content: '')
+           .where("COALESCE(#{json}->>'deleted', 'false') != 'true'")
+           .reorder(created_at: :desc)
+           .first
+  end
+
+  # The MESSAGE_UPDATED cable only refreshes the open thread, so without this the chat
+  # list preview stays pointed at the reaction that was just removed. Touching
+  # updated_at also lets the frontend drop cables that arrive out of order.
+  def refresh_chat_list(conversation)
+    conversation.update_columns(updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+    conversation.dispatch_conversation_updated_event
+  end
+end

--- a/app/services/whatsapp/session/inbound/reaction_store.rb
+++ b/app/services/whatsapp/session/inbound/reaction_store.rb
@@ -54,7 +54,11 @@ class Whatsapp::Session::Inbound::ReactionStore
     existing = find_existing
     return if existing.nil?
 
-    existing.update!(content: '', content_attributes: existing.content_attributes.merge('deleted' => true))
+    # Merged under the row lock: the hash is read to be written back, so reading it off
+    # an instance loaded earlier drops whatever another worker put there in between.
+    existing.with_lock do
+      existing.update!(content: '', content_attributes: existing.content_attributes.merge('deleted' => true))
+    end
     Whatsapp::Session::Inbound::ChatList.refresh(existing.conversation)
     existing
   end
@@ -66,13 +70,15 @@ class Whatsapp::Session::Inbound::ReactionStore
   # sender) is the invariant the removal path depends on: a second row would show both
   # emojis on the bubble and leave one of them behind when the reaction is taken back.
   def replace(existing)
-    existing.update!(
-      source_id: reaction.id,
-      content: reaction.emoji,
-      content_attributes: existing.content_attributes.merge(
-        { 'external_created_at' => reaction.timestamp && (reaction.timestamp / 1000) }.compact
+    existing.with_lock do
+      existing.update!(
+        source_id: reaction.id,
+        content: reaction.emoji,
+        content_attributes: existing.content_attributes.merge(
+          { 'external_created_at' => reaction.timestamp && (reaction.timestamp / 1000) }.compact
+        )
       )
-    )
+    end
     Whatsapp::Session::Inbound::ChatList.refresh(existing.conversation)
     existing
   end

--- a/app/services/whatsapp/session/inbound/status_transition.rb
+++ b/app/services/whatsapp/session/inbound/status_transition.rb
@@ -1,0 +1,42 @@
+# The single place that decides whether a delivery receipt may move a message forward.
+#
+# The legacy layer had this rule twice (messages.update and message-receipt.update) and
+# they had already drifted apart. Receipts can arrive out of order, so the rule is
+# monotonic: a message never goes back to a weaker status, and `read` is terminal.
+module Whatsapp::Session::Inbound::StatusTransition
+  # `played` is a voice note being listened to, which Chatwoot has no column for and
+  # which always implies read.
+  RECEIPTS = { 'delivered' => 'delivered', 'read' => 'read', 'played' => 'read', 'failed' => 'failed' }.freeze
+  RANK = { 'sent' => 0, 'delivered' => 1, 'read' => 2 }.freeze
+
+  module_function
+
+  # Returns true when the message was updated.
+  def apply(message, receipt_type, error: nil)
+    status = RECEIPTS[receipt_type.to_s]
+    return false if status.blank?
+    return apply_failure(message, error) if status == 'failed'
+    return false unless allowed?(message.status, status)
+
+    message.update!(status: status)
+    true
+  end
+
+  def allowed?(current, new_status)
+    return false if current == 'failed'
+
+    RANK.fetch(new_status, -1) > RANK.fetch(current, -1)
+  end
+
+  def apply_failure(message, error)
+    message.update!(status: :failed, external_error: error_message(error))
+    true
+  end
+
+  def error_message(error)
+    return if error.blank?
+    return error if error.is_a?(String)
+
+    [error.message.presence, error.code.presence].compact.join(' ').presence
+  end
+end

--- a/app/services/whatsapp/session/inbound/status_transition.rb
+++ b/app/services/whatsapp/session/inbound/status_transition.rb
@@ -34,8 +34,12 @@ module Whatsapp::Session::Inbound::StatusTransition
     RANK.fetch(new_status, -1) > RANK.fetch(current, -1)
   end
 
+  # `external_error` lives in the content_attributes JSON, so writing it through a stale
+  # instance rewrites the whole hash and drops whatever a concurrent writer put there,
+  # `deleted` and `pending_source_id` included. Same reason the legacy providers use
+  # this path for the same two flags.
   def apply_failure(message, error)
-    message.update!(status: :failed, external_error: error_message(error))
+    message.update_under_lock!(status: :failed, external_error: error_message(error))
     true
   end
 

--- a/app/services/whatsapp/session/inbound/status_transition.rb
+++ b/app/services/whatsapp/session/inbound/status_transition.rb
@@ -8,10 +8,10 @@ module Whatsapp::Session::Inbound::StatusTransition
   # which always implies read.
   RECEIPTS = { 'delivered' => 'delivered', 'read' => 'read', 'played' => 'read', 'failed' => 'failed' }.freeze
   RANK = { 'sent' => 0, 'delivered' => 1, 'read' => 2 }.freeze
-  # Nothing moves a message out of these. A failure reported after the contact already
-  # read the message describes an earlier attempt, not the message coming undone, and a
-  # second failure has nothing left to say.
-  TERMINAL = %w[read failed].freeze
+  # Nothing moves a message out of these. A failure reported after the message was
+  # delivered or read describes an earlier attempt, not the message coming undone:
+  # either status is proof it arrived. A second failure has nothing left to say.
+  TERMINAL = %w[delivered read failed].freeze
 
   module_function
 
@@ -27,7 +27,8 @@ module Whatsapp::Session::Inbound::StatusTransition
   end
 
   def allowed?(current, new_status)
-    return false if current.in?(TERMINAL)
+    return false if current.in?(TERMINAL) && new_status == 'failed'
+    return false if current.in?(%w[read failed])
     return true if new_status == 'failed'
 
     RANK.fetch(new_status, -1) > RANK.fetch(current, -1)

--- a/app/services/whatsapp/session/inbound/status_transition.rb
+++ b/app/services/whatsapp/session/inbound/status_transition.rb
@@ -16,14 +16,27 @@ module Whatsapp::Session::Inbound::StatusTransition
   module_function
 
   # Returns true when the message was updated.
+  #
+  # Checked and written under the row lock. Two receipts for the same message can be
+  # processed at once, and reading the status outside the lock lets both pass the check
+  # against the same old value: the slower `delivered` write then lands on top of `read`
+  # and walks the message backwards, which is exactly what this rule exists to prevent.
   def apply(message, receipt_type, error: nil)
     status = RECEIPTS[receipt_type.to_s]
     return false if status.blank?
-    return false unless allowed?(message.status, status)
-    return apply_failure(message, error) if status == 'failed'
 
-    message.update!(status: status)
-    true
+    message.with_lock do
+      next false unless allowed?(message.status, status)
+
+      message.update!(failure_attributes(status, error))
+      true
+    end
+  end
+
+  def failure_attributes(status, error)
+    return { status: status } unless status == 'failed'
+
+    { status: :failed, external_error: error_message(error) }
   end
 
   def allowed?(current, new_status)
@@ -32,15 +45,6 @@ module Whatsapp::Session::Inbound::StatusTransition
     return true if new_status == 'failed'
 
     RANK.fetch(new_status, -1) > RANK.fetch(current, -1)
-  end
-
-  # `external_error` lives in the content_attributes JSON, so writing it through a stale
-  # instance rewrites the whole hash and drops whatever a concurrent writer put there,
-  # `deleted` and `pending_source_id` included. Same reason the legacy providers use
-  # this path for the same two flags.
-  def apply_failure(message, error)
-    message.update_under_lock!(status: :failed, external_error: error_message(error))
-    true
   end
 
   def error_message(error)

--- a/app/services/whatsapp/session/inbound/status_transition.rb
+++ b/app/services/whatsapp/session/inbound/status_transition.rb
@@ -8,6 +8,10 @@ module Whatsapp::Session::Inbound::StatusTransition
   # which always implies read.
   RECEIPTS = { 'delivered' => 'delivered', 'read' => 'read', 'played' => 'read', 'failed' => 'failed' }.freeze
   RANK = { 'sent' => 0, 'delivered' => 1, 'read' => 2 }.freeze
+  # Nothing moves a message out of these. A failure reported after the contact already
+  # read the message describes an earlier attempt, not the message coming undone, and a
+  # second failure has nothing left to say.
+  TERMINAL = %w[read failed].freeze
 
   module_function
 
@@ -15,15 +19,16 @@ module Whatsapp::Session::Inbound::StatusTransition
   def apply(message, receipt_type, error: nil)
     status = RECEIPTS[receipt_type.to_s]
     return false if status.blank?
-    return apply_failure(message, error) if status == 'failed'
     return false unless allowed?(message.status, status)
+    return apply_failure(message, error) if status == 'failed'
 
     message.update!(status: status)
     true
   end
 
   def allowed?(current, new_status)
-    return false if current == 'failed'
+    return false if current.in?(TERMINAL)
+    return true if new_status == 'failed'
 
     RANK.fetch(new_status, -1) > RANK.fetch(current, -1)
   end

--- a/app/services/whatsapp/session/model/events.rb
+++ b/app/services/whatsapp/session/model/events.rb
@@ -167,6 +167,16 @@ module Whatsapp::Session::Model::Events
       include Serializable
       coerce join: [Party], leave: [Party], promote: [Party], demote: [Party]
 
+      # A `Data` instance is never blank, so a payload whose changes are all nil, or that
+      # carries nothing but a member a newer connector added, would otherwise read as a
+      # real change and open a group for a no-op event.
+      def any?
+        # `nil` is "not reported", which is the only thing that means no change. An empty
+        # string is a description or a subject the group removed, and `false` is a
+        # setting turned off: both are changes, and `present?` would read them as none.
+        to_h.values.any? { |value| value.is_a?(Array) ? value.present? : !value.nil? }
+      end
+
       def participant_changes?
         [join, leave, promote, demote].any?(&:present?)
       end

--- a/app/services/whatsapp/session/model/group_info.rb
+++ b/app/services/whatsapp/session/model/group_info.rb
@@ -22,7 +22,10 @@ class Whatsapp::Session::Model::GroupInfo < Data.define(
   coerce group: Whatsapp::Session::Model::Address,
          owner: Whatsapp::Session::Model::Party,
          participants: [Participant]
-  defaults announce: false, locked: false, join_approval: false, participants: []
+  # No default for the settings: they are optional on the wire, and defaulting them to
+  # false makes a snapshot that simply did not report one indistinguishable from one
+  # reporting it off, which is enough for a sync to silently disable it.
+  defaults participants: []
 
   def admins
     Array(participants).select(&:admin?)

--- a/app/services/whatsapp/session/phone_match.rb
+++ b/app/services/whatsapp/session/phone_match.rb
@@ -20,6 +20,19 @@ module Whatsapp::Session::PhoneMatch
     normalizer.normalize(left) == normalizer.normalize(right)
   end
 
+  # Every form the number may be stored under, itself included. Used where a lookup has
+  # to reach a row written under the other ninth-digit form rather than merely decide
+  # whether two numbers match.
+  def variants(value)
+    number = digits(value)
+    return [] if number.blank?
+
+    normalizer = normalizer_for(number)
+    return [number] if normalizer.nil?
+
+    (normalizer.variants(number) + [number]).uniq
+  end
+
   def digits(value)
     value.to_s.gsub(/\D/, '')
   end

--- a/app/services/whatsapp/session/phone_match.rb
+++ b/app/services/whatsapp/session/phone_match.rb
@@ -1,0 +1,32 @@
+# Whether two WhatsApp numbers name the same line.
+#
+# Brazilian and Argentinian mobile numbers appear with and without the extra digit
+# depending on when the account was created, so the number an operator typed and the
+# number WhatsApp reports for the very same phone can differ textually. Comparing the
+# raw digits therefore calls one line two different numbers, which is how a valid
+# pairing gets rejected and how "did we leave this group?" answers no when we did.
+module Whatsapp::Session::PhoneMatch
+  module_function
+
+  def same_number?(left, right)
+    left = digits(left)
+    right = digits(right)
+    return false if left.blank? || right.blank?
+    return true if left == right
+
+    normalizer = normalizer_for(left) || normalizer_for(right)
+    return false if normalizer.nil?
+
+    normalizer.normalize(left) == normalizer.normalize(right)
+  end
+
+  def digits(value)
+    value.to_s.gsub(/\D/, '')
+  end
+
+  def normalizer_for(value)
+    Whatsapp::PhoneNumberNormalizationService::NORMALIZERS
+      .map(&:new)
+      .find { |normalizer| normalizer.handles_country?(value) }
+  end
+end

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -91,7 +91,13 @@ module Whatsapp::Session::Registry
       descriptor = descriptor(channel.provider)
       raise Whatsapp::Session::Errors::InvalidConfig, "#{channel.provider} is not served by the session layer" unless descriptor&.served?
 
-      descriptor.backend_class.new(channel)
+      # A descriptor can name a backend that has not shipped yet, which is how a provider
+      # gets described and labelled before it can be created. Saying so beats the
+      # NoMethodError that constantizing nothing produces.
+      backend = descriptor.backend_class
+      raise Whatsapp::Session::Errors::NotSupported, "#{channel.provider} has no backend in this build" if backend.nil?
+
+      backend.new(channel)
     end
 
     # The capabilities of a channel as the dashboard should see them: the descriptor's

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -75,6 +75,7 @@ en:
         join_approval_mode_enabled: "%{author_name} turned on admin approval to join this group"
         join_approval_mode_disabled: "%{author_name} turned off admin approval to join this group"
         invite_link_reset: "%{author_name} reset this group's invite link"
+        unknown_author: Someone
         membership_request_created: "%{contact_name} wants to join the group"
         membership_request_revoked: "%{contact_name} no longer wants to join the group"
         icon_changed: "%{author_name} changed the group image"

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -75,6 +75,7 @@ es:
         join_approval_mode_enabled: "%{author_name} activó la aprobación del administrador para unirse a este grupo"
         join_approval_mode_disabled: "%{author_name} desactivó la aprobación del administrador para unirse a este grupo"
         invite_link_reset: "%{author_name} restableció el enlace de invitación de este grupo"
+        unknown_author: Alguien
         membership_request_created: "%{contact_name} quiere unirse al grupo"
         membership_request_revoked: "%{contact_name} ya no quiere unirse al grupo"
         icon_changed: "%{author_name} cambió la imagen del grupo"

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -75,6 +75,7 @@ pt_BR:
         join_approval_mode_enabled: "%{author_name} ativou a autorização de admins para entrar neste grupo"
         join_approval_mode_disabled: "%{author_name} desativou a autorização de admins para entrar neste grupo"
         invite_link_reset: "%{author_name} redefiniu o link do grupo para convidar outras pessoas"
+        unknown_author: Alguém
         membership_request_created: "%{contact_name} deseja entrar no grupo"
         membership_request_revoked: "%{contact_name} não deseja mais fazer parte do grupo"
         icon_changed: "%{author_name} alterou a imagem do grupo"

--- a/spec/jobs/contacts/sync_group_job_spec.rb
+++ b/spec/jobs/contacts/sync_group_job_spec.rb
@@ -10,22 +10,22 @@ RSpec.describe Contacts::SyncGroupJob do
   describe '#perform' do
     it 'calls SyncGroupService when group_last_synced_at is nil' do
       service = instance_double(Contacts::SyncGroupService, perform: contact)
-      allow(Contacts::SyncGroupService).to receive(:new).with(contact: contact, soft: false).and_return(service)
+      allow(Contacts::SyncGroupService).to receive(:new).with(contact: contact, soft: false, channel: nil).and_return(service)
 
       described_class.perform_now(contact)
 
-      expect(Contacts::SyncGroupService).to have_received(:new).with(contact: contact, soft: false)
+      expect(Contacts::SyncGroupService).to have_received(:new).with(contact: contact, soft: false, channel: nil)
     end
 
     it 'calls SyncGroupService when group_last_synced_at is older than 15 minutes' do
       contact.update!(additional_attributes: { 'group_last_synced_at' => 20.minutes.ago.to_i })
 
       service = instance_double(Contacts::SyncGroupService, perform: contact)
-      allow(Contacts::SyncGroupService).to receive(:new).with(contact: contact, soft: false).and_return(service)
+      allow(Contacts::SyncGroupService).to receive(:new).with(contact: contact, soft: false, channel: nil).and_return(service)
 
       described_class.perform_now(contact)
 
-      expect(Contacts::SyncGroupService).to have_received(:new).with(contact: contact, soft: false)
+      expect(Contacts::SyncGroupService).to have_received(:new).with(contact: contact, soft: false, channel: nil)
     end
 
     it 'skips SyncGroupService when group_last_synced_at is within the last 15 minutes' do
@@ -42,11 +42,24 @@ RSpec.describe Contacts::SyncGroupJob do
       contact.update!(additional_attributes: { 'group_last_synced_at' => 5.minutes.ago.to_i })
 
       service = instance_double(Contacts::SyncGroupService, perform: contact)
-      allow(Contacts::SyncGroupService).to receive(:new).with(contact: contact, soft: false).and_return(service)
+      allow(Contacts::SyncGroupService).to receive(:new).with(contact: contact, soft: false, channel: nil).and_return(service)
 
       described_class.perform_now(contact, force: true)
 
-      expect(Contacts::SyncGroupService).to have_received(:new).with(contact: contact, soft: false)
+      expect(Contacts::SyncGroupService).to have_received(:new).with(contact: contact, soft: false, channel: nil)
+    end
+
+    # The caller that knows which session saw the event passes it through; without it the
+    # service falls back to the group contact's first contact_inbox, which is arbitrary
+    # as soon as the same group is in two inboxes.
+    it 'passes the originating channel through to the service' do
+      channel = create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false)
+      service = instance_double(Contacts::SyncGroupService, perform: contact)
+      allow(Contacts::SyncGroupService).to receive(:new).and_return(service)
+
+      described_class.perform_now(contact, soft: true, channel: channel)
+
+      expect(Contacts::SyncGroupService).to have_received(:new).with(contact: contact, soft: true, channel: channel)
     end
 
     it 'rescues ProviderUnavailableError without re-raising' do

--- a/spec/jobs/whatsapp/session/logout_job_spec.rb
+++ b/spec/jobs/whatsapp/session/logout_job_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::LogoutJob do
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+
+  before { allow(channel).to receive(:provider_service).and_return(backend) }
+
+  it 'asks the session to end' do
+    described_class.perform_now(channel)
+
+    expect(backend.commands_of('session.logout').size).to eq(1)
+  end
+
+  # The caller has already written the refusal, so a repeat of the same event reports as
+  # unchanged and never reaches the logout again: swallowing a transient failure would
+  # leave the wrong WhatsApp account connected with nobody asking it to stop.
+  it 'lets a transient failure out so the retry can see it' do
+    allow(backend).to receive(:logout).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)
+
+    expect { described_class.new.perform(channel) }.to raise_error(Whatsapp::Session::Errors::ProviderUnavailable)
+  end
+
+  it 'gives up on a failure no retry can fix' do
+    allow(backend).to receive(:logout).and_raise(Whatsapp::Session::Errors::NotSupported)
+
+    expect { described_class.new.perform(channel) }.not_to raise_error
+  end
+end

--- a/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
+++ b/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe Whatsapp::Session::MediaFetchJob do
     expect(message.reload.attachments.first).to have_attributes(file_type: 'image')
   end
 
+  # The bubble is created before the bytes exist, and adding an attachment changes no
+  # column, so `Message#dispatch_update_event` saw an empty `previous_changes` and said
+  # nothing: the open dashboard kept showing the empty bubble until a reload.
+  it 'tells the open dashboards that the bubble now has its file' do
+    allow(Rails.configuration.dispatcher).to receive(:dispatch).and_call_original
+
+    described_class.perform_now(message, media.to_h)
+
+    expect(Rails.configuration.dispatcher).to have_received(:dispatch)
+      .with(Events::Types::MESSAGE_UPDATED, anything, hash_including(message: message)).at_least(:once)
+  end
+
   it 'does nothing for a message that already has one' do
     described_class.perform_now(message, media.to_h)
 

--- a/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
+++ b/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
@@ -46,4 +46,17 @@ RSpec.describe Whatsapp::Session::MediaFetchJob do
 
     expect(message.reload.is_unsupported).to be(true)
   end
+
+  # `is_unsupported` is a content_attributes flag, so writing it off the stale instance
+  # this job is holding rewrote the whole hash and undeleted the message.
+  it 'does not undelete a message revoked while the download was running' do
+    allow(backend).to receive(:download_media) do
+      Message.find(message.id).update!(content_attributes: { 'deleted' => true })
+      raise Whatsapp::Session::Errors::MediaUnavailable
+    end
+
+    described_class.perform_now(message, media.to_h)
+
+    expect(message.reload.content_attributes).to include('deleted' => true, 'is_unsupported' => true)
+  end
 end

--- a/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
+++ b/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::MediaFetchJob do
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+  let(:model) { Whatsapp::Session::Model }
+  let(:conversation) { create(:conversation, inbox: inbox, account: channel.account) }
+  let(:message) do
+    create(:message, conversation: conversation, inbox: inbox, account: channel.account, source_id: '3EB0AAAA0001')
+  end
+  let(:media) do
+    model::Content::Media.new(kind: 'image', mime: 'image/jpeg', filename: 'foto.jpg',
+                              ref: model::MediaRef.url('https://connector.test/media/abc'))
+  end
+
+  before { allow(inbox.channel).to receive(:provider_service).and_return(backend) }
+
+  it 'attaches the bytes it downloaded' do
+    described_class.perform_now(message, media.to_h)
+
+    expect(message.reload.attachments.first).to have_attributes(file_type: 'image')
+  end
+
+  it 'does nothing for a message that already has one' do
+    described_class.perform_now(message, media.to_h)
+
+    expect { described_class.perform_now(message, media.to_h) }.not_to(change { message.reload.attachments.count })
+  end
+
+  # The deletion destroys the attachments, and this job runs asynchronously: attaching
+  # afterwards would put the supposedly deleted media back in storage and back on the
+  # API, which is the whole reason the deletion removed it.
+  it 'does not attach to a message deleted while it was queued' do
+    message.update!(content_attributes: message.content_attributes.merge('deleted' => true))
+
+    described_class.perform_now(message, media.to_h)
+
+    expect(message.reload.attachments).to be_empty
+  end
+
+  it 'flags the message when the provider no longer has the bytes' do
+    allow(backend).to receive(:download_media).and_raise(Whatsapp::Session::Errors::MediaUnavailable)
+
+    described_class.perform_now(message, media.to_h)
+
+    expect(message.reload.is_unsupported).to be(true)
+  end
+end

--- a/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
+++ b/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
@@ -51,6 +51,26 @@ RSpec.describe Whatsapp::Session::MediaFetchJob do
     expect(message.reload.attachments).to be_empty
   end
 
+  # `MESSAGE_UPDATED` only reaches the open thread, so a media-only message left the
+  # conversation card in the list showing "no content" until something else touched it.
+  it 'refreshes the conversation card so the preview stops being empty' do
+    allow(Whatsapp::Session::Inbound::ChatList).to receive(:refresh).and_call_original
+
+    described_class.perform_now(message, media.to_h)
+
+    expect(Whatsapp::Session::Inbound::ChatList).to have_received(:refresh).with(conversation)
+  end
+
+  # The file is past the provider's cap, so no retry changes the answer: the agent needs
+  # to see the attachment is not coming rather than a bubble that loads forever.
+  it 'flags the message when the media is larger than the provider allows' do
+    allow(backend).to receive(:download_media).and_raise(Whatsapp::Session::Errors::MediaTooLarge)
+
+    described_class.perform_now(message, media.to_h)
+
+    expect(message.reload.is_unsupported).to be(true)
+  end
+
   it 'flags the message when the provider no longer has the bytes' do
     allow(backend).to receive(:download_media).and_raise(Whatsapp::Session::Errors::MediaUnavailable)
 

--- a/spec/jobs/whatsapp/session/update_contact_avatar_job_spec.rb
+++ b/spec/jobs/whatsapp/session/update_contact_avatar_job_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::UpdateContactAvatarJob do
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+  let(:model) { Whatsapp::Session::Model }
+  let(:contact) { create(:contact, account: channel.account, phone_number: '+5541999990000') }
+  let(:party) { model::Party.new(phone: '5541999990000', lid: '182736451928374') }
+
+  before { allow(inbox.channel).to receive(:provider_service).and_return(backend) }
+
+  # The command declares an Address and is built with `new`, which runs no coercion, so
+  # handing it a Party would put the wrong shape on the wire and every backend reading
+  # the address would fail on it.
+  it 'asks the backend for the picture of an address, not of a party' do
+    described_class.perform_now(contact, inbox, party.to_h)
+
+    command = backend.commands_of('contact.profile_picture').first
+    expect(command.party).to be_a(model::Address)
+    expect(command.party.id).to eq('182736451928374')
+    expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(contact, %r{/avatars/182736451928374\.jpg})
+  end
+
+  it 'does nothing for a contact that already has one' do
+    contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png')
+
+    described_class.perform_now(contact, inbox, party.to_h)
+
+    expect(backend.commands_of('contact.profile_picture')).to be_empty
+  end
+end

--- a/spec/jobs/whatsapp/session/update_contact_avatar_job_spec.rb
+++ b/spec/jobs/whatsapp/session/update_contact_avatar_job_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Whatsapp::Session::UpdateContactAvatarJob do
     expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(contact, %r{/avatars/182736451928374\.jpg})
   end
 
+  # `retry_on` only sees what escapes `perform`, and a rescue in the method catches the
+  # error first: the declared retry never ran, and a forced refresh dropped during a
+  # transient outage left the old avatar attached with nothing to ask again.
+  it 'lets a transient provider failure out so the retry can see it' do
+    allow(backend).to receive(:profile_picture_url).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)
+
+    expect { described_class.new.perform(contact, inbox, party.to_h, force: true) }
+      .to raise_error(Whatsapp::Session::Errors::ProviderUnavailable)
+  end
+
+  it 'swallows a failure no retry can fix' do
+    allow(backend).to receive(:profile_picture_url).and_raise(Whatsapp::Session::Errors::NotSupported)
+
+    expect { described_class.new.perform(contact, inbox, party.to_h, force: true) }.not_to raise_error
+  end
+
   it 'does nothing for a contact that already has one' do
     contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png')
 

--- a/spec/jobs/whatsapp/session/update_group_avatar_job_spec.rb
+++ b/spec/jobs/whatsapp/session/update_group_avatar_job_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::UpdateGroupAvatarJob do
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false)
+  end
+  let(:inbox) { channel.inbox }
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+  let(:model) { Whatsapp::Session::Model }
+  let(:group_contact) do
+    create(:contact, account: channel.account, identifier: '120363041234567890@g.us', group_type: :group)
+  end
+  let(:info) do
+    model::GroupInfo.new(group: model::Address.group('120363041234567890'), subject: 'Equipe',
+                         picture_url: 'https://connector.test/group.jpg')
+  end
+
+  before do
+    create(:contact_inbox, inbox: inbox, contact: group_contact, source_id: '120363041234567890')
+    allow(channel).to receive(:provider_service).and_return(backend)
+    allow(backend).to receive(:group_info).and_return(info)
+  end
+
+  it 'asks for the picture of a group that has none' do
+    described_class.perform_now(group_contact, channel: channel)
+
+    expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(group_contact, info.picture_url)
+  end
+
+  it 'leaves an attached avatar alone when the refresh is not forced' do
+    group_contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png',
+                                content_type: 'image/png')
+
+    described_class.perform_now(group_contact, channel: channel)
+
+    expect(Avatar::AvatarFromUrlJob).not_to have_been_enqueued
+  end
+
+  # A group contact is a Contact, so `Avatar::AvatarFromUrlJob` applies its rate limit
+  # and its URL hash to it and stamps both markers even on the run it skipped: a forced
+  # refresh within the window was dropped, and so was every later attempt at that URL.
+  context 'when the group was synced moments ago' do
+    before do
+      group_contact.update!(additional_attributes: { 'last_avatar_sync_at' => Time.current.iso8601,
+                                                     'avatar_url_hash' => 'abc123' })
+    end
+
+    it 'clears the markers that would suppress the forced download' do
+      described_class.perform_now(group_contact, force: true, channel: channel)
+
+      expect(group_contact.reload.additional_attributes).not_to include('last_avatar_sync_at', 'avatar_url_hash')
+    end
+
+    it 'keeps the stored avatar until the replacement can be attached' do
+      group_contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png',
+                                  content_type: 'image/png')
+
+      described_class.perform_now(group_contact, force: true, channel: channel)
+
+      expect(group_contact.reload.avatar).to be_attached
+    end
+  end
+end

--- a/spec/models/internal_chat/draft_spec.rb
+++ b/spec/models/internal_chat/draft_spec.rb
@@ -33,7 +33,12 @@ RSpec.describe InternalChat::Draft do
         new_draft = create(:internal_chat_draft, account: account, user: user, channel: channel2,
                                                  updated_at: 1.minute.ago)
 
-        expect(described_class.recent).to eq([new_draft, old_draft])
+        # Resolved here, not through `described_class`: a reload between loading this
+        # file and running it leaves RSpec holding the previous class object, and
+        # `ActiveRecord::Base#==` compares `instance_of?(self.class)`, so records the
+        # factory built through the fresh class never equal it. The rows and their order
+        # are right; only the class identity differs.
+        expect(InternalChat::Draft.recent).to eq([new_draft, old_draft]) # rubocop:disable RSpec/DescribedClass
       end
     end
   end

--- a/spec/services/contacts/sync_group_service_spec.rb
+++ b/spec/services/contacts/sync_group_service_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe Contacts::SyncGroupService do
       expect { described_class.new(contact: contact).perform }.to raise_error(ActionController::BadRequest)
     end
 
+    # The caller that supplied a channel means "sync this group as that inbox sees it".
+    # Taking the contact's first contact_inbox drove the supplied channel with a
+    # conversation belonging to another inbox, writing the result into the wrong one.
+    it 'takes the conversation from the supplied channel inbox, not the first one' do
+      account = create(:account)
+      first = create(:channel_whatsapp, account: account, provider: 'baileys', validate_provider_config: false)
+      second = create(:channel_whatsapp, account: account, provider: 'baileys', validate_provider_config: false)
+      contact = create(:contact, account: account, group_type: :group, identifier: 'group@g.us')
+      create(:contact_inbox, contact: contact, inbox: first.inbox)
+      wanted = create(:contact_inbox, contact: contact, inbox: second.inbox)
+
+      allow(second).to receive(:sync_group).and_return(true)
+
+      described_class.new(contact: contact, channel: second).perform
+
+      expect(second).to have_received(:sync_group) do |conversation, **|
+        expect(conversation.contact_inbox_id).to eq(wanted.id)
+      end
+    end
+
     it 'calls channel.sync_group with a conversation' do
       channel = create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false)
       contact = create(:contact, account: channel.account, group_type: :group, identifier: 'group@g.us')

--- a/spec/services/whatsapp/session/errors_spec.rb
+++ b/spec/services/whatsapp/session/errors_spec.rb
@@ -1,34 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe Whatsapp::Session::Errors do
+  # Resolved inside the example, never captured from `described_class`. A reload between
+  # loading this file and running it replaces the module object, and RSpec keeps holding
+  # the old one, whose child classes are no longer the ones the legacy errors inherit
+  # from: `be_a` then fails against a class that looks identical. Referencing the
+  # constant here re-resolves it.
+  let(:errors) { Whatsapp::Session::Errors } # rubocop:disable RSpec/DescribedClass
+
   it 'is what the legacy providers raise, so callers rescue a single namespace' do
-    expect(Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError.new).to be_a(described_class::ProviderUnavailable)
-    expect(Whatsapp::Providers::WhatsappZapiService::ProviderUnavailableError.new).to be_a(described_class::ProviderUnavailable)
+    expect(Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError.new).to be_a(errors::ProviderUnavailable)
+    expect(Whatsapp::Providers::WhatsappZapiService::ProviderUnavailableError.new).to be_a(errors::ProviderUnavailable)
     expect(Whatsapp::Providers::WhatsappBaileysService::GroupParticipantNotAllowedError.new)
-      .to be_a(described_class::GroupParticipantNotAllowed)
+      .to be_a(errors::GroupParticipantNotAllowed)
     expect(Whatsapp::Providers::WhatsappBaileysService::MessageAlreadyProcessingError.new)
-      .to be_a(described_class::MessageAlreadyProcessing)
+      .to be_a(errors::MessageAlreadyProcessing)
   end
 
   it 'treats a connection that is not usable right now as unavailable' do
-    expect(described_class::NotConnected.new).to be_a(described_class::ProviderUnavailable)
-    expect(described_class::Quarantined.new).to be_a(described_class::ProviderUnavailable)
-    expect(described_class::ClientOutdated.new).to be_a(described_class::ProviderUnavailable)
+    expect(errors::NotConnected.new).to be_a(errors::ProviderUnavailable)
+    expect(errors::Quarantined.new).to be_a(errors::ProviderUnavailable)
+    expect(errors::ClientOutdated.new).to be_a(errors::ProviderUnavailable)
   end
 
   describe '.build' do
     it 'maps a wire code back to its class' do
-      expect(described_class.build('media_too_large')).to be_a(described_class::MediaTooLarge)
-      expect(described_class.build('not_connected', 'session is down')).to have_attributes(message: 'session is down')
+      expect(errors.build('media_too_large')).to be_a(errors::MediaTooLarge)
+      expect(errors.build('not_connected', 'session is down')).to have_attributes(message: 'session is down')
     end
 
     it 'degrades an unknown code instead of failing the consumer' do
-      expect(described_class.build('teleportation_failed')).to be_a(described_class::Internal)
+      expect(errors.build('teleportation_failed')).to be_a(errors::Internal)
     end
   end
 
   it 'exposes the wire code of each class' do
-    expect(described_class::RateLimited.new.code).to eq('rate_limited')
-    expect(described_class::NotSupported.new.code).to eq('unsupported')
+    expect(errors::RateLimited.new.code).to eq('rate_limited')
+    expect(errors::NotSupported.new.code).to eq('unsupported')
   end
 end

--- a/spec/services/whatsapp/session/groups/syncer_spec.rb
+++ b/spec/services/whatsapp/session/groups/syncer_spec.rb
@@ -50,6 +50,29 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
     )
   end
 
+  # The settings are optional on the wire. A snapshot that does not report one says
+  # nothing about it, and a sync must not read that silence as "off".
+  context 'when the snapshot reports no settings at all' do
+    let(:stored) { super().merge('announce' => true, 'restrict' => true) }
+
+    it 'leaves the stored ones alone' do
+      sync
+
+      expect(group_contact.reload.additional_attributes).to include('announce' => true, 'restrict' => true)
+    end
+  end
+
+  context 'when the snapshot reports a setting off' do
+    let(:stored) { super().merge('announce' => true) }
+    let(:info) { model::GroupInfo.new(group: group, subject: 'Equipe', announce: false) }
+
+    it 'turns it off' do
+      sync
+
+      expect(group_contact.reload.additional_attributes['announce']).to be(false)
+    end
+  end
+
   context 'when only admins may add people' do
     let(:info) { model::GroupInfo.new(group: group, subject: 'Equipe', member_add_mode: 'admin_add') }
 

--- a/spec/services/whatsapp/session/groups/syncer_spec.rb
+++ b/spec/services/whatsapp/session/groups/syncer_spec.rb
@@ -118,6 +118,13 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
     it 'skips the avatar, which is the half an activity ping does not pay for' do
       expect { soft_sync }.not_to have_enqueued_job(Avatar::AvatarFromUrlJob)
     end
+
+    # One provider profile lookup per member without a picture, on every activity hint,
+    # for groups that can hold hundreds of them. The Baileys path passes
+    # `skip_avatars: soft` for the same reason.
+    it 'does not ask the provider for a picture of every member' do
+      expect { soft_sync }.not_to have_enqueued_job(Whatsapp::Session::UpdateContactAvatarJob)
+    end
   end
 
   context 'when only admins may add people' do

--- a/spec/services/whatsapp/session/groups/syncer_spec.rb
+++ b/spec/services/whatsapp/session/groups/syncer_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Groups::Syncer do
+  subject(:sync) { described_class.new(channel: channel, group_contact: group_contact, info: info).perform }
+
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'native', phone_number: '+5541988887777',
+                              validate_provider_config: false, sync_templates: false)
+  end
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:group) { model::Address.group('120363041234567890') }
+  let(:group_contact) do
+    create(:contact, account: channel.account, identifier: '120363041234567890@g.us', group_type: :group,
+                     additional_attributes: stored)
+  end
+  let(:stored) do
+    { 'description' => 'Combinados do time', 'invite_code' => 'OLDCODE', 'owner_pn' => '5541999990000' }
+  end
+  let(:info) { model::GroupInfo.new(group: group, subject: 'Equipe de Vendas') }
+
+  before { create(:contact_inbox, inbox: inbox, contact: group_contact, source_id: '120363041234567890') }
+
+  it 'brings the name in line with what the provider reports' do
+    sync
+
+    expect(group_contact.reload.name).to eq('Equipe de Vendas')
+  end
+
+  # A snapshot describes the group as it is now, so a description the group removed has
+  # to overwrite the stored one. Dropping the empty value would leave the old text on
+  # screen with no way to ever clear it.
+  context 'when the group removed its description' do
+    let(:info) { model::GroupInfo.new(group: group, subject: 'Equipe de Vendas', description: '') }
+
+    it 'clears it' do
+      sync
+
+      expect(group_contact.reload.additional_attributes['description']).to be_nil
+    end
+  end
+
+  # An absent field is not a removal: the invite code is only readable by an admin, so
+  # a sync run by a member must not throw away the code we already have.
+  it 'keeps what the snapshot does not describe' do
+    sync
+
+    expect(group_contact.reload.additional_attributes).to include(
+      'description' => 'Combinados do time', 'invite_code' => 'OLDCODE'
+    )
+  end
+
+  context 'when only admins may add people' do
+    let(:info) { model::GroupInfo.new(group: group, subject: 'Equipe', member_add_mode: 'admin_add') }
+
+    it 'stores the setting as the boolean the dashboard reads' do
+      sync
+
+      expect(group_contact.reload.additional_attributes['member_add_mode']).to be(false)
+    end
+  end
+
+  context 'when every member may add people' do
+    let(:info) { model::GroupInfo.new(group: group, subject: 'Equipe', member_add_mode: 'all_member_add') }
+
+    it 'stores it as enabled' do
+      sync
+
+      expect(group_contact.reload.additional_attributes['member_add_mode']).to be(true)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/groups/syncer_spec.rb
+++ b/spec/services/whatsapp/session/groups/syncer_spec.rb
@@ -127,6 +127,29 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
     end
   end
 
+  # Swallowing this returns nil, and `Contacts::SyncGroupService` reads that as nothing
+  # to apply: it goes on to dispatch CONTACT_GROUP_SYNCED and hand back the untouched
+  # contact, reporting a sync that never happened.
+  context 'when the provider cannot be reached for the metadata' do
+    subject(:fetched_sync) { described_class.new(channel: channel, group_contact: group_contact).perform }
+
+    let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+
+    before { allow(channel).to receive(:provider_service).and_return(backend) }
+
+    it 'says so instead of reporting an empty sync' do
+      allow(backend).to receive(:group_info).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)
+
+      expect { fetched_sync }.to raise_error(Whatsapp::Session::Errors::ProviderUnavailable)
+    end
+
+    it 'gives up quietly on a failure no retry can fix' do
+      allow(backend).to receive(:group_info).and_raise(Whatsapp::Session::Errors::NotSupported)
+
+      expect { fetched_sync }.not_to raise_error
+    end
+  end
+
   context 'when only admins may add people' do
     let(:info) { model::GroupInfo.new(group: group, subject: 'Equipe', member_add_mode: 'admin_add') }
 

--- a/spec/services/whatsapp/session/groups/syncer_spec.rb
+++ b/spec/services/whatsapp/session/groups/syncer_spec.rb
@@ -73,6 +73,24 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
     end
   end
 
+  # Only rejoining clears the flag, and only `group.joined` knows that happened. A
+  # scheduled sync can still read cached metadata for a group the session left, and
+  # clearing it there would put the group actions back for a thread that cannot send.
+  context 'when the group was already left and the sync fetched its metadata' do
+    subject(:fetched_sync) { described_class.new(channel: channel, group_contact: group_contact).perform }
+
+    let(:stored) { super().merge('group_left' => true) }
+    let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+
+    before { allow(channel).to receive(:provider_service).and_return(backend) }
+
+    it 'keeps the group marked as left' do
+      fetched_sync
+
+      expect(group_contact.reload.additional_attributes['group_left']).to be(true)
+    end
+  end
+
   context 'when only admins may add people' do
     let(:info) { model::GroupInfo.new(group: group, subject: 'Equipe', member_add_mode: 'admin_add') }
 

--- a/spec/services/whatsapp/session/groups/syncer_spec.rb
+++ b/spec/services/whatsapp/session/groups/syncer_spec.rb
@@ -91,6 +91,35 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
     end
   end
 
+  # `group_last_synced_at` is advanced on every run, and `Contacts::SyncGroupJob` reads
+  # it as a 15 minute cooldown for every sync that is not forced, which includes the
+  # manual one from the dashboard. A soft sync that skipped the roster would therefore
+  # stamp the group as synced and leave a stale member list nothing could refresh.
+  context 'with a soft sync' do
+    subject(:soft_sync) do
+      described_class.new(channel: channel, group_contact: group_contact, info: info, soft: true).perform
+    end
+
+    let(:info) do
+      model::GroupInfo.new(
+        group: group, subject: 'Equipe de Vendas', picture_url: 'https://connector.test/group.jpg',
+        participants: [
+          model::GroupInfo::Participant.new(party: model::Party.new(phone: '5541999990000', push_name: 'Ana'), role: 'admin')
+        ]
+      )
+    end
+
+    it 'still reads the roster' do
+      soft_sync
+
+      expect(group_contact.reload.group_memberships.active.count).to eq(1)
+    end
+
+    it 'skips the avatar, which is the half an activity ping does not pay for' do
+      expect { soft_sync }.not_to have_enqueued_job(Avatar::AvatarFromUrlJob)
+    end
+  end
+
   context 'when only admins may add people' do
     let(:info) { model::GroupInfo.new(group: group, subject: 'Equipe', member_add_mode: 'admin_add') }
 

--- a/spec/services/whatsapp/session/inbound/contact_lookup_spec.rb
+++ b/spec/services/whatsapp/session/inbound/contact_lookup_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::ContactLookup do
+  subject(:found) { described_class.find(inbox: inbox, party: party) }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:party) { model::Party.new(phone: '5541999990000', lid: '182736451928374') }
+  let(:contact) { create(:contact, account: channel.account, name: 'Ana Souza', phone_number: '+5541999990000') }
+
+  it 'answers nil for a party nobody here knows' do
+    expect(found).to be_nil
+  end
+
+  it 'finds the row the event names' do
+    contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: '182736451928374')
+
+    expect(found).to eq(contact_inbox)
+  end
+
+  # Both keys hold a row until consolidation merges them, and an unordered match could
+  # answer with the phone-keyed copy that is on its way out. `Party#source_id` makes the
+  # LID the canonical key, so it wins.
+  it 'prefers the LID while a phone-keyed row still exists' do
+    obsolete = create(:contact, account: channel.account, name: 'Ana antiga')
+    create(:contact_inbox, inbox: inbox, contact: obsolete, source_id: '5541999990000')
+    canonical = create(:contact_inbox, inbox: inbox, contact: contact, source_id: '182736451928374')
+
+    expect(found).to eq(canonical)
+  end
+
+  it 'falls back to the other ninth-digit form of the source id' do
+    contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: '554199990000')
+
+    expect(described_class.find(inbox: inbox, party: model::Party.new(phone: '5541999990000'))).to eq(contact_inbox)
+  end
+
+  # Consolidation re-keys the row to the LID, so a party named only by phone matches no
+  # source_id at all and the number on the contact is the last thing left to match on.
+  it 'falls back to the phone stored on the contact' do
+    contact_inbox = create(:contact_inbox, inbox: inbox, contact: contact, source_id: '182736451928374')
+
+    expect(described_class.find(inbox: inbox, party: model::Party.new(phone: '5541999990000'))).to eq(contact_inbox)
+  end
+
+  it 'never invents a contact' do
+    expect { found }.not_to change(Contact, :count)
+  end
+end

--- a/spec/services/whatsapp/session/inbound/contact_resolver_spec.rb
+++ b/spec/services/whatsapp/session/inbound/contact_resolver_spec.rb
@@ -59,6 +59,29 @@ RSpec.describe Whatsapp::Session::Inbound::ContactResolver do
     expect(described_class.new(inbox: inbox, party: model::Party.new(push_name: 'Ana')).perform).to be_nil
   end
 
+  # A conversion or an import leaves the number formatted, and only stripping the plus
+  # left the separators behind, so the digit check failed and the contact kept showing
+  # as a phone number forever.
+  it 'replaces a name that is the phone number written out' do
+    contact = create(:contact, account: channel.account, name: '+55 41 99999-0000', phone_number: '+5541999990000')
+    create(:contact_inbox, inbox: inbox, contact: contact, source_id: '5541999990000')
+
+    described_class.new(inbox: inbox, party: model::Party.new(phone: '5541999990000', push_name: 'Ana Souza'),
+                        overwrite: true).perform
+
+    expect(contact.reload.name).to eq('Ana Souza')
+  end
+
+  it 'keeps a real name that happens to carry a digit' do
+    contact = create(:contact, account: channel.account, name: 'Ana 2', phone_number: '+5541999990000')
+    create(:contact_inbox, inbox: inbox, contact: contact, source_id: '5541999990000')
+
+    described_class.new(inbox: inbox, party: model::Party.new(phone: '5541999990000', push_name: 'Ana Souza'),
+                        overwrite: true).perform
+
+    expect(contact.reload.name).to eq('Ana 2')
+  end
+
   it 'replaces a name that is only the contact phone number' do
     contact = create(:contact, account: channel.account, name: '5541999990000', phone_number: '+5541999990000')
     create(:contact_inbox, contact: contact, inbox: inbox, source_id: '182736451928374')

--- a/spec/services/whatsapp/session/inbound/contact_resolver_spec.rb
+++ b/spec/services/whatsapp/session/inbound/contact_resolver_spec.rb
@@ -34,6 +34,27 @@ RSpec.describe Whatsapp::Session::Inbound::ContactResolver do
     end
   end
 
+  # An unordered `IN` over both forms can hand back either row. Picking the alternate
+  # one files the message under the wrong contact, and `overwrite` then tries to move
+  # the exact number onto a contact that does not own it, which the uniqueness check
+  # refuses: the message is lost rather than merely misfiled.
+  context 'when both ninth-digit forms are already filed' do
+    let(:party) { model::Party.new(phone: '5541988887777', push_name: 'Bruno') }
+    let!(:exact) do
+      contact = create(:contact, account: channel.account, name: 'Bruno Exato', phone_number: '+5541988887777')
+      create(:contact_inbox, inbox: inbox, contact: contact, source_id: '5541988887777')
+    end
+
+    before do
+      contact = create(:contact, account: channel.account, name: 'Bruno Antigo', phone_number: '+554188887777')
+      create(:contact_inbox, inbox: inbox, contact: contact, source_id: '554188887777')
+    end
+
+    it 'files the message under the number as reported' do
+      expect(described_class.new(inbox: inbox, party: party, overwrite: true).perform.id).to eq(exact.id)
+    end
+  end
+
   it 'answers nil for a party with nothing to key on' do
     expect(described_class.new(inbox: inbox, party: model::Party.new(push_name: 'Ana')).perform).to be_nil
   end

--- a/spec/services/whatsapp/session/inbound/contact_resolver_spec.rb
+++ b/spec/services/whatsapp/session/inbound/contact_resolver_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::ContactResolver do
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:party) { model::Party.new(phone: '5541999990000', lid: '182736451928374', push_name: 'Ana Souza') }
+
+  it 'keys the contact_inbox by LID and fills the contact in' do
+    contact_inbox = described_class.new(inbox: inbox, party: party, overwrite: true).perform
+
+    expect(contact_inbox.source_id).to eq('182736451928374')
+    expect(contact_inbox.contact).to have_attributes(
+      name: 'Ana Souza', phone_number: '+5541999990000', identifier: '182736451928374@lid'
+    )
+  end
+
+  it 'answers nil for a party with nothing to key on' do
+    expect(described_class.new(inbox: inbox, party: model::Party.new(push_name: 'Ana')).perform).to be_nil
+  end
+
+  it 'replaces a name that is only the contact phone number' do
+    contact = create(:contact, account: channel.account, name: '5541999990000', phone_number: '+5541999990000')
+    create(:contact_inbox, contact: contact, inbox: inbox, source_id: '182736451928374')
+
+    described_class.new(inbox: inbox, party: party, overwrite: true).perform
+
+    expect(contact.reload.name).to eq('Ana Souza')
+  end
+
+  it 'keeps a name a human typed' do
+    contact = create(:contact, account: channel.account, name: 'Ana (financeiro)', phone_number: '+5541999990000')
+    create(:contact_inbox, contact: contact, inbox: inbox, source_id: '182736451928374')
+
+    described_class.new(inbox: inbox, party: party, overwrite: true).perform
+
+    expect(contact.reload.name).to eq('Ana (financeiro)')
+  end
+
+  it 'only fills blanks for a group participant' do
+    contact = create(:contact, account: channel.account, name: 'Ana', phone_number: '+5541999999999')
+    create(:contact_inbox, contact: contact, inbox: inbox, source_id: '182736451928374')
+
+    described_class.new(inbox: inbox, party: party).perform
+
+    expect(contact.reload.phone_number).to eq('+5541999999999')
+  end
+
+  it 'merges a contact_inbox that was keyed by phone before the LID showed up' do
+    contact = create(:contact, account: channel.account, name: 'Ana', phone_number: '+5541999990000')
+    create(:contact_inbox, contact: contact, inbox: inbox, source_id: '5541999990000')
+
+    contact_inbox = described_class.new(inbox: inbox, party: party, overwrite: true).perform
+
+    expect(contact_inbox.contact_id).to eq(contact.id)
+    expect(inbox.contacts.count).to eq(1)
+  end
+
+  it 'asks for the profile picture of a contact that has none' do
+    contact_inbox = described_class.new(inbox: inbox, party: party, overwrite: true).perform
+
+    expect(Whatsapp::Session::UpdateContactAvatarJob).to have_been_enqueued.with(contact_inbox.contact, inbox, party.to_h)
+  end
+end

--- a/spec/services/whatsapp/session/inbound/contact_resolver_spec.rb
+++ b/spec/services/whatsapp/session/inbound/contact_resolver_spec.rb
@@ -15,6 +15,25 @@ RSpec.describe Whatsapp::Session::Inbound::ContactResolver do
     )
   end
 
+  # Consolidation needs a phone *and* a LID, so it can do nothing for a phone-only
+  # party. Without a variant-aware lookup the builder matches exactly, misses the row
+  # the contact is already filed under, and files the same person a second time with a
+  # conversation of their own.
+  context 'when the contact is already filed under the other ninth-digit form' do
+    let(:party) { model::Party.new(phone: '5541988887777', push_name: 'Bruno') }
+    let!(:existing) do
+      contact = create(:contact, account: channel.account, phone_number: '+554188887777')
+      create(:contact_inbox, inbox: inbox, contact: contact, source_id: '554188887777')
+    end
+
+    it 'reuses it instead of creating a second contact' do
+      expect { described_class.new(inbox: inbox, party: party, overwrite: true).perform }
+        .not_to change(inbox.contact_inboxes, :count)
+
+      expect(described_class.new(inbox: inbox, party: party, overwrite: true).perform.id).to eq(existing.id)
+    end
+  end
+
   it 'answers nil for a party with nothing to key on' do
     expect(described_class.new(inbox: inbox, party: model::Party.new(push_name: 'Ana')).perform).to be_nil
   end

--- a/spec/services/whatsapp/session/inbound/dispatcher_spec.rb
+++ b/spec/services/whatsapp/session/inbound/dispatcher_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Dispatcher do
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:model) { Whatsapp::Session::Model }
+
+  it 'routes every canonical type to a handler or to the ignore list' do
+    routed = described_class::HANDLERS.keys + described_class::IGNORED
+
+    expect(model::Events::TYPES - routed).to be_empty
+  end
+
+  # An added type is additive, so it ships on the same protocol major. A frame on a
+  # major this build does not read is refused earlier, by the parser.
+  it 'ignores a type this build does not know instead of failing the shard' do
+    event = model::Event.from_frame({ 'v' => 1, 'type' => 'session.teleported', 'payload' => { 'anything' => true } })
+
+    expect(described_class.dispatch(channel, event)).to eq(:ignored)
+  end
+
+  it 'ignores a type the catalog knows but this layer does not act on' do
+    event = model::Event.build(model::Events::HistorySync.new(kind: 'recent', progress: 10))
+
+    expect(described_class.dispatch(channel, event)).to eq(:ignored)
+  end
+
+  it 'hands the event to the handler of its type' do
+    event = model::Event.build(model::Events::SessionState.new(state: 'open'))
+
+    expect(described_class.dispatch(channel, event)).to eq(:handled)
+    expect(channel.reload.provider_connection['connection']).to eq('open')
+  end
+end

--- a/spec/services/whatsapp/session/inbound/dispatcher_spec.rb
+++ b/spec/services/whatsapp/session/inbound/dispatcher_spec.rb
@@ -25,8 +25,11 @@ RSpec.describe Whatsapp::Session::Inbound::Dispatcher do
   # this its chats would be filed here in the meantime.
   context 'when the inbox has disowned its session' do
     before do
+      # Written the way the state handler writes it: the sentence for the dashboard and
+      # the key for code to compare against.
       channel.update_provider_connection!(
-        'connection' => 'close', 'error' => I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
+        'connection' => 'close', 'error_code' => 'wrong_phone_number',
+        'error' => I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
       )
     end
 

--- a/spec/services/whatsapp/session/inbound/dispatcher_spec.rb
+++ b/spec/services/whatsapp/session/inbound/dispatcher_spec.rb
@@ -20,6 +20,32 @@ RSpec.describe Whatsapp::Session::Inbound::Dispatcher do
     expect(missing).to be_empty
   end
 
+  # A session paired with a number the inbox is not configured for is somebody else's
+  # WhatsApp account. The logout that removes it is asynchronous and retried, so without
+  # this its chats would be filed here in the meantime.
+  context 'when the inbox has disowned its session' do
+    before do
+      channel.update_provider_connection!(
+        'connection' => 'close', 'error' => I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
+      )
+    end
+
+    it 'refuses a message event' do
+      inbound = model::InboundMessage.new(id: '3EB0AAAA0001', chat: model::Address.phone('5541999990000'),
+                                          from_me: false, content: model::Content::Text.new(body: 'oi'))
+      event = model::Event.build(model::Events::MessageReceived.new(message: inbound))
+
+      expect(described_class.dispatch(channel, event)).to eq(:ignored)
+      expect(channel.inbox.messages).to be_empty
+    end
+
+    it 'still takes connection events, which is how the inbox recovers' do
+      event = model::Event.build(model::Events::PairingQr.new(png_data_url: 'data:image/png;base64,AAA'), epoch: 9)
+
+      expect(described_class.dispatch(channel, event)).to eq(:handled)
+    end
+  end
+
   # An added type is additive, so it ships on the same protocol major. A frame on a
   # major this build does not read is refused earlier, by the parser.
   it 'ignores a type this build does not know instead of failing the shard' do

--- a/spec/services/whatsapp/session/inbound/dispatcher_spec.rb
+++ b/spec/services/whatsapp/session/inbound/dispatcher_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe Whatsapp::Session::Inbound::Dispatcher do
     expect(model::Events::TYPES - routed).to be_empty
   end
 
+  # The table holds names rather than classes, so a typo would otherwise only surface
+  # the day that event arrives. This keeps it a load-time guarantee.
+  it 'names a handler that exists for every type it routes' do
+    missing = described_class::HANDLERS.values.uniq.reject do |name|
+      "Whatsapp::Session::Inbound::Handlers::#{name}".safe_constantize.present?
+    end
+
+    expect(missing).to be_empty
+  end
+
   # An added type is additive, so it ships on the same protocol major. A frame on a
   # major this build does not read is refused earlier, by the parser.
   it 'ignores a type this build does not know instead of failing the shard' do

--- a/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
+++ b/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::GroupResolver do
+  subject(:resolve) { described_class.new(inbox: inbox, group: group, sender: sender, subject: 'Equipe de Vendas').perform }
+
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'native', phone_number: '+5541988887777',
+                              validate_provider_config: false, sync_templates: false)
+  end
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:group) { model::Address.group('120363041234567890') }
+  let(:sender) { model::Party.new(phone: '5541999990000', lid: '182736451928374', push_name: 'Ana Souza') }
+
+  it 'files the sender as a member of the group' do
+    result = resolve
+
+    member = GroupMember.find_by(group_contact: result.group_contact, contact: result.sender_contact)
+    expect(member).to have_attributes(role: 'member', is_active: true)
+  end
+
+  # A message says who wrote it, never what they are in the group. Writing the default
+  # role here demoted an administrator on every message they sent, and `inbox_admin?` is
+  # what decides whether this inbox may post in an announce-only group.
+  it 'keeps a role a roster sync or a promotion already recorded' do
+    first = resolve
+    GroupMember.find_by(group_contact: first.group_contact, contact: first.sender_contact).update!(role: :admin)
+
+    result = described_class.new(inbox: inbox, group: group, sender: sender).perform
+
+    expect(GroupMember.find_by(group_contact: result.group_contact, contact: result.sender_contact).role).to eq('admin')
+  end
+
+  it 'reactivates a member who had left and came back' do
+    first = resolve
+    GroupMember.find_by(group_contact: first.group_contact, contact: first.sender_contact)
+               .update!(role: :admin, is_active: false)
+
+    result = described_class.new(inbox: inbox, group: group, sender: sender).perform
+
+    expect(GroupMember.find_by(group_contact: result.group_contact, contact: result.sender_contact))
+      .to have_attributes(role: 'admin', is_active: true)
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
@@ -79,4 +79,23 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ConnectionState do
 
     expect(channel.reload.provider_connection).to include('connection' => 'connecting', 'reachout_time_lock' => { 'until' => 123 })
   end
+
+  # `pairing.success` is not the only event that names the paired number. One already
+  # queued behind it, or one arriving because the logout failed, used to be accepted on
+  # its own and put the inbox back to work on somebody else's WhatsApp account.
+  context 'when a session state reports a number the inbox is not configured for' do
+    let(:event) do
+      model::Event.build(
+        model::Events::SessionState.new(state: 'open', phone: '5541900001111'), epoch: 5
+      )
+    end
+
+    it 'closes the inbox instead of opening it' do
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+
+      expect(channel.reload.provider_connection).to include(
+        'connection' => 'close', 'error' => I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
+      )
+    end
+  end
 end

--- a/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ConnectionState do
       expect(channel.reload.provider_connection).to include(
         'connection' => 'close', 'error' => I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
       )
-      expect(backend.commands_of('session.logout').size).to eq(1)
+      expect(Whatsapp::Session::LogoutJob).to have_been_enqueued.with(channel)
     end
   end
 

--- a/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ConnectionState do
     end
   end
 
+  # The inbox is configured as +55 41 98888-7777 and WhatsApp reports the same line as
+  # 554188887777, because Brazilian numbers registered before the ninth digit are still
+  # addressed without it. Comparing the raw digits would log the operator out of the
+  # very number they configured.
+  context 'when the paired number is the configured one without its ninth digit' do
+    let(:event) { model::Event.build(model::Events::PairingSuccess.new(phone: '554188887777', lid: '99887766'), epoch: 1) }
+
+    it 'accepts the session' do
+      expect(dispatch).to eq(:handled)
+
+      expect(channel.reload.provider_connection['error']).to be_blank
+      expect(backend.commands_of('session.logout')).to be_empty
+    end
+  end
+
   it 'keeps the account limits a poll wrote while the state changes' do
     channel.update_provider_connection!({ 'connection' => 'open', 'reachout_time_lock' => { 'until' => 123 } })
     described_class.new(channel: channel, event: model::Event.build(model::Events::SessionState.new(state: 'connecting'))).perform

--- a/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
@@ -51,8 +51,12 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ConnectionState do
     it 'refuses the session and says why' do
       expect(dispatch).to eq(:handled)
 
+      # Both: the sentence is what the dashboard renders, and the key is what the
+      # dispatcher compares against to keep the wrong account's chats out. Comparing the
+      # sentence would fail open under another locale or a reworded translation.
       expect(channel.reload.provider_connection).to include(
-        'connection' => 'close', 'error' => I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
+        'connection' => 'close', 'error_code' => 'wrong_phone_number',
+        'error' => I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
       )
       expect(Whatsapp::Session::LogoutJob).to have_been_enqueued.with(channel)
     end

--- a/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::ConnectionState do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'native', phone_number: '+5541988887777',
+                              validate_provider_config: false, sync_templates: false)
+  end
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+  let(:model) { Whatsapp::Session::Model }
+  let(:event) { model::Event.build(model::Events::SessionState.new(state: 'open', phone: '5541988887777'), epoch: 2) }
+
+  before { allow(channel).to receive(:provider_service).and_return(backend) }
+
+  it 'writes the connection the provider reports' do
+    expect(dispatch).to eq(:handled)
+
+    expect(channel.reload.provider_connection).to include('connection' => 'open', 'phone_number' => '5541988887777', 'epoch' => 2)
+  end
+
+  it 'keeps the QR of a pairing event' do
+    event = model::Event.build(model::Events::PairingQr.new(png_data_url: 'data:image/png;base64,AAA'), epoch: 1)
+    described_class.new(channel: channel, event: event).perform
+
+    expect(channel.reload.provider_connection).to include('connection' => 'connecting', 'qr_data_url' => 'data:image/png;base64,AAA')
+  end
+
+  # The wire carries a key and the writer stores the sentence, because an Action Cable
+  # broadcast has no single reader whose locale could be used on read.
+  it 'turns a session that died into the sentence the dashboard renders' do
+    event = model::Event.build(model::Events::SessionLoggedOut.new(reason: 'device_removed'), epoch: 3)
+    described_class.new(channel: channel, event: event).perform
+
+    expect(channel.reload.provider_connection).to include(
+      'connection' => 'close', 'error' => I18n.t('errors.inboxes.channel.provider_connection.logged_out')
+    )
+  end
+
+  it 'discards an event from a previous owner of the session' do
+    dispatch
+    stale = model::Event.build(model::Events::SessionState.new(state: 'close'), epoch: 1)
+
+    expect(described_class.new(channel: channel, event: stale).perform).to eq(:ignored)
+    expect(channel.reload.provider_connection['connection']).to eq('open')
+  end
+
+  context 'when a different number was paired' do
+    let(:event) { model::Event.build(model::Events::PairingSuccess.new(phone: '5541900001111', lid: '99887766'), epoch: 1) }
+
+    it 'refuses the session and says why' do
+      expect(dispatch).to eq(:handled)
+
+      expect(channel.reload.provider_connection).to include(
+        'connection' => 'close', 'error' => I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number')
+      )
+      expect(backend.commands_of('session.logout').size).to eq(1)
+    end
+  end
+
+  it 'keeps the account limits a poll wrote while the state changes' do
+    channel.update_provider_connection!({ 'connection' => 'open', 'reachout_time_lock' => { 'until' => 123 } })
+    described_class.new(channel: channel, event: model::Event.build(model::Events::SessionState.new(state: 'connecting'))).perform
+
+    expect(channel.reload.provider_connection).to include('connection' => 'connecting', 'reachout_time_lock' => { 'until' => 123 })
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
@@ -102,4 +102,54 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ConnectionState do
       )
     end
   end
+
+  # `session.state` only requires `state`, so a live session can report itself without
+  # naming whose account it is. Accepting one of those while the logout that removes the
+  # wrong account is still being retried would clear the quarantine and let the dispatcher
+  # file that account's chats here again.
+  context 'when a state names no number while the inbox is disowned' do
+    before do
+      channel.update_provider_connection!(
+        { 'connection' => 'close', 'error_code' => 'wrong_phone_number', 'epoch' => 5 }
+      )
+    end
+
+    it 'keeps the inbox closed on the wrong number' do
+      described_class.new(
+        channel: channel, event: model::Event.build(model::Events::SessionState.new(state: 'open'), epoch: 5)
+      ).perform
+
+      expect(channel.reload.provider_connection).to include(
+        'connection' => 'close', 'error_code' => 'wrong_phone_number'
+      )
+    end
+
+    it 'keeps refusing the wrong account\'s messages' do
+      described_class.new(
+        channel: channel, event: model::Event.build(model::Events::SessionState.new(state: 'open'), epoch: 5)
+      ).perform
+
+      message = model::Event.build(
+        model::Events::MessageReceived.new(
+          message: model::InboundMessage.new(
+            id: '3EB0AAA', chat: model::Address.new(kind: 'phone', id: '5541900001111'),
+            sender: model::Party.new(phone: '5541900001111'), from_me: false, timestamp: 1_755_440_000,
+            content: model::Content::Text.new(body: 'hi')
+          )
+        ), epoch: 5
+      )
+
+      expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel.reload, message)).to eq(:ignored)
+    end
+
+    it 'lifts the quarantine once a state names the configured number' do
+      described_class.new(
+        channel: channel,
+        event: model::Event.build(model::Events::SessionState.new(state: 'open', phone: '5541988887777'), epoch: 5)
+      ).perform
+
+      expect(channel.reload.provider_connection).to include('connection' => 'open')
+      expect(channel.provider_connection).not_to have_key('error_code')
+    end
+  end
 end

--- a/spec/services/whatsapp/session/inbound/handlers/contact_picture_changed_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/contact_picture_changed_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::ContactPictureChanged do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:contact) { create(:contact, account: channel.account, phone_number: '+5541999990000', identifier: '182736451928374@lid') }
+  let(:party) { model::Party.new(phone: '5541999990000', lid: '182736451928374') }
+  let(:removed) { false }
+  let(:event) { model::Event.build(model::Events::ContactPictureChanged.new(party: party, removed: removed)) }
+
+  before { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '182736451928374') }
+
+  it 'drops the stored avatar and asks for the new one' do
+    dispatch
+
+    expect(Whatsapp::Session::UpdateContactAvatarJob).to have_been_enqueued.with(contact, inbox, hash_including('phone' => '5541999990000'))
+  end
+
+  context 'when the photo was removed' do
+    let(:removed) { true }
+
+    it 'does not ask for a replacement' do
+      expect(dispatch).to eq(:handled)
+      expect(Whatsapp::Session::UpdateContactAvatarJob).not_to have_been_enqueued
+    end
+  end
+
+  # A contact inbox keyed by LID is invisible to a lookup holding only the phone, which
+  # is what the event carries for a contact created before the inbox moved provider.
+  context 'when the event carries only the phone' do
+    let(:party) { model::Party.new(phone: '5541999990000') }
+
+    it 'still finds the contact behind the LID' do
+      expect(dispatch).to eq(:handled)
+      expect(Whatsapp::Session::UpdateContactAvatarJob).to have_been_enqueued.with(contact, inbox, hash_including('phone' => '5541999990000'))
+    end
+  end
+
+  context 'when nobody here knows the number' do
+    let(:party) { model::Party.new(phone: '5541900001111') }
+
+    it 'ignores the event instead of inventing a contact' do
+      expect { expect(dispatch).to eq(:ignored) }.not_to change(Contact, :count)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/contact_picture_changed_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/contact_picture_changed_spec.rb
@@ -16,7 +16,33 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ContactPictureChanged do
   it 'drops the stored avatar and asks for the new one' do
     dispatch
 
-    expect(Whatsapp::Session::UpdateContactAvatarJob).to have_been_enqueued.with(contact, inbox, hash_including('phone' => '5541999990000'))
+    expect(Whatsapp::Session::UpdateContactAvatarJob)
+      .to have_been_enqueued.with(contact, inbox, hash_including('phone' => '5541999990000'), force: true)
+  end
+
+  # `Avatar::AvatarFromUrlJob` skips a contact synced in the last minute or handed a URL
+  # it already fetched, and stamps both markers even on the run it skipped. Purging the
+  # avatar up front and then having the download skipped left the contact with no
+  # picture and no attempt that would ever fire again.
+  context 'when the contact already has an avatar' do
+    before do
+      contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png',
+                            content_type: 'image/png')
+      contact.update!(additional_attributes: { 'last_avatar_sync_at' => Time.current.iso8601,
+                                               'avatar_url_hash' => 'abc123' })
+    end
+
+    it 'keeps it until the replacement can be attached' do
+      dispatch
+
+      expect(contact.reload.avatar).to be_attached
+    end
+
+    it 'clears the markers that would suppress the download' do
+      dispatch
+
+      expect(contact.reload.additional_attributes).not_to include('last_avatar_sync_at', 'avatar_url_hash')
+    end
   end
 
   context 'when the photo was removed' do
@@ -35,7 +61,8 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ContactPictureChanged do
 
     it 'still finds the contact behind the LID' do
       expect(dispatch).to eq(:handled)
-      expect(Whatsapp::Session::UpdateContactAvatarJob).to have_been_enqueued.with(contact, inbox, hash_including('phone' => '5541999990000'))
+      expect(Whatsapp::Session::UpdateContactAvatarJob)
+        .to have_been_enqueued.with(contact, inbox, hash_including('phone' => '5541999990000'), force: true)
     end
   end
 

--- a/spec/services/whatsapp/session/inbound/handlers/contact_picture_changed_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/contact_picture_changed_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ContactPictureChanged do
     end
   end
 
+  # The event may carry the other ninth-digit form of the same line, and the contact is
+  # stored under whichever one first reached us.
+  context 'when the event carries the other ninth-digit form' do
+    let(:party) { model::Party.new(phone: '554199990000') }
+
+    it 'still finds the contact' do
+      expect(dispatch).to eq(:handled)
+      expect(Whatsapp::Session::UpdateContactAvatarJob).to have_been_enqueued
+    end
+  end
+
   context 'when nobody here knows the number' do
     let(:party) { model::Party.new(phone: '5541900001111') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_activity_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_activity_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupActivity do
+  subject(:dispatch) do
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+    end
+  end
+
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'native', phone_number: '+5541988887777',
+                              validate_provider_config: false, sync_templates: false)
+  end
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:group) { model::Address.group('120363041234567890') }
+  let(:event) { model::Event.build(model::Events::GroupActivity.new(groups: [group])) }
+
+  it 'is ignored while the group capability is off' do
+    expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)).to eq(:ignored)
+  end
+
+  it 'opens the group and moves its card up the chat list' do
+    expect(dispatch).to eq(:handled)
+
+    group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+    expect(group_contact.conversations.last.last_activity_at).to be_present
+  end
+
+  # Without the originating channel the service falls back to `Contact#group_channel`,
+  # which picks the group contact's first contact_inbox: an arbitrary choice as soon as
+  # the same group is in two inboxes, and the sync can run through a session that is not
+  # connected while the one that saw the activity stays stale.
+  it 'asks for the soft sync on the inbox that saw the activity' do
+    dispatch
+
+    expect(Contacts::SyncGroupJob).to have_been_enqueued.with(anything, soft: true, channel: channel)
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/group_joined_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_joined_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupJoined do
+  subject(:dispatch) do
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+    end
+  end
+
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'native', phone_number: '+5541988887777',
+                              validate_provider_config: false, sync_templates: false)
+  end
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:group) { model::Address.group('120363041234567890') }
+  let(:info) do
+    model::GroupInfo.new(
+      group: group, subject: 'Equipe de Vendas', description: 'Combinados do time',
+      participants: [
+        model::GroupInfo::Participant.new(party: model::Party.new(phone: '5541999990000', push_name: 'Ana'), role: 'admin'),
+        model::GroupInfo::Participant.new(party: model::Party.new(phone: '5541977776666', push_name: 'Bruno'))
+      ]
+    )
+  end
+  let(:event) { model::Event.build(model::Events::GroupJoined.new(info: info)) }
+
+  it 'is ignored while the group capability is off' do
+    expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)).to eq(:ignored)
+  end
+
+  it 'opens the group with its members and its metadata' do
+    expect(dispatch).to eq(:handled)
+
+    group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+    expect(group_contact.name).to eq('Equipe de Vendas')
+    expect(group_contact.additional_attributes['description']).to eq('Combinados do time')
+    expect(group_contact.group_memberships.active.count).to eq(2)
+    expect(group_contact.conversations).to be_present
+  end
+
+  # An ordinary contact update does not carry `group_members`, so without this an open
+  # dashboard keeps showing the roster (and the admin rights) the group had before.
+  it 'broadcasts the roster it just synced' do
+    channel
+    allow(Rails.configuration.dispatcher).to receive(:dispatch).and_call_original
+    expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+      Events::Types::CONTACT_GROUP_SYNCED, anything, hash_including(:contact)
+    ).at_least(:once)
+
+    dispatch
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/group_joined_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_joined_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupJoined do
 
       expect(resolved.reload.status).to eq('open')
     end
+
+    # The snooze job reopens on its own schedule, and this event creates no message to
+    # trigger the reopen a message would: the restored group stayed hidden until then.
+    context 'when the thread was snoozed rather than resolved' do
+      before { resolved.update!(status: :snoozed, snoozed_until: 2.days.from_now) }
+
+      it 'reopens it as well' do
+        expect(dispatch).to eq(:handled)
+
+        expect(resolved.reload.status).to eq('open')
+      end
+    end
   end
 
   # An ordinary contact update does not carry `group_members`, so without this an open

--- a/spec/services/whatsapp/session/inbound/handlers/group_joined_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_joined_spec.rb
@@ -29,6 +29,38 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupJoined do
     expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)).to eq(:ignored)
   end
 
+  # Nothing replays the picture-change events from while the session was out of the
+  # group, so the snapshot this event carries is the only chance to notice the photo
+  # changed; the "already attached" guard kept the old one forever.
+  context 'when the group already has a stored avatar' do
+    let(:info) do
+      model::GroupInfo.new(group: group, subject: 'Equipe de Vendas',
+                           picture_url: 'https://connector.test/new.jpg')
+    end
+
+    before do
+      group_contact = create(:contact, account: channel.account, identifier: '120363041234567890@g.us',
+                                       group_type: :group,
+                                       additional_attributes: { 'avatar_url_hash' => 'old', 'last_avatar_sync_at' => Time.current.iso8601 })
+      create(:contact_inbox, inbox: inbox, contact: group_contact, source_id: '120363041234567890')
+      group_contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png',
+                                  content_type: 'image/png')
+    end
+
+    it 'asks for the picture the snapshot reports' do
+      dispatch
+
+      expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(anything, 'https://connector.test/new.jpg')
+    end
+
+    it 'clears the markers that would suppress the download' do
+      dispatch
+
+      expect(inbox.contacts.find_by(identifier: '120363041234567890@g.us').additional_attributes)
+        .not_to include('avatar_url_hash', 'last_avatar_sync_at')
+    end
+  end
+
   it 'opens the group with its members and its metadata' do
     expect(dispatch).to eq(:handled)
 
@@ -37,6 +69,28 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupJoined do
     expect(group_contact.additional_attributes['description']).to eq('Combinados do time')
     expect(group_contact.group_memberships.active.count).to eq(2)
     expect(group_contact.conversations).to be_present
+  end
+
+  # This event creates no message, so nothing else moves the thread off resolved: an
+  # inbox that locks to a single conversation handed back the resolved thread of the
+  # group it was in before, and the rejoined group sat there looking closed.
+  context 'when the group was left and its only thread was resolved' do
+    let(:group_contact) do
+      create(:contact, account: channel.account, identifier: '120363041234567890@g.us', group_type: :group)
+    end
+    let!(:resolved) do
+      contact_inbox = create(:contact_inbox, inbox: inbox, contact: group_contact, source_id: '120363041234567890')
+      create(:conversation, inbox: inbox, account: channel.account, contact: group_contact,
+                            contact_inbox: contact_inbox, group_type: :group, status: :resolved)
+    end
+
+    before { inbox.update!(lock_to_single_conversation: true) }
+
+    it 'reopens it instead of reusing it resolved' do
+      expect(dispatch).to eq(:handled)
+
+      expect(resolved.reload.status).to eq('open')
+    end
   end
 
   # An ordinary contact update does not carry `group_members`, so without this an open

--- a/spec/services/whatsapp/session/inbound/handlers/group_picture_changed_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_picture_changed_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupPictureChanged do
 
     group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
     expect(group_contact.conversations.last.messages.last.content).to include('changed the group image')
-    expect(Whatsapp::Session::UpdateGroupAvatarJob).to have_been_enqueued.with(group_contact, force: true)
+    # The inbox the event came from, not whichever contact_inbox happens to be first:
+    # the same group can be in two inboxes of one account.
+    expect(Whatsapp::Session::UpdateGroupAvatarJob).to have_been_enqueued.with(group_contact, force: true, channel: channel)
   end
 
   # The job returns before purging when the group reports no photo, so asking it to

--- a/spec/services/whatsapp/session/inbound/handlers/group_picture_changed_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_picture_changed_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupPictureChanged do
+  subject(:dispatch) do
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+    end
+  end
+
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'native', phone_number: '+5541988887777',
+                              validate_provider_config: false, sync_templates: false)
+  end
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:group) { model::Address.group('120363041234567890') }
+  let(:actor) { model::Party.new(phone: '5541999990000', push_name: 'Ana Souza') }
+  let(:removed) { false }
+  let(:event) do
+    model::Event.build(model::Events::GroupPictureChanged.new(group: group, actor: actor, removed: removed))
+  end
+
+  it 'is ignored while the group capability is off' do
+    expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)).to eq(:ignored)
+  end
+
+  it 'records who changed it and asks for the new image' do
+    expect(dispatch).to eq(:handled)
+
+    group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+    expect(group_contact.conversations.last.messages.last.content).to include('changed the group image')
+    expect(Whatsapp::Session::UpdateGroupAvatarJob).to have_been_enqueued.with(group_contact, force: true)
+  end
+
+  # The job returns before purging when the group reports no photo, so asking it to
+  # refresh a removed image would leave the old one attached for good.
+  context 'when the photo was removed' do
+    let(:removed) { true }
+
+    it 'purges instead of refetching' do
+      expect(dispatch).to eq(:handled)
+      expect(Whatsapp::Session::UpdateGroupAvatarJob).not_to have_been_enqueued
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -83,6 +83,21 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
     end
   end
 
+  # WhatsApp may name the session's own participant by LID alone, and the contact
+  # resolved from that has no phone at all, so comparing numbers can only answer no.
+  context 'when the inbox itself is named only by its LID' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new(leave: [model::Party.new(lid: '998877665544332')]) }
+
+    before { channel.update_provider_connection!('connection' => 'open', 'lid' => '998877665544332') }
+
+    it 'still recognizes the group as left' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.additional_attributes['group_left']).to be(true)
+    end
+  end
+
   context 'when the description was removed' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(description: '') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -44,6 +44,45 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
     end
   end
 
+  # The wire says `admin_add` or `all_member_add`; the dashboard reads the stored value
+  # as "may every member add people" and treats anything but `false` as yes. Storing the
+  # enum raw therefore shows the exact opposite of the setting the group has.
+  context 'when only admins may add people' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new(member_add_mode: 'admin_add') }
+
+    it 'stores the setting as the boolean the dashboard reads' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.additional_attributes['member_add_mode']).to be(false)
+      expect(group_contact.conversations.last.messages.last.content).to include('only admins to add others')
+    end
+  end
+
+  context 'when every member may add people' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new(member_add_mode: 'all_member_add') }
+
+    it 'stores it as enabled' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.additional_attributes['member_add_mode']).to be(true)
+    end
+  end
+
+  # WhatsApp reports the inbox's own line without its ninth digit, and it is the phone
+  # comparison that decides whether the threads get resolved.
+  context 'when the inbox number was removed under its other ninth-digit form' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new(leave: [model::Party.new(phone: '554188887777')]) }
+
+    it 'still recognizes the group as left' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.additional_attributes['group_left']).to be(true)
+    end
+  end
+
   context 'when the description was removed' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(description: '') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
+  subject(:dispatch) do
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+    end
+  end
+
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'native', phone_number: '+5541988887777',
+                              validate_provider_config: false, sync_templates: false)
+  end
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:group) { model::Address.group('120363041234567890') }
+  let(:actor) { model::Party.new(phone: '5541999990000', lid: '182736451928374', push_name: 'Ana Souza') }
+  let(:changes) { model::Events::GroupUpdated::Changes.new(subject: 'Equipe de Vendas') }
+  let(:event) { model::Event.build(model::Events::GroupUpdated.new(group: group, actor: actor, changes: changes)) }
+
+  it 'is ignored while the group capability is off' do
+    expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)).to eq(:ignored)
+  end
+
+  it 'renames the group and records who did it' do
+    expect(dispatch).to eq(:handled)
+
+    group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+    expect(group_contact.name).to eq('Equipe de Vendas')
+    activity = group_contact.conversations.last.messages.last
+    expect(activity.message_type).to eq('activity')
+    expect(activity.content).to include('Equipe de Vendas')
+  end
+
+  context 'when a setting changed' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new(announce: true, locked: false) }
+
+    it 'persists both settings and writes one activity each' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.additional_attributes).to include('announce' => true, 'restrict' => false)
+      expect(group_contact.conversations.last.messages.where(message_type: :activity).count).to eq(2)
+    end
+  end
+
+  context 'when the description was removed' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new(description: '') }
+
+    it 'clears it and says so' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.additional_attributes['description']).to be_nil
+      expect(group_contact.conversations.last.messages.last.content).to include('removed the group description')
+    end
+  end
+
+  context 'when participants joined' do
+    let(:joined) { model::Party.new(phone: '5541977776666', lid: '55443322', push_name: 'Bruno') }
+    let(:changes) { model::Events::GroupUpdated::Changes.new(join: [joined]) }
+
+    it 'adds them as members' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.group_memberships.active.count).to eq(1)
+      expect(group_contact.group_memberships.active.first.contact.name).to eq('Bruno')
+    end
+  end
+
+  context 'when the inbox number itself was removed' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new(leave: [model::Party.new(phone: '5541988887777')]) }
+
+    before do
+      with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(
+          channel,
+          model::Event.build(model::Events::GroupUpdated.new(group: group, actor: actor,
+                                                             changes: model::Events::GroupUpdated::Changes.new(subject: 'Equipe')))
+        )
+      end
+    end
+
+    it 'marks the group as left and resolves its threads' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.additional_attributes['group_left']).to be(true)
+      expect(group_contact.conversations.where(status: %i[open pending])).to be_empty
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -32,6 +32,25 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
     expect(activity.content).to include('Equipe de Vendas')
   end
 
+  # A group event may name its author by the other ninth-digit form of the same line.
+  # The exact lookup missed the contact and printed the raw number in an activity line
+  # that had the person's name available all along.
+  context 'when the actor is filed under the other ninth-digit form' do
+    let(:actor) { model::Party.new(phone: '5541999990000') }
+
+    before do
+      contact = create(:contact, account: channel.account, name: 'Ana Souza', phone_number: '+554199990000')
+      create(:contact_inbox, inbox: inbox, contact: contact, source_id: '554199990000')
+    end
+
+    it 'blames them by name' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.conversations.last.messages.last.content).to include('Ana Souza')
+    end
+  end
+
   context 'when a setting changed' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(announce: true, locked: false) }
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
     end
   end
 
+  # Consolidation re-keys the contact_inbox to the LID, so an actor named only by phone
+  # matches no source_id at all and the activity line printed the raw number.
+  context 'when the actor is filed under a LID and the event carries only the phone' do
+    let(:actor) { model::Party.new(phone: '5541999990000') }
+
+    before do
+      contact = create(:contact, account: channel.account, name: 'Ana Souza', phone_number: '+5541999990000')
+      create(:contact_inbox, inbox: inbox, contact: contact, source_id: '182736451928374')
+    end
+
+    it 'blames them by name' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.conversations.last.messages.last.content).to include('Ana Souza')
+    end
+  end
+
   context 'when a setting changed' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(announce: true, locked: false) }
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -69,6 +69,22 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
     end
   end
 
+  # A promote can be the first thing seen about a participant: the roster sync may never
+  # have run, or the person joined before the inbox existed. `update_member_role` only
+  # touches a membership that already exists, so the roster kept omitting somebody the
+  # event had just confirmed is in the group.
+  context 'when a promotion is the first thing seen about the participant' do
+    let(:promoted) { model::Party.new(phone: '5541977776666', push_name: 'Bruno') }
+    let(:changes) { model::Events::GroupUpdated::Changes.new(promote: [promoted]) }
+
+    it 'files them as an admin instead of doing nothing' do
+      expect(dispatch).to eq(:handled)
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact.group_memberships.active.map(&:role)).to include('admin')
+    end
+  end
+
   context 'when a setting changed' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(announce: true, locked: false) }
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
     end
   end
 
+  # `changes` is a Data instance and is never blank, so a payload reporting nothing, or
+  # nothing this build knows, used to open a group contact, a conversation and a sync
+  # broadcast for an event that says nothing.
+  context 'when the payload reports no change this build knows' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new }
+
+    it 'ignores it instead of opening the group' do
+      expect { expect(dispatch).to eq(:ignored) }.not_to change(Contact, :count)
+    end
+  end
+
   context 'when a setting changed' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(announce: true, locked: false) }
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -98,6 +98,32 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
     end
   end
 
+  # The group contact is shared by every inbox of the account that is in the same
+  # WhatsApp group, so closing all of its threads would end a conversation another
+  # number can still use.
+  context 'when another inbox of the account is in the same group' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new(leave: [model::Party.new(phone: '5541988887777')]) }
+    let(:other_inbox) do
+      create(:channel_whatsapp, account: channel.account, provider: 'native', phone_number: '+5541977776666',
+                                validate_provider_config: false, sync_templates: false).inbox
+    end
+
+    it 'closes only its own threads' do
+      dispatch
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      other_contact_inbox = create(:contact_inbox, inbox: other_inbox, contact: group_contact,
+                                                   source_id: '120363041234567890')
+      other_thread = create(:conversation, contact: group_contact, contact_inbox: other_contact_inbox,
+                                           inbox: other_inbox, account: channel.account, status: :open)
+
+      with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+      end
+
+      expect(other_thread.reload.status).to eq('open')
+    end
+  end
+
   context 'when the description was removed' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(description: '') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -96,6 +96,27 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
     end
   end
 
+  # A thread the snooze job would reopen for a group this inbox has left can no longer
+  # send anything, so leaving has to close that one too.
+  context 'when the session itself leaves and its thread is snoozed' do
+    let(:changes) { model::Events::GroupUpdated::Changes.new(leave: [model::Party.new(phone: '5541988887777')]) }
+    let(:group_contact) do
+      create(:contact, account: channel.account, identifier: '120363041234567890@g.us', group_type: :group)
+    end
+    let!(:snoozed) do
+      contact_inbox = create(:contact_inbox, inbox: inbox, contact: group_contact, source_id: '120363041234567890')
+      create(:conversation, inbox: inbox, account: channel.account, contact: group_contact,
+                            contact_inbox: contact_inbox, group_type: :group, status: :snoozed,
+                            snoozed_until: 2.days.from_now)
+    end
+
+    it 'resolves it' do
+      expect(dispatch).to eq(:handled)
+
+      expect(snoozed.reload.status).to eq('resolved')
+    end
+  end
+
   context 'when a setting changed' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(announce: true, locked: false) }
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageEdited do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:conversation) { create(:conversation, inbox: inbox, account: channel.account) }
+  let(:message) do
+    create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                     content: 'oi', source_id: '3EB0AAAA0001')
+  end
+  let(:event) do
+    model::Event.build(
+      model::Events::MessageEdited.new(
+        chat: model::Address.phone('5541999990000'), message_id: message.source_id,
+        content: model::Content::Text.new(body: 'oi, corrigido')
+      )
+    )
+  end
+
+  it 'replaces the content and keeps the original' do
+    expect(dispatch).to eq(:handled)
+
+    expect(message.reload.content).to eq('oi, corrigido')
+    expect(message.is_edited).to be(true)
+    expect(message.previous_content).to eq('oi')
+  end
+
+  it 'keeps the first version across a second edit' do
+    dispatch
+    described_class.new(
+      channel: channel,
+      event: model::Event.build(
+        model::Events::MessageEdited.new(
+          chat: model::Address.phone('5541999990000'), message_id: message.source_id,
+          content: model::Content::Text.new(body: 'terceira versão')
+        )
+      )
+    ).perform
+
+    expect(message.reload.previous_content).to eq('oi')
+    expect(message.content).to eq('terceira versão')
+  end
+
+  it 'ignores an edit of a message it never stored' do
+    event = model::Event.build(
+      model::Events::MessageEdited.new(chat: model::Address.phone('5541999990000'), message_id: '3EB0UNKNOWN',
+                                       content: model::Content::Text.new(body: 'x'))
+    )
+
+    expect(described_class.new(channel: channel, event: event).perform).to eq(:ignored)
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
@@ -52,4 +52,22 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageEdited do
 
     expect(described_class.new(channel: channel, event: event).perform).to eq(:ignored)
   end
+
+  # Removing a caption is a real edit, and dropping it left the old caption on screen
+  # with no way to clear it.
+  context 'when the edit clears a media caption' do
+    let(:event) do
+      model::Event.build(
+        model::Events::MessageEdited.new(
+          chat: model::Address.phone('5541999990000'), message_id: message.source_id,
+          content: model::Content::Media.new(kind: 'image', mime: 'image/jpeg', caption: '')
+        )
+      )
+    end
+
+    it 'clears the stored caption' do
+      expect(dispatch).to eq(:handled)
+      expect(message.reload.content).to eq('')
+    end
+  end
 end

--- a/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
@@ -90,13 +90,6 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReaction do
     end
   end
 
-  it 'does not open a thread for a reaction whose target is unknown' do
-    event = model::Event.build(reaction.with(target_id: '3EB0MISSING', id: '3EB0REACTION2'))
-
-    expect(described_class.new(channel: channel, event: event).perform).to eq(:handled)
-    expect(inbox.messages.find_by(source_id: '3EB0REACTION2').conversation).to eq(inbox.conversations.last)
-  end
-
   context 'when the contact takes the reaction back' do
     let(:emoji) { nil }
 
@@ -120,6 +113,23 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReaction do
            .update_all(content: '') # rubocop:disable Rails/SkipsModelValidations
 
       expect(dispatch).to eq(:ignored)
+    end
+  end
+
+  # Resolving the peer creates a Contact, a ContactInbox and an avatar job, and a
+  # reaction whose target was never stored has nothing to annotate: it used to open a
+  # thread of its own to hold a reaction pointing at a message that does not exist.
+  context 'when the message it reacts to was never stored' do
+    let(:reaction) do
+      model::Events::MessageReaction.new(
+        id: '3EB0REACTION', chat: model::Address.phone('5541999990000'), sender: sender,
+        from_me: false, target_id: '3EB0NEVERSEEN', emoji: emoji, timestamp: 1_755_440_000_123
+      )
+    end
+
+    it 'drops it instead of inventing a contact and a thread' do
+      expect { expect(dispatch).to eq(:ignored) }
+        .to not_change(Contact, :count).and not_change(inbox.conversations, :count)
     end
   end
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
@@ -119,6 +119,30 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReaction do
   # Resolving the peer creates a Contact, a ContactInbox and an avatar job, and a
   # reaction whose target was never stored has nothing to annotate: it used to open a
   # thread of its own to hold a reaction pointing at a message that does not exist.
+  # Scoped to the target alone, somebody else's reaction answered yes and the removal
+  # resolved a contact on its way to doing nothing, which is the exact leak the guard
+  # exists to stop.
+  context 'when the removal comes from somebody who never reacted' do
+    let(:emoji) { nil }
+    let(:reaction) do
+      model::Events::MessageReaction.new(
+        id: '3EB0REMOVE2', chat: model::Address.phone('5541900002222'),
+        sender: model::Party.new(phone: '5541900002222'), from_me: false,
+        target_id: target.source_id, emoji: '', timestamp: 1_755_440_000_123
+      )
+    end
+
+    before do
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       message_type: :incoming, sender: contact, content: '👍',
+                       content_attributes: { is_reaction: true, in_reply_to_external_id: '3EB0TARGET' })
+    end
+
+    it 'leaves no contact behind' do
+      expect { expect(dispatch).to eq(:ignored) }.not_to change(Contact, :count)
+    end
+  end
+
   context 'when the message it reacts to was never stored' do
     let(:reaction) do
       model::Events::MessageReaction.new(

--- a/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReaction do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:contact) { create(:contact, account: channel.account, phone_number: '+5541999990000', identifier: '182736451928374@lid') }
+  let(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox, source_id: '182736451928374') }
+  let(:conversation) { create(:conversation, contact: contact, contact_inbox: contact_inbox, inbox: inbox, account: channel.account) }
+  let(:target) do
+    create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                     message_type: :outgoing, source_id: '3EB0TARGET')
+  end
+  let(:sender) { model::Party.new(phone: '5541999990000', lid: '182736451928374', push_name: 'Ana Souza') }
+  let(:emoji) { '👍' }
+  let(:reaction) do
+    model::Events::MessageReaction.new(
+      id: '3EB0REACTION', chat: model::Address.phone('5541999990000'), sender: sender,
+      from_me: false, target_id: target.source_id, emoji: emoji, timestamp: 1_755_440_000_123
+    )
+  end
+  let(:event) { model::Event.build(reaction) }
+
+  it 'stores the reaction in the thread of the message it annotates' do
+    expect(dispatch).to eq(:handled)
+
+    stored = inbox.messages.find_by(source_id: '3EB0REACTION')
+    expect(stored.content).to eq('👍')
+    expect(stored.conversation).to eq(conversation)
+    expect(stored.content_attributes['is_reaction']).to be(true)
+    expect(stored.content_attributes['in_reply_to_external_id']).to eq('3EB0TARGET')
+  end
+
+  it 'does not open a thread for a reaction whose target is unknown' do
+    event = model::Event.build(reaction.with(target_id: '3EB0MISSING', id: '3EB0REACTION2'))
+
+    expect(described_class.new(channel: channel, event: event).perform).to eq(:handled)
+    expect(inbox.messages.find_by(source_id: '3EB0REACTION2').conversation).to eq(inbox.conversations.last)
+  end
+
+  context 'when the contact takes the reaction back' do
+    let(:emoji) { nil }
+
+    before do
+      target
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       message_type: :incoming, sender: contact, content: '👍',
+                       content_attributes: { is_reaction: true, in_reply_to_external_id: '3EB0TARGET' })
+    end
+
+    it 'empties the stored reaction instead of creating a row' do
+      expect(dispatch).to eq(:handled)
+
+      removed = inbox.messages.find_by("(content_attributes#>>'{}')::jsonb->>'is_reaction' = 'true'")
+      expect(removed.content).to eq('')
+      expect(removed.content_attributes['deleted']).to be(true)
+    end
+
+    it 'ignores a removal with nothing left to remove' do
+      inbox.messages.where("(content_attributes#>>'{}')::jsonb->>'is_reaction' = 'true'")
+           .update_all(content: '') # rubocop:disable Rails/SkipsModelValidations
+
+      expect(dispatch).to eq(:ignored)
+    end
+  end
+
+  context 'when the reaction was made on the connected phone' do
+    let(:emoji) { nil }
+    let(:reaction) do
+      model::Events::MessageReaction.new(
+        id: '3EB0REACTION', chat: model::Address.phone('5541999990000'), sender: nil,
+        from_me: true, target_id: target.source_id, emoji: nil, timestamp: 1_755_440_000_123
+      )
+    end
+
+    before do
+      target
+      # :bot_message is the factory trait for an outgoing message with no agent behind it,
+      # which is how a reaction made on the connected phone is stored.
+      create(:message, :bot_message, conversation: conversation, inbox: inbox, account: channel.account,
+                                     content: '👍', content_attributes: { is_reaction: true, in_reply_to_external_id: '3EB0TARGET' })
+    end
+
+    it 'removes the agent-less reaction row' do
+      expect(dispatch).to eq(:handled)
+
+      removed = inbox.messages.where(message_type: :outgoing)
+                     .find_by("(content_attributes#>>'{}')::jsonb->>'is_reaction' = 'true'")
+      expect(removed.content_attributes['deleted']).to be(true)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
@@ -33,6 +33,63 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReaction do
     expect(stored.content_attributes['in_reply_to_external_id']).to eq('3EB0TARGET')
   end
 
+  # WhatsApp gives a changed reaction a new id, so swapping one emoji for another is a
+  # fresh event, not an edit. A second row would show both emojis on the bubble and
+  # leave one behind when the reaction is taken back.
+  it 'replaces a reaction the same sender already left' do
+    target
+    dispatch
+
+    changed = model::Events::MessageReaction.new(
+      id: '3EB0REACTION2', chat: model::Address.phone('5541999990000'), sender: sender,
+      from_me: false, target_id: target.source_id, emoji: '❤️', timestamp: 1_755_440_000_456
+    )
+    Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, model::Event.build(changed))
+
+    rows = conversation.messages.where("(content_attributes#>>'{}')::jsonb->>'is_reaction' = 'true'")
+    expect(rows.count).to eq(1)
+    expect(rows.first).to have_attributes(content: '❤️', source_id: '3EB0REACTION2')
+  end
+
+  # The reaction Chatwoot sent reserved its id, and a lost send response makes the echo
+  # arrive under an id we never stored.
+  context 'with the echo of a reaction Chatwoot sent' do
+    let(:reaction) do
+      model::Events::MessageReaction.new(
+        id: '3EB0RESERVED', chat: model::Address.phone('5541999990000'), sender: nil,
+        from_me: true, target_id: target.source_id, emoji: emoji, timestamp: 1_755_440_000_123
+      )
+    end
+
+    it 'confirms the reserved row instead of adding a second reaction' do
+      reserved = create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                                  message_type: :outgoing, source_id: nil,
+                                  content_attributes: { is_reaction: true, pending_source_id: '3EB0RESERVED' })
+
+      expect(dispatch).to eq(:handled)
+
+      expect(reserved.reload.source_id).to eq('3EB0RESERVED')
+      expect(conversation.messages.where("(content_attributes#>>'{}')::jsonb->>'is_reaction' = 'true'").count).to eq(1)
+    end
+  end
+
+  # Resolving a sender creates a Contact, a ContactInbox and an avatar job, and a
+  # removal aimed at a message nobody reacted to has nothing to remove.
+  context 'with a removal that matches nothing' do
+    let(:emoji) { '' }
+    let(:reaction) do
+      model::Events::MessageReaction.new(
+        id: '3EB0REMOVE', chat: model::Address.phone('5541900001111'),
+        sender: model::Party.new(phone: '5541900001111'), from_me: false,
+        target_id: '3EB0UNKNOWN', emoji: '', timestamp: 1_755_440_000_123
+      )
+    end
+
+    it 'leaves no contact behind' do
+      expect { expect(dispatch).to eq(:ignored) }.not_to change(Contact, :count)
+    end
+  end
+
   it 'does not open a thread for a reaction whose target is unknown' do
     event = model::Event.build(reaction.with(target_id: '3EB0MISSING', id: '3EB0REACTION2'))
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_receipt_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_receipt_spec.rb
@@ -26,10 +26,41 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceipt do
   context 'when the contact read it' do
     let(:type) { 'read' }
 
-    it 'marks the message read and the thread seen' do
+    it 'marks the message read' do
       expect(dispatch).to eq(:handled)
       expect(message.reload.status).to eq('read')
+    end
+
+    # The contact reading us says nothing about what we have seen. Treating it as a
+    # read on our side would clear the unread badge for incoming messages that arrived
+    # before the receipt and that nobody here has opened.
+    it 'leaves the unread badge alone' do
+      conversation.update_columns(agent_last_seen_at: 1.hour.ago) # rubocop:disable Rails/SkipsModelValidations
+      incoming = create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                                  message_type: :incoming)
+
+      expect { dispatch }.not_to(change { conversation.reload.agent_last_seen_at })
+      expect(conversation.reload.unread_incoming_messages).to include(incoming)
+    end
+  end
+
+  context 'when one of our own devices marked the chat read' do
+    let(:type) { 'read' }
+    let(:message) do
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       message_type: :incoming, status: :sent, source_id: '3EB0AAAA0002')
+    end
+
+    it 'marks the thread seen' do
+      expect(dispatch).to eq(:handled)
       expect(conversation.reload.agent_last_seen_at).to be_present
+    end
+
+    it 'still advances the timestamps when the status has nowhere left to go' do
+      message.update!(status: :read)
+      conversation.update_columns(agent_last_seen_at: 1.hour.ago) # rubocop:disable Rails/SkipsModelValidations
+
+      expect { dispatch }.to(change { conversation.reload.agent_last_seen_at })
     end
   end
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_receipt_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_receipt_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceipt do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:conversation) { create(:conversation, inbox: inbox, account: channel.account) }
+  let(:message) do
+    create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                     message_type: :outgoing, status: :sent, source_id: '3EB0AAAA0001')
+  end
+  let(:receipt) do
+    model::Events::MessageReceipt.new(chat: model::Address.phone('5541999990000'),
+                                      message_ids: [message.source_id], type: type)
+  end
+  let(:type) { 'delivered' }
+  let(:event) { model::Event.build(receipt) }
+
+  it 'moves the message forward' do
+    expect(dispatch).to eq(:handled)
+    expect(message.reload.status).to eq('delivered')
+  end
+
+  context 'when the contact read it' do
+    let(:type) { 'read' }
+
+    it 'marks the message read and the thread seen' do
+      expect(dispatch).to eq(:handled)
+      expect(message.reload.status).to eq('read')
+      expect(conversation.reload.agent_last_seen_at).to be_present
+    end
+  end
+
+  context 'when a weaker receipt arrives late' do
+    let(:type) { 'delivered' }
+
+    before { message.update!(status: :read) }
+
+    it 'keeps the stronger status' do
+      expect(dispatch).to eq(:ignored)
+      expect(message.reload.status).to eq('read')
+    end
+  end
+
+  context 'when the message is not stored' do
+    let(:receipt) do
+      model::Events::MessageReceipt.new(chat: model::Address.phone('5541999990000'),
+                                        message_ids: ['3EB0UNKNOWN'], type: 'delivered')
+    end
+
+    it 'ignores the receipt' do
+      expect(dispatch).to eq(:ignored)
+    end
+  end
+
+  context 'when the provider reports a failure' do
+    let(:type) { 'failed' }
+    let(:receipt) do
+      model::Events::MessageReceipt.new(
+        chat: model::Address.phone('5541999990000'), message_ids: [message.source_id], type: 'failed',
+        error: model::WireError.new(code: 'recipient_not_on_whatsapp', message: 'not on whatsapp')
+      )
+    end
+
+    it 'fails the message and keeps the provider reason' do
+      expect(dispatch).to eq(:handled)
+      expect(message.reload.status).to eq('failed')
+      expect(message.external_error).to include('not on whatsapp')
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/message_receipt_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_receipt_spec.rb
@@ -23,6 +23,43 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceipt do
     expect(message.reload.status).to eq('delivered')
   end
 
+  context 'when the id covers every card of a shared-contact message' do
+    let!(:second_card) do
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       message_type: :outgoing, status: :sent, source_id: message.source_id)
+    end
+
+    it 'moves all of them forward' do
+      expect(dispatch).to eq(:handled)
+
+      expect(message.reload.status).to eq('delivered')
+      expect(second_card.reload.status).to eq('delivered')
+    end
+  end
+
+  # The race that motivates the locked write is covered where it happens, in the
+  # StatusTransition unit; this only checks the failure reaches the row it names.
+  context 'when the send failed for a message already deleted' do
+    let(:type) { 'failed' }
+    let(:receipt) do
+      model::Events::MessageReceipt.new(chat: model::Address.phone('5541999990000'),
+                                        message_ids: [message.source_id], type: 'failed',
+                                        error: 'recipient unreachable')
+    end
+
+    before do
+      message
+      Message.find(message.id).update!(content_attributes: { 'deleted' => true })
+    end
+
+    it 'records the error without undeleting the message' do
+      expect(dispatch).to eq(:handled)
+
+      expect(message.reload).to have_attributes(status: 'failed', external_error: 'recipient unreachable')
+      expect(message.content_attributes['deleted']).to be(true)
+    end
+  end
+
   context 'when the contact read it' do
     let(:type) { 'read' }
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_receipt_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_receipt_spec.rb
@@ -60,6 +60,34 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceipt do
     end
   end
 
+  # Unread counts compare a message's creation time against these markers, so stamping
+  # the clock marks every incoming message that arrived since as seen: a receipt for an
+  # older message, delivered late, cleared the badge for messages nobody here opened.
+  context 'when a read receipt for an older message arrives after a newer one' do
+    let(:type) { 'read' }
+    let(:receipt) do
+      model::Events::MessageReceipt.new(chat: model::Address.phone('5541999990000'),
+                                        message_ids: [old_incoming.source_id], type: 'read',
+                                        timestamp: 1.hour.ago.to_i * 1000)
+    end
+    let!(:old_incoming) do
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       message_type: :incoming, source_id: '3EB0OLD0001', created_at: 2.hours.ago)
+    end
+    let!(:newer_incoming) do
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       message_type: :incoming, source_id: '3EB0NEW0001')
+    end
+
+    it 'does not mark the newer message as seen' do
+      conversation.update_columns(agent_last_seen_at: nil) # rubocop:disable Rails/SkipsModelValidations
+
+      dispatch
+
+      expect(conversation.reload.agent_last_seen_at).to be < newer_incoming.created_at
+    end
+  end
+
   context 'when the contact read it' do
     let(:type) { 'read' }
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -31,6 +31,31 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
     expect(message.conversation).to eq(inbox.conversations.last)
   end
 
+  # The Baileys and Z-API writers both acknowledge every incoming row, which is what puts
+  # the second tick on the contact's screen and, when the inbox asks for it, marks the
+  # chat read. Without it every message this layer stores stays unread on their phone.
+  # `any_instance` because the writer reaches the channel through the conversation's own
+  # inbox, which is a different object than the one this spec holds.
+  it 'tells the provider the message was received' do
+    # `any_instance` because the writer reaches the channel through the conversation's
+    # own inbox, which is a different object than the one this spec holds.
+    expect_any_instance_of(Channel::Whatsapp).to receive(:received_messages) # rubocop:disable RSpec/AnyInstance
+
+    dispatch
+  end
+
+  it 'says nothing to the provider about a message the phone itself sent' do
+    expect_any_instance_of(Channel::Whatsapp).not_to receive(:received_messages) # rubocop:disable RSpec/AnyInstance
+
+    Whatsapp::Session::Inbound::Dispatcher.dispatch(
+      channel,
+      model::Event.build(model::Events::MessageReceived.new(
+                           message: model::InboundMessage.new(id: '3EB0ECHO01', chat: chat, sender: nil, from_me: true,
+                                                              timestamp: 1_755_440_000_123, content: content)
+                         ))
+    )
+  end
+
   it 'creates the contact behind the message' do
     dispatch
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -125,6 +125,28 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
     end
   end
 
+  # A rich card's header image is the same downloadable reference a plain media message
+  # carries, and the bubble renders it: without the fetch the card arrives text-only.
+  context 'with a rich card carrying a media header' do
+    let(:content) do
+      model::Content::Rich.new(
+        kind: 'button', title: 'Pedido #4312', body: 'Seu pedido saiu para entrega',
+        buttons: [{ 'text' => 'Acompanhar', 'url' => 'https://exemplo.test/4312' }],
+        media: model::Content::Media.new(
+          kind: 'image', mime: 'image/jpeg', ref: model::MediaRef.url('https://connector.test/media/xyz')
+        )
+      )
+    end
+
+    it 'hands the header download to a job' do
+      expect(dispatch).to eq(:handled)
+
+      message = inbox.messages.find_by(source_id: '3EB0AAAA0001')
+      expect(message.content_attributes['rich']).to include('title' => 'Pedido #4312')
+      expect(Whatsapp::Session::MediaFetchJob).to have_been_enqueued.with(message, hash_including('kind' => 'image'))
+    end
+  end
+
   context 'with a chat Chatwoot has no place for' do
     let(:chat) { model::Address.new(kind: 'status', id: 'status') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -178,6 +178,21 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
 
   # `Message#human_response?` reads this flag to count a reply typed in the WhatsApp app
   # as a real answer, which is what clears `waiting_since` and records a first response.
+  # WhatsApp already has it: the phone is reporting what it sent. Left at the default
+  # the agent sees a message stuck on one tick that no receipt will ever move.
+  it 'stores a message typed on the phone as delivered' do
+    echo = model::InboundMessage.new(
+      id: '3EB0DDDD0001', chat: chat, sender: nil, from_me: true,
+      timestamp: 1_755_440_000_123, content: content
+    )
+
+    Whatsapp::Session::Inbound::Dispatcher.dispatch(
+      channel, model::Event.build(model::Events::MessageReceived.new(message: echo))
+    )
+
+    expect(inbox.messages.find_by(source_id: '3EB0DDDD0001').status).to eq('delivered')
+  end
+
   context 'with a reply typed on the connected phone' do
     let(:inbound) do
       model::InboundMessage.new(
@@ -217,6 +232,23 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       it 'still writes a message instead of an empty conversation' do
         expect(dispatch).to eq(:handled)
         expect(inbox.messages.last.content).to eq('Carlos Dias')
+      end
+    end
+
+    # Both named fields are optional on the wire, so a share can be nothing but the
+    # vCard, and dropping it left a conversation with no message in it.
+    context 'when the card carries only a vCard' do
+      let(:vcard) do
+        "BEGIN:VCARD\nVERSION:3.0\nFN:Carlos Dias\nTEL;type=CELL;waid=5541988881111:+55 41 98888-1111\nEND:VCARD"
+      end
+      let(:content) { model::Content::Contacts.new(contacts: [{ 'vcard' => vcard }]) }
+
+      it 'reads the name and the number out of it' do
+        expect(dispatch).to eq(:handled)
+
+        message = inbox.messages.last
+        expect(message.content).to include('Carlos Dias', '+55 41 98888-1111')
+        expect(message.attachments.first.file_type).to eq('contact')
       end
     end
   end

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+
+  let(:model) { Whatsapp::Session::Model }
+  let(:sender) { model::Party.new(phone: '5541999990000', lid: '182736451928374', push_name: 'Ana Souza') }
+  let(:chat) { model::Address.phone('5541999990000') }
+  let(:content) { model::Content::Text.new(body: 'oi, tudo bem?') }
+  let(:inbound) do
+    model::InboundMessage.new(
+      id: '3EB0AAAA0001', chat: chat, sender: sender, from_me: false,
+      timestamp: 1_755_440_000_123, content: content
+    )
+  end
+  let(:event) { model::Event.build(model::Events::MessageReceived.new(message: inbound), epoch: 1, seq: 1) }
+
+  before { allow(channel).to receive(:provider_service).and_return(backend) }
+
+  it 'creates the conversation and the message' do
+    expect(dispatch).to eq(:handled)
+
+    message = inbox.messages.find_by(source_id: '3EB0AAAA0001')
+    expect(message.content).to eq('oi, tudo bem?')
+    expect(message.message_type).to eq('incoming')
+    expect(message.content_attributes['external_created_at']).to eq(1_755_440_000)
+    expect(message.conversation).to eq(inbox.conversations.last)
+  end
+
+  it 'creates the contact behind the message' do
+    dispatch
+
+    contact = inbox.messages.find_by(source_id: '3EB0AAAA0001').sender
+    expect(contact.name).to eq('Ana Souza')
+    expect(contact.phone_number).to eq('+5541999990000')
+    expect(contact.identifier).to eq('182736451928374@lid')
+    # The LID is what WhatsApp echoes back, so it is what the contact_inbox is keyed by.
+    expect(inbox.contact_inboxes.pluck(:source_id)).to contain_exactly('182736451928374')
+  end
+
+  it 'reuses the open conversation of the contact' do
+    dispatch
+    conversation = inbox.conversations.last
+
+    second = inbound.with(id: '3EB0AAAA0002')
+    described_class.new(channel: channel, event: model::Event.build(model::Events::MessageReceived.new(message: second))).perform
+
+    expect(inbox.conversations.count).to eq(1)
+    expect(conversation.messages.pluck(:source_id)).to include('3EB0AAAA0001', '3EB0AAAA0002')
+  end
+
+  it 'answers :duplicate when the message is already stored' do
+    expect(dispatch).to eq(:handled)
+
+    expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)).to eq(:duplicate)
+    expect(inbox.messages.where(source_id: '3EB0AAAA0001').count).to eq(1)
+  end
+
+  it 'links the quoted message and backfills the referral on the conversation it reuses' do
+    dispatch
+    quoted = inbox.messages.find_by(source_id: '3EB0AAAA0001')
+
+    quoting = inbound.with(id: '3EB0AAAA0003', quoted_id: '3EB0AAAA0001',
+                           referral: { 'source_type' => 'ad', 'title' => 'Promo' })
+    described_class.new(channel: channel, event: model::Event.build(model::Events::MessageReceived.new(message: quoting))).perform
+
+    message = inbox.messages.find_by(source_id: '3EB0AAAA0003')
+    expect(message.content_attributes['in_reply_to_external_id']).to eq('3EB0AAAA0001')
+    expect(message.content_attributes['in_reply_to']).to eq(quoted.id)
+    expect(inbox.conversations.last.additional_attributes['referral']).to include('title' => 'Promo')
+  end
+
+  context 'when the message came from the connected phone' do
+    let(:inbound) do
+      model::InboundMessage.new(
+        id: '3EB0BBBB0001', chat: chat, sender: nil, from_me: true,
+        timestamp: 1_755_440_000_123, content: content
+      )
+    end
+
+    it 'stores it as an outgoing message without an agent' do
+      expect(dispatch).to eq(:handled)
+
+      message = inbox.messages.find_by(source_id: '3EB0BBBB0001')
+      expect(message.message_type).to eq('outgoing')
+      expect(message.sender).to be_nil
+      expect(message.content_attributes['external_sender_name']).to eq('WhatsApp')
+      expect(inbox.contacts.first.phone_number).to eq('+5541999990000')
+    end
+
+    it 'confirms the message Chatwoot had already reserved instead of storing a second one' do
+      contact = create(:contact, account: channel.account, phone_number: '+5541999990000')
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox, source_id: '5541999990000')
+      conversation = create(:conversation, contact: contact, contact_inbox: contact_inbox, inbox: inbox,
+                                           account: channel.account)
+      reserved = create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                                  message_type: :outgoing, source_id: nil,
+                                  content_attributes: { pending_source_id: '3EB0BBBB0001' })
+
+      expect(dispatch).to eq(:handled)
+
+      expect(reserved.reload.source_id).to eq('3EB0BBBB0001')
+      expect(conversation.messages.count).to eq(1)
+    end
+  end
+
+  context 'with media' do
+    let(:content) do
+      model::Content::Media.new(
+        kind: 'image', mime: 'image/jpeg', caption: 'olha isso', filename: 'foto.jpg',
+        ref: model::MediaRef.url('https://connector.test/media/abc')
+      )
+    end
+
+    it 'stores the caption and hands the download to a job' do
+      expect(dispatch).to eq(:handled)
+
+      message = inbox.messages.find_by(source_id: '3EB0AAAA0001')
+      expect(message.content).to eq('olha isso')
+      expect(Whatsapp::Session::MediaFetchJob).to have_been_enqueued.with(message, hash_including('kind' => 'image'))
+    end
+  end
+
+  context 'with a chat Chatwoot has no place for' do
+    let(:chat) { model::Address.new(kind: 'status', id: 'status') }
+
+    it 'ignores it' do
+      expect(dispatch).to eq(:ignored)
+      expect(inbox.messages).to be_empty
+    end
+  end
+
+  context 'with a group message' do
+    let(:chat) { model::Address.group('120363041234567890') }
+
+    it 'is ignored while the group capability is off' do
+      expect(dispatch).to eq(:ignored)
+      expect(inbox.messages).to be_empty
+    end
+
+    it 'opens the group conversation and files the sender as a member' do
+      with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+        expect(dispatch).to eq(:handled)
+      end
+
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      expect(group_contact).to be_group_type_group
+      conversation = group_contact.conversations.last
+      expect(conversation.messages.last.content).to eq('oi, tudo bem?')
+      expect(conversation.messages.last.sender.identifier).to eq('182736451928374@lid')
+      expect(group_contact.group_memberships.active.count).to eq(1)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -235,6 +235,30 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       end
     end
 
+    # Each card was committed on its own, so a later one failing left the earlier rows
+    # holding the event's source id and the redelivery was read as a duplicate: the
+    # cards that never landed were dropped for good.
+    context 'when a later card cannot be saved' do
+      let(:content) do
+        model::Content::Contacts.new(contacts: [{ 'display_name' => 'Carlos Dias', 'phone' => '+5541988881111' },
+                                                { 'display_name' => 'Bruno Lima', 'phone' => '+5541977776666' }])
+      end
+
+      before do
+        allow_any_instance_of(Message).to receive(:save!).and_wrap_original do |original, *args| # rubocop:disable RSpec/AnyInstance
+          raise ActiveRecord::RecordInvalid, original.receiver if original.receiver.content&.start_with?('Bruno Lima')
+
+          original.call(*args)
+        end
+      end
+
+      it 'stores none of them, so the redelivery can store all of them' do
+        expect { dispatch }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(inbox.messages).to be_empty
+      end
+    end
+
     # The conversation is opened before the cards are read, so a share with nothing to
     # render used to leave an empty thread and no row holding the source id, which meant
     # every redelivery walked the same path again.
@@ -271,6 +295,49 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
         message = inbox.messages.last
         expect(message.content).to include('Carlos Dias', '+55 41 98888-1111')
         expect(message.attachments.first.file_type).to eq('contact')
+      end
+    end
+  end
+
+  # `GroupConversationHandler#find_or_create_group_conversation` only reuses open and
+  # pending rows, so a snoozed group thread, or a resolved one under
+  # `lock_to_single_conversation`, used to get a second conversation and split the group.
+  context 'with a group message whose thread is not open' do
+    let(:chat) { model::Address.group('120363041234567890') }
+    let(:inbound) do
+      model::InboundMessage.new(id: '3EB0AAAA0002', chat: chat, sender: sender, from_me: false,
+                                timestamp: 1_755_440_000_123, content: content)
+    end
+    let(:group_dispatch) do
+      with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+      end
+    end
+    let(:group_contact) do
+      create(:contact, account: channel.account, identifier: '120363041234567890@g.us', group_type: :group)
+    end
+    let(:group_contact_inbox) do
+      create(:contact_inbox, inbox: inbox, contact: group_contact, source_id: '120363041234567890')
+    end
+    let!(:existing) do
+      create(:conversation, inbox: inbox, account: channel.account, contact: group_contact,
+                            contact_inbox: group_contact_inbox, group_type: :group, status: :snoozed)
+    end
+
+    it 'reuses the snoozed thread instead of opening a second one' do
+      expect { group_dispatch }.not_to change(inbox.conversations, :count)
+
+      expect(inbox.messages.last.conversation_id).to eq(existing.id)
+    end
+
+    context 'when the thread was resolved and the inbox locks to a single conversation' do
+      before do
+        existing.update!(status: :resolved)
+        inbox.update!(lock_to_single_conversation: true)
+      end
+
+      it 'reuses it too' do
+        expect { group_dispatch }.not_to change(inbox.conversations, :count)
       end
     end
   end

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -400,6 +400,19 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
     end
   end
 
+  # A worker killed between taking the in-flight marker and writing the row leaves the
+  # marker behind. Answering ":duplicate" there acknowledges the event and loses the
+  # message for good, so a held marker has to be retryable instead.
+  context 'when a marker from a killed worker is still held' do
+    before { Whatsapp::Session::Inbound::Locks.with_message_lock(inbox, inbound.id) { nil } }
+
+    it 'asks for a retry rather than reporting the message as already stored' do
+      allow(Redis::Alfred).to receive(:set).and_return(false)
+
+      expect { dispatch }.to raise_error(Whatsapp::Session::Inbound::Locks::Busy)
+    end
+  end
+
   context 'with a chat Chatwoot has no place for' do
     let(:chat) { model::Address.new(kind: 'status', id: 'status') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -235,6 +235,28 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       end
     end
 
+    # The conversation is opened before the cards are read, so a share with nothing to
+    # render used to leave an empty thread and no row holding the source id, which meant
+    # every redelivery walked the same path again.
+    context 'when nothing in the share can be read' do
+      let(:content) { model::Content::Contacts.new(contacts: [{ 'vcard' => 'BEGIN:VCARD\nEND:VCARD' }]) }
+
+      it 'stores an unsupported message instead of an empty conversation' do
+        expect(dispatch).to eq(:handled)
+
+        message = inbox.messages.last
+        expect(message.source_id).to eq(inbound.id)
+        expect(message.is_unsupported).to be(true)
+      end
+
+      it 'does not process the same event twice' do
+        dispatch
+
+        expect { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+          .not_to change(inbox.messages, :count)
+      end
+    end
+
     # Both named fields are optional on the wire, so a share can be nothing but the
     # vCard, and dropping it left a conversation with no message in it.
     context 'when the card carries only a vCard' do

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -369,6 +369,37 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
     end
   end
 
+  # WhatsApp may address the 1:1 chat by a LID the peer has no contact_inbox under yet.
+  # Resolving the peer first filed that person a second time, and the reservation was
+  # then looked for on the wrong contact: the echo was stored again, in a thread of its
+  # own, as if an agent had typed it on the phone.
+  context 'with the echo of a send whose chat is addressed only by LID' do
+    let(:chat) { model::Address.lid('182736451928374') }
+    let(:inbound) do
+      model::InboundMessage.new(id: '3EB0AAAA0009', chat: chat, sender: nil, from_me: true,
+                                timestamp: 1_755_440_000_123, content: content)
+    end
+    let!(:reserved) do
+      contact = create(:contact, account: channel.account, phone_number: '+5541999990000')
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox, source_id: '5541999990000')
+      conversation = create(:conversation, contact: contact, contact_inbox: contact_inbox, inbox: inbox,
+                                           account: channel.account)
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       message_type: :outgoing, source_id: nil,
+                       content_attributes: { pending_source_id: '3EB0AAAA0009' })
+    end
+
+    it 'confirms the message that was sent' do
+      expect(dispatch).to eq(:handled)
+
+      expect(reserved.reload.source_id).to eq('3EB0AAAA0009')
+    end
+
+    it 'files no second contact and opens no second thread' do
+      expect { dispatch }.to not_change(inbox.contact_inboxes, :count).and not_change(inbox.messages, :count)
+    end
+  end
+
   context 'with a chat Chatwoot has no place for' do
     let(:chat) { model::Address.new(kind: 'status', id: 'status') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -147,6 +147,54 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
     end
   end
 
+  # Blocking has to actually stop the messages and the notifications they raise, which
+  # is the rule the Cloud path already applies.
+  context 'when the contact is blocked' do
+    before do
+      contact = create(:contact, account: channel.account, phone_number: '+5541999990000', identifier: '182736451928374@lid')
+      create(:contact_inbox, inbox: inbox, contact: contact, source_id: '182736451928374')
+      contact.update!(blocked: true)
+    end
+
+    it 'writes nothing' do
+      expect(dispatch).to eq(:ignored)
+      expect(inbox.messages).to be_empty
+    end
+
+    context 'when it is the echo of a reply typed on the phone' do
+      let(:inbound) do
+        model::InboundMessage.new(
+          id: '3EB0AAAA0002', chat: chat, sender: sender, from_me: true,
+          timestamp: 1_755_440_000_123, content: content
+        )
+      end
+
+      it 'is still stored, so the agent answer does not go missing' do
+        expect(dispatch).to eq(:handled)
+        expect(inbox.messages.find_by(source_id: '3EB0AAAA0002')).to be_outgoing
+      end
+    end
+  end
+
+  # `Message#human_response?` reads this flag to count a reply typed in the WhatsApp app
+  # as a real answer, which is what clears `waiting_since` and records a first response.
+  context 'with a reply typed on the connected phone' do
+    let(:inbound) do
+      model::InboundMessage.new(
+        id: '3EB0CCCC0001', chat: chat, sender: sender, from_me: true,
+        timestamp: 1_755_440_000_123, content: content
+      )
+    end
+
+    it 'marks the message as an external echo, so it counts as a reply' do
+      expect(dispatch).to eq(:handled)
+
+      message = inbox.messages.find_by(source_id: '3EB0CCCC0001')
+      expect(message.content_attributes['external_echo']).to be(true)
+      expect(message.send(:human_response?)).to be(true)
+    end
+  end
+
   context 'with a chat Chatwoot has no place for' do
     let(:chat) { model::Address.new(kind: 'status', id: 'status') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -195,6 +195,59 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
     end
   end
 
+  # The contract calls the field `display_name`. Reading `name` found nothing, so the
+  # card lost its name and a name-only card produced no message at all, leaving the
+  # conversation that had just been opened empty.
+  context 'with a shared contact card' do
+    let(:content) do
+      model::Content::Contacts.new(contacts: [{ 'display_name' => 'Carlos Dias', 'phone' => '+55 41 98888-1111' }])
+    end
+
+    it 'stores the shared name alongside the number' do
+      expect(dispatch).to eq(:handled)
+
+      message = inbox.messages.last
+      expect(message.content).to include('Carlos Dias')
+      expect(message.attachments.first.meta['firstName']).to eq('Carlos Dias')
+    end
+
+    context 'when the card carries only a name' do
+      let(:content) { model::Content::Contacts.new(contacts: [{ 'display_name' => 'Carlos Dias' }]) }
+
+      it 'still writes a message instead of an empty conversation' do
+        expect(dispatch).to eq(:handled)
+        expect(inbox.messages.last.content).to eq('Carlos Dias')
+      end
+    end
+  end
+
+  # A provider that assigns its own id cannot take ours, so the echo comes back under an
+  # id Chatwoot has never seen and the correlation token is the only thing tying it to
+  # the message that was sent.
+  context 'with the echo of a send correlated by client_ref' do
+    let(:inbound) do
+      model::InboundMessage.new(
+        id: 'UAZAPI-XYZ', chat: chat, sender: nil, from_me: true,
+        timestamp: 1_755_440_000_123, content: content, client_ref: 'cw:4312'
+      )
+    end
+
+    it 'confirms the message that was sent instead of storing a second one' do
+      contact = create(:contact, account: channel.account, phone_number: '+5541999990000')
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox, source_id: '5541999990000')
+      conversation = create(:conversation, contact: contact, contact_inbox: contact_inbox, inbox: inbox,
+                                           account: channel.account)
+      reserved = create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                                  message_type: :outgoing, source_id: nil,
+                                  content_attributes: { pending_source_id: 'cw:4312' })
+
+      expect(dispatch).to eq(:handled)
+
+      expect(reserved.reload.source_id).to eq('UAZAPI-XYZ')
+      expect(conversation.messages.count).to eq(1)
+    end
+  end
+
   context 'with a chat Chatwoot has no place for' do
     let(:chat) { model::Address.new(kind: 'status', id: 'status') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_revoked_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_revoked_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageRevoked do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:conversation) { create(:conversation, inbox: inbox, account: channel.account) }
+  let(:message) do
+    create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                     content: 'mensagem original', source_id: '3EB0AAAA0001')
+  end
+  let(:by) { 'contact' }
+  let(:event) do
+    model::Event.build(
+      model::Events::MessageRevoked.new(chat: model::Address.phone('5541999990000'),
+                                        message_id: message.source_id, by: by)
+    )
+  end
+
+  it 'flags a contact revoke without losing the content' do
+    expect(dispatch).to eq(:handled)
+
+    expect(message.reload.deleted_by_contact).to be(true)
+    expect(message.content).to eq('mensagem original')
+  end
+
+  context 'when it was deleted from the connected phone' do
+    let(:by) { 'self' }
+
+    it 'marks the message deleted the same way Chatwoot does' do
+      expect(dispatch).to eq(:handled)
+
+      expect(message.reload).to be_deleted
+      expect(message.content).to eq('')
+    end
+
+    it 'ignores the echo of a deletion Chatwoot already applied' do
+      message.update!(content: '', content_attributes: message.content_attributes.merge('deleted' => true))
+
+      expect(dispatch).to eq(:ignored)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/message_revoked_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_revoked_spec.rb
@@ -33,7 +33,16 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageRevoked do
       expect(dispatch).to eq(:handled)
 
       expect(message.reload).to be_deleted
-      expect(message.content).to eq('')
+      expect(message.content).to eq(I18n.t('conversations.messages.deleted'))
+    end
+
+    # The messages controller destroys them, and leaving them behind would keep the
+    # deleted media readable through the API and in storage.
+    it 'takes the attachments with it' do
+      message.attachments.create!(account_id: message.account_id, file_type: :image)
+
+      expect(dispatch).to eq(:handled)
+      expect(message.reload.attachments).to be_empty
     end
 
     it 'ignores the echo of a deletion Chatwoot already applied' do

--- a/spec/services/whatsapp/session/inbound/handlers/message_revoked_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_revoked_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageRevoked do
     )
   end
 
+  # A shared-contact payload is stored as one row per card, all under the provider's
+  # single id. Revoking only the row `find_by` happened to return left the other cards
+  # on screen after the contact deleted the share.
+  context 'when the id covers every card of a shared-contact message' do
+    let!(:second_card) do
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       content: 'Bruno Lima', source_id: message.source_id)
+    end
+
+    it 'revokes all of them' do
+      expect(dispatch).to eq(:handled)
+
+      expect(message.reload.deleted_by_contact).to be(true)
+      expect(second_card.reload.deleted_by_contact).to be(true)
+    end
+  end
+
   it 'flags a contact revoke without losing the content' do
     expect(dispatch).to eq(:handled)
 

--- a/spec/services/whatsapp/session/inbound/handlers/presence_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/presence_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::Presence do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'native', provider_config: { 'presence_subscribe' => true },
+                              validate_provider_config: false, sync_templates: false)
+  end
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:contact) { create(:contact, account: channel.account, phone_number: '+5541999990000') }
+  let(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox, source_id: '182736451928374') }
+  let(:conversation) { create(:conversation, contact: contact, contact_inbox: contact_inbox, inbox: inbox, account: channel.account) }
+  let(:sender) { model::Party.new(phone: '5541999990000', lid: '182736451928374') }
+  let(:event) do
+    model::Event.build(
+      model::Events::ChatPresence.new(chat: model::Address.phone('5541999990000'), sender: sender, state: 'composing')
+    )
+  end
+
+  before { conversation }
+
+  it 'tells the dashboard the contact is typing' do
+    expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+      Events::Types::CONVERSATION_TYPING_ON, anything, hash_including(conversation: conversation, user: contact)
+    )
+
+    expect(dispatch).to eq(:handled)
+  end
+
+  it 'maps a recording indicator to its own event' do
+    event = model::Event.build(
+      model::Events::ChatPresence.new(chat: model::Address.phone('5541999990000'), sender: sender, state: 'recording')
+    )
+
+    expect(Rails.configuration.dispatcher).to receive(:dispatch).with(Events::Types::CONVERSATION_RECORDING, anything, anything)
+
+    described_class.new(channel: channel, event: event).perform
+  end
+
+  it 'stays quiet when the inbox did not subscribe to presence' do
+    channel.update!(provider_config: channel.provider_config.merge('presence_subscribe' => false))
+
+    expect(Rails.configuration.dispatcher).not_to receive(:dispatch)
+    expect(dispatch).to eq(:ignored)
+  end
+
+  it 'ignores a group typing indicator, which has no per-contact place in the UI' do
+    event = model::Event.build(
+      model::Events::ChatPresence.new(chat: model::Address.group('120363041234567890'), sender: sender, state: 'composing')
+    )
+
+    expect(described_class.new(channel: channel, event: event).perform).to eq(:ignored)
+  end
+
+  it 'turns typing off when the contact goes offline' do
+    event = model::Event.build(model::Events::PresenceUpdate.new(party: sender, state: 'unavailable'))
+
+    expect(Rails.configuration.dispatcher).to receive(:dispatch).with(Events::Types::CONVERSATION_TYPING_OFF, anything, anything)
+
+    described_class.new(channel: channel, event: event).perform
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/presence_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/presence_spec.rb
@@ -29,6 +29,28 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::Presence do
     expect(dispatch).to eq(:handled)
   end
 
+  # The event carries whichever ninth-digit form WhatsApp uses, and the contact is
+  # stored under whichever one reached us first. An exact match drops the indicator.
+  context 'when the event carries the other ninth-digit form' do
+    let(:contact) { create(:contact, account: channel.account, phone_number: '+554188887777') }
+    let(:event) do
+      model::Event.build(
+        model::Events::ChatPresence.new(
+          chat: model::Address.phone('5541988887777'),
+          sender: model::Party.new(phone: '5541988887777'), state: 'composing'
+        )
+      )
+    end
+
+    it 'still reaches the contact' do
+      expect(Rails.configuration.dispatcher).to receive(:dispatch).with(
+        Events::Types::CONVERSATION_TYPING_ON, anything, hash_including(conversation: conversation, user: contact)
+      )
+
+      expect(dispatch).to eq(:handled)
+    end
+  end
+
   it 'maps a recording indicator to its own event' do
     event = model::Event.build(
       model::Events::ChatPresence.new(chat: model::Address.phone('5541999990000'), sender: sender, state: 'recording')

--- a/spec/services/whatsapp/session/inbound/locks_spec.rb
+++ b/spec/services/whatsapp/session/inbound/locks_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe Whatsapp::Session::Inbound::Locks do
       expect { described_class.with_message_lock(inbox, message_id) { :ran } }.to raise_error(described_class::Busy)
     end
 
+    # Same failure the chat lock had: a pass that outran the TTL deleted the marker a
+    # redelivery had already taken, and a third delivery could then run alongside it.
+    it 'leaves a marker another worker took over in place' do
+      key = described_class.message_key(inbox, message_id)
+
+      described_class.with_message_lock(inbox, message_id) do
+        Redis::Alfred.delete(key)
+        Redis::Alfred.set(key, 'another-worker', ex: 30)
+      end
+
+      expect(Redis::Alfred.get(key)).to eq('another-worker')
+    end
+
     it 'runs unguarded when there is no id to key on' do
       expect(described_class.with_message_lock(inbox, nil) { :ran }).to eq(:ran)
     end

--- a/spec/services/whatsapp/session/inbound/locks_spec.rb
+++ b/spec/services/whatsapp/session/inbound/locks_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Locks do
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:chat) { '5541999990000' }
+  let(:message_id) { '3EB0AAAA0001' }
+
+  describe '.with_chat_lock' do
+    it 'runs the block and releases the chat' do
+      expect(described_class.with_chat_lock(inbox, chat) { :done }).to eq(:done)
+      expect(Redis::Alfred.get(described_class.chat_key(inbox, chat))).to be_nil
+    end
+
+    it 'refuses a chat another worker holds' do
+      described_class.with_chat_lock(inbox, chat) do
+        expect { described_class.with_chat_lock(inbox, chat) { :nested } }.to raise_error(described_class::Busy)
+      end
+    end
+
+    # An operation that outran the TTL, syncing a large group roster being the realistic
+    # one, used to delete the lock a second worker had already taken: from there the two
+    # interleave their conversation, membership and activity writes.
+    it 'leaves a lock another worker took over in place' do
+      key = described_class.chat_key(inbox, chat)
+
+      described_class.with_chat_lock(inbox, chat) do
+        Redis::Alfred.delete(key)
+        Redis::Alfred.set(key, 'another-worker', ex: 30)
+      end
+
+      expect(Redis::Alfred.get(key)).to eq('another-worker')
+    end
+  end
+
+  describe '.with_message_lock' do
+    it 'releases the marker so a later pass can run' do
+      described_class.with_message_lock(inbox, message_id) { :first }
+
+      expect(described_class.with_message_lock(inbox, message_id) { :second }).to eq(:second)
+    end
+
+    # Answering ":duplicate" here acknowledges the event: a worker killed between taking
+    # the marker and writing the row would turn its own retry into a lost message. What
+    # makes a finished message a duplicate is its stored source_id, which the caller
+    # checks inside the block.
+    it 'asks for a retry while the marker is held instead of calling it a duplicate' do
+      Redis::Alfred.set(described_class.message_key(inbox, message_id), true, ex: 30)
+
+      expect { described_class.with_message_lock(inbox, message_id) { :ran } }.to raise_error(described_class::Busy)
+    end
+
+    it 'runs unguarded when there is no id to key on' do
+      expect(described_class.with_message_lock(inbox, nil) { :ran }).to eq(:ran)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/locks_spec.rb
+++ b/spec/services/whatsapp/session/inbound/locks_spec.rb
@@ -18,6 +18,34 @@ RSpec.describe Whatsapp::Session::Inbound::Locks do
       end
     end
 
+    # WhatsApp names the same 1:1 peer by phone in one event and by LID in the next, and
+    # both resolve to one contact: locking only the id an event carries let a worker
+    # holding the other alias run alongside, and each opened a conversation of its own.
+    it 'refuses a chat another worker holds under a different alias' do
+      described_class.with_chat_lock(inbox, %w[5541999990000 182736451928374]) do
+        expect { described_class.with_chat_lock(inbox, '182736451928374') { :nested } }
+          .to raise_error(described_class::Busy)
+      end
+    end
+
+    it 'releases every alias it took' do
+      described_class.with_chat_lock(inbox, %w[5541999990000 182736451928374]) { :done }
+
+      expect(Redis::Alfred.get(described_class.chat_key(inbox, '182736451928374'))).to be_nil
+      expect(Redis::Alfred.get(described_class.chat_key(inbox, '5541999990000'))).to be_nil
+    end
+
+    # The second alias being held is a Busy for the whole call, and the first must not be
+    # left behind: the next delivery would find it locked by nobody until the TTL.
+    it 'releases what it took when a later alias is already held' do
+      Redis::Alfred.set(described_class.chat_key(inbox, '182736451928374'), 'other', ex: 30)
+
+      expect { described_class.with_chat_lock(inbox, %w[5541999990000 182736451928374]) { :never } }
+        .to raise_error(described_class::Busy)
+
+      expect(Redis::Alfred.get(described_class.chat_key(inbox, '5541999990000'))).to be_nil
+    end
+
     # An operation that outran the TTL, syncing a large group roster being the realistic
     # one, used to delete the lock a second worker had already taken: from there the two
     # interleave their conversation, membership and activity writes.

--- a/spec/services/whatsapp/session/inbound/status_transition_spec.rb
+++ b/spec/services/whatsapp/session/inbound/status_transition_spec.rb
@@ -37,4 +37,22 @@ RSpec.describe Whatsapp::Session::Inbound::StatusTransition do
 
     expect(described_class.apply(message, 'delivered')).to be(false)
   end
+
+  # Receipts arrive out of order, so a failure can land after the read that followed a
+  # later retry. Letting it through would tell the agent a message the contact already
+  # read never arrived.
+  it 'does not fail a message the contact already read' do
+    message.update!(status: :read)
+
+    expect(described_class.apply(message, 'failed', error: 'boom')).to be(false)
+    expect(message.reload.status).to eq('read')
+    expect(message.external_error).to be_blank
+  end
+
+  it 'has nothing to say about a second failure' do
+    message.update!(status: :failed, external_error: 'first')
+
+    expect(described_class.apply(message, 'failed', error: 'second')).to be(false)
+    expect(message.reload.external_error).to eq('first')
+  end
 end

--- a/spec/services/whatsapp/session/inbound/status_transition_spec.rb
+++ b/spec/services/whatsapp/session/inbound/status_transition_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe Whatsapp::Session::Inbound::StatusTransition do
     expect(message.external_error).to be_blank
   end
 
+  # Delivery is proof the message arrived, so a failure reported afterwards belongs to
+  # an earlier attempt of the same send.
+  it 'does not fail a message already delivered' do
+    message.update!(status: :delivered)
+
+    expect(described_class.apply(message, 'failed', error: 'boom')).to be(false)
+    expect(message.reload.status).to eq('delivered')
+  end
+
   it 'has nothing to say about a second failure' do
     message.update!(status: :failed, external_error: 'first')
 

--- a/spec/services/whatsapp/session/inbound/status_transition_spec.rb
+++ b/spec/services/whatsapp/session/inbound/status_transition_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::StatusTransition do
+  let(:message) { create(:message, status: :sent) }
+
+  it 'moves a message forward' do
+    expect(described_class.apply(message, 'delivered')).to be(true)
+    expect(message.reload.status).to eq('delivered')
+  end
+
+  it 'treats a played voice note as read' do
+    expect(described_class.apply(message, 'played')).to be(true)
+    expect(message.reload.status).to eq('read')
+  end
+
+  it 'never walks a status back' do
+    message.update!(status: :read)
+
+    expect(described_class.apply(message, 'delivered')).to be(false)
+    expect(message.reload.status).to eq('read')
+  end
+
+  it 'ignores a receipt type it does not know' do
+    expect(described_class.apply(message, 'teleported')).to be(false)
+  end
+
+  it 'keeps the provider reason on a failure' do
+    error = Whatsapp::Session::Model::WireError.new(code: 'media_too_large', message: 'file is too big')
+
+    expect(described_class.apply(message, 'failed', error: error)).to be(true)
+    expect(message.reload.status).to eq('failed')
+    expect(message.external_error).to eq('file is too big media_too_large')
+  end
+
+  it 'leaves a failed message alone' do
+    message.update!(status: :failed)
+
+    expect(described_class.apply(message, 'delivered')).to be(false)
+  end
+end

--- a/spec/services/whatsapp/session/inbound/status_transition_spec.rb
+++ b/spec/services/whatsapp/session/inbound/status_transition_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe Whatsapp::Session::Inbound::StatusTransition do
     expect(stale.reload.content_attributes).to include('deleted' => true, 'external_error' => 'recipient unreachable')
   end
 
+  # Two receipts for one message can be processed at the same time. Reading the status
+  # outside the lock let both pass the check against the same old value, and the slower
+  # `delivered` write then landed on top of `read`, which is the one thing the monotonic
+  # rule exists to prevent.
+  it 'does not walk a status backwards when two receipts race' do
+    first = Message.find(message.id)
+    second = Message.find(message.id)
+
+    expect(described_class.apply(first, 'read')).to be(true)
+    expect(described_class.apply(second, 'delivered')).to be(false)
+
+    expect(message.reload.status).to eq('read')
+  end
+
   it 'ignores a receipt type it does not know' do
     expect(described_class.apply(message, 'teleported')).to be(false)
   end

--- a/spec/services/whatsapp/session/inbound/status_transition_spec.rb
+++ b/spec/services/whatsapp/session/inbound/status_transition_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe Whatsapp::Session::Inbound::StatusTransition do
     expect(message.reload.status).to eq('read')
   end
 
+  # `external_error` lives in the content_attributes JSON, so writing it through the
+  # instance this held before the delete endpoint ran rewrites the whole hash and
+  # undeletes the message.
+  it 'keeps a flag a concurrent writer added while it held the message' do
+    stale = Message.find(message.id)
+    Message.find(message.id).update!(content_attributes: { 'deleted' => true })
+
+    expect(described_class.apply(stale, 'failed', error: 'recipient unreachable')).to be(true)
+
+    expect(stale.reload.content_attributes).to include('deleted' => true, 'external_error' => 'recipient unreachable')
+  end
+
   it 'ignores a receipt type it does not know' do
     expect(described_class.apply(message, 'teleported')).to be(false)
   end

--- a/spec/services/whatsapp/session/model_spec.rb
+++ b/spec/services/whatsapp/session/model_spec.rb
@@ -5,7 +5,11 @@ require 'rails_helper'
 # accepted `:open` and then stored the symbol would make every predicate on it false and
 # put a non-canonical value on the wire, and it would do so silently.
 RSpec.describe Whatsapp::Session::Model do
-  let(:model) { described_class }
+  # Resolved inside the example, never captured from `described_class`. Model is an
+  # implicit namespace, so a reload between loading this file and running it leaves the
+  # module RSpec is holding without its autoloads, and every `model::Something` below
+  # raises `uninitialized constant`. Referencing the constant here re-resolves it.
+  let(:model) { Whatsapp::Session::Model } # rubocop:disable RSpec/DescribedClass
 
   it 'stores a symbol connection as the canonical string' do
     state = model::ConnectionState.new(connection: :open)

--- a/spec/services/whatsapp/session/phone_match_spec.rb
+++ b/spec/services/whatsapp/session/phone_match_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe Whatsapp::Session::PhoneMatch do
     expect(described_class.same_number?('12025550100', '12025550101')).to be(false)
   end
 
+  it 'lists both ninth-digit forms of a Brazilian line' do
+    expect(described_class.variants('5541988887777')).to contain_exactly('5541988887777', '554188887777')
+  end
+
+  it 'lists a number no normalizer knows as itself' do
+    expect(described_class.variants('12025550100')).to eq(['12025550100'])
+    expect(described_class.variants(nil)).to eq([])
+  end
+
   it 'refuses to match anything against a blank' do
     expect(described_class.same_number?(nil, '5541988887777')).to be(false)
     expect(described_class.same_number?('', '')).to be(false)

--- a/spec/services/whatsapp/session/phone_match_spec.rb
+++ b/spec/services/whatsapp/session/phone_match_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::PhoneMatch do
+  it 'matches a Brazilian line with and without its ninth digit' do
+    expect(described_class.same_number?('+55 41 98888-7777', '554188887777')).to be(true)
+  end
+
+  it 'matches an Argentinian line with and without its 9' do
+    expect(described_class.same_number?('+5491123456789', '541123456789')).to be(true)
+  end
+
+  it 'does not match two different lines' do
+    expect(described_class.same_number?('5541988887777', '5541900001111')).to be(false)
+  end
+
+  # No normalizer knows this country, so the only safe answer for two different strings
+  # is "not the same line": guessing would merge two unrelated numbers.
+  it 'falls back to an exact comparison where no normalizer applies' do
+    expect(described_class.same_number?('12025550100', '12025550100')).to be(true)
+    expect(described_class.same_number?('12025550100', '12025550101')).to be(false)
+  end
+
+  it 'refuses to match anything against a blank' do
+    expect(described_class.same_number?(nil, '5541988887777')).to be(false)
+    expect(described_class.same_number?('', '')).to be(false)
+  end
+end


### PR DESCRIPTION
Third slice of the WhatsApp session layer. It is the receiving half: everything that arrives from a session provider now lands on one path, written once against the canonical event model instead of once per provider.

Nothing is wired to a live provider yet, so no existing inbox changes behavior. A backend hands the dispatcher a `Model::Event` and the dispatcher routes it; the two backends that will produce those events arrive in later slices.

## What changed

**One dispatch table.** A type absent from `HANDLERS` is ignored, never guessed at by name. That is what lets an older Chatwoot keep running against a newer connector, and what keeps the Uazapi translator honest about what it can actually produce. Types the catalog defines and this layer deliberately drops are listed in `IGNORED`, so a type missing from both shows up as a gap instead of as silence.

**One rule for delivery receipts.** The Baileys layer had it in both `messages.update` and `message-receipt.update` and the two had already drifted apart. `StatusTransition` is monotonic: a message never moves back to a weaker status, `read` is terminal, and `played` counts as read since Chatwoot has no column for it.

**Both concurrency guards in one place.** The chat lock serializes contact resolution and conversation pick for a chat, so two messages of the same chat cannot each create a conversation. The message lock makes a redelivery answer `:duplicate` instead of writing a second row. `native` delivers a session's events in order on a single consumer thread and cannot race, but Uazapi arrives as webhooks fanned out over Sidekiq, so both guards hold for the family as a whole. A held chat raises `Locks::Busy` and the job retries rather than parking a Sidekiq thread on Redis.

**One contact lookup.** `ContactResolver` tries LID, then the phone with its Brazilian nono-dígito variants, then the identifier on the account, then the phone on the account. It never creates a contact when one already exists, which is what keeps converting an inbox between providers from duplicating everyone.

`Dispatcher` carries a `prepend_mod_with` so the Enterprise tree can extend the inbound path without editing this file.

## How to test

There is no provider to receive from yet. The specs drive the pipeline through `Backends::Fake` with canonical events: 1:1 and group messages, echo of an agent reply, reaction add and remove, edit, revoke, receipts arriving out of order, presence, a stale epoch being discarded, and a pairing that reports the wrong number.

## Known gap, tracked

HTTP providers deliver a chat's events out of order, because one Sidekiq job runs per event. A revoke, an edit or a reaction whose job beats the `message.received` that stores its target finds nothing and is dropped. The guard belongs in `EventJob` and the mechanism depends on what the provider's webhook actually carries, which is captured from a live instance in the Uazapi slice. Tracked in #373, with the note in the code at the point where the fix goes. The connector path is unaffected: it dispatches inline on one thread per shard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/372)
<!-- Reviewable:end -->
