### PR TITLE
feat(whatsapp): session layer 4/8, outbound sends and the channel facade

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -50,6 +50,8 @@ app/services/whatsapp/session/groups/syncer.rb: Remove avatars absent from rejoi
 # guard is ours, from #353, and it is shared by every channel, so the fix goes to main
 # rather than to a branch that merges in weeks. Removing this waiver does not close the issue.
 app/services/whatsapp/session/outbound/message_sender.rb: Allow deleted reaction rows to send removals  # PR#377
+# Same defect under the reviewer's other name for it.
+app/services/whatsapp/session/outbound/message_sender.rb: Allow removed reactions to reach the sender  # PR#377
 # PR#377: not a defect. A reaction stored with only `in_reply_to_external_id` gets its
 # `in_reply_to` filled in by Message's own `before_save :ensure_in_reply_to`, which runs
 # InReplyToMessageBuilder and resolves the target by source_id within the conversation. The

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -67,3 +67,19 @@ app/services/whatsapp/session/outbound/message_sender.rb: Resolve phone-originat
 # ends the wrong account inline before connecting and the retry then stands down. Revisit
 # with the session-scoped logout in the connector slice.
 app/jobs/whatsapp/session/logout_job.rb: Serialize stale logout checks with reconnects  # PR#377
+# PR#377: half fixed, half refused. The claim being refused after a conversion is fixed:
+# setup returns without asking the old provider, so no session is left behind. Serializing
+# the provider call itself against a second connect is not, and it is the same question as
+# the logout above: it needs a lock held across the connect. A provider answering two
+# overlapping connects converges on one pairing (both `POST /instance/connect` and
+# `session.connect` return the pairing in progress), and where it does not, the next QR
+# rotation arrives as an event and corrects the screen within ~20s.
+app/services/whatsapp/session/facade.rb: Fence the provider call against superseded setup attempts  # PR#377
+# PR#377: not a defect. The window named is between two lines of one synchronous call
+# chain: SendReplyJob -> SendOnChannelService#invalid_message? -> channel.send_message ->
+# this sender, with no I/O in between. The window that is actually open is the provider
+# call itself, and that one is already covered: `SourceIdReservation.assign` returns
+# `:revoke` when it fills source_id on a message deleted meanwhile, and the sender enqueues
+# Messages::DeleteOnChannelJob after the lock commits. A second deletion check could not
+# close that window either, since deletion can always commit after the last check.
+app/services/whatsapp/session/outbound/message_sender.rb: Recheck deletion before sending the command  # PR#377

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -50,3 +50,10 @@ app/services/whatsapp/session/groups/syncer.rb: Remove avatars absent from rejoi
 # guard is ours, from #353, and it is shared by every channel, so the fix goes to main
 # rather than to a branch that merges in weeks. Removing this waiver does not close the issue.
 app/services/whatsapp/session/outbound/message_sender.rb: Allow deleted reaction rows to send removals  # PR#377
+# PR#377: not a defect. A reaction stored with only `in_reply_to_external_id` gets its
+# `in_reply_to` filled in by Message's own `before_save :ensure_in_reply_to`, which runs
+# InReplyToMessageBuilder and resolves the target by source_id within the conversation. The
+# row id is therefore always there by the time a send reads it, and resolving it again here
+# would duplicate the model's guarantee. Covered by "reacts to a target a phone-originated
+# reaction knows only by its WhatsApp id" in message_sender_spec.
+app/services/whatsapp/session/outbound/message_sender.rb: Resolve phone-originated reactions by external target ID  # PR#377

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -57,3 +57,13 @@ app/services/whatsapp/session/outbound/message_sender.rb: Allow deleted reaction
 # would duplicate the model's guarantee. Covered by "reacts to a target a phone-originated
 # reaction knows only by its WhatsApp id" in message_sender_spec.
 app/services/whatsapp/session/outbound/message_sender.rb: Resolve phone-originated reactions by external target ID  # PR#377
+# PR#377: real, and deliberately left open. A logout retry that passes the quarantine
+# check and is still inside its provider call when the operator connects again can end the
+# replacement session. Closing it needs the logout to name the session it is meant to end,
+# which the contract does not have: `session.logout` addresses whatever session the inbox
+# holds now. The alternative, a distributed lock held across both provider calls, buys a
+# very rare and self-healing case (the operator scans again) at the price of a lock on the
+# connect path. The operator-driven sequence is already covered: `Facade#setup_channel_provider`
+# ends the wrong account inline before connecting and the retry then stands down. Revisit
+# with the session-scoped logout in the connector slice.
+app/jobs/whatsapp/session/logout_job.rb: Serialize stale logout checks with reconnects  # PR#377

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -44,3 +44,9 @@ app/services/whatsapp/session/inbound/dispatcher.rb: Deduplicate events before i
 # field the snapshot did not mention. Fixing it is a contract change, decided with the
 # payloads captured in the Uazapi slice. Removing this waiver does not close the issue.
 app/services/whatsapp/session/groups/syncer.rb: Remove avatars absent from rejoin snapshots  # PR#372
+# PR#377: real, tracked in fazer-ai/chatwoot#378, and not this stack's to fix. Removing a
+# reaction never reaches any provider, legacy included: the reactions controller marks the
+# reused row deleted and Base::SendOnChannelService refuses to send a deleted message. The
+# guard is ours, from #353, and it is shared by every channel, so the fix goes to main
+# rather than to a branch that merges in weeks. Removing this waiver does not close the issue.
+app/services/whatsapp/session/outbound/message_sender.rb: Allow deleted reaction rows to send removals  # PR#377

--- a/app/controllers/api/v1/accounts/contacts/group_admin_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_admin_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Accounts::Contacts::GroupAdminController < Api::V1::Accounts::Con
     authorize @contact, :update?
     channel.group_leave(@contact.identifier)
     head :ok
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
@@ -18,7 +18,7 @@ class Api::V1::Accounts::Contacts::GroupAdminController < Api::V1::Accounts::Con
     apply_property_change(property, enabled)
     update_contact_attribute(property, enabled)
     head :ok
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 

--- a/app/controllers/api/v1/accounts/contacts/group_invites_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_invites_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::Accounts::Contacts::GroupInvitesController < Api::V1::Accounts::C
     authorize @contact, :show?
     code = channel.group_invite_code(@contact.identifier)
     render json: invite_response(code)
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
@@ -11,7 +11,7 @@ class Api::V1::Accounts::Contacts::GroupInvitesController < Api::V1::Accounts::C
     authorize @contact, :update?
     code = channel.revoke_group_invite(@contact.identifier)
     render json: invite_response(code)
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 

--- a/app/controllers/api/v1/accounts/contacts/group_join_requests_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_join_requests_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::Accounts::Contacts::GroupJoinRequestsController < Api::V1::Accoun
     authorize @contact, :show?
     requests = channel.group_join_requests(@contact.identifier)
     render json: { payload: requests }
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::NotSupported => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
@@ -12,7 +12,7 @@ class Api::V1::Accounts::Contacts::GroupJoinRequestsController < Api::V1::Accoun
     channel.handle_group_join_requests(@contact.identifier, handle_params[:participants], handle_params[:request_action])
     remove_handled_requests(handle_params[:participants])
     head :ok
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::NotSupported => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 

--- a/app/controllers/api/v1/accounts/contacts/group_join_requests_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_join_requests_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::Accounts::Contacts::GroupJoinRequestsController < Api::V1::Accoun
     authorize @contact, :show?
     requests = channel.group_join_requests(@contact.identifier)
     render json: { payload: requests }
-  rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::NotSupported => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
@@ -12,7 +12,7 @@ class Api::V1::Accounts::Contacts::GroupJoinRequestsController < Api::V1::Accoun
     channel.handle_group_join_requests(@contact.identifier, handle_params[:participants], handle_params[:request_action])
     remove_handled_requests(handle_params[:participants])
     head :ok
-  rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::NotSupported => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 

--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     channel.update_group_participants(@contact.identifier, format_participants(participants), 'add')
     add_group_members(participants)
     head :ok
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
@@ -47,7 +47,7 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     head :ok
   rescue Whatsapp::Session::Errors::GroupParticipantNotAllowed
     render json: { error: 'group_creator_not_modifiable' }, status: :unprocessable_entity
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
@@ -60,7 +60,7 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     head :ok
   rescue Whatsapp::Session::Errors::GroupParticipantNotAllowed
     render json: { error: 'group_creator_not_modifiable' }, status: :unprocessable_entity
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 

--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -124,8 +124,16 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     Array(phone_numbers).map { |phone| "#{phone.to_s.delete('+')}@s.whatsapp.net" }
   end
 
+  # A group roster can name a participant WhatsApp only ever gave a LID for, and those
+  # contacts have no phone number at all: building a phone JID from one produced
+  # `@s.whatsapp.net`, which no provider accepts, so the member could not be promoted,
+  # demoted or removed. Address is where the rule for which id a contact is reachable by
+  # already lives.
   def jid_for_member(member)
-    "#{member.contact.phone_number.to_s.delete('+')}@s.whatsapp.net"
+    address = Whatsapp::Session::Model::Address.for_contact(member.contact)
+    raise Whatsapp::Session::Errors::InvalidPayload, 'group member has no WhatsApp address' if address.nil?
+
+    address.to_jid
   end
 
   def add_group_members(phone_numbers)

--- a/app/controllers/api/v1/accounts/contacts/group_metadata_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_metadata_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Accounts::Contacts::GroupMetadataController < Api::V1::Accounts::
     update_description if metadata_params[:description].present?
     update_picture if metadata_params[:avatar].present?
     render json: { id: @contact.id, name: @contact.name, additional_attributes: @contact.additional_attributes }
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 

--- a/app/controllers/api/v1/accounts/groups_controller.rb
+++ b/app/controllers/api/v1/accounts/groups_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Accounts::GroupsController < Api::V1::Accounts::BaseController
     ).perform
 
     render json: result
-  rescue Whatsapp::Session::Errors::ProviderUnavailable => e
+  rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
   end
 

--- a/app/jobs/whatsapp/session/logout_job.rb
+++ b/app/jobs/whatsapp/session/logout_job.rb
@@ -11,6 +11,13 @@ class Whatsapp::Session::LogoutJob < ApplicationJob
   retry_on Whatsapp::Session::Errors::RateLimited, wait: :polynomially_longer, attempts: 6
 
   def perform(channel)
+    # Re-read, because a retry of this job can run minutes after the rejection that
+    # queued it: the administrator may have corrected the number and paired again, or
+    # converted the inbox altogether, and logging out then kills the session that
+    # replaced the one this was sent to remove. The quarantine is the whole reason this
+    # job exists, so its absence is reason enough not to run.
+    return unless Whatsapp::Session::ConnectionStateWriter.disowned?(channel.reload)
+
     channel.session_backend.logout
   rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
     raise

--- a/app/jobs/whatsapp/session/logout_job.rb
+++ b/app/jobs/whatsapp/session/logout_job.rb
@@ -11,7 +11,7 @@ class Whatsapp::Session::LogoutJob < ApplicationJob
   retry_on Whatsapp::Session::Errors::RateLimited, wait: :polynomially_longer, attempts: 6
 
   def perform(channel)
-    channel.provider_service.logout
+    channel.session_backend.logout
   rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
     raise
   rescue Whatsapp::Session::Errors::Error => e

--- a/app/jobs/whatsapp/session/logout_job.rb
+++ b/app/jobs/whatsapp/session/logout_job.rb
@@ -16,6 +16,13 @@ class Whatsapp::Session::LogoutJob < ApplicationJob
     # converted the inbox altogether, and logging out then kills the session that
     # replaced the one this was sent to remove. The quarantine is the whole reason this
     # job exists, so its absence is reason enough not to run.
+    #
+    # A check, not a fence, and it cannot be one here: a retry that passes it and is still
+    # inside the provider call when the operator reconnects ends the new session anyway.
+    # Closing that needs a logout naming the session it means to end, and `session.logout`
+    # addresses whichever session the inbox holds now. The operator's own sequence does
+    # not depend on it: `Facade#setup_channel_provider` ends the wrong account inline
+    # before connecting, and this job then finds no quarantine and stands down.
     return unless Whatsapp::Session::ConnectionStateWriter.disowned?(channel.reload)
 
     channel.session_backend.logout

--- a/app/jobs/whatsapp/session/media_fetch_job.rb
+++ b/app/jobs/whatsapp/session/media_fetch_job.rb
@@ -14,7 +14,7 @@ class Whatsapp::Session::MediaFetchJob < ApplicationJob
     return if message.attachments.any?
 
     media = Whatsapp::Session::Model::Content.from_h(content)
-    payload = message.inbox.channel.provider_service.download_media(media.ref)
+    payload = message.inbox.channel.session_backend.download_media(media.ref)
     # Re-read under lock, after the download: a deletion that landed while this job was
     # queued or running destroyed the attachments, and attaching now would put the
     # supposedly deleted media back into storage and back on the API.

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -67,7 +67,10 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
     state = backend.fetch_connection_state
     return unless current?
 
-    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(stamped(state))
+    # Fenced, not merely checked above: a second connect claiming the pairing between that
+    # check and this write would have its QR replaced by the one this chain is holding,
+    # and the chain driving the screen would retire itself over a token it never wrote.
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(stamped(state), attempt: attempt)
     return if settled?(state)
     return give_up(TIMEOUT_ERRORS.fetch(pairing, 'pairing_timed_out')) if Time.current + INTERVAL >= deadline_at
 
@@ -91,7 +94,7 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
     return unless current?
 
     Whatsapp::Session::ConnectionStateWriter.new(channel).apply(
-      Whatsapp::Session::Model::ConnectionState.new(connection: 'close', error: error)
+      Whatsapp::Session::Model::ConnectionState.new(connection: 'close', error: error), attempt: attempt
     )
   end
 

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -9,8 +9,17 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
 
   INTERVAL = 15.seconds
   # A QR expires far sooner than a pairing code, which the operator has to type on the
-  # phone. Both are ceilings on the whole attempt, not on a single code.
-  DEADLINES = { 'qr' => 2.minutes, 'code' => 5.minutes }.freeze
+  # phone. A resume has neither in front of it: nothing on screen is going stale and the
+  # provider is bringing an existing pairing back up, which takes as long as the network
+  # makes it take, so it gets the longer of the two. All three are ceilings on the whole
+  # attempt, not on a single code.
+  DEADLINES = { 'qr' => 2.minutes, 'code' => 5.minutes, 'resume' => 5.minutes }.freeze
+
+  # What the operator reads when the ceiling is reached. A resume never showed a code, so
+  # reporting an expired one sends them looking for a screen that was never there: what
+  # happened is that the session did not come back, and the provider keeps trying on its
+  # own.
+  TIMEOUT_ERRORS = { 'resume' => 'connect_failure' }.freeze
 
   # `pairing` is the mode the connect command asked for; `deadline_at` is set on the first
   # run and carried forward so re-enqueueing never extends the ceiling. `provider` and
@@ -55,7 +64,7 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
 
     Whatsapp::Session::ConnectionStateWriter.new(channel).apply(stamped(state))
     return if settled?(state)
-    return give_up('pairing_timed_out') if Time.current + INTERVAL >= deadline_at
+    return give_up(TIMEOUT_ERRORS.fetch(pairing, 'pairing_timed_out')) if Time.current + INTERVAL >= deadline_at
 
     self.class.set(wait: INTERVAL).perform_later(
       channel, pairing: pairing, deadline_at: deadline_at, provider: provider, attempt: attempt

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -12,31 +12,47 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
   # phone. Both are ceilings on the whole attempt, not on a single code.
   DEADLINES = { 'qr' => 2.minutes, 'code' => 5.minutes }.freeze
 
-  # `pairing` is the mode the connect command asked for; `deadline_at` is set on the
-  # first run and carried forward so re-enqueueing never extends the ceiling.
-  def perform(channel, pairing: 'qr', deadline_at: nil)
-    deadline_at ||= Time.current + DEADLINES.fetch(pairing.to_s, DEADLINES['qr'])
+  # `pairing` is the mode the connect command asked for; `deadline_at` is set on the first
+  # run and carried forward so re-enqueueing never extends the ceiling. `provider` is the
+  # provider that started this pairing: an inbox converted while a poll sat in the queue
+  # would otherwise be polled, and failed, against whatever it became.
+  def perform(channel, pairing: 'qr', deadline_at: nil, provider: nil)
+    @channel = channel
+    @pairing = pairing.to_s
+    @provider = provider || channel.provider
+    @deadline_at = deadline_at || (Time.current + DEADLINES.fetch(@pairing, DEADLINES['qr']))
+    return unless channel.provider == @provider
+
     backend = channel.session_backend
-    return unless backend.class.state_polling?
-
-    state = backend.fetch_connection_state
-    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state)
-    return if settled?(state) || Time.current + INTERVAL >= deadline_at
-
-    self.class.set(wait: INTERVAL).perform_later(channel, pairing: pairing, deadline_at: deadline_at)
+    poll(backend) if backend.class.state_polling?
   rescue Whatsapp::Session::Errors::Error => e
     # The instance being unreachable mid-pairing is the operator's problem to see on the
     # screen, not something a retry storm fixes: the next connect starts a fresh poll.
-    # Said on the screen, though, and not only in the log: leaving the state untouched
-    # parks the dashboard on a QR that expired minutes ago, waiting for a rotation that
-    # is never coming.
     Rails.logger.warn("[WHATSAPP SESSION] pairing poll failed for ##{channel.id}: #{e.message}")
-    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(
-      Whatsapp::Session::Model::ConnectionState.new(connection: 'close', error: 'connect_failure')
-    )
+    give_up('connect_failure')
   end
 
   private
+
+  attr_reader :channel, :pairing, :provider, :deadline_at
+
+  def poll(backend)
+    state = backend.fetch_connection_state
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state)
+    return if settled?(state)
+    return give_up('pairing_timed_out') if Time.current + INTERVAL >= deadline_at
+
+    self.class.set(wait: INTERVAL).perform_later(channel, pairing: pairing, deadline_at: deadline_at, provider: provider)
+  end
+
+  # Both ways a pairing ends without succeeding write the reason to the connection record.
+  # Leaving the last `connecting` state in place parks the dashboard on a QR that expired
+  # minutes ago, waiting for a rotation that is never coming.
+  def give_up(error)
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(
+      Whatsapp::Session::Model::ConnectionState.new(connection: 'close', error: error)
+    )
+  end
 
   # Anything that is not still trying to connect ends the poll: `open` means paired, and
   # a closed connection means the attempt was abandoned or refused. `reconnecting` is

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -53,13 +53,21 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
     state = backend.fetch_connection_state
     return unless current?
 
-    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state.with(pairing_attempt: attempt))
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(stamped(state))
     return if settled?(state)
     return give_up('pairing_timed_out') if Time.current + INTERVAL >= deadline_at
 
     self.class.set(wait: INTERVAL).perform_later(
       channel, pairing: pairing, deadline_at: deadline_at, provider: provider, attempt: attempt
     )
+  end
+
+  # The token rides along only while the attempt is still running. Stamping it onto a
+  # settled state keeps it on the record, and then a duplicate or late delivery of this
+  # job still passes `current?`: it would poll a session that has already opened and, if
+  # that request fails, write `connect_failure` over it.
+  def stamped(state)
+    state.connecting? ? state.with(pairing_attempt: attempt) : state
   end
 
   # Both ways a pairing ends without succeeding write the reason to the connection record.

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -33,8 +33,11 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
   private
 
   # Anything that is not still trying to connect ends the poll: `open` means paired, and
-  # a closed connection means the attempt was abandoned or refused.
+  # a closed connection means the attempt was abandoned or refused. `reconnecting` is
+  # the provider still working on it, which is exactly when the poll is needed: the QR
+  # keeps rotating and the push that would carry it is the thing this job exists to
+  # replace, so treating it as settled leaves the operator on a dead code.
   def settled?(state)
-    state.connection != 'connecting'
+    !state.connecting?
   end
 end

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -21,6 +21,11 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
   # own.
   TIMEOUT_ERRORS = { 'resume' => 'connect_failure' }.freeze
 
+  # Resolved by whoever starts the attempt, so the ceiling covers the queue wait too.
+  def self.deadline_for(pairing)
+    Time.current + DEADLINES.fetch(pairing.to_s, DEADLINES['qr'])
+  end
+
   # `pairing` is the mode the connect command asked for; `deadline_at` is set on the first
   # run and carried forward so re-enqueueing never extends the ceiling. `provider` and
   # `attempt` say which pairing this chain belongs to: an inbox converted, or connected
@@ -31,7 +36,7 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
     @pairing = pairing.to_s
     @provider = provider
     @attempt = attempt
-    @deadline_at = deadline_at || (Time.current + DEADLINES.fetch(@pairing, DEADLINES['qr']))
+    @deadline_at = deadline_at || self.class.deadline_for(@pairing)
     return unless current?
 
     backend = channel.session_backend

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -1,0 +1,40 @@
+# Drives the pairing screen for backends that have to be polled.
+#
+# A QR rotates about every 20 seconds and the provider's webhook is not guaranteed to
+# push every rotation, so the operator would be left staring at a code that stopped
+# working. This job pulls the state until the session opens, the pairing is abandoned,
+# or the ceiling below is reached.
+class Whatsapp::Session::PairingPollJob < ApplicationJob
+  queue_as :high
+
+  INTERVAL = 15.seconds
+  # A QR expires far sooner than a pairing code, which the operator has to type on the
+  # phone. Both are ceilings on the whole attempt, not on a single code.
+  DEADLINES = { 'qr' => 2.minutes, 'code' => 5.minutes }.freeze
+
+  # `pairing` is the mode the connect command asked for; `deadline_at` is set on the
+  # first run and carried forward so re-enqueueing never extends the ceiling.
+  def perform(channel, pairing: 'qr', deadline_at: nil)
+    deadline_at ||= Time.current + DEADLINES.fetch(pairing.to_s, DEADLINES['qr'])
+    backend = channel.session_backend
+    return unless backend.class.state_polling?
+
+    state = backend.fetch_connection_state
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state)
+    return if settled?(state) || Time.current + INTERVAL >= deadline_at
+
+    self.class.set(wait: INTERVAL).perform_later(channel, pairing: pairing, deadline_at: deadline_at)
+  rescue Whatsapp::Session::Errors::Error => e
+    # The instance being unreachable mid-pairing is the operator's problem to see on the
+    # screen, not something a retry storm fixes: the next connect starts a fresh poll.
+    Rails.logger.warn("[WHATSAPP SESSION] pairing poll failed for ##{channel.id}: #{e.message}")
+  end
+
+  private
+
+  # Anything that is not still trying to connect ends the poll: `open` means paired, and
+  # a closed connection means the attempt was abandoned or refused.
+  def settled?(state)
+    state.connection != 'connecting'
+  end
+end

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -27,7 +27,13 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
   rescue Whatsapp::Session::Errors::Error => e
     # The instance being unreachable mid-pairing is the operator's problem to see on the
     # screen, not something a retry storm fixes: the next connect starts a fresh poll.
+    # Said on the screen, though, and not only in the log: leaving the state untouched
+    # parks the dashboard on a QR that expired minutes ago, waiting for a rotation that
+    # is never coming.
     Rails.logger.warn("[WHATSAPP SESSION] pairing poll failed for ##{channel.id}: #{e.message}")
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(
+      Whatsapp::Session::Model::ConnectionState.new(connection: 'close', error: 'connect_failure')
+    )
   end
 
   private

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -13,15 +13,17 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
   DEADLINES = { 'qr' => 2.minutes, 'code' => 5.minutes }.freeze
 
   # `pairing` is the mode the connect command asked for; `deadline_at` is set on the first
-  # run and carried forward so re-enqueueing never extends the ceiling. `provider` is the
-  # provider that started this pairing: an inbox converted while a poll sat in the queue
-  # would otherwise be polled, and failed, against whatever it became.
-  def perform(channel, pairing: 'qr', deadline_at: nil, provider: nil)
+  # run and carried forward so re-enqueueing never extends the ceiling. `provider` and
+  # `attempt` say which pairing this chain belongs to: an inbox converted, or connected
+  # again, while a poll sat in the queue would otherwise be polled against whatever it
+  # became, and this chain's timeout would land on somebody else's live QR.
+  def perform(channel, pairing: 'qr', deadline_at: nil, provider: nil, attempt: nil)
     @channel = channel
     @pairing = pairing.to_s
-    @provider = provider || channel.provider
+    @provider = provider
+    @attempt = attempt
     @deadline_at = deadline_at || (Time.current + DEADLINES.fetch(@pairing, DEADLINES['qr']))
-    return unless channel.provider == @provider
+    return unless current?
 
     backend = channel.session_backend
     poll(backend) if backend.class.state_polling?
@@ -34,21 +36,38 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
 
   private
 
-  attr_reader :channel, :pairing, :provider, :deadline_at
+  attr_reader :channel, :pairing, :provider, :attempt, :deadline_at
+
+  # Whether the inbox is still the one this chain started on, and still on this attempt.
+  # Re-read every time, including after the provider request, because a conversion or a
+  # second connect can land while this job is waiting on the network.
+  def current?
+    channel.reload
+    return false if provider.present? && channel.provider != provider
+    return true if attempt.blank?
+
+    channel.provider_connection['pairing_attempt'] == attempt
+  end
 
   def poll(backend)
     state = backend.fetch_connection_state
-    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state)
+    return unless current?
+
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state.with(pairing_attempt: attempt))
     return if settled?(state)
     return give_up('pairing_timed_out') if Time.current + INTERVAL >= deadline_at
 
-    self.class.set(wait: INTERVAL).perform_later(channel, pairing: pairing, deadline_at: deadline_at, provider: provider)
+    self.class.set(wait: INTERVAL).perform_later(
+      channel, pairing: pairing, deadline_at: deadline_at, provider: provider, attempt: attempt
+    )
   end
 
   # Both ways a pairing ends without succeeding write the reason to the connection record.
   # Leaving the last `connecting` state in place parks the dashboard on a QR that expired
   # minutes ago, waiting for a rotation that is never coming.
   def give_up(error)
+    return unless current?
+
     Whatsapp::Session::ConnectionStateWriter.new(channel).apply(
       Whatsapp::Session::Model::ConnectionState.new(connection: 'close', error: error)
     )

--- a/app/jobs/whatsapp/session/pairing_poll_job.rb
+++ b/app/jobs/whatsapp/session/pairing_poll_job.rb
@@ -70,21 +70,13 @@ class Whatsapp::Session::PairingPollJob < ApplicationJob
     # Fenced, not merely checked above: a second connect claiming the pairing between that
     # check and this write would have its QR replaced by the one this chain is holding,
     # and the chain driving the screen would retire itself over a token it never wrote.
-    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(stamped(state), attempt: attempt)
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state.with_attempt(attempt), attempt: attempt)
     return if settled?(state)
     return give_up(TIMEOUT_ERRORS.fetch(pairing, 'pairing_timed_out')) if Time.current + INTERVAL >= deadline_at
 
     self.class.set(wait: INTERVAL).perform_later(
       channel, pairing: pairing, deadline_at: deadline_at, provider: provider, attempt: attempt
     )
-  end
-
-  # The token rides along only while the attempt is still running. Stamping it onto a
-  # settled state keeps it on the record, and then a duplicate or late delivery of this
-  # job still passes `current?`: it would poll a session that has already opened and, if
-  # that request fails, write `connect_failure` over it.
-  def stamped(state)
-    state.connecting? ? state.with(pairing_attempt: attempt) : state
   end
 
   # Both ways a pairing ends without succeeding write the reason to the connection record.

