### PR TITLE
fix(specs): stop the test suite from reloading itself mid-run

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,17 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = false
+  # Reloading off, which is Rails' own default for this environment. With it on, the first
+  # job the suite runs inline wraps itself in the reloader, Zeitwerk unloads and reloads
+  # everything, and every spec file already required keeps the class object it captured
+  # before that: `described_class` and anything derived from it then names a class no
+  # example instantiates. `allow_any_instance_of(described_class)` stubs nothing, and
+  # `stub_const("#{described_class}::X", ...)` writes onto the live class while the code
+  # under test reads the stale one, both without a word. Which specs it breaks depends on
+  # the order rspec happened to load them in, so adding an unrelated file to the suite
+  # moves the failures somewhere else. Nothing here relies on reloading, and the suite is
+  # about five times faster without it.
+  config.cache_classes = true
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
A spec suite that reloads itself in the middle of a run breaks specs that have nothing to do with the change being tested, and which ones it breaks depends on the order rspec happened to load the files in. Turning reloading off in the test environment makes the suite say what it means, and makes it about five times faster.

## What was happening

`config.cache_classes = false` leaves reloading on in test. Spec files are all required before the first example runs, so each one captures the class object behind `RSpec.describe Foo` at that moment. The first job the suite runs inline wraps itself in `Rails.application.reloader`, Zeitwerk unloads and reloads every autoloaded class, and from then on `described_class` names a class nothing instantiates.

Nothing reports this. `allow_any_instance_of(described_class)` stubs a class no record belongs to, and `stub_const("#{described_class}::CONST", ...)` writes onto the live class while the code under test reads the stale one.

Because the trigger is load order, adding one unrelated spec file anywhere reshuffles the CI shards and moves the failures somewhere else. On #380 it cost eight failures in `spec/models/message_spec.rb` and `spec/services/whatsapp/connector/consumer/shard_worker_spec.rb`, neither of which that PR touches.

## Evidence

FOSS shards reproduced locally the way `run_foss_spec.yml` builds them (`rm -rf enterprise spec/enterprise`, `find spec -name '*_spec.rb' | sort`, round robin over 16):

| | reloading on | reloading off |
| --- | --- | --- |
| shard 10 | 10 failures, 6m10s | 2 failures, 1m10s |
| shard 3 | 3 failures | the same 3 |
| shard 11 | 4 failures | the same 4 |
| the other 13 shards | | 0 failures |

The nine that remain fail on their own, off any shard, on this machine: two are the known local-environment ones (`confirmation_instructions_spec`, `slack_uploads_controller_spec`) and `label_summary_builder_spec:360` is the documented non-UTC one.

`spec/enterprise` was run separately, since `run_foss_spec.yml` deletes it before the suite: 2072 examples, the same 9 failures either way.

## How to test

Nothing to see in the product. `bundle exec rspec` locally, and the CE workflow on this branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/381)
<!-- Reviewable:end -->