--- a/app/jobs/whatsapp/session/update_contact_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_contact_avatar_job.rb
@@ -22,7 +22,7 @@ class Whatsapp::Session::UpdateContactAvatarJob < ApplicationJob
     # handing it a Party would put the wrong shape on the wire and break every backend
     # that reads the address.
     address = Whatsapp::Session::Model::Party.from_h(party).address
-    url = channel.provider_service.profile_picture_url(
+    url = channel.session_backend.profile_picture_url(
       Whatsapp::Session::Model::Commands::ContactProfilePicture.new(party: address)
     )
     # RACE, TRACKED (fazer-ai/chatwoot#375). A picture-removed event that purges the

--- a/app/jobs/whatsapp/session/update_group_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_group_avatar_job.rb
@@ -36,7 +36,7 @@ class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
     address = Whatsapp::Session::Model::Address.parse(group_contact.identifier)
     return if address.blank?
 
-    channel.provider_service.group_info(Whatsapp::Session::Model::Commands::GroupInfo.new(group: address))
+    channel.session_backend.group_info(Whatsapp::Session::Model::Commands::GroupInfo.new(group: address))
   rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
     # Raised on, not swallowed: the job retries and the retry is what keeps a forced
     # refresh from leaving the old picture attached for good.

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -98,7 +98,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     # this column, the echo of our own send, and both of them seeing `deleted` would ask
     # the provider to revoke the same message twice. The assignment and that decision
     # share one row lock, which is what makes the answer unambiguous.
-    return unless Whatsapp::Session::Outbound::SourceIdReservation.assign(message, { source_id: message_id })
+    return unless Whatsapp::Session::Outbound::SourceIdReservation.assign(message, { source_id: message_id }) == :revoke
 
     ::Messages::DeleteOnChannelJob.perform_later(message.id)
   end

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -94,13 +94,11 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
   def persist_source_id(message_id)
     return if message_id.blank?
 
-    # Only whoever assigns the id owns the revoke. A session inbox has a second writer of
-    # this column, the echo of our own send, which takes the row lock and enqueues the
-    # revoke itself when it is the one that filled the id in; both of them seeing
-    # `deleted` would ask the provider to revoke the same message twice.
-    claimed = Whatsapp::Session::Outbound::SourceIdReservation.claim_source_id(message, message_id)
-    message.update_under_lock!(source_id: message_id)
-    return unless claimed && message.deleted?
+    # Only whoever assigns the id owns the revoke: a session inbox has a second writer of
+    # this column, the echo of our own send, and both of them seeing `deleted` would ask
+    # the provider to revoke the same message twice. The assignment and that decision
+    # share one row lock, which is what makes the answer unambiguous.
+    return unless Whatsapp::Session::Outbound::SourceIdReservation.assign(message, { source_id: message_id })
 
     ::Messages::DeleteOnChannelJob.perform_later(message.id)
   end

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -98,9 +98,9 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     # this column, the echo of our own send, which takes the row lock and enqueues the
     # revoke itself when it is the one that filled the id in; both of them seeing
     # `deleted` would ask the provider to revoke the same message twice.
-    already_assigned = Message.where(id: message.id).where.not(source_id: nil).exists?
+    claimed = Whatsapp::Session::Outbound::SourceIdReservation.claim_source_id(message, message_id)
     message.update_under_lock!(source_id: message_id)
-    return if already_assigned || !message.deleted?
+    return unless claimed && message.deleted?
 
     ::Messages::DeleteOnChannelJob.perform_later(message.id)
   end

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -94,8 +94,13 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
   def persist_source_id(message_id)
     return if message_id.blank?
 
+    # Only whoever assigns the id owns the revoke. A session inbox has a second writer of
+    # this column, the echo of our own send, which takes the row lock and enqueues the
+    # revoke itself when it is the one that filled the id in; both of them seeing
+    # `deleted` would ask the provider to revoke the same message twice.
+    already_assigned = Message.where(id: message.id).where.not(source_id: nil).exists?
     message.update_under_lock!(source_id: message_id)
-    return unless message.deleted?
+    return if already_assigned || !message.deleted?
 
     ::Messages::DeleteOnChannelJob.perform_later(message.id)
   end

--- a/app/services/whatsapp/session/backend.rb
+++ b/app/services/whatsapp/session/backend.rb
@@ -25,6 +25,14 @@ class Whatsapp::Session::Backend
       capabilities.include?(capability.to_s)
     end
 
+    # Whether this backend's connection state has to be pulled. A backend that pushes
+    # every transition answers false and is never polled; one whose provider pushes only
+    # some of them answers true. Uazapi's webhook, for one, does not carry the QR as it
+    # rotates nor the account limits, so its inboxes would sit on a stale QR forever.
+    def state_polling?
+      false
+    end
+
     # Schema-only validation: returns the list of invalid/missing config keys. Must not
     # touch the network, so saving an inbox never depends on a provider being up.
     def validate_config(_provider_config)

--- a/app/services/whatsapp/session/backend.rb
+++ b/app/services/whatsapp/session/backend.rb
@@ -80,6 +80,9 @@ class Whatsapp::Session::Backend
   def update_group_description(_command) = not_supported!(:update_group_description)
   def update_group_photo(_command) = not_supported!(:update_group_photo)
   def update_group_setting(_command) = not_supported!(:update_group_setting)
+  # Returns the invite code alone, never the chat.whatsapp.com link: the dashboard
+  # endpoint builds the URL from it, so a backend handing back a full link produces one
+  # with the host in it twice.
   def group_invite_code(_command) = not_supported!(:group_invite_code)
   def group_join_requests(_command) = not_supported!(:group_join_requests)
   def handle_group_join_requests(_command) = not_supported!(:handle_group_join_requests)

--- a/app/services/whatsapp/session/backends/fake.rb
+++ b/app/services/whatsapp/session/backends/fake.rb
@@ -176,7 +176,7 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
 
   def group_invite_code(command)
     record(command)
-    'https://chat.whatsapp.com/FAKEINVITE0001'
+    'FAKEINVITE0001'
   end
 
   def group_join_requests(command)

--- a/app/services/whatsapp/session/backends/fake.rb
+++ b/app/services/whatsapp/session/backends/fake.rb
@@ -5,7 +5,9 @@
 # Commands are kept in `commands` for assertions; `emit` builds canonical events with a
 # monotonic cursor, the way a real backend would.
 class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
-  Model = Whatsapp::Session::Model
+  # Per call, never aliased: a constant would hold the pre-reload module. See Handlers::Base.
+  def model = Whatsapp::Session::Model
+
   QR_DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='.freeze
 
   class << self
@@ -24,12 +26,12 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
     super
     @commands = []
     @seq = 0
-    @connection_state = Model::ConnectionState.new(connection: 'close')
+    @connection_state = model::ConnectionState.new(connection: 'close')
   end
 
   def connect(command)
     record(command)
-    @connection_state = Model::ConnectionState.new(
+    @connection_state = model::ConnectionState.new(
       connection: 'connecting',
       qr_data_url: (QR_DATA_URL if command.pairing == 'qr'),
       epoch: (connection_state.epoch || 0) + 1
@@ -37,17 +39,17 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
   end
 
   def disconnect
-    @connection_state = Model::ConnectionState.new(connection: 'close', epoch: connection_state.epoch)
-    record(Model::Commands::SessionDisconnect.new)
+    @connection_state = model::ConnectionState.new(connection: 'close', epoch: connection_state.epoch)
+    record(model::Commands::SessionDisconnect.new)
   end
 
   def logout
-    @connection_state = Model::ConnectionState.new(connection: 'close', epoch: connection_state.epoch)
-    record(Model::Commands::SessionLogout.new)
+    @connection_state = model::ConnectionState.new(connection: 'close', epoch: connection_state.epoch)
+    record(model::Commands::SessionLogout.new)
   end
 
   def delete_session
-    record(Model::Commands::SessionDelete.new)
+    record(model::Commands::SessionDelete.new)
   end
 
   def fetch_connection_state
@@ -56,12 +58,12 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
 
   def request_pairing_code(command)
     record(command)
-    Model::Events::PairingCode.new(code: 'K7QP-2M4X', phone: command.phone)
+    model::Events::PairingCode.new(code: 'K7QP-2M4X', phone: command.phone)
   end
 
   def import_session(payload)
     record(payload)
-    @connection_state = Model::ConnectionState.new(connection: 'connecting', epoch: (connection_state.epoch || 0) + 1)
+    @connection_state = model::ConnectionState.new(connection: 'connecting', epoch: (connection_state.epoch || 0) + 1)
   end
 
   def fetch_account_limits
@@ -70,12 +72,12 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
 
   def send_message(command)
     record(command)
-    Model::SendResult.new(message_id: command.message_id, timestamp: now_ms, client_ref: command.client_ref)
+    model::SendResult.new(message_id: command.message_id, timestamp: now_ms, client_ref: command.client_ref)
   end
 
   def edit_message(command)
     record(command)
-    Model::SendResult.new(message_id: command.message_id || generated_id, timestamp: now_ms)
+    model::SendResult.new(message_id: command.message_id || generated_id, timestamp: now_ms)
   end
 
   def revoke_message(command)
@@ -85,7 +87,7 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
 
   def react_message(command)
     record(command)
-    Model::SendResult.new(message_id: command.message_id || generated_id, timestamp: now_ms)
+    model::SendResult.new(message_id: command.message_id || generated_id, timestamp: now_ms)
   end
 
   def mark_read(command)
@@ -100,7 +102,7 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
 
   def download_media(ref)
     record(ref)
-    Model::MediaPayload.new(io: StringIO.new('fake-media'), mime: ref.mime || 'application/octet-stream',
+    model::MediaPayload.new(io: StringIO.new('fake-media'), mime: ref.mime || 'application/octet-stream',
                             filename: 'fake-media', size: 10)
   end
 
@@ -121,7 +123,7 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
 
   def check_numbers(command)
     record(command)
-    command.phones.map { |phone| Model::NumberCheck.new(phone: phone, exists: true, address: Model::Address.phone(phone)) }
+    command.phones.map { |phone| model::NumberCheck.new(phone: phone, exists: true, address: model::Address.phone(phone)) }
   end
 
   def profile_picture_url(command)
@@ -131,7 +133,7 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
 
   def create_group(command)
     record(command)
-    group_info_for(Model::Address.group('120363040000000001'), subject: command.subject)
+    group_info_for(model::Address.group('120363040000000001'), subject: command.subject)
   end
 
   def group_info(command)
@@ -141,13 +143,10 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
 
   def list_groups(command)
     record(command)
-    [group_info_for(Model::Address.group('120363040000000001'))]
+    [group_info_for(model::Address.group('120363040000000001'))]
   end
 
-  def leave_group(command)
-    record(command)
-    true
-  end
+  def leave_group(command) = record(command) && true
 
   def update_group_participants(command)
     record(command)
@@ -194,7 +193,7 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
   # Builds an event as the connector would, with the session id and a monotonic cursor.
   def emit(payload, epoch: connection_state.epoch || 1)
     @seq += 1
-    Model::Event.build(payload, id: SecureRandom.uuid, sid: channel.id.to_s, epoch: epoch, seq: @seq,
+    model::Event.build(payload, id: SecureRandom.uuid, sid: channel.id.to_s, epoch: epoch, seq: @seq,
                                 ts: now_ms, inst: 'fake')
   end
 
@@ -222,9 +221,9 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
   end
 
   def group_info_for(group, subject: 'Grupo de teste')
-    Model::GroupInfo.new(
+    model::GroupInfo.new(
       group: group, subject: subject, size: 1,
-      participants: [Model::GroupInfo::Participant.new(party: Model::Party.new(phone: '5541999990000'), role: 'superadmin')]
+      participants: [model::GroupInfo::Participant.new(party: model::Party.new(phone: '5541999990000'), role: 'superadmin')]
     )
   end
 end

--- a/app/services/whatsapp/session/channel_extension.rb
+++ b/app/services/whatsapp/session/channel_extension.rb
@@ -41,6 +41,16 @@ module Whatsapp::Session::ChannelExtension
     Whatsapp::Session::Registry.backend_for(self)
   end
 
+  # A session provider fetches outbound media from Rails itself, so on an installation
+  # where it cannot reach the public frontend URL (local Active Storage behind a private
+  # network) the operator points INTERNAL_HOST_URL at something it can. Setting it is the
+  # whole opt-in: unlike the Baileys flag this replaces, there is nothing else to turn on.
+  def use_internal_host?
+    return super unless session_provider?
+
+    ENV['INTERNAL_HOST_URL'].present?
+  end
+
   def supports_reactions?
     return super unless session_provider?
 

--- a/app/services/whatsapp/session/channel_extension.rb
+++ b/app/services/whatsapp/session/channel_extension.rb
@@ -28,9 +28,16 @@ module Whatsapp::Session::ChannelExtension
     Whatsapp::Session::Registry.capabilities_for(self)
   end
 
+  # The channel talks to its provider in legacy provider terms, so it gets the facade;
+  # everything inside the session layer asks for `session_backend` instead and speaks
+  # the canonical command API.
   def provider_service
     return super unless session_provider?
 
+    Whatsapp::Session::Facade.new(self)
+  end
+
+  def session_backend
     Whatsapp::Session::Registry.backend_for(self)
   end
 

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -134,9 +134,22 @@ class Whatsapp::Session::ConnectionStateWriter
   end
 
   def carry_pairing(payload, persisted)
+    carry_attempt(payload, persisted)
     return payload.except!(*PAIRING_KEYS) if PAIRING_ENDED.include?(payload['error_code'])
 
     PAIRING_KEYS.each { |key| payload[key] = persisted[key] if payload[key].nil? && persisted[key].present? }
+  end
+
+  # The token identifying the pairing attempt in progress. Only the connect answer and the
+  # poll carry one, and every other event about the same attempt (a rotated QR, a pairing
+  # code, a connecting state) arrives without it: dropping it there retires the polling
+  # chain that is driving the very screen those events are updating, and the code on it
+  # stops rotating. Kept while the attempt is still connecting, gone once it resolved.
+  def carry_attempt(payload, persisted)
+    return if payload['pairing_attempt'].present?
+    return unless payload['connection'].in?(%w[connecting reconnecting])
+
+    payload['pairing_attempt'] = persisted['pairing_attempt'] if persisted['pairing_attempt'].present?
   end
 
   # Events without an epoch (Uazapi, which has no ownership model) are always accepted.

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -23,6 +23,15 @@ class Whatsapp::Session::ConnectionStateWriter
   # succeeds, so the three places that used to spell it out cannot drift apart.
   WRONG_PHONE_ERROR = 'wrong_phone_number'.freeze
 
+  # Which number this session is paired with is not part of the connection lifecycle: a
+  # close does not un-pair anything, and the provider still holds the credentials.
+  # Clearing these on every close is what would make the next connect ask for a QR rather
+  # than resume, so a transient disconnect would cost the operator a fresh scan.
+  PAIRING_KEYS = %w[phone_number lid].freeze
+
+  # The two ways a pairing really ends. Everything else is a connection that may come back.
+  PAIRING_ENDED = [WRONG_PHONE_ERROR, 'logged_out'].freeze
+
   # Quarantined: the connection belongs to somebody else's WhatsApp account.
   def self.disowned?(channel)
     channel.provider_connection.to_h['error_code'] == WRONG_PHONE_ERROR
@@ -103,6 +112,7 @@ class Whatsapp::Session::ConnectionStateWriter
     end
     payload['connection'] ||= persisted['connection']
     payload['epoch'] ||= persisted['epoch']
+    carry_pairing(payload, persisted)
     STICKY_KEYS.each do |key|
       payload[key] = persisted[key] if payload[key].nil? && persisted[key].present?
     end
@@ -117,6 +127,12 @@ class Whatsapp::Session::ConnectionStateWriter
   # it. This matches what the Baileys handler has always done.
   def translate(key)
     I18n.t("errors.inboxes.channel.provider_connection.#{key}", default: key.to_s.humanize)
+  end
+
+  def carry_pairing(payload, persisted)
+    return payload.except!(*PAIRING_KEYS) if PAIRING_ENDED.include?(payload['error_code'])
+
+    PAIRING_KEYS.each { |key| payload[key] = persisted[key] if payload[key].nil? && persisted[key].present? }
   end
 
   # Events without an epoch (Uazapi, which has no ownership model) are always accepted.

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -1,14 +1,20 @@
 # The only writer of channel_whatsapp.provider_connection for session providers.
 #
-# Three rules live here, all of them learned from the Baileys layer:
+# Four rules live here, all of them learned from the Baileys layer:
 #   1. Ownership fencing: a late event from a previous owner (lower lease epoch) must not
 #      overwrite the current owner's state, or the inbox gets stuck reporting a stale
 #      status while the connection is actually open.
-#   2. Whole-hash replacement: qr_data_url, pairing_code, error and quarantine share the
+#   2. Number ownership: a session paired with a number this inbox is not configured for
+#      is somebody else's WhatsApp account, and no state may report it as usable.
+#   3. Whole-hash replacement: qr_data_url, pairing_code, error and quarantine share the
 #      lifecycle of the state they arrived with, so anything the new state does not carry
 #      is cleared.
-#   3. Sticky keys: reach-out lock and new-chat cap arrive out of band (poll or their own
+#   4. Sticky keys: reach-out lock and new-chat cap arrive out of band (poll or their own
 #      event), so they survive a state update instead of flickering off until the next poll.
+#
+# Rule 2 lives here rather than in the event handler because a handler is only one of the
+# ways a state is written: the pairing poll and the connect answer write one directly, and
+# a check on the handler leaves those two admitting the wrong account.
 class Whatsapp::Session::ConnectionStateWriter
   STICKY_KEYS = Whatsapp::Session::Model::ConnectionState::STICKY_KEYS
 
@@ -29,8 +35,13 @@ class Whatsapp::Session::ConnectionStateWriter
   end
 
   # Returns :written, :stale or :unchanged.
-  def apply(state)
-    channel.with_lock do
+  #
+  # `reset: true` means the operator asked for this connection: a quarantine from the
+  # previous pairing does not carry over, because re-pairing is the way out of one.
+  def apply(state, reset: false)
+    state = enforce_number_ownership(state, reset: reset)
+
+    result = channel.with_lock do
       persisted = channel.provider_connection.presence || {}
       next :stale if stale?(state, persisted)
 
@@ -40,9 +51,45 @@ class Whatsapp::Session::ConnectionStateWriter
       channel.update_provider_connection!(payload)
       :written
     end
+
+    # Through a job, not inline. The state is already written when this runs, so a repeat
+    # of the same state is reported as unchanged and never gets here again: a logout that
+    # failed once inline would never be attempted a second time, and the wrong WhatsApp
+    # account would stay connected.
+    Whatsapp::Session::LogoutJob.perform_later(channel) if result == :written && state.error == WRONG_PHONE_ERROR
+    result
   end
 
   private
+
+  # Two ways a state can belong to the wrong account. It can name the wrong number, which
+  # is the operator having scanned with a different phone. Or it can name no number at all
+  # while the inbox is already quarantined: `session.state` only requires `state`, so a
+  # live session reports itself without saying whose it is, and accepting one of those
+  # would clear the quarantine while the logout that removes that account is still being
+  # retried. Only a state that names the configured number lifts it.
+  def enforce_number_ownership(state, reset:)
+    return quarantine(state) if wrong_phone?(state)
+    return state if reset || state.phone_number.present?
+    return state unless self.class.disowned?(channel)
+
+    quarantine(state)
+  end
+
+  def quarantine(state)
+    Whatsapp::Session::Model::ConnectionState.new(
+      connection: 'close', error: WRONG_PHONE_ERROR, epoch: state.epoch
+    )
+  end
+
+  # Compared through the normalizers, never as raw digits: a Brazilian line is reported by
+  # WhatsApp with or without the ninth digit depending on when it was registered, so a
+  # textual comparison would reject the very number the operator configured.
+  def wrong_phone?(state)
+    configured = channel.phone_number.to_s
+    paired = state.phone_number.to_s
+    configured.present? && paired.present? && !Whatsapp::Session::PhoneMatch.same_number?(configured, paired)
+  end
 
   def merge(state, persisted)
     payload = state.to_h

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -48,13 +48,17 @@ class Whatsapp::Session::ConnectionStateWriter
   # `reset: true` means the operator asked for this connection: a quarantine from the
   # previous pairing does not carry over, because re-pairing is the way out of one.
   def apply(state, reset: false)
-    state = enforce_number_ownership(state, reset: reset)
+    written = nil
 
     result = channel.with_lock do
+      # Inside the lock, because `with_lock` is also what reloads the row. Deciding
+      # ownership against the caller's copy means a poll that started before a concurrent
+      # event quarantined the inbox reads the pre-quarantine record and clears it.
+      written = enforce_number_ownership(state, reset: reset)
       persisted = channel.provider_connection.presence || {}
-      next :stale if stale?(state, persisted)
+      next :stale if stale?(written, persisted)
 
-      payload = merge(state, persisted)
+      payload = merge(written, persisted)
       next :unchanged if payload == persisted
 
       channel.update_provider_connection!(payload)
@@ -65,7 +69,7 @@ class Whatsapp::Session::ConnectionStateWriter
     # of the same state is reported as unchanged and never gets here again: a logout that
     # failed once inline would never be attempted a second time, and the wrong WhatsApp
     # account would stay connected.
-    Whatsapp::Session::LogoutJob.perform_later(channel) if result == :written && state.error == WRONG_PHONE_ERROR
+    Whatsapp::Session::LogoutJob.perform_later(channel) if result == :written && written.error == WRONG_PHONE_ERROR
     result
   end
 

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -47,7 +47,11 @@ class Whatsapp::Session::ConnectionStateWriter
   #
   # `reset: true` means the operator asked for this connection: a quarantine from the
   # previous pairing does not carry over, because re-pairing is the way out of one.
-  def apply(state, reset: false)
+  #
+  # `attempt:` fences the write to one pairing attempt. Two connects racing (the operator
+  # clicking twice, or two tabs) both answer, and the one that answers last would
+  # otherwise be the state on screen even when it is the older of the two.
+  def apply(state, reset: false, attempt: nil)
     written = nil
 
     result = channel.with_lock do
@@ -56,7 +60,7 @@ class Whatsapp::Session::ConnectionStateWriter
       # event quarantined the inbox reads the pre-quarantine record and clears it.
       written = enforce_number_ownership(state, reset: reset)
       persisted = channel.provider_connection.presence || {}
-      next :stale if stale?(written, persisted)
+      next :stale if superseded?(attempt, persisted) || stale?(written, persisted)
 
       payload = merge(written, persisted)
       next :unchanged if payload == persisted
@@ -150,6 +154,19 @@ class Whatsapp::Session::ConnectionStateWriter
     return unless payload['connection'].in?(%w[connecting reconnecting])
 
     payload['pairing_attempt'] = persisted['pairing_attempt'] if persisted['pairing_attempt'].present?
+  end
+
+  # The record has moved on to another pairing attempt, so this is an older connect
+  # answering late: its QR is not the one the operator is looking at, and the poll driving
+  # that screen would be retired by it. Epoch does not cover this one: two connects on the
+  # same session raise it in the order the provider answers, and a backend without an
+  # ownership model (Uazapi) has no epoch at all.
+  def superseded?(attempt, persisted)
+    return false if attempt.blank? || persisted['pairing_attempt'].blank?
+
+    superseded = persisted['pairing_attempt'] != attempt
+    Rails.logger.warn("[WHATSAPP SESSION] connect answer for a retired attempt discarded on ##{channel.id}") if superseded
+    superseded
   end
 
   # Events without an epoch (Uazapi, which has no ownership model) are always accepted.

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -48,10 +48,11 @@ class Whatsapp::Session::ConnectionStateWriter
   # `reset: true` means the operator asked for this connection: a quarantine from the
   # previous pairing does not carry over, because re-pairing is the way out of one.
   #
-  # `attempt:` fences the write to one pairing attempt. Two connects racing (the operator
-  # clicking twice, or two tabs) both answer, and the one that answers last would
-  # otherwise be the state on screen even when it is the older of the two.
-  def apply(state, reset: false, attempt: nil)
+  # `attempt:` fences the write to one pairing attempt and `provider:` to the provider the
+  # caller was built for. Both are checked inside the lock, which is the only place they
+  # mean anything: a caller that reads the record, then asks the provider, then writes,
+  # has left a gap in the middle for a second connect or a conversion to land in.
+  def apply(state, reset: false, attempt: nil, provider: nil)
     written = nil
 
     result = channel.with_lock do
@@ -60,7 +61,7 @@ class Whatsapp::Session::ConnectionStateWriter
       # event quarantined the inbox reads the pre-quarantine record and clears it.
       written = enforce_number_ownership(state, reset: reset)
       persisted = channel.provider_connection.presence || {}
-      next :stale if superseded?(attempt, persisted) || stale?(written, persisted)
+      next :stale if refuse?(written, persisted, attempt: attempt, provider: provider)
 
       payload = merge(written, persisted)
       next :unchanged if payload == persisted
@@ -156,17 +157,38 @@ class Whatsapp::Session::ConnectionStateWriter
     payload['pairing_attempt'] = persisted['pairing_attempt'] if persisted['pairing_attempt'].present?
   end
 
-  # The record has moved on to another pairing attempt, so this is an older connect
-  # answering late: its QR is not the one the operator is looking at, and the poll driving
-  # that screen would be retired by it. Epoch does not cover this one: two connects on the
-  # same session raise it in the order the provider answers, and a backend without an
-  # ownership model (Uazapi) has no epoch at all.
+  # Three ways a state arrives too late to be true: the inbox is on another provider now,
+  # the pairing it belongs to has been retired, or an older owner of the session is still
+  # talking.
+  def refuse?(state, persisted, attempt:, provider:)
+    converted?(provider) || superseded?(attempt, persisted) || stale?(state, persisted)
+  end
+
+  # The record has moved on from the pairing attempt this write belongs to, so it is an
+  # older connect or an older poll answering late: its QR is not the one the operator is
+  # looking at, and the chain driving that screen would be retired by it. A record with no
+  # token at all counts as moved on, because the token is only ever absent once the
+  # attempt it named has ended. Epoch does not cover this: two connects on the same
+  # session raise it in the order the provider answers, and a backend without an ownership
+  # model (Uazapi) has no epoch at all.
   def superseded?(attempt, persisted)
-    return false if attempt.blank? || persisted['pairing_attempt'].blank?
+    return false if attempt.blank?
 
     superseded = persisted['pairing_attempt'] != attempt
-    Rails.logger.warn("[WHATSAPP SESSION] connect answer for a retired attempt discarded on ##{channel.id}") if superseded
+    Rails.logger.warn("[WHATSAPP SESSION] write for a retired pairing attempt discarded on ##{channel.id}") if superseded
     superseded
+  end
+
+  # The inbox was converted while this write was in flight. `convert_provider!` empties the
+  # connection record, so what would land here is one provider's state under another
+  # provider's name: a QR nobody can scan, or an `open` for a session this inbox no longer
+  # has.
+  def converted?(provider)
+    return false if provider.blank?
+
+    converted = channel.provider != provider
+    Rails.logger.warn("[WHATSAPP SESSION] #{provider} state discarded on ##{channel.id}, now #{channel.provider}") if converted
+    converted
   end
 
   # Events without an epoch (Uazapi, which has no ownership model) are always accepted.

--- a/app/services/whatsapp/session/errors.rb
+++ b/app/services/whatsapp/session/errors.rb
@@ -14,6 +14,14 @@ module Whatsapp::Session::Errors
     def code
       self.class::CODE
     end
+
+    # Whether running the same command again could produce a different answer. Asked of
+    # the exception rather than tested against a list of classes, because a constant
+    # holding another file's class keeps the object from before the last reload and
+    # `is_a?` against it then answers false without saying why.
+    def retryable?
+      false
+    end
   end
 
   # The provider could not be reached, or answered with something we cannot act on.
@@ -21,6 +29,11 @@ module Whatsapp::Session::Errors
   # lives under this class.
   class ProviderUnavailable < Error
     CODE = 'wa_error'.freeze
+
+    # The provider, not the command: the same thing asked again once it is back can work.
+    def retryable?
+      true
+    end
   end
 
   class Internal < ProviderUnavailable
@@ -83,6 +96,10 @@ module Whatsapp::Session::Errors
 
   class RateLimited < Error
     CODE = 'rate_limited'.freeze
+
+    def retryable?
+      true
+    end
   end
 
   class MediaTooLarge < Error

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -1,0 +1,168 @@
+# The provider service of a session channel.
+#
+# Channel::Whatsapp talks to its provider in the shape the legacy providers established:
+# a recipient id that is a phone number or a JID, a Chatwoot message, a group JID. This
+# translates all of it into the canonical commands the backend takes, so the channel
+# model, the group controllers and the presence services keep working untouched.
+#
+# Session-internal code does not come through here: it asks the channel for
+# `session_backend` and speaks the canonical API directly.
+class Whatsapp::Session::Facade
+  include Whatsapp::Session::Facade::Groups
+
+  TYPING_STATES = {
+    Events::Types::CONVERSATION_TYPING_ON => 'composing',
+    Events::Types::CONVERSATION_RECORDING => 'recording',
+    Events::Types::CONVERSATION_TYPING_OFF => 'paused'
+  }.freeze
+
+  attr_reader :channel, :backend
+
+  # Resolved on every call, never held in a constant: `Whatsapp::Session::Model` is an
+  # implicit namespace (there is no model.rb), so a constant here captures a module
+  # object that a reload strips of its autoloads, and every lookup through it then
+  # raises `uninitialized constant`.
+  def model = Whatsapp::Session::Model
+
+  def initialize(channel)
+    @channel = channel
+    @backend = Whatsapp::Session::Registry.backend_for(channel)
+  end
+
+  # --- session lifecycle ---------------------------------------------------------
+
+  # "Make sure this session is up": resumes an existing pairing, or starts a new one.
+  def setup_channel_provider
+    mode = pairing_mode
+    state = backend.connect(
+      model::Commands::SessionConnect.new(
+        pairing: mode, phone: channel.phone_number.to_s.delete('+'),
+        groups: capability?('groups'), calls: capability?('calls')
+      )
+    )
+    # The connect answer is the first state the dashboard has to show (it carries the QR
+    # for a provider that returns one), and for a polled backend it is also what starts
+    # the pairing poll: nothing else would refresh the code as it rotates.
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state)
+    Whatsapp::Session::PairingPollJob.perform_later(channel, pairing: mode) if backend.class.state_polling?
+    state
+  end
+
+  def import_session(session:, candidate_index: 0)
+    backend.import_session(session: session, candidate_index: candidate_index)
+  end
+
+  def disconnect_channel_provider
+    backend.disconnect
+  end
+
+  # Session providers pair a real phone: there is no template catalog to sync and no
+  # template to send.
+  def sync_templates
+    true
+  end
+
+  def send_template(_recipient_id, _template_info, _message = nil)
+    raise Whatsapp::Session::Errors::NotSupported, 'templates are a cloud API feature'
+  end
+
+  # --- messages ------------------------------------------------------------------
+
+  def send_message(_recipient_id, message)
+    Whatsapp::Session::Outbound::MessageSender.new(message).perform
+  end
+
+  def edit_message(recipient_id, message, new_content)
+    backend.edit_message(
+      model::Commands::MessageEdit.new(
+        message_id: Whatsapp::Session::Outbound::SourceIdReservation.generate,
+        target_id: message.source_id, to: address(recipient_id),
+        content: model::Content::Text.new(body: new_content)
+      )
+    )
+  end
+
+  def delete_message(recipient_id, message)
+    return if message.source_id.blank?
+
+    to = address(recipient_id)
+    backend.revoke_message(
+      model::Commands::MessageRevoke.new(
+        target_id: message.source_id, to: to,
+        participant: (model::Address.for_contact(message.sender) if to.group? && message.incoming?)
+      )
+    )
+  end
+
+  def read_messages(messages, recipient_id:, **)
+    source_ids = Array(messages).filter_map(&:source_id)
+    return if source_ids.empty?
+
+    backend.mark_read(model::Commands::MessageMarkRead.new(chat: address(recipient_id), message_ids: source_ids))
+  end
+
+  def unread_message(recipient_id, message)
+    backend.mark_unread(
+      model::Commands::MessageMarkUnread.new(
+        chat: address(recipient_id), last_message_id: message.source_id, from_me: message.outgoing?
+      )
+    )
+  end
+
+  # The provider acknowledges delivery itself as it takes the message off WhatsApp;
+  # there is nothing for Chatwoot to send back.
+  def received_messages(_recipient_id, _messages)
+    true
+  end
+
+  # --- presence and contacts -----------------------------------------------------
+
+  def toggle_typing_status(typing_status, recipient_id:, **)
+    state = TYPING_STATES[typing_status]
+    return if state.blank?
+
+    backend.send_chat_presence(model::Commands::ChatPresence.new(chat: address(recipient_id), state: state))
+  end
+
+  def update_presence(status)
+    backend.update_presence(model::Commands::PresenceSet.new(state: status))
+  end
+
+  def presence_subscribe(jids)
+    Array(jids).each do |jid|
+      party = model::Party.from_address(model::Address.parse(jid))
+      next if party.blank?
+
+      backend.subscribe_presence(model::Commands::PresenceSubscribe.new(party: party))
+    end
+  end
+
+  # Answered in the shape the contact builder and the inbox controller already read:
+  # `exists` plus the JID WhatsApp actually knows the number by, which is what the
+  # ninth-digit normalization needs.
+  def on_whatsapp(recipient_id)
+    digits = recipient_id.to_s.split('@').first.to_s.delete('+')
+    check = backend.check_numbers(model::Commands::ContactCheck.new(phones: [digits])).first
+    return { 'jid' => "#{digits}@s.whatsapp.net", 'exists' => false } if check.blank?
+
+    { 'jid' => (check.address || model::Address.phone(check.phone)).to_jid, 'exists' => check.exists }
+  end
+
+  private
+
+  def capability?(capability)
+    channel.session_capabilities.include?(capability)
+  end
+
+  # A session that was already paired resumes; one that never was needs a QR (a pairing
+  # code is requested explicitly from the dashboard).
+  def pairing_mode
+    channel.provider_connection['phone_number'].present? ? 'resume' : 'qr'
+  end
+
+  # Recipient ids reach the channel as bare phone numbers or as JIDs, depending on the
+  # caller and on whether the contact has a LID.
+  def address(recipient_id)
+    recipient_id.to_s.include?('@') ? model::Address.parse(recipient_id) : model::Address.phone(recipient_id)
+  end
+end

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -47,9 +47,11 @@ class Whatsapp::Session::Facade
     state = connect(mode, attempt)
     # The connect answer is the first state the dashboard has to show (it carries the QR
     # for a provider that returns one), and for a polled backend it is also what starts
-    # the pairing poll: nothing else would refresh the code as it rotates.
-    writer.apply(state.with(pairing_attempt: attempt), reset: true, attempt: attempt, provider: provider)
-    start_pairing_poll(mode, attempt) if backend.class.state_polling?
+    # the pairing poll: nothing else would refresh the code as it rotates. A resume that
+    # answers `open` has nothing left to poll, and a chain started over one would write
+    # `connect_failure` over a healthy connection the first time a request failed.
+    writer.apply(state.with_attempt(attempt), reset: true, attempt: attempt, provider: provider)
+    start_pairing_poll(mode, attempt) if state.connecting? && backend.class.state_polling?
     state
   end
 

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -43,7 +43,7 @@ class Whatsapp::Session::Facade
     # The connect answer is the first state the dashboard has to show (it carries the QR
     # for a provider that returns one), and for a polled backend it is also what starts
     # the pairing poll: nothing else would refresh the code as it rotates.
-    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state)
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state, reset: true)
     Whatsapp::Session::PairingPollJob.perform_later(channel, pairing: mode) if backend.class.state_polling?
     state
   end
@@ -103,12 +103,18 @@ class Whatsapp::Session::Facade
     backend.mark_read(model::Commands::MessageMarkRead.new(chat: address(recipient_id), message_ids: source_ids))
   end
 
+  # Addressed from the conversation's contact rather than from `recipient_id`: the
+  # channel always hands this one `contact.phone_number`, which for a LID contact is not
+  # the id WhatsApp knows the chat by, and for a LID-only contact is nothing at all.
   def unread_message(recipient_id, message)
     return unless capability?('mark_unread')
 
+    contact = message.conversation&.contact
+    chat = contact.present? ? model::Address.for_contact(contact) : address(recipient_id)
+
     backend.mark_unread(
       model::Commands::MessageMarkUnread.new(
-        chat: address(recipient_id), last_message_id: message.source_id, from_me: message.outgoing?
+        chat: chat, last_message_id: message.source_id, from_me: message.outgoing?
       )
     )
   end
@@ -142,14 +148,14 @@ class Whatsapp::Session::Facade
     backend.update_presence(model::Commands::PresenceSet.new(state: status))
   end
 
+  # The command's `party` field carries an Address, not a Party: `PresenceSubscribe`
+  # coerces it as one, and `.new` does not run that coercion, so building a Party here
+  # put `{phone, lid}` on the wire where the connector expects `{kind, id}`.
   def presence_subscribe(jids)
     return unless capability?('presence_subscribe')
 
-    Array(jids).each do |jid|
-      party = model::Party.from_address(model::Address.parse(jid))
-      next if party.blank?
-
-      backend.subscribe_presence(model::Commands::PresenceSubscribe.new(party: party))
+    Array(jids).filter_map { |jid| model::Address.parse(jid) }.each do |address|
+      backend.subscribe_presence(model::Commands::PresenceSubscribe.new(party: address))
     end
   end
 

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -37,7 +37,7 @@ class Whatsapp::Session::Facade
     state = backend.connect(
       model::Commands::SessionConnect.new(
         pairing: mode, phone: channel.phone_number.to_s.delete('+'),
-        groups: capability?('groups'), calls: capability?('calls')
+        groups: capability?('groups'), calls: call_policy
       )
     )
     # The connect answer is the first state the dashboard has to show (it carries the QR
@@ -52,7 +52,13 @@ class Whatsapp::Session::Facade
     backend.import_session(session: session, candidate_index: candidate_index)
   end
 
+  # The channel calls this when an inbox is destroyed or converted to another provider,
+  # so it is a teardown, not a pause: the Baileys service answers it with
+  # `DELETE /connections/<phone>`. Merely disconnecting would leave the pairing and its
+  # credentials alive on the provider under a session id Chatwoot no longer has.
   def disconnect_channel_provider
+    backend.delete_session
+  rescue Whatsapp::Session::Errors::NotSupported
     backend.disconnect
   end
 
@@ -142,10 +148,17 @@ class Whatsapp::Session::Facade
     backend.send_chat_presence(model::Commands::ChatPresence.new(chat: address(recipient_id), state: state))
   end
 
+  # `online`, `offline` and `busy` are Chatwoot availability; the contract knows only
+  # `available` and `unavailable`. The same mapping the Baileys service has.
+  PRESENCE_STATES = { 'online' => 'available', 'offline' => 'unavailable', 'busy' => 'unavailable' }.freeze
+
   def update_presence(status)
     return unless capability?('presence')
 
-    backend.update_presence(model::Commands::PresenceSet.new(state: status))
+    state = PRESENCE_STATES[status.to_s]
+    return if state.blank?
+
+    backend.update_presence(model::Commands::PresenceSet.new(state: state))
   end
 
   # The command's `party` field carries an Address, not a Party: `PresenceSubscribe`
@@ -174,6 +187,13 @@ class Whatsapp::Session::Facade
 
   def capability?(capability)
     channel.session_capabilities.include?(capability)
+  end
+
+  # An object in the contract, not a flag: the field says how calls are handled, and the
+  # only policy this layer has is to reject them. Omitted when the backend does not do
+  # calls at all, because `false` is not a value the schema accepts either.
+  def call_policy
+    { 'auto_reject' => true } if capability?('calls')
   end
 
   # A session that was already paired resumes; one that never was needs a QR (a pairing

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -40,6 +40,10 @@ class Whatsapp::Session::Facade
     end_disowned_session
     mode = pairing_mode
     attempt = claim_pairing_attempt
+    # The inbox was converted while this was running, so it is not this backend's to
+    # connect: asking the old provider anyway leaves a session behind that no inbox owns.
+    return if attempt.nil?
+
     state = connect(mode, attempt)
     # The connect answer is the first state the dashboard has to show (it carries the QR
     # for a provider that returns one), and for a polled backend it is also what starts
@@ -218,10 +222,10 @@ class Whatsapp::Session::Facade
   # the fence in the writer then enforces: the older answer, and its dead QR, is refused.
   def claim_pairing_attempt
     attempt = SecureRandom.uuid
-    writer.apply(
+    result = writer.apply(
       model::ConnectionState.new(connection: 'connecting', pairing_attempt: attempt), reset: true, provider: provider
     )
-    attempt
+    attempt if result == :written
   end
 
   # The claim above already moved the dashboard to "connecting". Leaving it there when the

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -33,6 +33,7 @@ class Whatsapp::Session::Facade
 
   # "Make sure this session is up": resumes an existing pairing, or starts a new one.
   def setup_channel_provider
+    end_disowned_session
     mode = pairing_mode
     # Identifies this attempt. Two connects for the same provider produce two polling
     # chains, and without a token the older one cannot tell that the QR on screen is no
@@ -211,6 +212,25 @@ class Whatsapp::Session::Facade
   # calls at all, because `false` is not a value the schema accepts either.
   def call_policy
     { 'auto_reject' => true } if capability?('calls')
+  end
+
+  # Connecting again is the way out of a wrong-number quarantine, and the connect below
+  # is what lifts it. The rejected account is still on the provider until its logout
+  # lands, though, and that marker is the only thing keeping its chats out of this inbox:
+  # lifting it first and pairing second would file somebody else's messages here for as
+  # long as the new QR is on screen. So the wrong account goes before the marker does,
+  # which also stands the asynchronous retry down before there is a new session for it to
+  # kill. A provider that cannot be reached raises, and nothing was cleared or connected.
+  def end_disowned_session
+    writer = Whatsapp::Session::ConnectionStateWriter
+    return unless writer.disowned?(channel)
+
+    backend.logout
+    writer.new(channel).apply(model::ConnectionState.new(connection: 'close'), reset: true)
+  rescue Whatsapp::Session::Errors::NotSupported
+    # A backend with no logout cannot be held in quarantine either: pairing again is the
+    # only exit it has, and refusing that would leave the inbox with none at all.
+    nil
   end
 
   # A session that was already paired resumes; one that never was needs a QR (a pairing

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -16,7 +16,7 @@ class Whatsapp::Session::Facade
     Events::Types::CONVERSATION_TYPING_OFF => 'paused'
   }.freeze
 
-  attr_reader :channel, :backend
+  attr_reader :channel, :backend, :provider
 
   # Resolved on every call, never held in a constant: `Whatsapp::Session::Model` is an
   # implicit namespace (there is no model.rb), so a constant here captures a module
@@ -27,6 +27,10 @@ class Whatsapp::Session::Facade
   def initialize(channel)
     @channel = channel
     @backend = Whatsapp::Session::Registry.backend_for(channel)
+    # The provider this backend was resolved for. An inbox converted while a connect is in
+    # flight has an empty connection record belonging to another provider, and every write
+    # below is fenced against landing there.
+    @provider = channel.provider
   end
 
   # --- session lifecycle ---------------------------------------------------------
@@ -40,7 +44,7 @@ class Whatsapp::Session::Facade
     # The connect answer is the first state the dashboard has to show (it carries the QR
     # for a provider that returns one), and for a polled backend it is also what starts
     # the pairing poll: nothing else would refresh the code as it rotates.
-    writer.apply(state.with(pairing_attempt: attempt), reset: true, attempt: attempt)
+    writer.apply(state.with(pairing_attempt: attempt), reset: true, attempt: attempt, provider: provider)
     start_pairing_poll(mode, attempt) if backend.class.state_polling?
     state
   end
@@ -214,7 +218,9 @@ class Whatsapp::Session::Facade
   # the fence in the writer then enforces: the older answer, and its dead QR, is refused.
   def claim_pairing_attempt
     attempt = SecureRandom.uuid
-    writer.apply(model::ConnectionState.new(connection: 'connecting', pairing_attempt: attempt), reset: true)
+    writer.apply(
+      model::ConnectionState.new(connection: 'connecting', pairing_attempt: attempt), reset: true, provider: provider
+    )
     attempt
   end
 
@@ -229,7 +235,9 @@ class Whatsapp::Session::Facade
       )
     )
   rescue Whatsapp::Session::Errors::Error
-    writer.apply(model::ConnectionState.new(connection: 'close', error: 'connect_failure'), attempt: attempt)
+    writer.apply(
+      model::ConnectionState.new(connection: 'close', error: 'connect_failure'), attempt: attempt, provider: provider
+    )
     raise
   end
 
@@ -255,7 +263,7 @@ class Whatsapp::Session::Facade
     return unless Whatsapp::Session::ConnectionStateWriter.disowned?(channel)
 
     backend.logout
-    writer.apply(model::ConnectionState.new(connection: 'close'), reset: true)
+    writer.apply(model::ConnectionState.new(connection: 'close'), reset: true, provider: provider)
   rescue Whatsapp::Session::Errors::NotSupported
     # A backend with no logout cannot be held in quarantine either: pairing again is the
     # only exit it has, and refusing that would leave the inbox with none at all.

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -100,13 +100,22 @@ class Whatsapp::Session::Facade
     )
   end
 
+  # One command per participant in a group. A receipt on WhatsApp is addressed by the
+  # message key, and in a group that key includes who sent it, so a single command
+  # covering several senders cannot be acknowledged. In a 1:1 chat the peer is the chat
+  # itself and the field stays empty.
   def read_messages(messages, recipient_id:, **)
     return unless capability?('read_receipts')
 
-    source_ids = Array(messages).filter_map(&:source_id)
-    return if source_ids.empty?
-
-    backend.mark_read(model::Commands::MessageMarkRead.new(chat: address(recipient_id), message_ids: source_ids))
+    chat = address(recipient_id)
+    readable = Array(messages).select { |message| message.source_id.present? }
+    readable.group_by { |message| chat.group? ? message.sender : nil }.each do |sender, group|
+      backend.mark_read(
+        model::Commands::MessageMarkRead.new(
+          chat: chat, message_ids: group.map(&:source_id), sender: participant_address(group.first, sender)
+        )
+      )
+    end
   end
 
   # Addressed from the conversation's contact rather than from `recipient_id`: the
@@ -200,6 +209,14 @@ class Whatsapp::Session::Facade
   # code is requested explicitly from the dashboard).
   def pairing_mode
     channel.provider_connection['phone_number'].present? ? 'resume' : 'qr'
+  end
+
+  # `sender_type` rather than a class check: the association can hold a User (an agent's
+  # own message), and a class comparison is what a reload breaks.
+  def participant_address(message, sender)
+    return if sender.nil? || message.sender_type != 'Contact'
+
+    model::Address.for_contact(sender)
   end
 
   # Recipient ids reach the channel as bare phone numbers or as JIDs, depending on the

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -95,6 +95,8 @@ class Whatsapp::Session::Facade
   end
 
   def read_messages(messages, recipient_id:, **)
+    return unless capability?('read_receipts')
+
     source_ids = Array(messages).filter_map(&:source_id)
     return if source_ids.empty?
 
@@ -102,6 +104,8 @@ class Whatsapp::Session::Facade
   end
 
   def unread_message(recipient_id, message)
+    return unless capability?('mark_unread')
+
     backend.mark_unread(
       model::Commands::MessageMarkUnread.new(
         chat: address(recipient_id), last_message_id: message.source_id, from_me: message.outgoing?
@@ -116,19 +120,31 @@ class Whatsapp::Session::Facade
   end
 
   # --- presence and contacts -----------------------------------------------------
+  #
+  # These four are background synchronization the dashboard triggers as a side effect of
+  # something else: a listener firing on a typing event, a conversation being marked
+  # unread. `Channel::Whatsapp` used to skip them by asking `respond_to?`, which was true
+  # of the legacy service and false of anything it did not implement; a facade that
+  # answers every message makes that test useless, so the capability is what decides now.
+  # Nothing here is an action the agent waits on, so an unsupported one is skipped rather
+  # than raised: a listener that raises takes the whole event down with it.
 
   def toggle_typing_status(typing_status, recipient_id:, **)
     state = TYPING_STATES[typing_status]
-    return if state.blank?
+    return if state.blank? || !capability?('typing')
 
     backend.send_chat_presence(model::Commands::ChatPresence.new(chat: address(recipient_id), state: state))
   end
 
   def update_presence(status)
+    return unless capability?('presence')
+
     backend.update_presence(model::Commands::PresenceSet.new(state: status))
   end
 
   def presence_subscribe(jids)
+    return unless capability?('presence_subscribe')
+
     Array(jids).each do |jid|
       party = model::Party.from_address(model::Address.parse(jid))
       next if party.blank?

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -34,6 +34,10 @@ class Whatsapp::Session::Facade
   # "Make sure this session is up": resumes an existing pairing, or starts a new one.
   def setup_channel_provider
     mode = pairing_mode
+    # Identifies this attempt. Two connects for the same provider produce two polling
+    # chains, and without a token the older one cannot tell that the QR on screen is no
+    # longer the one it was following: it would time out and overwrite a live pairing.
+    attempt = SecureRandom.uuid
     state = backend.connect(
       model::Commands::SessionConnect.new(
         pairing: mode, phone: channel.phone_number.to_s.delete('+'),
@@ -43,8 +47,12 @@ class Whatsapp::Session::Facade
     # The connect answer is the first state the dashboard has to show (it carries the QR
     # for a provider that returns one), and for a polled backend it is also what starts
     # the pairing poll: nothing else would refresh the code as it rotates.
-    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state, reset: true)
-    Whatsapp::Session::PairingPollJob.perform_later(channel, pairing: mode) if backend.class.state_polling?
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state.with(pairing_attempt: attempt), reset: true)
+    if backend.class.state_polling?
+      Whatsapp::Session::PairingPollJob.perform_later(
+        channel, pairing: mode, provider: channel.provider, attempt: attempt
+      )
+    end
     state
   end
 

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -35,25 +35,13 @@ class Whatsapp::Session::Facade
   def setup_channel_provider
     end_disowned_session
     mode = pairing_mode
-    # Identifies this attempt. Two connects for the same provider produce two polling
-    # chains, and without a token the older one cannot tell that the QR on screen is no
-    # longer the one it was following: it would time out and overwrite a live pairing.
-    attempt = SecureRandom.uuid
-    state = backend.connect(
-      model::Commands::SessionConnect.new(
-        pairing: mode, phone: channel.phone_number.to_s.delete('+'),
-        groups: capability?('groups'), calls: call_policy
-      )
-    )
+    attempt = claim_pairing_attempt
+    state = connect(mode, attempt)
     # The connect answer is the first state the dashboard has to show (it carries the QR
     # for a provider that returns one), and for a polled backend it is also what starts
     # the pairing poll: nothing else would refresh the code as it rotates.
-    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state.with(pairing_attempt: attempt), reset: true)
-    if backend.class.state_polling?
-      Whatsapp::Session::PairingPollJob.perform_later(
-        channel, pairing: mode, provider: channel.provider, attempt: attempt
-      )
-    end
+    writer.apply(state.with(pairing_attempt: attempt), reset: true, attempt: attempt)
+    start_pairing_poll(mode, attempt) if backend.class.state_polling?
     state
   end
 
@@ -214,6 +202,48 @@ class Whatsapp::Session::Facade
     { 'auto_reject' => true } if capability?('calls')
   end
 
+  def writer
+    Whatsapp::Session::ConnectionStateWriter.new(channel)
+  end
+
+  # Identifies this attempt, and claims it before the provider is asked rather than after
+  # it answers. Two connects for the same inbox produce two polling chains, and without a
+  # token the older one cannot tell that the QR on screen is no longer the one it was
+  # following: it would time out over a live pairing. Claiming first also orders the two
+  # by the click rather than by which provider call happens to answer first, which is what
+  # the fence in the writer then enforces: the older answer, and its dead QR, is refused.
+  def claim_pairing_attempt
+    attempt = SecureRandom.uuid
+    writer.apply(model::ConnectionState.new(connection: 'connecting', pairing_attempt: attempt), reset: true)
+    attempt
+  end
+
+  # The claim above already moved the dashboard to "connecting". Leaving it there when the
+  # provider refuses the connection parks the operator on a pairing that never started,
+  # which is the same dead screen the poll's ceiling exists to prevent.
+  def connect(mode, attempt)
+    backend.connect(
+      model::Commands::SessionConnect.new(
+        pairing: mode, phone: channel.phone_number.to_s.delete('+'),
+        groups: capability?('groups'), calls: call_policy
+      )
+    )
+  rescue Whatsapp::Session::Errors::Error
+    writer.apply(model::ConnectionState.new(connection: 'close', error: 'connect_failure'), attempt: attempt)
+    raise
+  end
+
+  # With the deadline resolved here, not by the worker. It is a ceiling on the attempt,
+  # and a busy queue would otherwise hand a QR that expired while the job waited its own
+  # two full minutes of polling on top of the wait.
+  def start_pairing_poll(mode, attempt)
+    Whatsapp::Session::PairingPollJob.perform_later(
+      channel,
+      pairing: mode, provider: channel.provider, attempt: attempt,
+      deadline_at: Whatsapp::Session::PairingPollJob.deadline_for(mode)
+    )
+  end
+
   # Connecting again is the way out of a wrong-number quarantine, and the connect below
   # is what lifts it. The rejected account is still on the provider until its logout
   # lands, though, and that marker is the only thing keeping its chats out of this inbox:
@@ -222,11 +252,10 @@ class Whatsapp::Session::Facade
   # which also stands the asynchronous retry down before there is a new session for it to
   # kill. A provider that cannot be reached raises, and nothing was cleared or connected.
   def end_disowned_session
-    writer = Whatsapp::Session::ConnectionStateWriter
-    return unless writer.disowned?(channel)
+    return unless Whatsapp::Session::ConnectionStateWriter.disowned?(channel)
 
     backend.logout
-    writer.new(channel).apply(model::ConnectionState.new(connection: 'close'), reset: true)
+    writer.apply(model::ConnectionState.new(connection: 'close'), reset: true)
   rescue Whatsapp::Session::Errors::NotSupported
     # A backend with no logout cannot be held in quarantine either: pairing again is the
     # only exit it has, and refusing that would leave the inbox with none at all.

--- a/app/services/whatsapp/session/facade/groups.rb
+++ b/app/services/whatsapp/session/facade/groups.rb
@@ -1,0 +1,107 @@
+# The group half of the Facade. It was split out because the class was doing two jobs
+# at once: translating the messaging API and translating the group API. Same contract,
+# same legacy shapes the six group controllers and Groups::CreateService already read.
+module Whatsapp::Session::Facade::Groups
+  # The properties the group settings endpoint accepts, in contract terms.
+  GROUP_SETTINGS = { 'announce' => 'announce', 'restrict' => 'locked', 'locked' => 'locked' }.freeze
+
+  # --- groups --------------------------------------------------------------------
+
+  def allow_group_creation?
+    capability?('groups')
+  end
+
+  def create_group(subject, participants)
+    info = backend.create_group(model::Commands::GroupCreate.new(subject: subject, participants: addresses(participants)))
+    # Groups::CreateService reads :id from this, the same key the Baileys response had.
+    { id: info.group.to_jid, subject: info.subject }
+  end
+
+  def update_group_subject(group_jid, subject)
+    backend.update_group_name(model::Commands::GroupNameSet.new(group: group(group_jid), subject: subject))
+  end
+
+  def update_group_description(group_jid, description)
+    backend.update_group_description(model::Commands::GroupDescriptionSet.new(group: group(group_jid), description: description))
+  end
+
+  def update_group_picture(group_jid, image_base64)
+    backend.update_group_photo(model::Commands::GroupPhotoSet.new(group: group(group_jid), image: image_base64))
+  end
+
+  def update_group_participants(group_jid, participants, action)
+    backend.update_group_participants(
+      model::Commands::GroupParticipantsUpdate.new(group: group(group_jid), participants: addresses(participants), action: action)
+    )
+  end
+
+  def group_invite_code(group_jid)
+    backend.group_invite_code(model::Commands::GroupInviteGet.new(group: group(group_jid)))
+  end
+
+  def revoke_group_invite(group_jid)
+    backend.group_invite_code(model::Commands::GroupInviteGet.new(group: group(group_jid), revoke: true))
+  end
+
+  # Rendered straight to the dashboard, so the entries keep the keys it already reads.
+  def group_join_requests(group_jid)
+    requests = backend.group_join_requests(model::Commands::GroupJoinRequestsList.new(group: group(group_jid)))
+    Array(requests).map { |request| join_request_payload(request) }
+  end
+
+  def handle_group_join_requests(group_jid, participants, action)
+    backend.handle_group_join_requests(
+      model::Commands::GroupJoinRequestsUpdate.new(group: group(group_jid), participants: addresses(participants), action: action)
+    )
+  end
+
+  def group_leave(group_jid)
+    backend.leave_group(model::Commands::GroupLeave.new(group: group(group_jid)))
+  end
+
+  def group_setting_update(group_jid, property, enabled)
+    setting = GROUP_SETTINGS[property.to_s]
+    raise Whatsapp::Session::Errors::InvalidPayload, "unknown group setting: #{property}" if setting.blank?
+
+    update_group_setting(group_jid, setting, enabled)
+  end
+
+  def group_join_approval_mode(group_jid, mode)
+    update_group_setting(group_jid, 'join_approval', mode.to_s == 'on')
+  end
+
+  def group_member_add_mode(group_jid, mode)
+    update_group_setting(group_jid, 'member_add_mode', mode.to_s == 'all_member_add')
+  end
+
+  def sync_group(conversation, soft: false)
+    Whatsapp::Session::Groups::Syncer.new(channel: channel, group_contact: conversation.contact, soft: soft).perform
+  end
+
+  private
+
+  def group(group_jid)
+    parsed = model::Address.parse(group_jid)
+    raise Whatsapp::Session::Errors::InvalidPayload, "not a group: #{group_jid}" unless parsed&.group?
+
+    parsed
+  end
+
+  def addresses(jids)
+    Array(jids).filter_map { |jid| model::Address.parse(jid) }
+  end
+
+  def update_group_setting(group_jid, setting, value)
+    backend.update_group_setting(model::Commands::GroupSettingsSet.new(group: group(group_jid), setting: setting, value: value))
+  end
+
+  def join_request_payload(request)
+    request = request.stringify_keys
+    party = model::Party.from_h(request['party'] || {})
+    {
+      'jid' => party.identifier || model::Address.phone(party.phone)&.to_jid,
+      'phone_number' => party.phone,
+      'request_time' => request['requested_at']
+    }.compact
+  end
+end

--- a/app/services/whatsapp/session/facade/groups.rb
+++ b/app/services/whatsapp/session/facade/groups.rb
@@ -12,6 +12,8 @@ module Whatsapp::Session::Facade::Groups
   end
 
   def create_group(subject, participants)
+    raise Whatsapp::Session::Errors::NotSupported, 'groups are disabled on this installation' unless capability?('groups')
+
     info = backend.create_group(model::Commands::GroupCreate.new(subject: subject, participants: addresses(participants)))
     # Groups::CreateService reads :id from this, the same key the Baileys response had.
     { id: info.group.to_jid, subject: info.subject }
@@ -75,12 +77,21 @@ module Whatsapp::Session::Facade::Groups
   end
 
   def sync_group(conversation, soft: false)
+    return unless capability?('groups')
+
     Whatsapp::Session::Groups::Syncer.new(channel: channel, group_contact: conversation.contact, soft: soft).perform
   end
 
   private
 
+  # `WHATSAPP_GROUPS_ENABLED=false` takes every group capability away from the descriptor,
+  # and the dashboard hides the group panel accordingly. The API endpoints behind that
+  # panel are still routable, though, so the switch has to be enforced where the calls
+  # land: gating only creation left participants, metadata, invites, settings, leaving and
+  # syncing reaching the provider on an installation that turned groups off.
   def group(group_jid)
+    raise Whatsapp::Session::Errors::NotSupported, 'groups are disabled on this installation' unless capability?('groups')
+
     parsed = model::Address.parse(group_jid)
     raise Whatsapp::Session::Errors::InvalidPayload, "not a group: #{group_jid}" unless parsed&.group?
 

--- a/app/services/whatsapp/session/facade/groups.rb
+++ b/app/services/whatsapp/session/facade/groups.rb
@@ -46,12 +46,20 @@ module Whatsapp::Session::Facade::Groups
   end
 
   # Rendered straight to the dashboard, so the entries keep the keys it already reads.
+  #
+  # Approving people into a group is a capability of its own, and a provider can do groups
+  # without it: Uazapi is one. Asking its backend anyway raises NotSupported, which the
+  # controller does not answer for, so a routable endpoint turns into a 500.
   def group_join_requests(group_jid)
+    return [] unless capability?('group_join_requests')
+
     requests = backend.group_join_requests(model::Commands::GroupJoinRequestsList.new(group: group(group_jid)))
     Array(requests).map { |request| join_request_payload(request) }
   end
 
   def handle_group_join_requests(group_jid, participants, action)
+    raise Whatsapp::Session::Errors::NotSupported, 'this provider cannot approve join requests' unless capability?('group_join_requests')
+
     backend.handle_group_join_requests(
       model::Commands::GroupJoinRequestsUpdate.new(group: group(group_jid), participants: addresses(participants), action: action)
     )

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -71,7 +71,7 @@ class Whatsapp::Session::Groups::Syncer
     address = group_address
     return if address.blank?
 
-    channel.provider_service.group_info(Model::Commands::GroupInfo.new(group: address))
+    channel.session_backend.group_info(Model::Commands::GroupInfo.new(group: address))
   rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
     # Raised on. Swallowing it here returns nil, and the caller reads that as "nothing to
     # apply" and goes on to dispatch CONTACT_GROUP_SYNCED and hand back the untouched

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -5,10 +5,12 @@
 # already carries the group (group.joined) supplies it directly, while a scheduled or
 # manual sync fetches it through the backend.
 class Whatsapp::Session::Groups::Syncer
-  Model = Whatsapp::Session::Model
-
   # Group settings, as WhatsApp names them on the wire and as the dashboard reads them
   # from additional_attributes (the keys the Baileys layer already writes).
+  # Same reason as everywhere else in this layer: an implicit namespace captured in a
+  # constant is the module object from before the last reload.
+  def model = Whatsapp::Session::Model
+
   SETTINGS = { announce: 'announce', locked: 'restrict',
                join_approval: 'join_approval_mode', member_add_mode: 'member_add_mode' }.freeze
 
@@ -63,7 +65,7 @@ class Whatsapp::Session::Groups::Syncer
   end
 
   def group_address
-    address = Model::Address.parse(group_contact.identifier)
+    address = model::Address.parse(group_contact.identifier)
     address if address.present? && address.group?
   end
 
@@ -71,7 +73,7 @@ class Whatsapp::Session::Groups::Syncer
     address = group_address
     return if address.blank?
 
-    channel.session_backend.group_info(Model::Commands::GroupInfo.new(group: address))
+    channel.session_backend.group_info(model::Commands::GroupInfo.new(group: address))
   rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
     # Raised on. Swallowing it here returns nil, and the caller reads that as "nothing to
     # apply" and goes on to dispatch CONTACT_GROUP_SYNCED and hand back the untouched

--- a/app/services/whatsapp/session/inbound/echo_matcher.rb
+++ b/app/services/whatsapp/session/inbound/echo_matcher.rb
@@ -24,7 +24,7 @@ class Whatsapp::Session::Inbound::EchoMatcher
     reserved = reserved_message
     return if reserved.nil?
 
-    confirm_source_id(reserved) if reserved.source_id.blank?
+    confirm_source_id(reserved)
     reserved
   end
 
@@ -47,10 +47,20 @@ class Whatsapp::Session::Inbound::EchoMatcher
   # The id the send never got to store is what a revoke needs, so a message deleted
   # while that send was in flight can only be taken off the contact's phone once this
   # echo supplies it.
+  #
+  # Both the read and the decision happen inside the row lock, and only whoever moves
+  # `source_id` from blank to set enqueues the revoke. There are two writers of that
+  # column on a send (this echo and the send response), and the revoke job is not
+  # idempotent: the second one asks the provider to revoke a message it has already
+  # revoked, and fails five times retrying.
   def confirm_source_id(reserved)
     return if message_id.blank?
 
-    reserved.update_under_lock!(source_id: message_id)
-    ::Messages::DeleteOnChannelJob.perform_later(reserved.id) if reserved.deleted?
+    reserved.with_lock do
+      next if reserved.source_id.present?
+
+      reserved.update!(source_id: message_id)
+      Messages::DeleteOnChannelJob.perform_later(reserved.id) if reserved.deleted?
+    end
   end
 end

--- a/app/services/whatsapp/session/inbound/echo_matcher.rb
+++ b/app/services/whatsapp/session/inbound/echo_matcher.rb
@@ -44,23 +44,16 @@ class Whatsapp::Session::Inbound::EchoMatcher
          .first
   end
 
-  # The id the send never got to store is what a revoke needs, so a message deleted
-  # while that send was in flight can only be taken off the contact's phone once this
-  # echo supplies it.
-  #
-  # Both the read and the decision happen inside the row lock, and only whoever moves
-  # `source_id` from blank to set enqueues the revoke. There are two writers of that
-  # column on a send (this echo and the send response), and the revoke job is not
-  # idempotent: the second one asks the provider to revoke a message it has already
-  # revoked, and fails five times retrying.
+  # The id the send never got to store is what a revoke needs, so a message deleted while
+  # that send was in flight can only be taken off the contact's phone once this echo
+  # supplies it. Same rule as the send response, through the same helper: whoever moves
+  # `source_id` from blank to set owes the revoke, decided under the row lock, enqueued
+  # after it commits. Enqueued inside, the job can run before the commit, read a blank id
+  # and return, while the other writer sees the id already set and enqueues nothing.
   def confirm_source_id(reserved)
     return if message_id.blank?
+    return unless Whatsapp::Session::Outbound::SourceIdReservation.assign(reserved, { source_id: message_id })
 
-    reserved.with_lock do
-      next if reserved.source_id.present?
-
-      reserved.update!(source_id: message_id)
-      Messages::DeleteOnChannelJob.perform_later(reserved.id) if reserved.deleted?
-    end
+    Messages::DeleteOnChannelJob.perform_later(reserved.id)
   end
 end

--- a/app/services/whatsapp/session/inbound/echo_matcher.rb
+++ b/app/services/whatsapp/session/inbound/echo_matcher.rb
@@ -52,7 +52,7 @@ class Whatsapp::Session::Inbound::EchoMatcher
   # and return, while the other writer sees the id already set and enqueues nothing.
   def confirm_source_id(reserved)
     return if message_id.blank?
-    return unless Whatsapp::Session::Outbound::SourceIdReservation.assign(reserved, { source_id: message_id })
+    return unless Whatsapp::Session::Outbound::SourceIdReservation.assign(reserved, { source_id: message_id }) == :revoke
 
     Messages::DeleteOnChannelJob.perform_later(reserved.id)
   end

--- a/app/services/whatsapp/session/inbound/handlers/account_limits.rb
+++ b/app/services/whatsapp/session/inbound/handlers/account_limits.rb
@@ -2,12 +2,10 @@
 # start new conversations, and how many it may start. They arrive out of band and stay
 # on the connection record until the provider says otherwise.
 class Whatsapp::Session::Inbound::Handlers::AccountLimits < Whatsapp::Session::Inbound::Handlers::Base
-  Events = Whatsapp::Session::Model::Events
-
   def perform
-    case payload
-    when Events::AccountReachoutTimelock then write('reachout_time_lock', payload.reachout_time_lock)
-    when Events::AccountNewChatCap then write('new_chat_cap', payload.new_chat_cap)
+    case payload&.wire_type
+    when 'account.reachout_timelock' then write('reachout_time_lock', payload.reachout_time_lock)
+    when 'account.new_chat_cap' then write('new_chat_cap', payload.new_chat_cap)
     else :ignored
     end
   end

--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -5,14 +5,11 @@
 # writer allowed to touch it. The i18n key in `error` is what the dashboard renders;
 # a provider message never reaches the UI.
 class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session::Inbound::Handlers::Base
-  Events = Whatsapp::Session::Model::Events
-
   def perform
     state = build_state
     return :ignored if state.nil?
 
     result = Whatsapp::Session::ConnectionStateWriter.new(channel).apply(state)
-    after_write(state) if result == :written
     result == :stale ? :ignored : :handled
   end
 
@@ -20,53 +17,42 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
 
   # Every event that only means "the session closed, and here is why" maps straight to
   # its i18n key; the rest need a little more than that.
+  #
+  # Keyed by wire type rather than by event class. A class in a constant is captured when
+  # this file loads, and after a reload the incoming payload is an instance of the new
+  # generation: the lookup misses, the case below misses too, and the session state is
+  # dropped without an error anywhere.
   CLOSING_ERRORS = {
-    Events::SessionLoggedOut => 'logged_out',
-    Events::SessionStreamReplaced => 'stream_replaced',
-    Events::SessionTemporaryBan => 'temporary_ban',
-    Events::SessionClientOutdated => 'client_outdated',
-    Events::SessionConnectFailure => 'connect_failure',
-    Events::PairingError => 'connect_failure'
+    'session.logged_out' => 'logged_out',
+    'session.stream_replaced' => 'stream_replaced',
+    'session.temporary_ban' => 'temporary_ban',
+    'session.client_outdated' => 'client_outdated',
+    'session.connect_failure' => 'connect_failure',
+    'pairing.error' => 'connect_failure'
   }.freeze
 
   def build_state
-    error = CLOSING_ERRORS[payload.class]
+    type = payload&.wire_type
+    error = CLOSING_ERRORS[type]
     return closed(error, ban: payload.try(:ban)) if error
 
-    case payload
-    when Events::SessionState then session_state
-    when Events::PairingQr then connecting(qr_data_url: payload.png_data_url)
-    when Events::PairingCode then connecting(pairing_code: payload.code)
-    when Events::PairingSuccess then pairing_success
+    case type
+    when 'session.state' then session_state
+    when 'pairing.qr' then connecting(qr_data_url: payload.png_data_url)
+    when 'pairing.code' then connecting(pairing_code: payload.code)
+    when 'pairing.success' then pairing_success
     end
   end
 
-  # The same check pairing does, and for the same reason. `pairing.success` is not the
-  # only event that names the paired number: a `session.state` already queued behind it,
-  # or one arriving because the logout below failed, would otherwise be accepted on its
-  # own and put the inbox back to work on somebody else's WhatsApp account.
+  # Whose account this is, is not decided here: the writer refuses any state that names
+  # the wrong number, or that names none while the inbox is quarantined, because the poll
+  # and the connect answer write states without ever passing through a handler.
   def session_state
-    return closed(wrong_phone_error) if wrong_phone? || unidentified_while_disowned?
-
     state(payload.state, error: payload.reason, phone_number: payload.phone, lid: payload.lid,
                          quarantine: payload.quarantine, ban: payload.ban)
   end
 
-  def pairing_success
-    return closed(wrong_phone_error) if wrong_phone?
-
-    connecting(phone_number: payload.phone, lid: payload.lid)
-  end
-
-  # `session.state` only requires `state`: the contract's own `connecting` fixture carries
-  # nothing else, and an `open` can arrive the same way. Such a state says nothing about
-  # whose account is connected, and writing it would clear the quarantine below while the
-  # logout that removes the wrong account is still being retried, so the dispatcher would
-  # start filing that account's chats here again. The quarantine is lifted only by a state
-  # that names a number, and names the right one.
-  def unidentified_while_disowned?
-    payload.phone.blank? && Whatsapp::Session::ConnectionStateWriter.disowned?(channel)
-  end
+  def pairing_success = connecting(phone_number: payload.phone, lid: payload.lid)
 
   def closed(error, **attributes) = state('close', error: error, **attributes)
   def connecting(**attributes) = state('connecting', **attributes)
@@ -80,27 +66,4 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
   def epoch
     event.epoch.to_i.positive? ? event.epoch.to_i : nil
   end
-
-  # The operator scanned the QR with a different number than the inbox is configured
-  # for. Keeping that session would file the wrong contacts under this inbox, so it is
-  # dropped and the inbox says why.
-  #
-  # Compared through the normalizers, never as raw digits: a Brazilian line is reported
-  # by WhatsApp with or without the ninth digit depending on when it was registered, so
-  # a textual comparison would reject the very number the operator configured.
-  def wrong_phone?
-    configured = channel.phone_number.to_s
-    paired = payload.phone.to_s
-    configured.present? && paired.present? && !Whatsapp::Session::PhoneMatch.same_number?(configured, paired)
-  end
-
-  # Through a job, not inline. The state has already been written by the time this runs,
-  # so a repeat of the same event is reported as unchanged and never gets here again: a
-  # logout that failed once inline would never be attempted a second time, and the wrong
-  # WhatsApp account would stay connected.
-  def after_write(state)
-    Whatsapp::Session::LogoutJob.perform_later(channel) if state.error == wrong_phone_error
-  end
-
-  def wrong_phone_error = Whatsapp::Session::ConnectionStateWriter::WRONG_PHONE_ERROR
 end

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -134,12 +134,7 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
   # resolved contact has no phone at all and comparing numbers can only answer no. The
   # LID the session paired under is on the connection record, so both identities are
   # checked.
-  def session_owner?(contact)
-    return true if Whatsapp::Session::PhoneMatch.same_number?(contact.phone_number, channel.phone_number)
-
-    lid = channel.provider_connection['lid'].presence
-    lid.present? && contact.identifier == "#{lid}@lid"
-  end
+  def session_owner?(contact) = Whatsapp::Session::Owner.owns?(channel, contact)
 
   def merge_attributes(attributes)
     merged = (@group_contact.additional_attributes || {}).merge(attributes)

--- a/app/services/whatsapp/session/inbound/handlers/message_edited.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_edited.rb
@@ -1,7 +1,5 @@
 # The contact (or the connected phone) edited a message that is already stored.
 class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::Inbound::Handlers::Base
-  Content = Whatsapp::Session::Model::Content
-
   def perform
     target = find_message(payload.message_id)
     return :ignored if target.nil?
@@ -32,11 +30,13 @@ class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::I
     end
   end
 
+  # By wire type, not by class: a class captured before a reload stops matching and the
+  # edit is dropped without a word.
   def edited_content
-    case payload.content
-    when Content::Text then payload.content.body.to_s
-    when Content::Media then payload.content.caption.to_s
-    when Content::Rich then payload.content.preview_text.to_s
+    case payload.content&.wire_type
+    when 'text' then payload.content.body.to_s
+    when 'media' then payload.content.caption.to_s
+    when 'rich' then payload.content.preview_text.to_s
     end
   end
 end

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -6,8 +6,6 @@
 # afterwards. Downloading inline would stall the consumer thread that keeps a session's
 # events in order, and the attachment lands within seconds either way.
 class Whatsapp::Session::Inbound::MessageWriter
-  Content = Whatsapp::Session::Model::Content
-
   attr_reader :conversation, :inbound, :sender
 
   def initialize(conversation:, inbound:, sender: nil)
@@ -17,7 +15,7 @@ class Whatsapp::Session::Inbound::MessageWriter
   end
 
   def perform
-    return build_contact_messages if content.is_a?(Content::Contacts)
+    return build_contact_messages if content_type == 'contacts'
 
     message = conversation.messages.build(content: message_content, **message_attributes)
     attach_location(message)
@@ -32,6 +30,11 @@ class Whatsapp::Session::Inbound::MessageWriter
   def inbox = conversation.inbox
   def content = inbound.content
   def incoming? = inbound.incoming?
+
+  # The kind of content, as the string the contract names it by. Never as a class: a
+  # class captured before a reload no longer matches the payload's own, and every branch
+  # below would fall through in silence.
+  def content_type = content&.wire_type
 
   def message_attributes
     {
@@ -49,10 +52,10 @@ class Whatsapp::Session::Inbound::MessageWriter
   end
 
   def message_content
-    case content
-    when Content::Text then convert_mentions(content.body)
-    when Content::Media then content.caption
-    when Content::Rich then content.preview_text
+    case content_type
+    when 'text' then convert_mentions(content.body)
+    when 'media' then content.caption
+    when 'rich' then content.preview_text
     end
   end
 
@@ -69,16 +72,16 @@ class Whatsapp::Session::Inbound::MessageWriter
       in_reply_to_external_id: inbound.quoted_id.presence,
       referral: inbound.referral.presence,
       is_unsupported: (true if unsupported?),
-      rich: (content.to_content_attribute if content.is_a?(Content::Rich))
+      rich: (content.to_content_attribute if content_type == 'rich')
     }.compact
   end
 
   # A rich card with no text and no media header renders as an empty bubble, which is
   # what the unsupported flag exists for.
   def unsupported?
-    return true if content.is_a?(Content::Unsupported)
+    return true if content_type == 'unsupported'
 
-    content.is_a?(Content::Rich) && content.preview_text.blank? && content.media.blank?
+    content_type == 'rich' && content.preview_text.blank? && content.media.blank?
   end
 
   def convert_mentions(text)
@@ -91,7 +94,7 @@ class Whatsapp::Session::Inbound::MessageWriter
 
   # Location carries no downloadable bytes: the coordinates are the attachment.
   def attach_location(message)
-    return unless content.is_a?(Content::Location)
+    return unless content_type == 'location'
 
     name = [content.name, content.address].compact_blank.join(', ')
     message.attachments.build(
@@ -107,8 +110,8 @@ class Whatsapp::Session::Inbound::MessageWriter
   # same downloadable reference a plain media message has: without this the card is
   # stored with its text and no attachment.
   def enqueue_media_fetch(message)
-    media = content if content.is_a?(Content::Media)
-    media ||= content.media if content.is_a?(Content::Rich)
+    media = content if content_type == 'media'
+    media ||= content.media if content_type == 'rich'
     return if media.blank? || media.ref.blank?
 
     Whatsapp::Session::MediaFetchJob.perform_later(message, media.to_h)

--- a/app/services/whatsapp/session/model/address.rb
+++ b/app/services/whatsapp/session/model/address.rb
@@ -58,9 +58,17 @@ class Whatsapp::Session::Model::Address < Data.define(:kind, :id)
     # present, because that is what the provider echoes back.
     def for_contact(contact)
       identifier = contact.identifier.presence
-      return parse(identifier) if identifier&.include?('@')
+      return parse(identifier) if whatsapp_jid?(identifier)
 
       phone(contact.phone_number)
+    end
+
+    # `identifier` is account-wide, not per-inbox, and another channel may own it: an API
+    # inbox writes the customer's id there, and that id is often an e-mail. Reading one of
+    # those as an address makes the contact unreachable on WhatsApp, number and all, so
+    # only a JID this layer knows the server of counts.
+    def whatsapp_jid?(value)
+      SERVER_KINDS.key?(value.to_s.split('@', 2).last)
     end
   end
 

--- a/app/services/whatsapp/session/model/connection_state.rb
+++ b/app/services/whatsapp/session/model/connection_state.rb
@@ -38,4 +38,14 @@ class Whatsapp::Session::Model::ConnectionState < Data.define(
   def connecting?
     connection.in?(%w[connecting reconnecting])
   end
+
+  # The pairing attempt token rides along only while the attempt is still running. Stamped
+  # onto a state that ended it, the token stays on the record and the polling chain looks
+  # current forever: it would poll a session that has already opened and, if that request
+  # failed, write `connect_failure` over a healthy connection.
+  def with_attempt(attempt)
+    return self if attempt.blank? || !connecting?
+
+    with(pairing_attempt: attempt)
+  end
 end

--- a/app/services/whatsapp/session/model/connection_state.rb
+++ b/app/services/whatsapp/session/model/connection_state.rb
@@ -7,7 +7,7 @@
 # before persisting, so what the dashboard reads is already a sentence.
 class Whatsapp::Session::Model::ConnectionState < Data.define(
   :connection, :qr_data_url, :pairing_code, :error, :epoch, :phone_number, :lid,
-  :quarantine, :ban, :reachout_time_lock, :new_chat_cap
+  :quarantine, :ban, :reachout_time_lock, :new_chat_cap, :pairing_attempt
 )
   include Whatsapp::Session::Model::Serializable
 

--- a/app/services/whatsapp/session/model/event.rb
+++ b/app/services/whatsapp/session/model/event.rb
@@ -52,7 +52,7 @@ class Whatsapp::Session::Model::Event < Data.define(:type, :payload, :id, :sid, 
   end
 
   def known?
-    !payload.is_a?(Events::Unknown)
+    payload.present? && payload.wire_type != 'unknown'
   end
 
   def at

--- a/app/services/whatsapp/session/model/events.rb
+++ b/app/services/whatsapp/session/model/events.rb
@@ -236,6 +236,7 @@ module Whatsapp::Session::Model::Events
   # failing the whole shard.
   class Unknown < Data.define(:type, :payload)
     include Serializable
+    wire_type 'unknown'
   end
 
   CLASSES = [

--- a/app/services/whatsapp/session/model/serializable.rb
+++ b/app/services/whatsapp/session/model/serializable.rb
@@ -67,6 +67,13 @@ module Whatsapp::Session::Model::Serializable
     end
   end
 
+  # What this payload is, as a string rather than as a class. Comparing classes is what
+  # a reload breaks: an alias or a `described_class` captured before it holds the
+  # previous generation, `case payload when Text` stops matching, and the branch falls
+  # through in silence rather than raising. The wire type is the same string on both
+  # sides of a reload, and it is the same string the contract uses.
+  def wire_type = self.class.wire_type
+
   # A nil always means "not provided", so a payload that omits a member and one that
   # sends it as null behave the same and both fall back to the declared default.
   def initialize(**attributes)

--- a/app/services/whatsapp/session/outbound/announcement_guard.rb
+++ b/app/services/whatsapp/session/outbound/announcement_guard.rb
@@ -23,16 +23,9 @@ class Whatsapp::Session::Outbound::AnnouncementGuard
   def contact = message.conversation.contact
   def channel = message.inbox.channel
 
-  # Compared through the normalizers rather than by a digit suffix: WhatsApp reports a
-  # Brazilian line with or without its ninth digit depending on when it was registered,
-  # so the raw digits of one line differ from themselves, while a plain suffix
-  # comparison calls two lines from different countries the same one and lets a send
-  # through that WhatsApp then drops in silence.
   def inbox_admin?
-    return false if channel.phone_number.blank?
-
     contact.group_memberships.active.where(role: :admin).includes(:contact).any? do |member|
-      Whatsapp::Session::PhoneMatch.same_number?(channel.phone_number, member.contact.phone_number)
+      Whatsapp::Session::Owner.owns?(channel, member.contact)
     end
   end
 end

--- a/app/services/whatsapp/session/outbound/announcement_guard.rb
+++ b/app/services/whatsapp/session/outbound/announcement_guard.rb
@@ -1,0 +1,38 @@
+# An announcement group only accepts messages from its admins. Sending anyway would
+# leave the message stuck as "sent" while WhatsApp silently dropped it, so it is failed
+# here with a reason the agent can read.
+class Whatsapp::Session::Outbound::AnnouncementGuard
+  attr_reader :message
+
+  def initialize(message)
+    @message = message
+  end
+
+  # Raises Errors::GroupParticipantNotAllowed when the send must not happen.
+  def ensure!
+    return unless contact.group_type_group?
+    return unless contact.additional_attributes&.dig('announce') == true
+    return if inbox_admin?
+
+    message.update_under_lock!(status: :failed, external_error: I18n.t('errors.whatsapp.group_announcement_only'))
+    raise Whatsapp::Session::Errors::GroupParticipantNotAllowed, 'only admins can send messages in this group'
+  end
+
+  private
+
+  def contact = message.conversation.contact
+  def channel = message.inbox.channel
+
+  # Compared through the normalizers rather than by a digit suffix: WhatsApp reports a
+  # Brazilian line with or without its ninth digit depending on when it was registered,
+  # so the raw digits of one line differ from themselves, while a plain suffix
+  # comparison calls two lines from different countries the same one and lets a send
+  # through that WhatsApp then drops in silence.
+  def inbox_admin?
+    return false if channel.phone_number.blank?
+
+    contact.group_memberships.active.where(role: :admin).includes(:contact).any? do |member|
+      Whatsapp::Session::PhoneMatch.same_number?(channel.phone_number, member.contact.phone_number)
+    end
+  end
+end

--- a/app/services/whatsapp/session/outbound/attachment_adapter.rb
+++ b/app/services/whatsapp/session/outbound/attachment_adapter.rb
@@ -8,11 +8,12 @@ class Whatsapp::Session::Outbound::AttachmentAdapter
   # Chatwoot's file_type enum, in the terms the WhatsApp protocol uses.
   KINDS = { 'image' => 'image', 'audio' => 'audio', 'video' => 'video', 'file' => 'document' }.freeze
 
-  attr_reader :attachment, :caption
+  attr_reader :attachment, :caption, :channel
 
-  def initialize(attachment, caption: nil)
+  def initialize(attachment, caption: nil, channel: nil)
     @attachment = attachment
     @caption = caption
+    @channel = channel
   end
 
   # Resolved per call rather than aliased: a constant pointing at another file's class
@@ -21,6 +22,18 @@ class Whatsapp::Session::Outbound::AttachmentAdapter
   def content = Whatsapp::Session::Model::Content
   def media_ref = Whatsapp::Session::Model::MediaRef
 
+  # `download_url` is built from Rails' default url options, which are the public
+  # FRONTEND_URL. That is the right address for a provider reaching Rails over the
+  # internet and the wrong one for a connector sitting next to it on a private network,
+  # so the host is swapped for the internal one where the inbox says to use it.
+  def media_url
+    url = attachment.download_url
+    internal = ENV.fetch('INTERNAL_HOST_URL', nil)
+    return url unless channel&.use_internal_host? && internal.present?
+
+    url.sub(%r{\A[a-z]+://[^/]+}, internal.chomp('/'))
+  end
+
   def perform
     return if attachment.blank? || !attachment.file.attached?
 
@@ -28,7 +41,7 @@ class Whatsapp::Session::Outbound::AttachmentAdapter
     content::Media.new(
       kind: kind, mime: file.content_type, filename: file.filename.to_s, caption: caption.presence,
       voice_note: voice_note?, size: file.byte_size,
-      ref: media_ref.url(attachment.download_url, mime: file.content_type, size: file.byte_size)
+      ref: media_ref.url(media_url, mime: file.content_type, size: file.byte_size)
     )
   end
 

--- a/app/services/whatsapp/session/outbound/attachment_adapter.rb
+++ b/app/services/whatsapp/session/outbound/attachment_adapter.rb
@@ -1,0 +1,49 @@
+# Turns a Chatwoot attachment into canonical media content.
+#
+# The bytes are not read here: the provider is given a URL and fetches them itself.
+# That keeps a 60 MB video out of the Rails process and out of the command frame, and
+# it is why an inbox behind a private network needs INTERNAL_HOST_URL to point at
+# something the provider can actually reach.
+class Whatsapp::Session::Outbound::AttachmentAdapter
+  # Chatwoot's file_type enum, in the terms the WhatsApp protocol uses.
+  KINDS = { 'image' => 'image', 'audio' => 'audio', 'video' => 'video', 'file' => 'document' }.freeze
+
+  attr_reader :attachment, :caption
+
+  def initialize(attachment, caption: nil)
+    @attachment = attachment
+    @caption = caption
+  end
+
+  # Resolved per call rather than aliased: a constant pointing at another file's class
+  # keeps the pre-reload object, and in development that object is the one Zeitwerk
+  # already discarded.
+  def content = Whatsapp::Session::Model::Content
+  def media_ref = Whatsapp::Session::Model::MediaRef
+
+  def perform
+    return if attachment.blank? || !attachment.file.attached?
+
+    file = attachment.file
+    content::Media.new(
+      kind: kind, mime: file.content_type, filename: file.filename.to_s, caption: caption.presence,
+      voice_note: voice_note?, size: file.byte_size,
+      ref: media_ref.url(attachment.download_url, mime: file.content_type, size: file.byte_size)
+    )
+  end
+
+  private
+
+  # A sticker is stored as an image with a webp body; WhatsApp needs the distinction.
+  def kind
+    return 'sticker' if attachment.file.content_type == 'image/webp'
+
+    KINDS.fetch(attachment.file_type, 'document')
+  end
+
+  # `is_recorded_audio` is the older fazer.ai key (transcode pipeline and old messages).
+  def voice_note?
+    meta = attachment.meta || {}
+    meta['is_voice_message'].present? || meta['is_recorded_audio'].present?
+  end
+end

--- a/app/services/whatsapp/session/outbound/attachment_adapter.rb
+++ b/app/services/whatsapp/session/outbound/attachment_adapter.rb
@@ -46,11 +46,15 @@ class Whatsapp::Session::Outbound::AttachmentAdapter
   def perform
     return if attachment.blank? || !attachment.file.attached?
 
+    # Resolved first, because `download_url` also rewrites the blob of an `.ogg` recorded
+    # as `audio/opus` to `audio/ogg`. Reading the type before it leaves the command
+    # advertising two different ones, and WhatsApp classifies a voice note by that type.
+    url = media_url
     file = attachment.file
     content::Media.new(
       kind: kind, mime: file.content_type, filename: file.filename.to_s, caption: caption.presence,
       voice_note: voice_note?, size: file.byte_size,
-      ref: media_ref.url(media_url, mime: file.content_type, size: file.byte_size)
+      ref: media_ref.url(url, mime: file.content_type, size: file.byte_size)
     )
   end
 

--- a/app/services/whatsapp/session/outbound/attachment_adapter.rb
+++ b/app/services/whatsapp/session/outbound/attachment_adapter.rb
@@ -8,6 +8,9 @@ class Whatsapp::Session::Outbound::AttachmentAdapter
   # Chatwoot's file_type enum, in the terms the WhatsApp protocol uses.
   KINDS = { 'image' => 'image', 'audio' => 'audio', 'video' => 'video', 'file' => 'document' }.freeze
 
+  SCHEME = %r{\A[a-z][a-z0-9+.-]*://}i
+  AUTHORITY = %r{\A[a-z][a-z0-9+.-]*://[^/]+}i
+
   attr_reader :attachment, :caption, :channel
 
   def initialize(attachment, caption: nil, channel: nil)
@@ -26,12 +29,18 @@ class Whatsapp::Session::Outbound::AttachmentAdapter
   # FRONTEND_URL. That is the right address for a provider reaching Rails over the
   # internet and the wrong one for a connector sitting next to it on a private network,
   # so the host is swapped for the internal one where the inbox says to use it.
+  #
+  # Only for a URL this app serves, which is not every blob: with a cloud storage service
+  # `download_url` is a presigned URL answered by S3 or GCS, whose path means nothing to
+  # Rails and whose signature is bound to the host it was made for. Moving that one to the
+  # internal host turns every outbound attachment into a 404, so it is left alone: a
+  # storage service reachable over the internet needs no internal address anyway.
   def media_url
     url = attachment.download_url
     internal = ENV.fetch('INTERNAL_HOST_URL', nil)
-    return url unless channel&.use_internal_host? && internal.present?
+    return url unless channel&.use_internal_host? && internal.present? && app_hosted?(url)
 
-    url.sub(%r{\A[a-z]+://[^/]+}, internal.chomp('/'))
+    url.sub(AUTHORITY, internal.chomp('/'))
   end
 
   def perform
@@ -46,6 +55,18 @@ class Whatsapp::Session::Outbound::AttachmentAdapter
   end
 
   private
+
+  # Compared against the same default url options `download_url` builds app-hosted URLs
+  # from (it seeds ActiveStorage::Current.url_options with them), so the two can never
+  # disagree about what "this app" is.
+  def app_hosted?(url)
+    host = authority(url)
+    host.present? && host == authority(Rails.application.routes.default_url_options[:host])
+  end
+
+  def authority(value)
+    value.to_s.sub(SCHEME, '').split('/').first
+  end
 
   # A sticker is stored as an image with a webp body; WhatsApp needs the distinction.
   def kind

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -121,12 +121,14 @@ class Whatsapp::Session::Outbound::MessageSender
 
     attributes = { source_id: result.message_id }
     attributes[:external_created_at] = result.timestamp / 1000 if result.timestamp.present?
+    already_assigned = Message.where(id: message.id).where.not(source_id: nil).exists?
     message.update_under_lock!(**attributes)
 
-    # A message deleted while this send was in flight still has to be revoked on the
-    # provider, and SendOnWhatsappService already does that from the id this returns.
-    # Doing it here as well would revoke the same message twice, the second one failing
-    # against a provider that refuses an unknown revoke, with five retries behind it.
+    # Three writers can fill this column on one send: this response, the echo of the same
+    # message coming back from WhatsApp, and the delete endpoint reading it. The revoke
+    # job is not idempotent, so the rule is the same in all three: whoever moves the id
+    # from blank to set is the one that enqueues it.
+    Messages::DeleteOnChannelJob.perform_later(message.id) if !already_assigned && message.deleted?
     result.message_id
   end
 

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -121,14 +121,16 @@ class Whatsapp::Session::Outbound::MessageSender
 
     attributes = { source_id: result.message_id }
     attributes[:external_created_at] = result.timestamp / 1000 if result.timestamp.present?
-    already_assigned = Message.where(id: message.id).where.not(source_id: nil).exists?
-    message.update_under_lock!(**attributes)
-
     # Three writers can fill this column on one send: this response, the echo of the same
     # message coming back from WhatsApp, and the delete endpoint reading it. The revoke
     # job is not idempotent, so the rule is the same in all three: whoever moves the id
-    # from blank to set is the one that enqueues it.
-    Messages::DeleteOnChannelJob.perform_later(message.id) if !already_assigned && message.deleted?
+    # from blank to set is the one that enqueues it. Claimed with a conditional UPDATE
+    # rather than read-then-write, because between a read and the row lock the echo can
+    # slip in and both sides would believe they were first.
+    claimed = outbound::SourceIdReservation.claim_source_id(message, result.message_id)
+    message.update_under_lock!(**attributes)
+
+    Messages::DeleteOnChannelJob.perform_later(message.id) if claimed && message.deleted?
     result.message_id
   end
 

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -26,6 +26,15 @@ class Whatsapp::Session::Outbound::MessageSender
       )
     )
     persist(result)
+  rescue Whatsapp::Session::Errors::Error => e
+    # A refusal the provider will repeat: the number is not on WhatsApp, the file is too
+    # large, the group takes messages from admins only. Letting it escape leaves the
+    # bubble reading "sent" while the job retries something that cannot work, so the
+    # reason goes on the message instead. Only a provider that might answer differently
+    # next time is worth raising for.
+    raise if e.retryable?
+
+    fail_message(e)
   end
 
   private
@@ -129,6 +138,17 @@ class Whatsapp::Session::Outbound::MessageSender
 
     Messages::DeleteOnChannelJob.perform_later(message.id) if outcome == :revoke
     result.message_id
+  end
+
+  # Never over a reason that is already there: the announcement guard writes a translated
+  # sentence before it raises, and the exception's own message would replace it with the
+  # English one meant for the log.
+  def fail_message(error)
+    message.reload
+    return if message.status == 'failed' && message.external_error.present?
+
+    message.update_under_lock!(status: :failed, external_error: error.message)
+    nil
   end
 
   def mark_unsupported

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -1,0 +1,136 @@
+# Sends one Chatwoot message through a session backend.
+#
+# What the legacy layer did with a 130-second channel lock (keeping a send and the echo
+# of the previous one from crossing) is done here by reserving the WhatsApp id before
+# the send: the echo is recognized by that id whether or not the response ever came
+# back, so nothing has to be serialized.
+class Whatsapp::Session::Outbound::MessageSender
+  attr_reader :message
+
+  def initialize(message)
+    @message = message
+  end
+
+  # Returns the provider message id, or nil when there was nothing to send.
+  def perform
+    outbound::AnnouncementGuard.new(message).ensure!
+    return react if reaction?
+
+    content = build_content
+    return mark_unsupported if content.nil?
+
+    result = backend.send_message(
+      model::Commands::MessageSend.new(
+        message_id: reserved_id, to: recipient, content: content, quoted: quoted, mentions: mentions,
+        client_ref: reserved_id
+      )
+    )
+    persist(result)
+  end
+
+  private
+
+  # Resolved per call, never aliased into a constant: both are implicit namespaces (no
+  # model.rb, no outbound.rb), and a constant would hold the module object from before
+  # the last reload, whose autoloads are gone.
+  def model = Whatsapp::Session::Model
+  def outbound = Whatsapp::Session::Outbound
+
+  def channel = message.inbox.channel
+  def backend = channel.session_backend
+  def conversation = message.conversation
+  def reaction? = message.content_attributes['is_reaction'].present?
+
+  def recipient
+    model::Address.for_contact(conversation.contact)
+  end
+
+  # The same token twice, because a provider takes it one way or the other. A backend
+  # that lets us assign the WhatsApp id uses `message_id` and the echo comes back under
+  # it; one that assigns its own id ignores `message_id` and returns `client_ref`
+  # untouched. Either way the echo carries the value stored as `pending_source_id`,
+  # which is the only thing EchoMatcher can recognize a send by.
+  def reserved_id
+    @reserved_id ||= outbound::SourceIdReservation.reserve(message)
+  end
+
+  def build_content
+    return attachment_content if message.attachments.present?
+    return text_content if message.outgoing_content.present?
+
+    nil
+  end
+
+  def text_content
+    model::Content::Text.new(body: outgoing_text)
+  end
+
+  # Only the first attachment travels with the message: WhatsApp has no multi-media
+  # message, and Chatwoot splits the rest into their own messages upstream.
+  def attachment_content
+    outbound::AttachmentAdapter.new(message.attachments.first, caption: message.outgoing_content).perform
+  end
+
+  # The agent typed "@Name"; WhatsApp matches mentions by id, so the rendered text
+  # carries the id and the mention list carries the addresses.
+  def outgoing_text
+    Whatsapp::MentionConverterService.replace_mentions_in_outgoing_text(
+      message.content, message.outgoing_content, channel.account
+    )
+  end
+
+  def mentions
+    return [] if message.content.blank?
+
+    jids = Whatsapp::MentionConverterService.extract_mentions_for_whatsapp(message.content, channel.account)[:mentions]
+    Array(jids).filter_map { |jid| model::Address.parse(jid) }
+  end
+
+  def quoted
+    external_id = message.content_attributes['in_reply_to_external_id']
+    return if external_id.blank?
+
+    target = conversation.messages.find_by(source_id: external_id)
+    return if target.nil?
+
+    model::Commands::Quoted.new(
+      id: target.source_id, from_me: target.outgoing?,
+      participant: (model::Address.for_contact(target.sender) if recipient.group? && target.incoming?)
+    )
+  end
+
+  # A reaction is not a message of its own on WhatsApp: it points at one. Chatwoot
+  # keeps a single row per (target, sender) and rewrites it, which is why the send
+  # reserves a fresh id every time.
+  def react
+    target = Message.find_by(id: message.content_attributes['in_reply_to'])
+    return mark_unsupported if target.nil?
+
+    result = backend.react_message(
+      model::Commands::MessageReact.new(
+        message_id: reserved_id, to: recipient, target_id: target.source_id, target_from_me: target.outgoing?,
+        target_participant: (model::Address.for_contact(target.sender) if recipient.group? && target.incoming?),
+        emoji: message.outgoing_content
+      )
+    )
+    persist(result)
+  end
+
+  def persist(result)
+    return if result.blank? || result.message_id.blank?
+
+    attributes = { source_id: result.message_id }
+    attributes[:external_created_at] = result.timestamp / 1000 if result.timestamp.present?
+    message.update_under_lock!(**attributes)
+
+    # The agent deleted the message while this send was in flight: the delete endpoint
+    # found no source_id to revoke and left it to whoever wrote one.
+    ::Messages::DeleteOnChannelJob.perform_later(message.id) if message.deleted?
+    result.message_id
+  end
+
+  def mark_unsupported
+    message.update_under_lock!(is_unsupported: true)
+    nil
+  end
+end

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -121,16 +121,9 @@ class Whatsapp::Session::Outbound::MessageSender
 
     attributes = { source_id: result.message_id }
     attributes[:external_created_at] = result.timestamp / 1000 if result.timestamp.present?
-    # Three writers can fill this column on one send: this response, the echo of the same
-    # message coming back from WhatsApp, and the delete endpoint reading it. The revoke
-    # job is not idempotent, so the rule is the same in all three: whoever moves the id
-    # from blank to set is the one that enqueues it. Claimed with a conditional UPDATE
-    # rather than read-then-write, because between a read and the row lock the echo can
-    # slip in and both sides would believe they were first.
-    claimed = outbound::SourceIdReservation.claim_source_id(message, result.message_id)
-    message.update_under_lock!(**attributes)
-
-    Messages::DeleteOnChannelJob.perform_later(message.id) if claimed && message.deleted?
+    # The write and the "do I owe a revoke?" answer come back together, decided inside the
+    # row lock. See SourceIdReservation.assign for why they cannot be separated.
+    Messages::DeleteOnChannelJob.perform_later(message.id) if outbound::SourceIdReservation.assign(message, attributes)
     result.message_id
   end
 

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -68,7 +68,7 @@ class Whatsapp::Session::Outbound::MessageSender
   # Only the first attachment travels with the message: WhatsApp has no multi-media
   # message, and Chatwoot splits the rest into their own messages upstream.
   def attachment_content
-    outbound::AttachmentAdapter.new(message.attachments.first, caption: message.outgoing_content).perform
+    outbound::AttachmentAdapter.new(message.attachments.first, caption: message.outgoing_content, channel: channel).perform
   end
 
   # The agent typed "@Name"; WhatsApp matches mentions by id, so the rendered text

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -121,9 +121,13 @@ class Whatsapp::Session::Outbound::MessageSender
 
     attributes = { source_id: result.message_id }
     attributes[:external_created_at] = result.timestamp / 1000 if result.timestamp.present?
-    # The write and the "do I owe a revoke?" answer come back together, decided inside the
-    # row lock. See SourceIdReservation.assign for why they cannot be separated.
-    Messages::DeleteOnChannelJob.perform_later(message.id) if outbound::SourceIdReservation.assign(message, attributes)
+    # The write, the "does this response still belong here?" check and the "do I owe a
+    # revoke?" answer all come back together, decided inside the row lock. See
+    # SourceIdReservation.assign for why they cannot be separated.
+    outcome = outbound::SourceIdReservation.assign(message, attributes, reservation: reserved_id)
+    return if outcome == :stale
+
+    Messages::DeleteOnChannelJob.perform_later(message.id) if outcome == :revoke
     result.message_id
   end
 

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -123,9 +123,10 @@ class Whatsapp::Session::Outbound::MessageSender
     attributes[:external_created_at] = result.timestamp / 1000 if result.timestamp.present?
     message.update_under_lock!(**attributes)
 
-    # The agent deleted the message while this send was in flight: the delete endpoint
-    # found no source_id to revoke and left it to whoever wrote one.
-    ::Messages::DeleteOnChannelJob.perform_later(message.id) if message.deleted?
+    # A message deleted while this send was in flight still has to be revoked on the
+    # provider, and SendOnWhatsappService already does that from the id this returns.
+    # Doing it here as well would revoke the same message twice, the second one failing
+    # against a provider that refuses an unknown revoke, with five retries behind it.
     result.message_id
   end
 

--- a/app/services/whatsapp/session/outbound/source_id_reservation.rb
+++ b/app/services/whatsapp/session/outbound/source_id_reservation.rb
@@ -24,6 +24,16 @@ module Whatsapp::Session::Outbound::SourceIdReservation
   # Written with update_columns: the reservation is bookkeeping for a send that has not
   # happened yet, so it must not fire message.updated (cable, webhooks, agent bots,
   # search reindex) nor bump updated_at.
+  # Whoever moves `source_id` from blank to set owns the revoke of a message deleted
+  # mid-send, and the send response, the echo and the delete endpoint all race for it.
+  # A conditional UPDATE decides that in one statement: exactly one caller sees a row
+  # affected, no matter how the three interleave. Returns whether this caller was it.
+  def claim_source_id(message, source_id)
+    return false if source_id.blank?
+
+    Message.where(id: message.id, source_id: nil).update_all(source_id: source_id).positive? # rubocop:disable Rails/SkipsModelValidations
+  end
+
   def reserve(message)
     message.with_lock do
       next message.pending_source_id if message.pending_source_id.present?

--- a/app/services/whatsapp/session/outbound/source_id_reservation.rb
+++ b/app/services/whatsapp/session/outbound/source_id_reservation.rb
@@ -17,40 +17,13 @@ module Whatsapp::Session::Outbound::SourceIdReservation
     "#{PREFIX}#{SecureRandom.hex(9).upcase}"
   end
 
-  # Read-or-generate runs under the row lock, which re-reads the row: a reaction toggle
-  # in the meantime clears the reservation precisely to force a fresh id, and sending
-  # under a stale one would resend the previous reaction with an unmatchable echo.
+  # Read-or-generate runs under the row lock, which re-reads the row: a reaction toggle in
+  # the meantime clears the reservation precisely to force a fresh id, and sending under a
+  # stale one would resend the previous reaction with an unmatchable echo.
   #
   # Written with update_columns: the reservation is bookkeeping for a send that has not
-  # happened yet, so it must not fire message.updated (cable, webhooks, agent bots,
-  # search reindex) nor bump updated_at.
-  # Writes what a send came back with, and answers whether this caller has to revoke the
-  # message afterwards.
-  #
-  # Three writers can fill `source_id` on one send: the send response, the echo of the
-  # same message arriving from WhatsApp, and the delete endpoint reading it. Provider
-  # revocation is not idempotent, so exactly one of them may enqueue it, and the rule is
-  # that it belongs to whoever moves the column from blank to set while the message is
-  # deleted. Both halves of that answer are read inside the row lock: deciding before it,
-  # or re-reading `deleted` after it, is what lets the delete endpoint slip into the gap
-  # and revoke the same message twice.
-  #
-  # The two lines before the lock are what `Message#update_under_lock!` does for the same
-  # reason: `lock!` refuses a record with unsaved changes, and the stale content_attributes
-  # hash must never be the thing that gets written back.
-  def assign(message, attributes)
-    message.restore_attributes(['content_attributes']) if message.content_attributes_changed?
-    message.save! if message.changed?
-
-    owns_revoke = false
-    message.with_lock do
-      assigned_here = message.source_id.blank? && attributes[:source_id].present?
-      message.update!(attributes)
-      owns_revoke = assigned_here && message.deleted?
-    end
-    owns_revoke
-  end
-
+  # happened yet, so it must not fire message.updated (cable, webhooks, agent bots, search
+  # reindex) nor bump updated_at.
   def reserve(message)
     message.with_lock do
       next message.pending_source_id if message.pending_source_id.present?
@@ -59,5 +32,44 @@ module Whatsapp::Session::Outbound::SourceIdReservation
       message.update_columns(content_attributes: message.content_attributes) # rubocop:disable Rails/SkipsModelValidations
       message.pending_source_id
     end
+  end
+
+  # Writes what a send came back with, and says what the caller still owes:
+  #
+  #   :stale   the response belongs to a send this row has moved on from; nothing written
+  #   :revoke  the id was assigned here and the message was deleted meanwhile
+  #   :written assigned or updated, nothing else to do
+  #
+  # Three writers can fill `source_id` on one send: the send response, the echo of the same
+  # message arriving from WhatsApp, and the delete endpoint reading it. Provider revocation
+  # is not idempotent, so exactly one of them may enqueue it, and it belongs to whoever
+  # moves the column from blank to set while the message is deleted. Both halves of that
+  # answer are read inside the row lock: deciding before it, or re-reading `deleted` after
+  # it, lets the delete endpoint slip into the gap and revoke the same message twice.
+  #
+  # `reservation` fences the write to the send it came from. Toggling a reaction rewrites
+  # the same row and clears its reservation on purpose, so the replacement is sent rather
+  # than mistaken for an echo; a slow response from the previous emoji landing after that
+  # would otherwise write its id back, and SendOnChannelService would skip the replacement
+  # as something the provider already has.
+  #
+  # The two lines before the lock are what `Message#update_under_lock!` does, for the same
+  # reason: `lock!` refuses a record with unsaved changes, and the stale content_attributes
+  # hash must never be the thing that gets written back.
+  def assign(message, attributes, reservation: nil)
+    message.restore_attributes(['content_attributes']) if message.content_attributes_changed?
+    message.save! if message.changed?
+
+    outcome = nil
+    message.with_lock { outcome = write(message, attributes, reservation) }
+    outcome
+  end
+
+  def write(message, attributes, reservation)
+    return :stale if reservation.present? && message.pending_source_id != reservation
+
+    assigned_here = message.source_id.blank? && attributes[:source_id].present?
+    message.update!(attributes)
+    assigned_here && message.deleted? ? :revoke : :written
   end
 end

--- a/app/services/whatsapp/session/outbound/source_id_reservation.rb
+++ b/app/services/whatsapp/session/outbound/source_id_reservation.rb
@@ -1,0 +1,36 @@
+# The WhatsApp id a send will use, chosen here instead of by the provider.
+#
+# `source_id` can only be written from the send response, so a send whose response never
+# arrives (socket drop, read timeout, worker restart) leaves nothing to recognize the
+# echo of our own message by: it lands as a fresh "sent from the phone" message.
+# Reserving the id up front closes that window, and a retry reuses it so WhatsApp still
+# sees a single message.
+#
+# The shape mirrors what WhatsApp clients generate: the "3EB0" prefix and 18 uppercase
+# hex characters.
+module Whatsapp::Session::Outbound::SourceIdReservation
+  PREFIX = '3EB0'.freeze
+
+  module_function
+
+  def generate
+    "#{PREFIX}#{SecureRandom.hex(9).upcase}"
+  end
+
+  # Read-or-generate runs under the row lock, which re-reads the row: a reaction toggle
+  # in the meantime clears the reservation precisely to force a fresh id, and sending
+  # under a stale one would resend the previous reaction with an unmatchable echo.
+  #
+  # Written with update_columns: the reservation is bookkeeping for a send that has not
+  # happened yet, so it must not fire message.updated (cable, webhooks, agent bots,
+  # search reindex) nor bump updated_at.
+  def reserve(message)
+    message.with_lock do
+      next message.pending_source_id if message.pending_source_id.present?
+
+      message.pending_source_id = generate
+      message.update_columns(content_attributes: message.content_attributes) # rubocop:disable Rails/SkipsModelValidations
+      message.pending_source_id
+    end
+  end
+end

--- a/app/services/whatsapp/session/outbound/source_id_reservation.rb
+++ b/app/services/whatsapp/session/outbound/source_id_reservation.rb
@@ -24,14 +24,31 @@ module Whatsapp::Session::Outbound::SourceIdReservation
   # Written with update_columns: the reservation is bookkeeping for a send that has not
   # happened yet, so it must not fire message.updated (cable, webhooks, agent bots,
   # search reindex) nor bump updated_at.
-  # Whoever moves `source_id` from blank to set owns the revoke of a message deleted
-  # mid-send, and the send response, the echo and the delete endpoint all race for it.
-  # A conditional UPDATE decides that in one statement: exactly one caller sees a row
-  # affected, no matter how the three interleave. Returns whether this caller was it.
-  def claim_source_id(message, source_id)
-    return false if source_id.blank?
+  # Writes what a send came back with, and answers whether this caller has to revoke the
+  # message afterwards.
+  #
+  # Three writers can fill `source_id` on one send: the send response, the echo of the
+  # same message arriving from WhatsApp, and the delete endpoint reading it. Provider
+  # revocation is not idempotent, so exactly one of them may enqueue it, and the rule is
+  # that it belongs to whoever moves the column from blank to set while the message is
+  # deleted. Both halves of that answer are read inside the row lock: deciding before it,
+  # or re-reading `deleted` after it, is what lets the delete endpoint slip into the gap
+  # and revoke the same message twice.
+  #
+  # The two lines before the lock are what `Message#update_under_lock!` does for the same
+  # reason: `lock!` refuses a record with unsaved changes, and the stale content_attributes
+  # hash must never be the thing that gets written back.
+  def assign(message, attributes)
+    message.restore_attributes(['content_attributes']) if message.content_attributes_changed?
+    message.save! if message.changed?
 
-    Message.where(id: message.id, source_id: nil).update_all(source_id: source_id).positive? # rubocop:disable Rails/SkipsModelValidations
+    owns_revoke = false
+    message.with_lock do
+      assigned_here = message.source_id.blank? && attributes[:source_id].present?
+      message.update!(attributes)
+      owns_revoke = assigned_here && message.deleted?
+    end
+    owns_revoke
   end
 
   def reserve(message)

--- a/app/services/whatsapp/session/owner.rb
+++ b/app/services/whatsapp/session/owner.rb
@@ -1,0 +1,20 @@
+# Whether a contact is the WhatsApp account this inbox is connected as.
+#
+# There are two ways to be it and both have to be tried. The phone number the operator
+# configured, compared through the normalizers because WhatsApp reports a Brazilian line
+# with or without its ninth digit depending on when it was registered. And the LID, which
+# for an account WhatsApp has not disclosed the number of is the only identity a group
+# roster carries: comparing phone numbers there compares nil to something and answers no
+# to "is this us?", which is how an inbox that administers an announcement-only group
+# ends up refusing to post in it.
+module Whatsapp::Session::Owner
+  module_function
+
+  def owns?(channel, contact)
+    return false if contact.blank?
+    return true if Whatsapp::Session::PhoneMatch.same_number?(contact.phone_number, channel.phone_number)
+
+    lid = channel.provider_connection['lid'].presence
+    lid.present? && contact.identifier == "#{lid}@lid"
+  end
+end

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -24,6 +24,8 @@ en:
       limit_reached: You can pin up to %{limit} conversations.
       conversation_resolved: A resolved conversation cannot be pinned.
       conversation_not_visible: This conversation is not in your list, so it cannot be pinned.
+    whatsapp:
+      group_announcement_only: Only administrators are allowed to send messages in this group
     inboxes:
       channel:
         provider_unavailable: This WhatsApp provider is not available on this installation yet.

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -43,6 +43,7 @@ en:
           connector_unavailable: The WhatsApp connector is not responding. Messages will only be sent again once it is back.
           connector_incompatible: The WhatsApp connector version is incompatible with this Chatwoot version. Update the connector.
           connect_failure: WhatsApp refused the connection. New attempts continue automatically.
+          pairing_timed_out: The code expired before the phone finished pairing. Start the connection again to get a new one.
   notifications:
     notification_title:
       internal_chat_mention: You have been mentioned in %{name}

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -43,6 +43,7 @@ es:
           connector_unavailable: El conector de WhatsApp no responde. Los mensajes volverán a enviarse cuando esté disponible.
           connector_incompatible: La versión del conector de WhatsApp es incompatible con esta versión de Chatwoot. Actualice el conector.
           connect_failure: WhatsApp rechazó la conexión. Los nuevos intentos continúan automáticamente.
+          pairing_timed_out: El código expiró antes de que el teléfono completara la vinculación. Inicie la conexión de nuevo para obtener uno nuevo.
   notifications:
     notification_title:
       internal_chat_mention: Le mencionaron en %{name}

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -24,6 +24,8 @@ es:
       limit_reached: Puede fijar hasta %{limit} conversaciones.
       conversation_resolved: No se puede fijar una conversación resuelta.
       conversation_not_visible: Esta conversación no está en su lista, así que no se puede fijar.
+    whatsapp:
+      group_announcement_only: Solo los administradores pueden enviar mensajes en este grupo
     inboxes:
       channel:
         provider_unavailable: Este proveedor de WhatsApp aún no está disponible en esta instalación.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -24,6 +24,8 @@ pt_BR:
       limit_reached: Você pode fixar no máximo %{limit} conversas.
       conversation_resolved: Não é possível fixar uma conversa resolvida.
       conversation_not_visible: Esta conversa não está na sua lista, então não pode ser fixada.
+    whatsapp:
+      group_announcement_only: Somente administradores podem enviar mensagens neste grupo
     inboxes:
       channel:
         provider_unavailable: Este provedor de WhatsApp ainda não está disponível nesta instalação.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -43,6 +43,7 @@ pt_BR:
           connector_unavailable: O conector do WhatsApp não está respondendo. As mensagens só voltarão a ser enviadas quando ele retornar.
           connector_incompatible: A versão do conector do WhatsApp é incompatível com esta versão do Chatwoot. Atualize o conector.
           connect_failure: O WhatsApp recusou a conexão. Novas tentativas continuam automaticamente.
+          pairing_timed_out: O código expirou antes de o telefone concluir o pareamento. Inicie a conexão novamente para obter um novo.
   notifications:
     notification_title:
       internal_chat_mention: Você foi mencionado em %{name}

--- a/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
@@ -184,6 +184,22 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
     end
 
     context 'when user is logged in' do
+      # A roster can name a participant WhatsApp only ever gave a LID for, and that contact
+      # has no phone number: the request used to build `@s.whatsapp.net` and come back 422
+      # with the member still a member.
+      it 'promotes a member the roster only knows by LID' do
+        member_contact.update!(phone_number: nil, identifier: '112233445566778@lid')
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members/#{member.id}",
+              params: { role: 'admin' },
+              headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(baileys_service).to have_received(:update_group_participants)
+          .with('group@g.us', ['112233445566778@lid'], 'promote')
+        expect(member.reload.role).to eq('admin')
+      end
+
       it 'promotes member to admin' do
         patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members/#{member.id}",
               params: { role: 'admin' },

--- a/spec/controllers/api/v1/accounts/contacts/group_metadata_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_metadata_controller_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_metadata', type
         expect(group_contact.additional_attributes['description']).to eq('Updated Desc')
       end
 
+      # Turning groups off strips the capability and hides the panel, but this endpoint
+      # stays routable, and the refusal it now raises has to render as the same JSON
+      # error the rest of the group API returns rather than as a 500.
+      it 'returns 422 when the provider cannot do what was asked' do
+        allow(baileys_service).to receive(:update_group_subject)
+          .and_raise(Whatsapp::Session::Errors::NotSupported, 'groups are disabled on this installation')
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_metadata",
+              params: { subject: 'New Name' },
+              headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to include('groups are disabled')
+      end
+
       it 'returns 422 when provider is unavailable' do
         allow(baileys_service).to receive(:update_group_subject)
           .and_raise(Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError, 'Offline')

--- a/spec/controllers/api/v1/accounts/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/groups_controller_spec.rb
@@ -52,6 +52,21 @@ RSpec.describe '/api/v1/accounts/{account.id}/groups', type: :request do
         expect(response.parsed_body['error']).to eq('Unavailable')
       end
 
+      # A blank participant reaches the session layer as `@s.whatsapp.net`, which Address
+      # refuses. That is client input, not a provider being down, and it used to leave the
+      # endpoint as the only one in the group family answering a 500 to a bad request.
+      it 'returns 422 when a participant is not an address' do
+        allow(create_service).to receive(:perform)
+          .and_raise(Whatsapp::Session::Errors::InvalidPayload, 'unknown whatsapp jid: @s.whatsapp.net')
+
+        post "/api/v1/accounts/#{account.id}/groups",
+             params: { inbox_id: inbox.id, subject: 'Test Group', participants: [''] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to include('@s.whatsapp.net')
+      end
+
       it 'returns 403 when agent does not have inbox access' do
         other_inbox = create(:inbox, account: account)
 

--- a/spec/jobs/whatsapp/session/logout_job_spec.rb
+++ b/spec/jobs/whatsapp/session/logout_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Whatsapp::Session::LogoutJob do
   let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
   let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
 
-  before { allow(channel).to receive(:provider_service).and_return(backend) }
+  before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
 
   it 'asks the session to end' do
     described_class.perform_now(channel)

--- a/spec/jobs/whatsapp/session/logout_job_spec.rb
+++ b/spec/jobs/whatsapp/session/logout_job_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe Whatsapp::Session::LogoutJob do
   let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
   let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
 
-  before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
+  before do
+    allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend)
+    # The quarantine is the whole reason this job is ever enqueued.
+    channel.update_provider_connection!({ 'connection' => 'close', 'error_code' => 'wrong_phone_number' })
+  end
 
   it 'asks the session to end' do
     described_class.perform_now(channel)
@@ -25,5 +29,16 @@ RSpec.describe Whatsapp::Session::LogoutJob do
     allow(backend).to receive(:logout).and_raise(Whatsapp::Session::Errors::NotSupported)
 
     expect { described_class.new.perform(channel) }.not_to raise_error
+  end
+
+  # A retry of this job can run minutes after the rejection that queued it. By then the
+  # administrator may have corrected the number and paired again, and logging out would
+  # kill the session that replaced the one this was sent to remove.
+  it 'does nothing once the inbox is no longer disowned' do
+    channel.update_provider_connection!({ 'connection' => 'open', 'phone_number' => '5541988887777' })
+
+    described_class.perform_now(channel)
+
+    expect(backend.commands_of('session.logout')).to be_empty
   end
 end

--- a/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
+++ b/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Whatsapp::Session::MediaFetchJob do
                               ref: model::MediaRef.url('https://connector.test/media/abc'))
   end
 
-  before { allow(inbox.channel).to receive(:provider_service).and_return(backend) }
+  before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
 
   it 'attaches the bytes it downloaded' do
     described_class.perform_now(message, media.to_h)

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe Whatsapp::Session::PairingPollJob do
     expect(channel.reload.provider_connection['connection']).to eq('open')
   end
 
+  # Keeping the token on a settled state leaves this chain looking current: a duplicate
+  # delivery of the job would poll a session that already opened, and write
+  # `connect_failure` over it if that request happened to fail.
+  it 'retires its token once the pairing has settled' do
+    channel.update_provider_connection!({ 'connection' => 'connecting', 'pairing_attempt' => 'attempt-1' })
+    allow(backend).to receive(:fetch_connection_state).and_return(state('open', phone_number: '5541988887777'))
+
+    described_class.perform_now(channel, pairing: 'qr', attempt: 'attempt-1')
+
+    expect(channel.reload.provider_connection).not_to have_key('pairing_attempt')
+  end
+
   # The poll writes state without ever passing through an event handler, so it used to be
   # a way around the ownership check: a missed webhook and a polled `open` was enough to
   # put the inbox back to work on the account the operator scanned by mistake.

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -59,6 +59,23 @@ RSpec.describe Whatsapp::Session::PairingPollJob do
     expect do
       described_class.perform_now(channel, pairing: 'qr', deadline_at: 10.seconds.from_now)
     end.not_to have_enqueued_job(described_class)
+
+    # And says so, rather than leaving the dashboard on the code that just expired.
+    expect(channel.reload.provider_connection).to include(
+      'connection' => 'close', 'error_code' => 'pairing_timed_out'
+    )
+  end
+
+  # A poll sits in the queue for fifteen seconds at a time. An inbox converted in that
+  # window is a different provider by the time the job runs, and polling it would write
+  # this pairing's outcome onto a session that has nothing to do with it.
+  it 'does nothing once the inbox has been converted to another provider' do
+    allow(backend).to receive(:fetch_connection_state).and_return(state('connecting'))
+
+    described_class.perform_now(channel, pairing: 'qr', provider: 'native')
+
+    expect(backend).not_to have_received(:fetch_connection_state)
+    expect(channel.reload.provider_connection).to eq({})
   end
 
   it 'gives a pairing code longer than a QR, since the operator has to type it' do

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -125,6 +125,21 @@ RSpec.describe Whatsapp::Session::PairingPollJob do
     expect(described_class::DEADLINES['code']).to be > described_class::DEADLINES['qr']
   end
 
+  # A resume never put a code on screen. Holding it to the QR ceiling cuts the poll two
+  # minutes into a reconnection the provider is still working on, and then tells the
+  # operator that a code they never saw expired.
+  it 'holds a resume to its own ceiling and reports it for what it is' do
+    expect(described_class::DEADLINES['resume']).to be > described_class::DEADLINES['qr']
+
+    allow(backend).to receive(:fetch_connection_state).and_return(state('reconnecting'))
+
+    expect do
+      described_class.perform_now(channel, pairing: 'resume', deadline_at: 10.seconds.from_now)
+    end.not_to have_enqueued_job(described_class)
+
+    expect(channel.reload.provider_connection).to include('connection' => 'close', 'error_code' => 'connect_failure')
+  end
+
   it 'does not poll a backend that pushes its own state' do
     allow(backend.class).to receive(:state_polling?).and_return(false)
     allow(backend).to receive(:fetch_connection_state)

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -74,9 +74,15 @@ RSpec.describe Whatsapp::Session::PairingPollJob do
     expect(backend).not_to have_received(:fetch_connection_state)
   end
 
-  it 'gives up quietly when the instance is unreachable mid-pairing' do
+  # Quietly for the job, not for the operator: leaving the state untouched parks the
+  # dashboard on a QR that expired minutes ago, waiting for a rotation that never comes.
+  it 'says on the screen that the pairing failed instead of leaving a dead QR up' do
+    channel.update_provider_connection!({ 'connection' => 'connecting', 'qr_data_url' => 'data:image/png;base64,OLD' })
     allow(backend).to receive(:fetch_connection_state).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)
 
     expect { described_class.perform_now(channel) }.not_to raise_error
+
+    expect(channel.reload.provider_connection).to include('connection' => 'close', 'error_code' => 'connect_failure')
+    expect(channel.provider_connection).not_to have_key('qr_data_url')
   end
 end

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::PairingPollJob do
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'uazapi', validate_provider_config: false, sync_templates: false)
+  end
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+
+  before do
+    allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend)
+    allow(backend.class).to receive(:state_polling?).and_return(true)
+  end
+
+  def state(connection, **attrs)
+    Whatsapp::Session::Model::ConnectionState.new(connection: connection, **attrs)
+  end
+
+  it 'writes the rotated QR and asks for another round while the session is still connecting' do
+    allow(backend).to receive(:fetch_connection_state).and_return(state('connecting', qr_data_url: 'data:image/png;base64,ROTATED'))
+
+    expect { described_class.perform_now(channel) }.to have_enqueued_job(described_class)
+    expect(channel.reload.provider_connection['qr_data_url']).to eq('data:image/png;base64,ROTATED')
+  end
+
+  it 'stops as soon as the session is paired' do
+    allow(backend).to receive(:fetch_connection_state).and_return(state('open', phone_number: '5541988887777'))
+
+    expect { described_class.perform_now(channel) }.not_to have_enqueued_job(described_class)
+    expect(channel.reload.provider_connection['connection']).to eq('open')
+  end
+
+  it 'stops at the ceiling instead of polling a pairing nobody completed' do
+    allow(backend).to receive(:fetch_connection_state).and_return(state('connecting'))
+
+    expect do
+      described_class.perform_now(channel, pairing: 'qr', deadline_at: 10.seconds.from_now)
+    end.not_to have_enqueued_job(described_class)
+  end
+
+  it 'gives a pairing code longer than a QR, since the operator has to type it' do
+    expect(described_class::DEADLINES['code']).to be > described_class::DEADLINES['qr']
+  end
+
+  it 'does not poll a backend that pushes its own state' do
+    allow(backend.class).to receive(:state_polling?).and_return(false)
+    allow(backend).to receive(:fetch_connection_state)
+
+    described_class.perform_now(channel)
+
+    expect(backend).not_to have_received(:fetch_connection_state)
+  end
+
+  it 'gives up quietly when the instance is unreachable mid-pairing' do
+    allow(backend).to receive(:fetch_connection_state).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)
+
+    expect { described_class.perform_now(channel) }.not_to raise_error
+  end
+end

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Whatsapp::Session::PairingPollJob do
   let(:channel) do
-    create(:channel_whatsapp, provider: 'uazapi', validate_provider_config: false, sync_templates: false)
+    create(:channel_whatsapp, provider: 'uazapi', phone_number: '+5541988887777',
+                              validate_provider_config: false, sync_templates: false)
   end
   let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
 
@@ -36,6 +37,20 @@ RSpec.describe Whatsapp::Session::PairingPollJob do
 
     expect { described_class.perform_now(channel) }.not_to have_enqueued_job(described_class)
     expect(channel.reload.provider_connection['connection']).to eq('open')
+  end
+
+  # The poll writes state without ever passing through an event handler, so it used to be
+  # a way around the ownership check: a missed webhook and a polled `open` was enough to
+  # put the inbox back to work on the account the operator scanned by mistake.
+  it 'refuses a polled state that reports a number this inbox is not configured for' do
+    allow(backend).to receive(:fetch_connection_state).and_return(state('open', phone_number: '5541900001111'))
+
+    described_class.perform_now(channel)
+
+    expect(channel.reload.provider_connection).to include(
+      'connection' => 'close', 'error_code' => 'wrong_phone_number'
+    )
+    expect(Whatsapp::Session::LogoutJob).to have_been_enqueued
   end
 
   it 'stops at the ceiling instead of polling a pairing nobody completed' do

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -78,6 +78,20 @@ RSpec.describe Whatsapp::Session::PairingPollJob do
     expect(channel.reload.provider_connection).to eq({})
   end
 
+  # A rotated QR, a pairing code or a connecting state arrives without the token, and the
+  # writer replaces the whole hash: dropping it there retires the chain that is driving
+  # the very screen those events update, and the code stops rotating.
+  it 'keeps polling after an event about the same attempt lands' do
+    channel.update_provider_connection!({ 'connection' => 'connecting', 'pairing_attempt' => 'attempt-1' })
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(
+      Whatsapp::Session::Model::ConnectionState.new(connection: 'connecting', qr_data_url: 'data:image/png;base64,ROTATED')
+    )
+    allow(backend).to receive(:fetch_connection_state).and_return(state('connecting'))
+
+    expect { described_class.perform_now(channel.reload, pairing: 'qr', attempt: 'attempt-1') }
+      .to have_enqueued_job(described_class)
+  end
+
   # Connecting twice leaves two chains running. The older one keeps its earlier deadline,
   # and without knowing which attempt it belongs to it would time out over the QR the
   # operator is looking at right now.

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe Whatsapp::Session::PairingPollJob do
     expect(channel.reload.provider_connection['qr_data_url']).to eq('data:image/png;base64,ROTATED')
   end
 
+  # `reconnecting` is the provider still working on it, which is when the poll is most
+  # needed: the code keeps rotating and the push that would carry it is exactly what
+  # this job stands in for.
+  it 'keeps polling while the provider reports it is reconnecting' do
+    allow(backend).to receive(:fetch_connection_state).and_return(state('reconnecting'))
+
+    expect { described_class.perform_now(channel) }.to have_enqueued_job(described_class)
+  end
+
   it 'stops as soon as the session is paired' do
     allow(backend).to receive(:fetch_connection_state).and_return(state('open', phone_number: '5541988887777'))
 

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -78,6 +78,23 @@ RSpec.describe Whatsapp::Session::PairingPollJob do
     expect(channel.reload.provider_connection).to eq({})
   end
 
+  # Connecting twice leaves two chains running. The older one keeps its earlier deadline,
+  # and without knowing which attempt it belongs to it would time out over the QR the
+  # operator is looking at right now.
+  it 'lets a newer pairing attempt retire the older chain' do
+    channel.update_provider_connection!(
+      { 'connection' => 'connecting', 'qr_data_url' => 'data:image/png;base64,NEW', 'pairing_attempt' => 'attempt-2' }
+    )
+    allow(backend).to receive(:fetch_connection_state).and_return(state('connecting'))
+
+    described_class.perform_now(channel, pairing: 'qr', deadline_at: 10.seconds.from_now, attempt: 'attempt-1')
+
+    expect(backend).not_to have_received(:fetch_connection_state)
+    expect(channel.reload.provider_connection).to include(
+      'connection' => 'connecting', 'qr_data_url' => 'data:image/png;base64,NEW'
+    )
+  end
+
   it 'gives a pairing code longer than a QR, since the operator has to type it' do
     expect(described_class::DEADLINES['code']).to be > described_class::DEADLINES['qr']
   end

--- a/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
+++ b/spec/jobs/whatsapp/session/pairing_poll_job_spec.rb
@@ -104,6 +104,27 @@ RSpec.describe Whatsapp::Session::PairingPollJob do
       .to have_enqueued_job(described_class)
   end
 
+  # `current?` runs before the provider is asked; the second connect lands after it and
+  # before the write. Without the fence this chain's QR replaces the one on screen and
+  # puts its own token back on the record, which retires the chain that is actually
+  # driving the pairing.
+  it 'refuses to write once a newer attempt has claimed the pairing' do
+    channel.update_provider_connection!({ 'connection' => 'connecting', 'pairing_attempt' => 'attempt-1' })
+    allow(backend).to receive(:fetch_connection_state).and_return(state('connecting', qr_data_url: 'data:image/png;base64,OLDER'))
+    allow(Whatsapp::Session::ConnectionStateWriter).to receive(:new).and_wrap_original do |original, argument|
+      channel.update_provider_connection!(
+        { 'connection' => 'connecting', 'qr_data_url' => 'data:image/png;base64,NEWER', 'pairing_attempt' => 'attempt-2' }
+      )
+      original.call(argument)
+    end
+
+    described_class.perform_now(channel, pairing: 'qr', attempt: 'attempt-1')
+
+    expect(channel.reload.provider_connection).to include(
+      'qr_data_url' => 'data:image/png;base64,NEWER', 'pairing_attempt' => 'attempt-2'
+    )
+  end
+
   # Connecting twice leaves two chains running. The older one keeps its earlier deadline,
   # and without knowing which attempt it belongs to it would time out over the QR the
   # operator is looking at right now.

--- a/spec/jobs/whatsapp/session/update_contact_avatar_job_spec.rb
+++ b/spec/jobs/whatsapp/session/update_contact_avatar_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Whatsapp::Session::UpdateContactAvatarJob do
   let(:contact) { create(:contact, account: channel.account, phone_number: '+5541999990000') }
   let(:party) { model::Party.new(phone: '5541999990000', lid: '182736451928374') }
 
-  before { allow(inbox.channel).to receive(:provider_service).and_return(backend) }
+  before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
 
   # The command declares an Address and is built with `new`, which runs no coercion, so
   # handing it a Party would put the wrong shape on the wire and every backend reading

--- a/spec/jobs/whatsapp/session/update_group_avatar_job_spec.rb
+++ b/spec/jobs/whatsapp/session/update_group_avatar_job_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Whatsapp::Session::UpdateGroupAvatarJob do
 
   before do
     create(:contact_inbox, inbox: inbox, contact: group_contact, source_id: '120363041234567890')
-    allow(channel).to receive(:provider_service).and_return(backend)
+    allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend)
     allow(backend).to receive(:group_info).and_return(info)
   end
 

--- a/spec/models/internal_chat/channel_spec.rb
+++ b/spec/models/internal_chat/channel_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe InternalChat::Channel do
+  # Named rather than taken from `described_class`, which RSpec captured when this file
+  # loaded: a reload later in the run replaces the class, and the old object's relations
+  # no longer resolve to what the factories build. `ActiveRecord::Base#==` compares
+  # `instance_of?(self.class)`, so the rows come back right and still fail to match.
+  subject { InternalChat::Channel.new } # rubocop:disable RSpec/DescribedClass
+
   describe 'associations' do
     it { is_expected.to belong_to(:account) }
     it { is_expected.to belong_to(:category).class_name('InternalChat::Category').optional }
@@ -54,6 +60,7 @@ RSpec.describe InternalChat::Channel do
     end
   end
 
+  # rubocop:disable RSpec/DescribedClass -- see the note on `subject` above
   describe 'scopes' do
     let(:account) { create(:account) }
     let!(:active_public) { create(:internal_chat_channel, account: account, channel_type: :public_channel, status: :active) }
@@ -63,32 +70,33 @@ RSpec.describe InternalChat::Channel do
 
     describe '.active' do
       it 'returns only active channels' do
-        expect(described_class.active).to include(active_public, active_private, active_dm)
-        expect(described_class.active).not_to include(archived_channel)
+        expect(InternalChat::Channel.active).to include(active_public, active_private, active_dm)
+        expect(InternalChat::Channel.active).not_to include(archived_channel)
       end
     end
 
     describe '.archived' do
       it 'returns only archived channels' do
-        expect(described_class.archived).to include(archived_channel)
-        expect(described_class.archived).not_to include(active_public, active_private, active_dm)
+        expect(InternalChat::Channel.archived).to include(archived_channel)
+        expect(InternalChat::Channel.archived).not_to include(active_public, active_private, active_dm)
       end
     end
 
     describe '.text_channels' do
       it 'returns public and private channels but not DMs' do
-        expect(described_class.text_channels).to include(active_public, active_private, archived_channel)
-        expect(described_class.text_channels).not_to include(active_dm)
+        expect(InternalChat::Channel.text_channels).to include(active_public, active_private, archived_channel)
+        expect(InternalChat::Channel.text_channels).not_to include(active_dm)
       end
     end
 
     describe '.direct_messages' do
       it 'returns only DM channels' do
-        expect(described_class.direct_messages).to include(active_dm)
-        expect(described_class.direct_messages).not_to include(active_public, active_private, archived_channel)
+        expect(InternalChat::Channel.direct_messages).to include(active_dm)
+        expect(InternalChat::Channel.direct_messages).not_to include(active_public, active_private, archived_channel)
       end
     end
   end
+  # rubocop:enable RSpec/DescribedClass
 
   describe '#dm?' do
     it 'returns true for DM channels' do

--- a/spec/services/whatsapp/session/connection_state_writer_spec.rb
+++ b/spec/services/whatsapp/session/connection_state_writer_spec.rb
@@ -45,6 +45,44 @@ RSpec.describe Whatsapp::Session::ConnectionStateWriter do
     expect(channel.reload.provider_connection).to include('connection' => 'close', 'epoch' => 5)
   end
 
+  describe 'writes fenced to the caller they came from' do
+    # The connect and the poll both read the record, ask the provider and then write, and
+    # a second connect claiming the pairing lands in that gap. Checking before the call
+    # cannot see it; the fence is read inside the lock that does the write.
+    it 'refuses a write whose pairing attempt the record has moved past' do
+      channel.update_provider_connection!({ 'connection' => 'connecting', 'pairing_attempt' => 'attempt-2' })
+
+      result = writer.apply(state.new(connection: 'connecting', qr_data_url: 'data:image/png;base64,OLD'), attempt: 'attempt-1')
+
+      expect(result).to eq(:stale)
+      expect(channel.reload.provider_connection).not_to have_key('qr_data_url')
+    end
+
+    # The token is only ever absent once the attempt it named is over, so a write still
+    # carrying one is answering about a pairing that has already ended.
+    it 'refuses a write for an attempt the record no longer names' do
+      channel.update_provider_connection!({ 'connection' => 'open', 'phone_number' => '5541988887777' })
+
+      result = writer.apply(state.new(connection: 'connecting'), attempt: 'attempt-1')
+
+      expect(result).to eq(:stale)
+      expect(channel.reload.provider_connection).to include('connection' => 'open')
+    end
+
+    # An inbox converted mid-connect has an empty record belonging to another provider,
+    # and the old backend's answer would land in it as a QR nobody can scan.
+    it 'refuses a write from the provider the inbox used to be on' do
+      result = writer.apply(state.new(connection: 'connecting', qr_data_url: 'data:image/png;base64,OLD'), provider: 'uazapi')
+
+      expect(result).to eq(:stale)
+      expect(channel.reload.provider_connection).to eq({})
+    end
+
+    it 'writes when the inbox is still on the provider the caller was built for' do
+      expect(writer.apply(state.new(connection: 'connecting'), provider: 'baileys')).to eq(:written)
+    end
+  end
+
   it 'does not rewrite an unchanged state' do
     writer.apply(state.new(connection: 'open', epoch: 1))
 

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -107,6 +107,19 @@ RSpec.describe Whatsapp::Session::Facade do
     expect(channel.reload.provider_connection).to include('connection' => 'close', 'error_code' => 'connect_failure')
   end
 
+  # Two operators, or two tabs: one converts the inbox while the other clicks connect.
+  # The facade holds the backend of the provider it was built for, and the record now
+  # belongs to another one, so connecting would leave a session behind that no inbox owns
+  # and no operator can see.
+  it 'does not connect an inbox that was converted while the request was running' do
+    facade = channel.provider_service
+    channel.update_columns(provider: 'uazapi') # rubocop:disable Rails/SkipsModelValidations
+
+    expect(facade.setup_channel_provider).to be_nil
+    expect(backend.commands).to be_empty
+    expect(channel.reload.provider_connection).to eq({})
+  end
+
   # The ceiling belongs to the attempt, not to the worker: a QR lives two minutes from
   # the moment the provider issued it, and a queue running ten minutes late would give
   # that dead code two more minutes of polling.

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe Whatsapp::Session::Facade do
   before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
 
   it 'is what a session channel answers with' do
-    expect(facade).to be_a(described_class)
+    # Named rather than `described_class`, which RSpec captured when this file loaded: a
+    # reload replaces the class, the channel builds an instance of the new one, and the
+    # identity check fails on a facade that is perfectly correct.
+    expect(facade).to be_a(Whatsapp::Session::Facade) # rubocop:disable RSpec/DescribedClass
     expect(channel.session_backend).to eq(backend)
   end
 
@@ -184,6 +187,63 @@ RSpec.describe Whatsapp::Session::Facade do
         [{ 'jid' => '182736451928374@lid', 'phone_number' => '5541999990000', 'request_time' => 1_755_440_000 }]
       )
     end
+  end
+
+  # The schema types `calls` as an object, so a boolean makes the whole connect command
+  # invalid and the session never pairs. `false` is not a value it accepts either, which
+  # is why a backend without the capability sends nothing at all.
+  it 'describes the call policy the way the contract types it' do
+    channel.setup_channel_provider
+    expect(backend.last_command.calls).to be_nil
+
+    allow(channel).to receive(:session_capabilities).and_return(%w[calls])
+    channel.provider_service.setup_channel_provider
+
+    expect(backend.last_command.calls).to eq({ 'auto_reject' => true })
+  end
+
+  # The channel calls this from before_destroy and from convert_provider!, so it is a
+  # teardown: the Baileys service answers it with DELETE /connections/<phone>. Only
+  # disconnecting leaves the pairing alive on the provider under a session id Chatwoot
+  # has just thrown away.
+  it 'deletes the session when the inbox is torn down' do
+    channel.disconnect_channel_provider
+
+    expect(backend.commands_of('session.delete')).to be_present
+  end
+
+  # Chatwoot availability is online/offline/busy; the contract knows available and
+  # unavailable. The Baileys service maps them, and this used to forward them raw.
+  it 'maps account availability onto the two states the contract accepts' do
+    channel.update_presence('online')
+    expect(backend.last_command.state).to eq('available')
+
+    channel.update_presence('busy')
+    expect(backend.last_command.state).to eq('unavailable')
+  end
+
+  it 'subscribes to presence with an address, which is what the command carries' do
+    facade.presence_subscribe(['182736451928374@lid'])
+
+    expect(backend.last_command.party).to be_a(Whatsapp::Session::Model::Address)
+    expect(backend.last_command.party.id).to eq('182736451928374')
+  end
+
+  # A close does not un-pair anything: the provider still holds the credentials, so the
+  # next connect resumes. Losing the number to a transient disconnect cost a fresh scan.
+  it 'resumes after a transient close, and asks for a QR after a logout' do
+    channel.update_provider_connection!({ 'connection' => 'open', 'phone_number' => '5541988887777' })
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(
+      Whatsapp::Session::Model::ConnectionState.new(connection: 'close', error: 'connection_closed')
+    )
+    channel.reload.provider_service.setup_channel_provider
+    expect(backend.last_command.pairing).to eq('resume')
+
+    Whatsapp::Session::ConnectionStateWriter.new(channel).apply(
+      Whatsapp::Session::Model::ConnectionState.new(connection: 'close', error: 'logged_out')
+    )
+    channel.reload.provider_service.setup_channel_provider
+    expect(backend.last_command.pairing).to eq('qr')
   end
 
   it 'connects with a QR when the session was never paired, and resumes afterwards' do

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -1,0 +1,170 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Facade do
+  subject(:facade) { channel.provider_service }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+  let(:contact) { create(:contact, account: channel.account, phone_number: '+5541999990000', identifier: '182736451928374@lid') }
+  let(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox, source_id: '182736451928374') }
+  let(:conversation) { create(:conversation, contact: contact, contact_inbox: contact_inbox, inbox: inbox, account: channel.account) }
+
+  before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
+
+  it 'is what a session channel answers with' do
+    expect(facade).to be_a(described_class)
+    expect(channel.session_backend).to eq(backend)
+  end
+
+  describe 'read receipts' do
+    it 'marks the stored messages read on WhatsApp' do
+      message = create(:message, conversation: conversation, inbox: inbox, account: channel.account, source_id: '3EB0AAAA')
+
+      channel.read_messages([message], conversation: conversation)
+
+      expect(backend.last_command.message_ids).to eq(['3EB0AAAA'])
+      expect(backend.last_command.chat.id).to eq('182736451928374')
+    end
+
+    it 'stays quiet when the inbox turned mark_as_read off' do
+      channel.update!(provider_config: channel.provider_config.merge('mark_as_read' => false))
+      message = create(:message, conversation: conversation, inbox: inbox, account: channel.account, source_id: '3EB0AAAA')
+
+      channel.read_messages([message], conversation: conversation)
+
+      expect(backend.commands).to be_empty
+    end
+  end
+
+  it 'maps a typing indicator to the chat presence the provider expects' do
+    channel.toggle_typing_status(Events::Types::CONVERSATION_RECORDING, conversation: conversation)
+
+    expect(backend.last_command.state).to eq('recording')
+  end
+
+  it 'answers the on_whatsapp check in the shape the contact builder reads' do
+    response = channel.on_whatsapp('+5541999990000')
+
+    expect(response).to eq({ 'jid' => '5541999990000@s.whatsapp.net', 'exists' => true })
+  end
+
+  it 'reports the group it created with the key the create service reads' do
+    group = channel.create_group('Equipe', ['5541999990000@s.whatsapp.net'])
+
+    expect(group[:id]).to end_with('@g.us')
+    expect(backend.last_command.participants.map(&:id)).to eq(['5541999990000'])
+  end
+
+  it 'refuses a group setting it has no name for' do
+    expect { channel.group_setting_update('120363041234567890@g.us', 'teleport', true) }
+      .to raise_error(Whatsapp::Session::Errors::InvalidPayload)
+  end
+
+  it 'translates a group settings toggle into the contract name' do
+    channel.group_member_add_mode('120363041234567890@g.us', 'all_member_add')
+
+    expect(backend.last_command.setting).to eq('member_add_mode')
+    expect(backend.last_command.value).to be(true)
+  end
+
+  it 'refuses to address a group by anything but a group jid' do
+    expect { channel.group_leave('5541999990000@s.whatsapp.net') }
+      .to raise_error(Whatsapp::Session::Errors::InvalidPayload)
+  end
+
+  # The factory neutralizes Channel::Whatsapp#sync_templates, so the facade is asked directly.
+  it 'has no templates to sync or to send' do
+    expect(facade.sync_templates).to be(true)
+    expect { channel.send_template('5541999990000', {}) }.to raise_error(Whatsapp::Session::Errors::NotSupported)
+  end
+
+  it 'persists the state the connect answered with, which is what carries the QR' do
+    channel.setup_channel_provider
+
+    expect(channel.reload.provider_connection).to include('connection' => 'connecting')
+    expect(channel.provider_connection['qr_data_url']).to be_present
+  end
+
+  it 'starts the pairing poll only for a backend that has to be polled' do
+    expect { channel.setup_channel_provider }.not_to have_enqueued_job(Whatsapp::Session::PairingPollJob)
+
+    allow(backend.class).to receive(:state_polling?).and_return(true)
+
+    expect { channel.provider_service.setup_channel_provider }
+      .to have_enqueued_job(Whatsapp::Session::PairingPollJob).with(channel, pairing: 'qr')
+  end
+
+  # The inbound layer keeps an inbox paired with the wrong number quarantined, and no
+  # event lifts that on its own: a state that names no number is refused precisely so a
+  # pending logout cannot clear it. Connecting again is the operator's way out, so it
+  # has to be the thing that clears it, or fixing the configured number changes nothing.
+  it 'lifts a wrong-number quarantine when the operator connects again' do
+    channel.update_provider_connection!(
+      { 'connection' => 'close', 'error_code' => 'wrong_phone_number',
+        'error' => I18n.t('errors.inboxes.channel.provider_connection.wrong_phone_number') }
+    )
+
+    channel.provider_service.setup_channel_provider
+
+    expect(channel.reload.provider_connection).to include('connection' => 'connecting')
+    expect(channel.provider_connection).not_to have_key('error_code')
+  end
+
+  describe 'the group half' do
+    let(:group_jid) { '120363041234567890@g.us' }
+
+    it 'answers group creation in the shape Groups::CreateService reads' do
+      result = facade.create_group('Equipe de Vendas', ['5541999990000@s.whatsapp.net'])
+
+      expect(result).to eq({ id: '120363040000000001@g.us', subject: 'Equipe de Vendas' })
+      expect(backend.last_command.subject).to eq('Equipe de Vendas')
+    end
+
+    it 'refuses a recipient that is not a group rather than addressing a person' do
+      expect { facade.group_leave('5541999990000@s.whatsapp.net') }
+        .to raise_error(Whatsapp::Session::Errors::InvalidPayload, /not a group/)
+      expect(backend.commands).to be_empty
+    end
+
+    it 'translates the dashboard setting names into contract ones' do
+      facade.group_setting_update(group_jid, 'restrict', true)
+
+      expect(backend.last_command.setting).to eq('locked')
+      expect(backend.last_command.value).to be(true)
+    end
+
+    it 'refuses a setting the contract has no name for' do
+      expect { facade.group_setting_update(group_jid, 'whatever', true) }
+        .to raise_error(Whatsapp::Session::Errors::InvalidPayload, /unknown group setting/)
+    end
+
+    it 'asks for a fresh invite link when revoking the current one' do
+      facade.group_invite_code(group_jid)
+      expect(backend.last_command.revoke).to be(false)
+
+      facade.revoke_group_invite(group_jid)
+      expect(backend.last_command.revoke).to be(true)
+    end
+
+    it 'renders a join request with the keys the dashboard already reads' do
+      allow(backend).to receive(:group_join_requests).and_return(
+        [{ 'party' => { 'phone' => '5541999990000', 'lid' => '182736451928374' }, 'requested_at' => 1_755_440_000 }]
+      )
+
+      expect(facade.group_join_requests(group_jid)).to eq(
+        [{ 'jid' => '182736451928374@lid', 'phone_number' => '5541999990000', 'request_time' => 1_755_440_000 }]
+      )
+    end
+  end
+
+  it 'connects with a QR when the session was never paired, and resumes afterwards' do
+    channel.setup_channel_provider
+    expect(backend.last_command.pairing).to eq('qr')
+
+    channel.update_provider_connection!({ 'connection' => 'open', 'phone_number' => '5541988887777' })
+    channel.provider_service.setup_channel_provider
+
+    expect(backend.last_command.pairing).to eq('resume')
+  end
+end

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -52,30 +52,6 @@ RSpec.describe Whatsapp::Session::Facade do
     expect(response).to eq({ 'jid' => '5541999990000@s.whatsapp.net', 'exists' => true })
   end
 
-  it 'reports the group it created with the key the create service reads' do
-    group = channel.create_group('Equipe', ['5541999990000@s.whatsapp.net'])
-
-    expect(group[:id]).to end_with('@g.us')
-    expect(backend.last_command.participants.map(&:id)).to eq(['5541999990000'])
-  end
-
-  it 'refuses a group setting it has no name for' do
-    expect { channel.group_setting_update('120363041234567890@g.us', 'teleport', true) }
-      .to raise_error(Whatsapp::Session::Errors::InvalidPayload)
-  end
-
-  it 'translates a group settings toggle into the contract name' do
-    channel.group_member_add_mode('120363041234567890@g.us', 'all_member_add')
-
-    expect(backend.last_command.setting).to eq('member_add_mode')
-    expect(backend.last_command.value).to be(true)
-  end
-
-  it 'refuses to address a group by anything but a group jid' do
-    expect { channel.group_leave('5541999990000@s.whatsapp.net') }
-      .to raise_error(Whatsapp::Session::Errors::InvalidPayload)
-  end
-
   # The factory neutralizes Channel::Whatsapp#sync_templates, so the facade is asked directly.
   it 'has no templates to sync or to send' do
     expect(facade.sync_templates).to be(true)
@@ -94,8 +70,10 @@ RSpec.describe Whatsapp::Session::Facade do
 
     allow(backend.class).to receive(:state_polling?).and_return(true)
 
+    # The attempt token is generated per connect, so it is matched by shape, not value.
     expect { channel.provider_service.setup_channel_provider }
-      .to have_enqueued_job(Whatsapp::Session::PairingPollJob).with(channel, pairing: 'qr')
+      .to have_enqueued_job(Whatsapp::Session::PairingPollJob)
+      .with(channel, hash_including(pairing: 'qr', provider: 'native'))
   end
 
   # The inbound layer keeps an inbox paired with the wrong number quarantined, and no
@@ -163,7 +141,48 @@ RSpec.describe Whatsapp::Session::Facade do
   end
 
   describe 'the group half' do
+    subject(:facade) { channel.provider_service }
+
     let(:group_jid) { '120363041234567890@g.us' }
+
+    around { |example| with_modified_env(WHATSAPP_GROUPS_ENABLED: 'true') { example.run } }
+
+    it 'reports the group it created with the key the create service reads' do
+      group = channel.create_group('Equipe', ['5541999990000@s.whatsapp.net'])
+
+      expect(group[:id]).to end_with('@g.us')
+      expect(backend.last_command.participants.map(&:id)).to eq(['5541999990000'])
+    end
+
+    it 'refuses a group setting it has no name for' do
+      expect { channel.group_setting_update('120363041234567890@g.us', 'teleport', true) }
+        .to raise_error(Whatsapp::Session::Errors::InvalidPayload)
+    end
+
+    it 'translates a group settings toggle into the contract name' do
+      channel.group_member_add_mode('120363041234567890@g.us', 'all_member_add')
+
+      expect(backend.last_command.setting).to eq('member_add_mode')
+      expect(backend.last_command.value).to be(true)
+    end
+
+    it 'refuses to address a group by anything but a group jid' do
+      expect { channel.group_leave('5541999990000@s.whatsapp.net') }
+        .to raise_error(Whatsapp::Session::Errors::InvalidPayload)
+    end
+
+    # The dashboard hides the group panel when the switch is off, but the endpoints behind
+    # it stay routable, so the switch has to hold where the calls land.
+    it 'refuses every group operation while the installation has groups off' do
+      with_modified_env WHATSAPP_GROUPS_ENABLED: 'false' do
+        expect { channel.provider_service.group_leave(group_jid) }
+          .to raise_error(Whatsapp::Session::Errors::NotSupported, /groups are disabled/)
+        expect { channel.provider_service.create_group('Equipe', []) }
+          .to raise_error(Whatsapp::Session::Errors::NotSupported, /groups are disabled/)
+      end
+
+      expect(backend.commands).to be_empty
+    end
 
     it 'answers group creation in the shape Groups::CreateService reads' do
       result = facade.create_group('Equipe de Vendas', ['5541999990000@s.whatsapp.net'])

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -132,6 +132,21 @@ RSpec.describe Whatsapp::Session::Facade do
     )
   end
 
+  # A resume answers `open` when the pairing is still good. There is nothing left to poll
+  # then, and a chain started over it would look current forever: the first request that
+  # failed would write `connect_failure` over a healthy connection.
+  it 'starts no poll for a connect that came back already paired' do
+    allow(backend.class).to receive(:state_polling?).and_return(true)
+    allow(backend).to receive(:connect).and_return(
+      Whatsapp::Session::Model::ConnectionState.new(connection: 'open', phone_number: channel.phone_number.delete('+'))
+    )
+
+    expect { channel.setup_channel_provider }.not_to have_enqueued_job(Whatsapp::Session::PairingPollJob)
+
+    expect(channel.reload.provider_connection).to include('connection' => 'open')
+    expect(channel.provider_connection).not_to have_key('pairing_attempt')
+  end
+
   # The inbound layer keeps an inbox paired with the wrong number quarantined, and no
   # event lifts that on its own: a state that names no number is refused precisely so a
   # pending logout cannot clear it. Connecting again is the operator's way out, so it

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -140,6 +140,28 @@ RSpec.describe Whatsapp::Session::Facade do
     end
   end
 
+  # A receipt on WhatsApp is addressed by the message key, and in a group that key
+  # includes who sent it: one command covering several senders cannot be acknowledged.
+  it 'marks a group read one participant at a time' do
+    group = create(:contact, account: channel.account, identifier: '120363041234567890@g.us', group_type: :group)
+    group_inbox = create(:contact_inbox, contact: group, inbox: inbox, source_id: '120363041234567890')
+    group_conversation = create(:conversation, contact: group, contact_inbox: group_inbox, inbox: inbox, account: channel.account)
+    ana = create(:contact, account: channel.account, phone_number: '+5541999991111')
+    bruno = create(:contact, account: channel.account, phone_number: '+5541999992222')
+    messages = [
+      create(:message, conversation: group_conversation, inbox: inbox, account: channel.account,
+                       message_type: :incoming, sender: ana, source_id: '3EB0AAAA'),
+      create(:message, conversation: group_conversation, inbox: inbox, account: channel.account,
+                       message_type: :incoming, sender: bruno, source_id: '3EB0BBBB')
+    ]
+
+    channel.read_messages(messages, conversation: group_conversation)
+
+    commands = backend.commands_of('message.mark_read')
+    expect(commands.map { |command| command.sender&.id }).to contain_exactly('5541999991111', '5541999992222')
+    expect(commands.flat_map(&:message_ids)).to contain_exactly('3EB0AAAA', '3EB0BBBB')
+  end
+
   describe 'the group half' do
     let(:group_jid) { '120363041234567890@g.us' }
 

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -92,6 +92,38 @@ RSpec.describe Whatsapp::Session::Facade do
     expect(channel.provider_connection).not_to have_key('error_code')
   end
 
+  # Lifting that marker is what lets the inbound layer file chats again, and the account
+  # that was rejected is still on the provider until its logout lands: pairing first and
+  # lifting second would file somebody else's messages here for as long as the new QR is
+  # on screen. It also stands the asynchronous logout retry down before there is a new
+  # session for it to kill.
+  it 'ends the wrong account before it lifts the quarantine keeping that account out' do
+    channel.update_provider_connection!({ 'connection' => 'close', 'error_code' => 'wrong_phone_number' })
+
+    channel.provider_service.setup_channel_provider
+
+    expect(backend.commands.map { |command| command.class.wire_type }).to eq(%w[session.logout session.connect])
+  end
+
+  # The quarantine is the only reason to end a session here. Doing it on every connect
+  # would throw away a perfectly good pairing and cost the operator a fresh scan.
+  it 'ends nothing when the inbox is not quarantined' do
+    channel.setup_channel_provider
+
+    expect(backend.commands_of('session.logout')).to be_empty
+  end
+
+  it 'leaves the inbox quarantined when the wrong account cannot be ended' do
+    channel.update_provider_connection!({ 'connection' => 'close', 'error_code' => 'wrong_phone_number' })
+    allow(backend).to receive(:logout).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)
+
+    expect { channel.provider_service.setup_channel_provider }
+      .to raise_error(Whatsapp::Session::Errors::ProviderUnavailable)
+
+    expect(channel.reload.provider_connection).to include('error_code' => 'wrong_phone_number')
+    expect(backend.commands_of('session.connect')).to be_empty
+  end
+
   # `Channel::Whatsapp` used to skip these by asking `respond_to?`, which the facade
   # makes true for every provider. The capability is what decides now, and an
   # unsupported one is skipped rather than raised: these run inside listeners, and a

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -111,6 +111,32 @@ RSpec.describe Whatsapp::Session::Facade do
     expect(channel.provider_connection).not_to have_key('error_code')
   end
 
+  # `Channel::Whatsapp` used to skip these by asking `respond_to?`, which the facade
+  # makes true for every provider. The capability is what decides now, and an
+  # unsupported one is skipped rather than raised: these run inside listeners, and a
+  # listener that raises takes the event it was handling down with it.
+  describe 'background synchronization a backend may not support' do
+    before { allow(channel).to receive(:session_capabilities).and_return(%w[groups revoke]) }
+
+    it 'skips marking a conversation unread' do
+      message = create(:message, conversation: conversation, inbox: inbox, account: channel.account, source_id: '3EB0AAAA')
+
+      expect { channel.unread_conversation(conversation.reload) }.not_to raise_error
+      expect(backend.commands).to be_empty
+      expect(message).to be_present
+    end
+
+    it 'skips read receipts, typing and presence' do
+      message = create(:message, conversation: conversation, inbox: inbox, account: channel.account, source_id: '3EB0AAAA')
+
+      channel.read_messages([message], conversation: conversation)
+      channel.toggle_typing_status(Events::Types::CONVERSATION_TYPING_ON, conversation: conversation)
+      channel.update_presence('available')
+
+      expect(backend.commands).to be_empty
+    end
+  end
+
   describe 'the group half' do
     let(:group_jid) { '120363041234567890@g.us' }
 
@@ -139,11 +165,13 @@ RSpec.describe Whatsapp::Session::Facade do
         .to raise_error(Whatsapp::Session::Errors::InvalidPayload, /unknown group setting/)
     end
 
-    it 'asks for a fresh invite link when revoking the current one' do
-      facade.group_invite_code(group_jid)
+    # The dashboard endpoint builds the URL from what comes back, so anything but the
+    # bare code renders a link with the host in it twice.
+    it 'answers an invite with the code alone, and asks for a fresh one when revoking' do
+      expect(facade.group_invite_code(group_jid)).to eq('FAKEINVITE0001')
       expect(backend.last_command.revoke).to be(false)
 
-      facade.revoke_group_invite(group_jid)
+      expect(facade.revoke_group_invite(group_jid)).to eq('FAKEINVITE0001')
       expect(backend.last_command.revoke).to be(true)
     end
 

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -76,6 +76,49 @@ RSpec.describe Whatsapp::Session::Facade do
       .with(channel, hash_including(pairing: 'qr', provider: 'native'))
   end
 
+  # Two connects racing: the operator clicking twice, or a second tab. Whichever provider
+  # call answers last would otherwise be the state on screen even when it belongs to the
+  # older attempt, and the poll driving the QR the operator is actually looking at would
+  # read the record, find somebody else's token and retire itself.
+  it 'refuses a connect answer for an attempt the inbox has already moved past' do
+    allow(backend).to receive(:connect) do
+      # The second click lands while this one is still waiting on the provider.
+      channel.update_provider_connection!(
+        { 'connection' => 'connecting', 'qr_data_url' => 'data:image/png;base64,NEWER', 'pairing_attempt' => 'attempt-2' }
+      )
+      Whatsapp::Session::Model::ConnectionState.new(connection: 'connecting', qr_data_url: 'data:image/png;base64,OLDER')
+    end
+
+    channel.provider_service.setup_channel_provider
+
+    expect(channel.reload.provider_connection).to include(
+      'qr_data_url' => 'data:image/png;base64,NEWER', 'pairing_attempt' => 'attempt-2'
+    )
+  end
+
+  # The attempt is claimed before the provider is asked, which puts the dashboard on
+  # "connecting" straight away. A refusal that left it there parks the operator on a
+  # pairing that never started, with no poll running to ever correct it.
+  it 'reports a refused connection instead of leaving the claim on screen' do
+    allow(backend).to receive(:connect).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)
+
+    expect { channel.setup_channel_provider }.to raise_error(Whatsapp::Session::Errors::ProviderUnavailable)
+
+    expect(channel.reload.provider_connection).to include('connection' => 'close', 'error_code' => 'connect_failure')
+  end
+
+  # The ceiling belongs to the attempt, not to the worker: a QR lives two minutes from
+  # the moment the provider issued it, and a queue running ten minutes late would give
+  # that dead code two more minutes of polling.
+  it 'hands the poll a deadline counted from the connect, not from the worker' do
+    allow(backend.class).to receive(:state_polling?).and_return(true)
+
+    expect { channel.setup_channel_provider }.to(
+      have_enqueued_job(Whatsapp::Session::PairingPollJob)
+        .with { |_channel, options| expect(options[:deadline_at]).to be_within(5.seconds).of(2.minutes.from_now) }
+    )
+  end
+
   # The inbound layer keeps an inbox paired with the wrong number quarantined, and no
   # event lifts that on its own: a state that names no number is refused precisely so a
   # pending logout cannot clear it. Connecting again is the operator's way out, so it

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -219,6 +219,17 @@ RSpec.describe Whatsapp::Session::Facade do
       expect(backend.last_command.revoke).to be(true)
     end
 
+    # A provider can do groups without doing join requests: Uazapi is one. Asking its
+    # backend anyway raises NotSupported on a routable endpoint.
+    it 'answers join requests without the backend when the provider cannot approve them' do
+      allow(channel).to receive(:session_capabilities).and_return(%w[groups])
+
+      expect(channel.provider_service.group_join_requests(group_jid)).to eq([])
+      expect { channel.provider_service.handle_group_join_requests(group_jid, ['5541999990000@s.whatsapp.net'], 'approve') }
+        .to raise_error(Whatsapp::Session::Errors::NotSupported)
+      expect(backend.commands).to be_empty
+    end
+
     it 'renders a join request with the keys the dashboard already reads' do
       allow(backend).to receive(:group_join_requests).and_return(
         [{ 'party' => { 'phone' => '5541999990000', 'lid' => '182736451928374' }, 'requested_at' => 1_755_440_000 }]

--- a/spec/services/whatsapp/session/groups/syncer_spec.rb
+++ b/spec/services/whatsapp/session/groups/syncer_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
     let(:stored) { super().merge('group_left' => true) }
     let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
 
-    before { allow(channel).to receive(:provider_service).and_return(backend) }
+    before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
 
     it 'keeps the group marked as left' do
       fetched_sync
@@ -135,7 +135,7 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
 
     let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
 
-    before { allow(channel).to receive(:provider_service).and_return(backend) }
+    before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
 
     it 'says so instead of reporting an empty sync' do
       allow(backend).to receive(:group_info).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)

--- a/spec/services/whatsapp/session/inbound/echo_matcher_spec.rb
+++ b/spec/services/whatsapp/session/inbound/echo_matcher_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::EchoMatcher do
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:conversation) { create(:conversation, inbox: inbox, account: channel.account) }
+  let(:message) do
+    create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                     message_type: :outgoing, content: 'olá!')
+  end
+
+  before { message.update_under_lock!(pending_source_id: '3EB0RESERVED') }
+
+  it 'finds the send its reservation belongs to and fills in the provider id' do
+    found = described_class.new(inbox: inbox, message_id: '3EB0FROMPROVIDER', client_ref: '3EB0RESERVED').perform
+
+    expect(found).to eq(message)
+    expect(message.reload.source_id).to eq('3EB0FROMPROVIDER')
+  end
+
+  it 'ignores an echo of a message this inbox never sent' do
+    expect(described_class.new(inbox: inbox, message_id: 'UNKNOWN', client_ref: 'UNKNOWN').perform).to be_nil
+  end
+
+  it 'revokes a message the agent deleted while the send was in flight' do
+    message.update_under_lock!(deleted: true)
+
+    expect { described_class.new(inbox: inbox, message_id: '3EB0FROMPROVIDER', client_ref: '3EB0RESERVED').perform }
+      .to have_enqueued_job(Messages::DeleteOnChannelJob).once
+  end
+
+  # Enqueued inside the row lock, the job can be picked up before the transaction commits:
+  # it reads a still-blank source_id, returns, and the send response then sees the id
+  # already set and enqueues nothing. The deleted message stays on WhatsApp.
+  it 'enqueues the revoke only after the assignment has committed' do
+    message.update_under_lock!(deleted: true)
+    depth_outside = ActiveRecord::Base.connection.open_transactions
+    depth_at_enqueue = nil
+    allow(Messages::DeleteOnChannelJob).to receive(:perform_later) do
+      depth_at_enqueue = ActiveRecord::Base.connection.open_transactions
+    end
+
+    described_class.new(inbox: inbox, message_id: '3EB0FROMPROVIDER', client_ref: '3EB0RESERVED').perform
+
+    expect(depth_at_enqueue).to eq(depth_outside)
+  end
+end

--- a/spec/services/whatsapp/session/outbound/attachment_adapter_spec.rb
+++ b/spec/services/whatsapp/session/outbound/attachment_adapter_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Outbound::AttachmentAdapter do
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:message) { create(:message, :with_attachment, account: channel.account, inbox: channel.inbox) }
+  let(:attachment) { message.attachments.first }
+
+  it 'describes the file in the terms the protocol uses' do
+    media = described_class.new(attachment, caption: 'segue a foto', channel: channel).perform
+
+    expect(media.kind).to eq('image')
+    expect(media.caption).to eq('segue a foto')
+    expect(media.ref.url).to be_present
+  end
+
+  describe 'the address the provider is told to fetch from' do
+    let(:disk_url) { 'http://localhost:3000/rails/active_storage/disk/TOKEN/avatar.png' }
+
+    before { allow(attachment).to receive(:download_url).and_return(disk_url) }
+
+    it 'is the public one until the inbox says the provider cannot reach it' do
+      expect(described_class.new(attachment, channel: channel).media_url).to eq(disk_url)
+    end
+
+    it 'moves to the internal host for a provider sitting on a private network' do
+      with_modified_env INTERNAL_HOST_URL: 'http://rails:3000' do
+        expect(described_class.new(attachment, channel: channel).media_url)
+          .to eq('http://rails:3000/rails/active_storage/disk/TOKEN/avatar.png')
+      end
+    end
+
+    # With S3, GCS or any other cloud service the blob answers a presigned URL of its
+    # own. Its path is not one Rails serves and its signature is bound to the host it was
+    # made for, so moving it to the internal host is a 404 on every attachment the inbox
+    # ever sends: the storage is reachable over the internet anyway.
+    it 'leaves a presigned cloud-storage URL where it is' do
+      url = 'https://bucket.s3.sa-east-1.amazonaws.com/xg7/avatar.png?X-Amz-Signature=deadbeef'
+      allow(attachment).to receive(:download_url).and_return(url)
+
+      with_modified_env INTERNAL_HOST_URL: 'http://rails:3000' do
+        expect(described_class.new(attachment, channel: channel).media_url).to eq(url)
+      end
+    end
+  end
+end

--- a/spec/services/whatsapp/session/outbound/attachment_adapter_spec.rb
+++ b/spec/services/whatsapp/session/outbound/attachment_adapter_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe Whatsapp::Session::Outbound::AttachmentAdapter do
     expect(media.ref.url).to be_present
   end
 
+  # `download_url` rewrites the blob of an `.ogg` recorded as `audio/opus`, which is the
+  # shape the fork's own transcode pipeline produces. Reading the type before that runs
+  # leaves the media and its ref advertising different ones, and the type is what decides
+  # whether WhatsApp plays it as a voice note.
+  it 'advertises one MIME type for a voice note whose blob is normalized on the way out' do
+    attachment.file.blob.update!(content_type: 'audio/opus', filename: 'gravacao.ogg')
+    attachment.update!(file_type: :audio, meta: { 'is_voice_message' => true })
+
+    media = described_class.new(attachment.reload, channel: channel).perform
+
+    expect(media.mime).to eq('audio/ogg')
+    expect(media.ref.mime).to eq(media.mime)
+    expect(media.voice_note).to be(true)
+  end
+
   describe 'the address the provider is told to fetch from' do
     let(:disk_url) { 'http://localhost:3000/rails/active_storage/disk/TOKEN/avatar.png' }
 

--- a/spec/services/whatsapp/session/outbound/message_sender_spec.rb
+++ b/spec/services/whatsapp/session/outbound/message_sender_spec.rb
@@ -80,6 +80,26 @@ RSpec.describe Whatsapp::Session::Outbound::MessageSender do
       .to have_enqueued_job(Messages::DeleteOnChannelJob).once
   end
 
+  # A reaction that arrived from the connected phone is stored knowing its target only by
+  # the target's WhatsApp id. `Message#ensure_in_reply_to` fills the row id in from it on
+  # save, which is what this send relies on: the coverage is here so that a change to that
+  # callback shows up as a WhatsApp reaction that stops being sent.
+  it 'reacts to a target a phone-originated reaction knows only by its WhatsApp id' do
+    target = create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                              message_type: :incoming, sender: contact, source_id: '3EB0TARGET')
+    message.update!(
+      content: '🎉',
+      content_attributes: { 'is_reaction' => true, 'in_reply_to_external_id' => target.source_id }
+    )
+
+    send_message
+
+    command = backend.last_command
+    expect(command.target_id).to eq('3EB0TARGET')
+    expect(command.emoji).to eq('🎉')
+    expect(message.reload.is_unsupported).to be_falsey
+  end
+
   it 'quotes the message the agent replied to' do
     quoted = create(:message, conversation: conversation, inbox: inbox, account: channel.account,
                               message_type: :incoming, sender: contact, source_id: '3EB0QUOTED')

--- a/spec/services/whatsapp/session/outbound/message_sender_spec.rb
+++ b/spec/services/whatsapp/session/outbound/message_sender_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Outbound::MessageSender do
+  subject(:send_message) { described_class.new(message).perform }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+  let(:contact) { create(:contact, account: channel.account, phone_number: '+5541999990000', identifier: '182736451928374@lid') }
+  let(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox, source_id: '182736451928374') }
+  let(:conversation) { create(:conversation, contact: contact, contact_inbox: contact_inbox, inbox: inbox, account: channel.account) }
+  let(:message) do
+    create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                     message_type: :outgoing, content: 'olá!')
+  end
+
+  before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
+
+  it 'sends the text under an id reserved before the request' do
+    expect(send_message).to be_present
+
+    command = backend.last_command
+    expect(command.to.id).to eq('182736451928374')
+    expect(command.content.body).to eq('olá!')
+    expect(command.message_id).to eq(message.reload.pending_source_id)
+  end
+
+  # A provider that assigns its own message id ignores the reserved one and hands the
+  # correlation token back on the echo. EchoMatcher looks the send up by whatever is in
+  # `pending_source_id`, so sending anything else as the token means the echo of our own
+  # message lands as a second outgoing message written by nobody.
+  it 'sends the reservation as the correlation token an echo can be found by' do
+    send_message
+
+    command = backend.last_command
+    expect(command.client_ref).to eq(message.reload.pending_source_id)
+    expect(
+      Whatsapp::Session::Inbound::EchoMatcher.new(inbox: inbox, message_id: 'PROVIDER-ASSIGNED', client_ref: command.client_ref).perform
+    ).to eq(message)
+  end
+
+  it 'reuses the reservation when the job runs twice' do
+    send_message
+    reserved = message.pending_source_id
+
+    described_class.new(message).perform
+
+    expect(reserved).to be_present
+    expect(backend.commands_of('message.send').map(&:message_id).uniq).to eq([reserved])
+  end
+
+  it 'quotes the message the agent replied to' do
+    quoted = create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                              message_type: :incoming, sender: contact, source_id: '3EB0QUOTED')
+    message.update!(content_attributes: message.content_attributes.merge('in_reply_to_external_id' => quoted.source_id))
+
+    send_message
+
+    expect(backend.last_command.quoted.id).to eq('3EB0QUOTED')
+    expect(backend.last_command.quoted.from_me).to be(false)
+  end
+
+  it 'flags a message with nothing to send instead of pretending it went out' do
+    message.update!(content: nil)
+
+    expect(send_message).to be_nil
+    expect(message.reload.is_unsupported).to be(true)
+    expect(backend.commands).to be_empty
+  end
+
+  context 'with an attachment' do
+    let(:message) do
+      create(:message, :with_attachment, conversation: conversation, inbox: inbox, account: channel.account,
+                                         message_type: :outgoing, content: 'segue a foto')
+    end
+
+    it 'sends media the provider fetches by URL, with the text as caption' do
+      send_message
+
+      content = backend.last_command.content
+      expect(content.kind).to eq('image')
+      expect(content.caption).to eq('segue a foto')
+      expect(content.ref.url).to be_present
+    end
+  end
+
+  context 'with a reaction' do
+    let(:target) do
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       message_type: :incoming, sender: contact, source_id: '3EB0TARGET')
+    end
+    let(:message) do
+      create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                       message_type: :outgoing, content: '👍',
+                       content_attributes: { is_reaction: true, in_reply_to: target.id })
+    end
+
+    it 'reacts to the target instead of sending a message' do
+      send_message
+
+      command = backend.last_command
+      expect(backend.commands_of('message.react').size).to eq(1)
+      expect(command.target_id).to eq('3EB0TARGET')
+      expect(command.emoji).to eq('👍')
+    end
+  end
+
+  context 'when the group only accepts messages from admins' do
+    let(:channel) do
+      create(:channel_whatsapp, provider: 'native', phone_number: '+5541988887777',
+                                validate_provider_config: false, sync_templates: false)
+    end
+    let(:contact) do
+      create(:contact, account: channel.account, identifier: '120363041234567890@g.us',
+                       group_type: :group, additional_attributes: { 'announce' => true })
+    end
+
+    it 'fails the message with a reason the agent can read' do
+      expect { send_message }.to raise_error(Whatsapp::Session::Errors::GroupParticipantNotAllowed)
+
+      expect(message.reload.status).to eq('failed')
+      expect(message.external_error).to include('administrators')
+      expect(backend.commands).to be_empty
+    end
+
+    it 'sends when this inbox is an admin recorded without the ninth digit' do
+      admin = create(:contact, account: channel.account, phone_number: '+554188887777')
+      create(:group_member, group_contact: contact, contact: admin, role: :admin)
+
+      expect { send_message }.not_to raise_error
+      expect(backend.commands_of('message.send')).to be_present
+    end
+
+    # The suffix comparison this replaced called these the same line, so the send went
+    # out and WhatsApp dropped it in silence while Chatwoot reported it as sent.
+    it 'does not mistake a foreign admin sharing the last eight digits for this inbox' do
+      admin = create(:contact, account: channel.account, phone_number: '+15588887777')
+      create(:group_member, group_contact: contact, contact: admin, role: :admin)
+
+      expect { send_message }.to raise_error(Whatsapp::Session::Errors::GroupParticipantNotAllowed)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/outbound/message_sender_spec.rb
+++ b/spec/services/whatsapp/session/outbound/message_sender_spec.rb
@@ -162,6 +162,18 @@ RSpec.describe Whatsapp::Session::Outbound::MessageSender do
       expect(backend.commands_of('message.send')).to be_present
     end
 
+    # A roster can name the session's own participant by LID alone, and then the admin
+    # contact has no phone at all: comparing numbers answers no to "is this us?" and the
+    # inbox refuses to post in a group it administers.
+    it 'sends when this inbox is an admin the roster only knows by LID' do
+      channel.update_provider_connection!({ 'connection' => 'open', 'lid' => '112233445566778' })
+      admin = create(:contact, account: channel.account, identifier: '112233445566778@lid', phone_number: nil)
+      create(:group_member, group_contact: contact, contact: admin, role: :admin)
+
+      expect { send_message }.not_to raise_error
+      expect(backend.commands_of('message.send')).to be_present
+    end
+
     # The suffix comparison this replaced called these the same line, so the send went
     # out and WhatsApp dropped it in silence while Chatwoot reported it as sent.
     it 'does not mistake a foreign admin sharing the last eight digits for this inbox' do

--- a/spec/services/whatsapp/session/outbound/message_sender_spec.rb
+++ b/spec/services/whatsapp/session/outbound/message_sender_spec.rb
@@ -156,6 +156,39 @@ RSpec.describe Whatsapp::Session::Outbound::MessageSender do
     end
   end
 
+  # The provider refusing for a reason that will not change: the bubble used to stay on
+  # "sent" while Sidekiq retried a send that could never work.
+  it 'fails the message when the provider refuses for good' do
+    allow(backend).to receive(:send_message).and_raise(
+      Whatsapp::Session::Errors::RecipientNotOnWhatsapp, 'number is not on whatsapp'
+    )
+
+    expect { send_message }.not_to raise_error
+
+    expect(message.reload.status).to eq('failed')
+    expect(message.external_error).to eq('number is not on whatsapp')
+  end
+
+  # The other half: a provider that is down answers differently once it is back, so the
+  # job has to fail and be retried rather than bury a message the agent could still send.
+  it 'lets a provider that may answer differently take the job down with it' do
+    allow(backend).to receive(:send_message).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)
+
+    expect { send_message }.to raise_error(Whatsapp::Session::Errors::ProviderUnavailable)
+    expect(message.reload.status).not_to eq('failed')
+  end
+
+  # `identifier` is account-wide and another channel may own it: an API inbox writes the
+  # customer's id there, often an e-mail. Reading that as an address made the contact
+  # unreachable on WhatsApp, number and all.
+  it 'addresses a contact by its number when the identifier belongs to another channel' do
+    contact.update!(identifier: 'cliente@example.com')
+
+    send_message
+
+    expect(backend.last_command.to.to_jid).to eq('5541999990000@s.whatsapp.net')
+  end
+
   context 'when the group only accepts messages from admins' do
     let(:channel) do
       create(:channel_whatsapp, provider: 'native', phone_number: '+5541988887777',
@@ -166,8 +199,10 @@ RSpec.describe Whatsapp::Session::Outbound::MessageSender do
                        group_type: :group, additional_attributes: { 'announce' => true })
     end
 
+    # Failed, and not raised: the refusal is the same on every retry, and a job dying over
+    # it only leaves the bubble reading "sent" until Sidekiq gives up.
     it 'fails the message with a reason the agent can read' do
-      expect { send_message }.to raise_error(Whatsapp::Session::Errors::GroupParticipantNotAllowed)
+      expect { send_message }.not_to raise_error
 
       expect(message.reload.status).to eq('failed')
       expect(message.external_error).to include('administrators')
@@ -200,7 +235,10 @@ RSpec.describe Whatsapp::Session::Outbound::MessageSender do
       admin = create(:contact, account: channel.account, phone_number: '+15588887777')
       create(:group_member, group_contact: contact, contact: admin, role: :admin)
 
-      expect { send_message }.to raise_error(Whatsapp::Session::Errors::GroupParticipantNotAllowed)
+      send_message
+
+      expect(message.reload.status).to eq('failed')
+      expect(backend.commands).to be_empty
     end
   end
 end

--- a/spec/services/whatsapp/session/outbound/message_sender_spec.rb
+++ b/spec/services/whatsapp/session/outbound/message_sender_spec.rb
@@ -64,6 +64,22 @@ RSpec.describe Whatsapp::Session::Outbound::MessageSender do
       .to have_enqueued_job(Messages::DeleteOnChannelJob).once
   end
 
+  # Three writers can fill `source_id` on one send. Here the echo wins the race, so it is
+  # the one that owns the revoke, and neither the send response nor the outer service may
+  # ask the provider to revoke the same message again.
+  it 'does not revoke twice when the echo arrives before the send response' do
+    allow(backend).to receive(:send_message).and_wrap_original do |original, command|
+      message.update_under_lock!(deleted: true)
+      Whatsapp::Session::Inbound::EchoMatcher.new(
+        inbox: inbox, message_id: 'ECHOED-FIRST', client_ref: message.reload.pending_source_id
+      ).perform
+      original.call(command)
+    end
+
+    expect { Whatsapp::SendOnWhatsappService.new(message: message).perform }
+      .to have_enqueued_job(Messages::DeleteOnChannelJob).once
+  end
+
   it 'quotes the message the agent replied to' do
     quoted = create(:message, conversation: conversation, inbox: inbox, account: channel.account,
                               message_type: :incoming, sender: contact, source_id: '3EB0QUOTED')

--- a/spec/services/whatsapp/session/outbound/message_sender_spec.rb
+++ b/spec/services/whatsapp/session/outbound/message_sender_spec.rb
@@ -49,6 +49,21 @@ RSpec.describe Whatsapp::Session::Outbound::MessageSender do
     expect(backend.commands_of('message.send').map(&:message_id).uniq).to eq([reserved])
   end
 
+  # Both layers used to enqueue it: this one from the id it just wrote, and
+  # SendOnWhatsappService from the same id returned to it. The second revoke hits a
+  # provider that no longer knows the message, and fails five times retrying.
+  it 'leaves the revoke of a message deleted mid-send to a single owner' do
+    # Deleted after the send started: one deleted beforehand never reaches the provider
+    # at all, and the revoke only matters once an id exists to revoke.
+    allow(backend).to receive(:send_message).and_wrap_original do |original, command|
+      message.update_under_lock!(deleted: true)
+      original.call(command)
+    end
+
+    expect { Whatsapp::SendOnWhatsappService.new(message: message).perform }
+      .to have_enqueued_job(Messages::DeleteOnChannelJob).once
+  end
+
   it 'quotes the message the agent replied to' do
     quoted = create(:message, conversation: conversation, inbox: inbox, account: channel.account,
                               message_type: :incoming, sender: contact, source_id: '3EB0QUOTED')

--- a/spec/services/whatsapp/session/outbound/source_id_reservation_spec.rb
+++ b/spec/services/whatsapp/session/outbound/source_id_reservation_spec.rb
@@ -28,12 +28,24 @@ RSpec.describe Whatsapp::Session::Outbound::SourceIdReservation do
       first = described_class.assign(message, { source_id: '3EB0FIRST' })
       second = described_class.assign(message.reload, { source_id: '3EB0FIRST' })
 
-      expect([first, second]).to eq([true, false])
+      expect([first, second]).to eq(%i[revoke written])
     end
 
     it 'owes nothing when the message is still alive' do
-      expect(described_class.assign(message, { source_id: '3EB0FIRST' })).to be(false)
+      expect(described_class.assign(message, { source_id: '3EB0FIRST' })).to eq(:written)
       expect(message.reload.source_id).to eq('3EB0FIRST')
+    end
+
+    # Toggling a reaction rewrites the same row and clears its reservation on purpose. A
+    # slow response from the emoji that was just replaced must not write its id back: the
+    # replacement send would then be skipped as something the provider already has.
+    it 'refuses a response whose reservation the row has moved on from' do
+      described_class.reserve(message)
+      stale = message.reload.pending_source_id
+      message.update_under_lock!(pending_source_id: nil)
+
+      expect(described_class.assign(message.reload, { source_id: '3EB0FIRST' }, reservation: stale)).to eq(:stale)
+      expect(message.reload.source_id).to be_nil
     end
 
     # `update_all` would have written the id without changing the record, leaving

--- a/spec/services/whatsapp/session/outbound/source_id_reservation_spec.rb
+++ b/spec/services/whatsapp/session/outbound/source_id_reservation_spec.rb
@@ -20,20 +20,29 @@ RSpec.describe Whatsapp::Session::Outbound::SourceIdReservation do
   end
 
   # Whoever moves `source_id` from blank to set owns the revoke of a message deleted
-  # mid-send, and three writers race for it. A conditional UPDATE is what makes the
-  # answer unambiguous no matter how they interleave.
-  describe '.claim_source_id' do
-    it 'is won by exactly one caller' do
-      first = described_class.claim_source_id(message, '3EB0FIRST')
-      second = described_class.claim_source_id(message.reload, '3EB0SECOND')
+  # mid-send, and three writers race for it.
+  describe '.assign' do
+    it 'owes the revoke only to the caller that assigned the id of a deleted message' do
+      message.update_under_lock!(deleted: true)
+
+      first = described_class.assign(message, { source_id: '3EB0FIRST' })
+      second = described_class.assign(message.reload, { source_id: '3EB0FIRST' })
 
       expect([first, second]).to eq([true, false])
+    end
+
+    it 'owes nothing when the message is still alive' do
+      expect(described_class.assign(message, { source_id: '3EB0FIRST' })).to be(false)
       expect(message.reload.source_id).to eq('3EB0FIRST')
     end
 
-    it 'claims nothing without an id to write' do
-      expect(described_class.claim_source_id(message, nil)).to be(false)
-      expect(message.reload.source_id).to be_nil
+    # `update_all` would have written the id without changing the record, leaving
+    # `previous_changes` empty: dashboards and webhooks never learn the provider id, and
+    # the reaction toolbar stays hidden until something else touches the message.
+    it 'writes through the model so the update is broadcast' do
+      described_class.assign(message, { source_id: '3EB0FIRST' })
+
+      expect(message.saved_changes).to include('source_id')
     end
   end
 end

--- a/spec/services/whatsapp/session/outbound/source_id_reservation_spec.rb
+++ b/spec/services/whatsapp/session/outbound/source_id_reservation_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Outbound::SourceIdReservation do
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:conversation) { create(:conversation, inbox: inbox, account: channel.account) }
+  let(:message) do
+    create(:message, conversation: conversation, inbox: inbox, account: channel.account, message_type: :outgoing)
+  end
+
+  it 'generates ids in the shape WhatsApp clients use' do
+    expect(described_class.generate).to match(/\A3EB0[0-9A-F]{18}\z/)
+  end
+
+  it 'reserves once and reuses the reservation on a retry' do
+    reserved = described_class.reserve(message)
+
+    expect(reserved).to be_present
+    expect(described_class.reserve(message.reload)).to eq(reserved)
+  end
+
+  # Whoever moves `source_id` from blank to set owns the revoke of a message deleted
+  # mid-send, and three writers race for it. A conditional UPDATE is what makes the
+  # answer unambiguous no matter how they interleave.
+  describe '.claim_source_id' do
+    it 'is won by exactly one caller' do
+      first = described_class.claim_source_id(message, '3EB0FIRST')
+      second = described_class.claim_source_id(message.reload, '3EB0SECOND')
+
+      expect([first, second]).to eq([true, false])
+      expect(message.reload.source_id).to eq('3EB0FIRST')
+    end
+
+    it 'claims nothing without an id to write' do
+      expect(described_class.claim_source_id(message, nil)).to be(false)
+      expect(message.reload.source_id).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Sending a WhatsApp message through one of the new session providers, and everything the channel already knew how to ask for, answered in canonical commands.

`Channel::Whatsapp`, the six group controllers, `PresenceSubscribeService` and `Groups::CreateService` keep speaking the shapes the legacy providers established: a recipient id that is a phone number or a JID, a Chatwoot message, a group JID. `Whatsapp::Session::Facade` translates all of it, so none of those callers change. Session-internal code does not come through it: it asks the channel for `session_backend` and speaks the canonical API directly.

Outbound sends reserve the WhatsApp id before the request rather than taking the 130-second channel lock the Baileys layer uses. The echo of our own message is then recognized by that reservation whether or not the send response ever came back, so a dropped socket no longer turns our own message into a second one that looks like the agent replied from the phone.

## Closes

Part of the WhatsApp session layer (slices 1/8, 2/8 and 3/8 already merged into `feat/whatsapp-session`).

## How to test

There is no provider to send through until slices 5 and 6 land, so the behaviour is exercised through the in-memory backend the specs use. What is worth reading:

- Send a message in a group whose `announce` flag is on while this inbox is not an admin: the message fails with a reason the agent can read, and nothing is sent.
- An inbox quarantined for having been paired with the wrong number: connecting again is what clears it.

## What changed

- `Whatsapp::Session::Facade` (+ its group half) implements every method the channel delegates, translating JIDs into `Address` and Chatwoot messages into canonical commands.
- `Outbound::MessageSender`, `SourceIdReservation`, `AttachmentAdapter` and `AnnouncementGuard`.
- `provider_service` returns the facade for a session channel; `session_backend` is the new internal accessor.
- `PairingPollJob` and `Backend.state_polling?`, which the facade's connect path drives.
- Three fixes for defects the slice-03 review left recorded: `client_ref` is now filled with the reservation, connecting lifts a wrong-number quarantine, and the announcement guard compares numbers through the normalizers instead of by an eight-digit suffix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/377)
<!-- Reviewable:end -->
