### PR TITLE
feat(whatsapp): session layer 8/9, the provider catalog in the dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -341,6 +341,10 @@ BAILEYS_WHATSAPP_GROUPS_ENABLED=false
 # already has `native` inboxes leaves them sending but never receiving. Convert them to
 # another provider first.
 WHATSAPP_CONNECTOR_ENABLED=false
+# Whether the frozen providers (baileys, zapi) are still offered when creating or
+# converting an inbox. They stay on offer until the deprecation withdraws them; existing
+# inboxes keep working either way.
+# WHATSAPP_LEGACY_PROVIDERS_CREATABLE=true
 # Key prefix shared with the connector. Only worth changing when one Redis serves two
 # Chatwoot installations, and then both sides have to be set to the same value.
 # WHATSAPP_CONNECTOR_REDIS_PREFIX=wa:

--- a/app/controllers/api/v1/accounts/whatsapp/session_providers_controller.rb
+++ b/app/controllers/api/v1/accounts/whatsapp/session_providers_controller.rb
@@ -28,13 +28,9 @@ class Api::V1::Accounts::Whatsapp::SessionProvidersController < Api::V1::Account
   # serves theirs, so it does not apply to them. Withdrawing them ahead of the removal is
   # then one env var on this line rather than a dashboard change.
   def creatable?(descriptor)
-    return legacy_creatable? if descriptor.legacy?
+    return Whatsapp::Session::Registry.legacy_creatable? if descriptor.legacy?
     return false unless descriptor.available?
 
     Current.account.whatsapp_session_provider_enabled?(descriptor.key)
-  end
-
-  def legacy_creatable?
-    ActiveModel::Type::Boolean.new.cast(ENV.fetch('WHATSAPP_LEGACY_PROVIDERS_CREATABLE', true))
   end
 end

--- a/app/controllers/api/v1/accounts/whatsapp/session_providers_controller.rb
+++ b/app/controllers/api/v1/accounts/whatsapp/session_providers_controller.rb
@@ -1,0 +1,31 @@
+class Api::V1::Accounts::Whatsapp::SessionProvidersController < Api::V1::Accounts::BaseController
+  # Only an administrator can create or convert an inbox, and this catalog exists to
+  # drive those two forms.
+  before_action :check_admin_authorization?
+
+  # GET /api/v1/accounts/:account_id/whatsapp/session_providers
+  #
+  # The catalog the setup form renders itself from: which session providers this account
+  # may pick, what each one asks for, and what it can do once connected. Legacy providers
+  # are described too, so an existing inbox can be labelled and gated without the
+  # dashboard carrying a provider name of its own.
+  def index
+    render json: { payload: session_descriptors.map { |d| d.to_h.merge('creatable' => creatable?(d)) } }
+  end
+
+  private
+
+  def session_descriptors
+    Whatsapp::Session::Registry.descriptors.select(&:session?)
+  end
+
+  # Whether this account may stand up a new inbox on this provider. The same rule the
+  # channel validates on create and convert, answered ahead of time so the picker does
+  # not offer a choice the server would reject.
+  def creatable?(descriptor)
+    return false if descriptor.legacy?
+    return false unless descriptor.available?
+
+    Current.account.whatsapp_session_provider_enabled?(descriptor.key)
+  end
+end

--- a/app/controllers/api/v1/accounts/whatsapp/session_providers_controller.rb
+++ b/app/controllers/api/v1/accounts/whatsapp/session_providers_controller.rb
@@ -19,13 +19,22 @@ class Api::V1::Accounts::Whatsapp::SessionProvidersController < Api::V1::Account
     Whatsapp::Session::Registry.descriptors.select(&:session?)
   end
 
-  # Whether this account may stand up a new inbox on this provider. The same rule the
-  # channel validates on create and convert, answered ahead of time so the picker does
-  # not offer a choice the server would reject.
+  # Whether this account may stand up a new inbox on this provider. The picker renders
+  # itself from this, so the answer has to be the whole rule rather than the part this
+  # layer happens to own.
+  #
+  # Legacy providers are still offered: they are frozen, not withdrawn, and they are what
+  # most inboxes run on today. `available?` asks who serves the session, and nobody here
+  # serves theirs, so it does not apply to them. Withdrawing them ahead of the removal is
+  # then one env var on this line rather than a dashboard change.
   def creatable?(descriptor)
-    return false if descriptor.legacy?
+    return legacy_creatable? if descriptor.legacy?
     return false unless descriptor.available?
 
     Current.account.whatsapp_session_provider_enabled?(descriptor.key)
+  end
+
+  def legacy_creatable?
+    ActiveModel::Type::Boolean.new.cast(ENV.fetch('WHATSAPP_LEGACY_PROVIDERS_CREATABLE', true))
   end
 end

--- a/app/javascript/dashboard/api/channel/whatsappChannel.js
+++ b/app/javascript/dashboard/api/channel/whatsappChannel.js
@@ -16,6 +16,12 @@ class WhatsappChannel extends ApiClient {
       inbox_id: inboxId,
     });
   }
+
+  // The provider catalog the session setup form renders itself from: which providers
+  // this account may pick, what each one asks for and what it can do once connected.
+  getSessionProviders() {
+    return axios.get(`${this.baseUrl()}/whatsapp/session_providers`);
+  }
 }
 
 export default new WhatsappChannel();

--- a/app/javascript/dashboard/composables/spec/useWhatsappSessionProviders.spec.js
+++ b/app/javascript/dashboard/composables/spec/useWhatsappSessionProviders.spec.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useWhatsappSessionProviders } from '../useWhatsappSessionProviders';
+import WhatsappChannel from 'dashboard/api/channel/whatsappChannel';
+
+vi.mock('dashboard/api/channel/whatsappChannel', () => ({
+  default: { getSessionProviders: vi.fn() },
+}));
+
+const CATALOG = [
+  { key: 'native', creatable: false, fields: [] },
+  { key: 'uazapi', creatable: true, fields: [{ name: 'token' }] },
+  { key: 'baileys', legacy: true, creatable: false, fields: [] },
+];
+
+describe('useWhatsappSessionProviders', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('exposes the catalog the server serves', async () => {
+    WhatsappChannel.getSessionProviders.mockResolvedValue({
+      data: { payload: CATALOG },
+    });
+
+    const { providers, descriptorFor, creatableProviders, fetchProviders } =
+      useWhatsappSessionProviders();
+    await fetchProviders();
+
+    expect(providers.value).toHaveLength(3);
+    expect(descriptorFor('uazapi').fields).toEqual([{ name: 'token' }]);
+    expect(creatableProviders.value.map(p => p.key)).toEqual(['uazapi']);
+  });
+
+  // The catalog is what the picker offers, so a failed fetch must offer nothing rather
+  // than a provider the server would then refuse on create.
+  it('offers nothing when the catalog cannot be read', async () => {
+    WhatsappChannel.getSessionProviders.mockRejectedValue(new Error('boom'));
+
+    const { providers, creatableProviders, isFetching, fetchProviders } =
+      useWhatsappSessionProviders();
+    await fetchProviders();
+
+    expect(providers.value).toEqual([]);
+    expect(creatableProviders.value).toEqual([]);
+    expect(isFetching.value).toBe(false);
+  });
+
+  it('offers nothing when the response carries no payload', async () => {
+    WhatsappChannel.getSessionProviders.mockResolvedValue({ data: {} });
+
+    const { providers, fetchProviders } = useWhatsappSessionProviders();
+    await fetchProviders();
+
+    expect(providers.value).toEqual([]);
+  });
+});

--- a/app/javascript/dashboard/composables/useWhatsappSessionProviders.js
+++ b/app/javascript/dashboard/composables/useWhatsappSessionProviders.js
@@ -1,0 +1,48 @@
+import { ref, computed } from 'vue';
+import WhatsappChannel from 'dashboard/api/channel/whatsappChannel';
+
+/**
+ * The WhatsApp session provider catalog, as the server describes it: which providers
+ * this account may pick, what each one's setup form asks for, and what it can do once
+ * connected.
+ *
+ * The dashboard renders the picker and the setup form from this instead of carrying a
+ * component and a provider name per provider, so adding one is a server-side change.
+ *
+ * Fetching is left to the caller: the catalog is read once per page, by whoever owns the
+ * page, and passed down. A composable that fetched on mount would fetch once per
+ * component that happened to need a field name.
+ */
+export const useWhatsappSessionProviders = () => {
+  const providers = ref([]);
+  const isFetching = ref(false);
+
+  const fetchProviders = async () => {
+    isFetching.value = true;
+    try {
+      const { data } = await WhatsappChannel.getSessionProviders();
+      providers.value = data?.payload ?? [];
+    } catch {
+      // The catalog is what the picker offers, so a failed fetch offers nothing rather
+      // than a provider the server would then refuse. The rest of the WhatsApp providers
+      // are static and keep working.
+      providers.value = [];
+    } finally {
+      isFetching.value = false;
+    }
+  };
+
+  const descriptorFor = key => providers.value.find(p => p.key === key);
+
+  const creatableProviders = computed(() =>
+    providers.value.filter(p => p.creatable)
+  );
+
+  return {
+    providers,
+    isFetching,
+    fetchProviders,
+    descriptorFor,
+    creatableProviders,
+  };
+};

--- a/app/javascript/dashboard/helper/specs/whatsappSession.spec.js
+++ b/app/javascript/dashboard/helper/specs/whatsappSession.spec.js
@@ -4,6 +4,7 @@ import {
   hasCapability,
   inboxCapabilities,
   isSessionProvider,
+  isHttpUrl,
 } from '../whatsappSession';
 
 describe('whatsappSession', () => {
@@ -32,6 +33,32 @@ describe('whatsappSession', () => {
       expect(inboxCapabilities({})).toEqual([]);
       expect(inboxCapabilities(null)).toEqual([]);
       expect(inboxCapabilities(undefined)).toEqual([]);
+    });
+  });
+
+  // The server takes any http(s) URL with a host and decides separately whether a private
+  // one is permitted, so the form must not refuse addresses it would have accepted.
+  describe('isHttpUrl', () => {
+    it('accepts a public address', () => {
+      expect(isHttpUrl('https://free.uazapi.com')).toBe(true);
+      expect(isHttpUrl('https://api.uazapi.com/v1')).toBe(true);
+    });
+
+    // The reason this helper exists: `isValidURL` needs a dot in the host, so it refused
+    // the compose-network address that `use_internal_host` is for.
+    it('accepts an address on the deployment own network', () => {
+      expect(isHttpUrl('http://uazapi:3000')).toBe(true);
+      expect(isHttpUrl('http://localhost:3000')).toBe(true);
+      expect(isHttpUrl('http://[::1]:3000')).toBe(true);
+      expect(isHttpUrl('http://192.168.1.10:3000')).toBe(true);
+    });
+
+    it('rejects anything that is not an http address', () => {
+      expect(isHttpUrl('ftp://uazapi.com')).toBe(false);
+      expect(isHttpUrl('uazapi.com')).toBe(false);
+      expect(isHttpUrl('http://')).toBe(false);
+      expect(isHttpUrl('')).toBe(false);
+      expect(isHttpUrl(undefined)).toBe(false);
     });
   });
 

--- a/app/javascript/dashboard/helper/whatsappSession.js
+++ b/app/javascript/dashboard/helper/whatsappSession.js
@@ -70,3 +70,29 @@ export const inboxCapabilities = inbox => inbox?.capabilities ?? [];
  */
 export const hasCapability = (inbox, capability) =>
   inboxCapabilities(inbox).includes(capability);
+
+/**
+ * Whether a provider address has a shape the server would accept.
+ *
+ * It lives here rather than in `helper/URLHelper` because it exists to mirror one
+ * server-side rule: `Backend.validate_config` takes any http(s) URI that has a host, and
+ * decides separately whether one inside the deployment's own network is permitted
+ * (`Whatsapp::Session::PrivateAddress` plus `SafeFetch.allow_private_network?`). The
+ * dashboard cannot know that policy, so it checks shape only.
+ *
+ * `isValidURL` is stricter than that: its regex needs a dot in the host, which refuses
+ * `http://uazapi:3000` and `http://localhost:3000` (the compose-network addresses the
+ * `use_internal_host` field exists for) and every IPv6 literal. A form that refuses more
+ * than the server does is a provider the operator cannot enter at all.
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+export const isHttpUrl = value => {
+  try {
+    const { protocol, hostname } = new URL(value);
+    return (protocol === 'http:' || protocol === 'https:') && hostname !== '';
+  } catch {
+    return false;
+  }
+};

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -166,7 +166,9 @@
     },
     "CHANNELS": {
       "WHATSAPP_BAILEYS": "WhatsApp - Baileys",
-      "WHATSAPP_ZAPI": "WhatsApp - Z-API"
+      "WHATSAPP_ZAPI": "WhatsApp - Z-API",
+      "WHATSAPP_NATIVE": "WhatsApp - native",
+      "WHATSAPP_UAZAPI": "WhatsApp - uazapi"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -7,7 +7,11 @@
           "BAILEYS": "Baileys",
           "BAILEYS_DESC": "Connect via non-official API Baileys",
           "ZAPI": "Z-API",
-          "ZAPI_DESC": "Connect via non-official API Z-API"
+          "ZAPI_DESC": "Connect via non-official API Z-API",
+          "NATIVE": "WhatsApp (native)",
+          "NATIVE_DESC": "Pair a phone through the connector that ships with this installation",
+          "UAZAPI": "uazapi",
+          "UAZAPI_DESC": "Pair a phone through your own uazapi instance"
         },
         "PROVIDER_URL": {
           "LABEL": "Provider URL",
@@ -51,6 +55,29 @@
             "IMPORT_SESSION_SHOW_MORE": "Show more",
             "IMPORT_SESSION_DESC": "WhatsApp now requires a passkey when linking some accounts, which blocks the QR code. Install the browser extension to import a session you're already logged into on WhatsApp Web.",
             "IMPORT_SESSION_INSTALL": "Install the extension"
+          }
+        },
+        "SESSION": {
+          "FIELDS": {
+            "BASE_URL": {
+              "LABEL": "Instance URL",
+              "PLACEHOLDER": "https://your-instance.uazapi.com",
+              "ERROR": "Enter the address of your instance"
+            },
+            "TOKEN": {
+              "LABEL": "Instance token",
+              "PLACEHOLDER": "Paste the token of the instance you want to use",
+              "ERROR": "The instance token is required"
+            },
+            "USE_INTERNAL_HOST": {
+              "LABEL": "Instance runs on this server’s network"
+            },
+            "MARK_AS_READ": {
+              "LABEL": "Mark messages as read on WhatsApp"
+            },
+            "PRESENCE_SUBSCRIBE": {
+              "LABEL": "Show when the contact is online"
+            }
           }
         }
       }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -7,7 +7,11 @@
           "BAILEYS": "Baileys",
           "BAILEYS_DESC": "Conectar mediante la API no oficial Baileys",
           "ZAPI": "Z-API",
-          "ZAPI_DESC": "Conectar mediante la API no oficial Z-API"
+          "ZAPI_DESC": "Conectar mediante la API no oficial Z-API",
+          "NATIVE": "WhatsApp (nativo)",
+          "NATIVE_DESC": "Conecta un teléfono con el conector que ya viene en esta instalación",
+          "UAZAPI": "uazapi",
+          "UAZAPI_DESC": "Conecta un teléfono con tu propia instancia de uazapi"
         },
         "PROVIDER_URL": {
           "LABEL": "URL del proveedor",
@@ -51,6 +55,29 @@
             "IMPORT_SESSION_SHOW_MORE": "Ver más",
             "IMPORT_SESSION_DESC": "WhatsApp ahora exige una clave de acceso al vincular algunas cuentas, lo que bloquea el código QR. Instale la extensión del navegador para importar una sesión que ya tenga iniciada en WhatsApp Web.",
             "IMPORT_SESSION_INSTALL": "Instalar la extensión"
+          }
+        },
+        "SESSION": {
+          "FIELDS": {
+            "BASE_URL": {
+              "LABEL": "URL de la instancia",
+              "PLACEHOLDER": "https://tu-instancia.uazapi.com",
+              "ERROR": "Indica la dirección de tu instancia"
+            },
+            "TOKEN": {
+              "LABEL": "Token de la instancia",
+              "PLACEHOLDER": "Pega el token de la instancia que quieres usar",
+              "ERROR": "El token de la instancia es obligatorio"
+            },
+            "USE_INTERNAL_HOST": {
+              "LABEL": "La instancia corre en la red de este servidor"
+            },
+            "MARK_AS_READ": {
+              "LABEL": "Marcar mensajes como leídos en WhatsApp"
+            },
+            "PRESENCE_SUBSCRIBE": {
+              "LABEL": "Mostrar cuándo el contacto está en línea"
+            }
           }
         }
       }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -166,7 +166,9 @@
     },
     "CHANNELS": {
       "WHATSAPP_BAILEYS": "WhatsApp - Baileys",
-      "WHATSAPP_ZAPI": "WhatsApp - Z-API"
+      "WHATSAPP_ZAPI": "WhatsApp - Z-API",
+      "WHATSAPP_NATIVE": "WhatsApp - nativo",
+      "WHATSAPP_UAZAPI": "WhatsApp - uazapi"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/overrides.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/overrides.json
@@ -1,4 +1,7 @@
 {
+  "GENERAL": {
+    "BETA_DESCRIPTION": "Esta función está en fase beta y puede cambiar a medida que la mejoramos."
+  },
   "CONVERSATION": {
     "UNSUPPORTED_MESSAGE": "Este mensaje no es compatible. Puede verlo en la aplicación."
   },

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -7,7 +7,11 @@
           "BAILEYS": "Baileys",
           "BAILEYS_DESC": "Conectar via API não-oficial Baileys",
           "ZAPI": "Z-API",
-          "ZAPI_DESC": "Conectar via API não-oficial Z-API"
+          "ZAPI_DESC": "Conectar via API não-oficial Z-API",
+          "NATIVE": "WhatsApp (nativo)",
+          "NATIVE_DESC": "Conecte um telefone pelo conector que já vem nesta instalação",
+          "UAZAPI": "uazapi",
+          "UAZAPI_DESC": "Conecte um telefone pela sua própria instância da uazapi"
         },
         "PROVIDER_URL": {
           "LABEL": "URL do provedor",
@@ -51,6 +55,29 @@
             "IMPORT_SESSION_SHOW_MORE": "Ver mais",
             "IMPORT_SESSION_DESC": "O WhatsApp passou a exigir chave de acesso ao vincular algumas contas, o que bloqueia o QR code. Instale a extensão de navegador para importar uma sessão em que você já está logado no WhatsApp Web.",
             "IMPORT_SESSION_INSTALL": "Instalar a extensão"
+          }
+        },
+        "SESSION": {
+          "FIELDS": {
+            "BASE_URL": {
+              "LABEL": "URL da instância",
+              "PLACEHOLDER": "https://sua-instancia.uazapi.com",
+              "ERROR": "Informe o endereço da sua instância"
+            },
+            "TOKEN": {
+              "LABEL": "Token da instância",
+              "PLACEHOLDER": "Cole o token da instância que você quer usar",
+              "ERROR": "O token da instância é obrigatório"
+            },
+            "USE_INTERNAL_HOST": {
+              "LABEL": "A instância roda na rede deste servidor"
+            },
+            "MARK_AS_READ": {
+              "LABEL": "Marcar mensagens como lidas no WhatsApp"
+            },
+            "PRESENCE_SUBSCRIBE": {
+              "LABEL": "Mostrar quando o contato está online"
+            }
           }
         }
       }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -166,7 +166,9 @@
     },
     "CHANNELS": {
       "WHATSAPP_BAILEYS": "WhatsApp - Baileys",
-      "WHATSAPP_ZAPI": "WhatsApp - Z-API"
+      "WHATSAPP_ZAPI": "WhatsApp - Z-API",
+      "WHATSAPP_NATIVE": "WhatsApp - nativo",
+      "WHATSAPP_UAZAPI": "WhatsApp - uazapi"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/overrides.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/overrides.json
@@ -1,4 +1,7 @@
 {
+  "GENERAL": {
+    "BETA_DESCRIPTION": "Este recurso está em fase beta e pode mudar conforme o aprimoramos."
+  },
   "CONVERSATION": {
     "UNSUPPORTED_MESSAGE": "Esta mensagem não é suportada. Você pode ver esta mensagem no aplicativo.",
     "REPLYBOX": {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/InboxConvert.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/InboxConvert.vue
@@ -4,14 +4,14 @@ import { useRoute, useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 import Whatsapp from './channels/Whatsapp.vue';
 import { INBOX_TYPES } from 'dashboard/helper/inbox';
+import { SESSION_PROVIDERS } from 'dashboard/helper/whatsappSession';
 
 // Mirrors Settings.vue's `isConvertibleWhatsAppChannel` so a direct visit to
 // /convert cannot bypass the provider allowlist exposed by the Convert button.
 const CONVERTIBLE_WHATSAPP_PROVIDERS = [
   'whatsapp_cloud',
   'default',
-  'baileys',
-  'zapi',
+  ...SESSION_PROVIDERS,
 ];
 
 const route = useRoute();

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -179,13 +179,17 @@ export default {
       if (this.isAWhatsAppZapiChannel) {
         return this.$t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.ZAPI');
       }
+      if (this.isASessionWhatsAppChannel) {
+        return this.$t(
+          `INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.${this.whatsAppAPIProvider.toUpperCase()}`
+        );
+      }
       return '';
     },
     isConvertibleWhatsAppChannel() {
       return (
         this.isAWhatsAppCloudChannel ||
-        this.isAWhatsAppBaileysChannel ||
-        this.isAWhatsAppZapiChannel ||
+        this.isASessionWhatsAppChannel ||
         this.is360DialogWhatsAppChannel
       );
     },
@@ -230,12 +234,7 @@ export default {
         (this.isAnEmailChannel && !this.inbox.provider) ||
         this.shouldShowWhatsAppConfiguration ||
         this.isAWebWidgetInbox ||
-        // Deliberately the two legacy providers rather than the session family: this
-        // tab has to track the branches ConfigurationPage actually renders, and the
-        // session providers get theirs with the provider catalog. Offering the tab
-        // first would land the agent on an empty page.
-        this.isAWhatsAppBaileysChannel ||
-        this.isAWhatsAppZapiChannel
+        this.isASessionWhatsAppChannel
       ) {
         visibleToAllChannelTabs = [
           ...visibleToAllChannelTabs,

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/BaileysWhatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/BaileysWhatsapp.vue
@@ -170,7 +170,13 @@ const setShowAdvancedOptions = () => {
       v-if="!showAdvancedOptions"
       class="w-[65%] flex-shrink-0 flex-grow-0 max-w-[65%] mb-4"
     >
-      <NextButton icon="i-lucide-plus" sm link @click="setShowAdvancedOptions">
+      <NextButton
+        type="button"
+        icon="i-lucide-plus"
+        sm
+        link
+        @click="setShowAdvancedOptions"
+      >
         {{ $t('INBOX_MGMT.ADD.WHATSAPP.ADVANCED_OPTIONS') }}
       </NextButton>
     </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -176,24 +176,19 @@ const PROVIDER_CATALOG = computed(() => [
   },
 ]);
 
-// Keys shown in the picker. 360Dialog is intentionally hidden in create mode
-// (URL-reachable only) but offered in convert mode where it is a valid target.
-const CREATE_PICKER_KEYS = [
-  PROVIDER_TYPES.WHATSAPP,
-  PROVIDER_TYPES.TWILIO,
-  PROVIDER_TYPES.BAILEYS,
-  PROVIDER_TYPES.ZAPI,
-];
+// The cloud family, which this dashboard has always known statically. 360Dialog is
+// intentionally hidden in create mode (URL-reachable only) but offered in convert mode
+// where it is a valid target.
+const CREATE_PICKER_KEYS = [PROVIDER_TYPES.WHATSAPP, PROVIDER_TYPES.TWILIO];
 const CONVERT_PICKER_KEYS = [
   PROVIDER_TYPES.WHATSAPP,
-  PROVIDER_TYPES.BAILEYS,
-  PROVIDER_TYPES.ZAPI,
   PROVIDER_TYPES.THREE_SIXTY_DIALOG,
 ];
 
-// The session providers are offered per account during the rollout, so the server is
-// what says whether this account may pick one. Offering a choice it would then refuse
-// is worse than not offering it.
+// Every session provider comes from the catalog instead, legacy included: eligibility is
+// per account during the rollout and per installation once the deprecation starts, and
+// the server is what knows both. Offering a choice it would then refuse is worse than
+// not offering it, and withdrawing one becomes a server-side change.
 const { creatableProviders, descriptorFor, fetchProviders } =
   useWhatsappSessionProviders();
 onMounted(fetchProviders);
@@ -452,7 +447,7 @@ const requestEmbeddedSignupAccess = () => {
           :inbox="inbox"
         />
         <SessionWhatsapp
-          v-else-if="selectedDescriptor"
+          v-else-if="selectedDescriptor && !selectedDescriptor.legacy"
           :descriptor="selectedDescriptor"
           :mode="mode"
           :inbox="inbox"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n, I18nT } from 'vue-i18n';
 import Twilio from './Twilio.vue';
@@ -9,10 +9,12 @@ import WhatsappEmbeddedSignup from './WhatsappEmbeddedSignup.vue';
 import ChannelSelector from 'dashboard/components/ChannelSelector.vue';
 import BaileysWhatsapp from './BaileysWhatsapp.vue';
 import ZapiWhatsapp from './ZapiWhatsapp.vue';
+import SessionWhatsapp from './session/SessionWhatsapp.vue';
 import Banner from 'dashboard/components-next/banner/Banner.vue';
 import Button from 'dashboard/components-next/button/Button.vue';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import { useAccount } from 'dashboard/composables/useAccount';
+import { useWhatsappSessionProviders } from 'dashboard/composables/useWhatsappSessionProviders';
 import { FEATURE_FLAGS } from 'dashboard/featureFlags';
 import { META_RESTRICTION_STATUS_URL } from 'dashboard/constants/globals';
 
@@ -58,6 +60,8 @@ const PROVIDER_TYPES = {
   THREE_SIXTY_DIALOG: '360dialog',
   BAILEYS: 'baileys',
   ZAPI: 'zapi',
+  NATIVE: 'native',
+  UAZAPI: 'uazapi',
 };
 
 // Upstream's own gate for the access-request card: the app id alone says embedded signup
@@ -88,6 +92,8 @@ const INBOX_PROVIDER_TO_KEY = {
   default: PROVIDER_TYPES.THREE_SIXTY_DIALOG,
   baileys: PROVIDER_TYPES.BAILEYS,
   zapi: PROVIDER_TYPES.ZAPI,
+  native: PROVIDER_TYPES.NATIVE,
+  uazapi: PROVIDER_TYPES.UAZAPI,
 };
 
 const currentProviderKey = computed(() => {
@@ -151,6 +157,18 @@ const PROVIDER_CATALOG = computed(() => [
     icon: 'i-woot-zapi',
   },
   {
+    key: PROVIDER_TYPES.NATIVE,
+    title: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.NATIVE'),
+    description: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.NATIVE_DESC'),
+    icon: 'i-woot-whatsapp',
+  },
+  {
+    key: PROVIDER_TYPES.UAZAPI,
+    title: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.UAZAPI'),
+    description: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.UAZAPI_DESC'),
+    icon: 'i-woot-whatsapp',
+  },
+  {
     key: PROVIDER_TYPES.THREE_SIXTY_DIALOG,
     title: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.360_DIALOG'),
     description: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.360_DIALOG_DESC'),
@@ -173,10 +191,25 @@ const CONVERT_PICKER_KEYS = [
   PROVIDER_TYPES.THREE_SIXTY_DIALOG,
 ];
 
+// The session providers are offered per account during the rollout, so the server is
+// what says whether this account may pick one. Offering a choice it would then refuse
+// is worse than not offering it.
+const { creatableProviders, descriptorFor, fetchProviders } =
+  useWhatsappSessionProviders();
+onMounted(fetchProviders);
+
+const creatableSessionKeys = computed(() =>
+  creatableProviders.value.map(({ key }) => key)
+);
+const selectedDescriptor = computed(() =>
+  descriptorFor(selectedProvider.value)
+);
+
 const availableProviders = computed(() => {
-  const allowed = isConvertMode.value
-    ? CONVERT_PICKER_KEYS
-    : CREATE_PICKER_KEYS;
+  const allowed = [
+    ...(isConvertMode.value ? CONVERT_PICKER_KEYS : CREATE_PICKER_KEYS),
+    ...creatableSessionKeys.value,
+  ];
   return PROVIDER_CATALOG.value
     .filter(p => allowed.includes(p.key))
     .filter(p => !isConvertMode.value || p.key !== currentProviderKey.value);
@@ -415,6 +448,12 @@ const requestEmbeddedSignupAccess = () => {
         />
         <ZapiWhatsapp
           v-else-if="selectedProvider === PROVIDER_TYPES.ZAPI"
+          :mode="mode"
+          :inbox="inbox"
+        />
+        <SessionWhatsapp
+          v-else-if="selectedDescriptor"
+          :descriptor="selectedDescriptor"
           :mode="mode"
           :inbox="inbox"
         />

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -200,6 +200,11 @@ const selectedDescriptor = computed(() =>
   descriptorFor(selectedProvider.value)
 );
 
+// The catalog is what knows a provider is still in beta, so the badge follows the server
+// rather than a literal in the label: ending the beta is one field on the descriptor.
+// The cloud providers have no descriptor here and answer false, which is what they are.
+const isBetaProvider = key => Boolean(descriptorFor(key)?.beta);
+
 const availableProviders = computed(() => {
   const allowed = [
     ...(isConvertMode.value ? CONVERT_PICKER_KEYS : CREATE_PICKER_KEYS),
@@ -306,6 +311,7 @@ const requestEmbeddedSignupAccess = () => {
           :title="provider.title"
           :description="provider.description"
           :icon="provider.icon"
+          :is-beta="isBetaProvider(provider.key)"
           @click="selectProvider(provider.key)"
         />
       </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/session/SessionWhatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/session/SessionWhatsapp.vue
@@ -201,6 +201,7 @@ const submit = async () => {
       class="w-[65%] flex-shrink-0 flex-grow-0 max-w-[65%] mb-4"
     >
       <NextButton
+        type="button"
         icon="i-lucide-plus"
         sm
         link

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/session/SessionWhatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/session/SessionWhatsapp.vue
@@ -7,7 +7,7 @@ import { useVuelidate } from '@vuelidate/core';
 import { useAlert } from 'dashboard/composables';
 import { required } from '@vuelidate/validators';
 import { isPhoneE164OrEmpty } from 'shared/helpers/Validators';
-import { isValidURL } from 'dashboard/helper/URLHelper';
+import { isHttpUrl } from 'dashboard/helper/whatsappSession';
 
 import NextButton from 'dashboard/components-next/button/Button.vue';
 import Switch from 'dashboard/components-next/switch/Switch.vue';
@@ -73,7 +73,7 @@ const fieldRules = field => {
   const rules = {};
   if (field.required) rules.required = required;
   if (field.type === 'url')
-    rules.isValidURL = value => !value || isValidURL(value);
+    rules.isHttpUrl = value => !value || isHttpUrl(value);
   return rules;
 };
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/session/SessionWhatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/session/SessionWhatsapp.vue
@@ -1,0 +1,248 @@
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { useStore } from 'vuex';
+import { useI18n } from 'vue-i18n';
+import { useVuelidate } from '@vuelidate/core';
+import { useAlert } from 'dashboard/composables';
+import { required } from '@vuelidate/validators';
+import { isPhoneE164OrEmpty } from 'shared/helpers/Validators';
+import { isValidURL } from 'dashboard/helper/URLHelper';
+
+import NextButton from 'dashboard/components-next/button/Button.vue';
+import Switch from 'dashboard/components-next/switch/Switch.vue';
+
+const props = defineProps({
+  // The provider's entry in the catalog: its key, the fields its form asks for and what
+  // it can do once connected. Owned by the page, so the form is a pure function of it.
+  descriptor: { type: Object, required: true },
+  mode: {
+    type: String,
+    default: 'create',
+    validator: value => ['create', 'convert'].includes(value),
+  },
+  inbox: { type: Object, default: null },
+});
+
+const isConvertMode = computed(() => props.mode === 'convert');
+
+const router = useRouter();
+const store = useStore();
+const { t } = useI18n();
+
+const descriptor = computed(() => props.descriptor);
+// Everything the provider asks for, in the order the server declared it. Booleans are
+// preferences with a sane default, so they sit behind the advanced toggle; the rest is
+// what the inbox cannot connect without.
+const credentialFields = computed(
+  () => descriptor.value?.fields?.filter(f => f.type !== 'boolean') ?? []
+);
+const preferenceFields = computed(
+  () => descriptor.value?.fields?.filter(f => f.type === 'boolean') ?? []
+);
+
+const inboxName = ref(isConvertMode.value ? props.inbox?.name || '' : '');
+const phoneNumber = ref(
+  isConvertMode.value ? props.inbox?.phone_number || '' : ''
+);
+const showAdvancedOptions = ref(false);
+const fieldValues = ref({});
+
+// The form is rendered from a catalog that arrives over the network, so the values are
+// seeded once it lands rather than at setup.
+watch(
+  descriptor,
+  value => {
+    if (!value) return;
+    const existing = isConvertMode.value ? {} : props.inbox?.provider_config;
+    fieldValues.value = Object.fromEntries(
+      value.fields.map(field => [
+        field.name,
+        existing?.[field.name] ??
+          field.default ??
+          (field.type === 'boolean' ? false : ''),
+      ])
+    );
+  },
+  { immediate: true }
+);
+
+const uiFlags = computed(() => store.getters['inboxes/getUIFlags']);
+
+const fieldRules = field => {
+  const rules = {};
+  if (field.required) rules.required = required;
+  if (field.type === 'url')
+    rules.isValidURL = value => !value || isValidURL(value);
+  return rules;
+};
+
+const rules = computed(() => ({
+  inboxName: { required },
+  phoneNumber: { required, isPhoneE164OrEmpty },
+  fieldValues: Object.fromEntries(
+    credentialFields.value.map(field => [field.name, fieldRules(field)])
+  ),
+}));
+
+const v$ = useVuelidate(rules, { inboxName, phoneNumber, fieldValues });
+
+const fieldKey = field =>
+  `INBOX_MGMT.ADD.WHATSAPP.SESSION.FIELDS.${field.name.toUpperCase()}`;
+const inputType = field => (field.type === 'password' ? 'password' : 'text');
+
+const submit = async () => {
+  v$.value.$touch();
+  if (v$.value.$invalid) return;
+
+  const providerConfig = { ...fieldValues.value };
+
+  try {
+    if (isConvertMode.value) {
+      await store.dispatch('inboxes/convertProvider', {
+        inboxId: props.inbox.id,
+        provider: props.descriptor.key,
+        providerConfig,
+      });
+
+      useAlert(t('INBOX_MGMT.CONVERT.API.SUCCESS_MESSAGE'));
+      router.replace({
+        name: 'settings_inbox_show',
+        params: {
+          accountId: router.currentRoute.value.params.accountId,
+          inboxId: props.inbox.id,
+        },
+      });
+      return;
+    }
+
+    const channel = await store.dispatch('inboxes/createChannel', {
+      name: inboxName.value,
+      channel: {
+        type: 'whatsapp',
+        phone_number: phoneNumber.value,
+        provider: props.descriptor.key,
+        provider_config: providerConfig,
+      },
+    });
+
+    router.replace({
+      name: 'settings_inboxes_add_agents',
+      params: { page: 'new', inbox_id: channel.id },
+    });
+  } catch (error) {
+    useAlert(
+      error.message ||
+        t(
+          isConvertMode.value
+            ? 'INBOX_MGMT.CONVERT.API.ERROR_MESSAGE'
+            : 'INBOX_MGMT.ADD.WHATSAPP.API.ERROR_MESSAGE'
+        )
+    );
+  }
+};
+</script>
+
+<template>
+  <form class="flex flex-wrap mx-0" @submit.prevent="submit()">
+    <div class="w-[65%] flex-shrink-0 flex-grow-0 max-w-[65%]">
+      <label :class="{ error: v$.inboxName.$error }">
+        {{ $t('INBOX_MGMT.ADD.WHATSAPP.INBOX_NAME.LABEL') }}
+        <input
+          v-model="inboxName"
+          type="text"
+          :disabled="isConvertMode"
+          :placeholder="$t('INBOX_MGMT.ADD.WHATSAPP.INBOX_NAME.PLACEHOLDER')"
+          @blur="v$.inboxName.$touch"
+        />
+        <span v-if="v$.inboxName.$error" class="message">
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.INBOX_NAME.ERROR') }}
+        </span>
+      </label>
+    </div>
+
+    <div class="w-[65%] flex-shrink-0 flex-grow-0 max-w-[65%]">
+      <label :class="{ error: v$.phoneNumber.$error }">
+        {{ $t('INBOX_MGMT.ADD.WHATSAPP.PHONE_NUMBER.LABEL') }}
+        <input
+          v-model="phoneNumber"
+          type="text"
+          :disabled="isConvertMode"
+          :placeholder="$t('INBOX_MGMT.ADD.WHATSAPP.PHONE_NUMBER.PLACEHOLDER')"
+          @blur="v$.phoneNumber.$touch"
+        />
+        <span v-if="v$.phoneNumber.$error" class="message">
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.PHONE_NUMBER.ERROR') }}
+        </span>
+      </label>
+    </div>
+
+    <div
+      v-for="field in credentialFields"
+      :key="field.name"
+      class="w-[65%] flex-shrink-0 flex-grow-0 max-w-[65%]"
+    >
+      <label :class="{ error: v$.fieldValues[field.name].$error }">
+        {{ $t(`${fieldKey(field)}.LABEL`) }}
+        <input
+          v-model="fieldValues[field.name]"
+          :type="inputType(field)"
+          :placeholder="$t(`${fieldKey(field)}.PLACEHOLDER`)"
+          @blur="v$.fieldValues[field.name].$touch"
+        />
+        <span v-if="v$.fieldValues[field.name].$error" class="message">
+          {{ $t(`${fieldKey(field)}.ERROR`) }}
+        </span>
+      </label>
+    </div>
+
+    <div
+      v-if="!showAdvancedOptions && preferenceFields.length"
+      class="w-[65%] flex-shrink-0 flex-grow-0 max-w-[65%] mb-4"
+    >
+      <NextButton
+        icon="i-lucide-plus"
+        sm
+        link
+        @click="showAdvancedOptions = true"
+      >
+        {{ $t('INBOX_MGMT.ADD.WHATSAPP.ADVANCED_OPTIONS') }}
+      </NextButton>
+    </div>
+    <template v-else-if="preferenceFields.length">
+      <div class="w-[65%] flex-shrink-0 flex-grow-0 max-w-[65%]">
+        <span class="text-sm text-gray-600">
+          {{ $t('INBOX_MGMT.ADD.WHATSAPP.ADVANCED_OPTIONS') }}
+        </span>
+      </div>
+      <div
+        v-for="field in preferenceFields"
+        :key="field.name"
+        class="w-[65%] flex-shrink-0 flex-grow-0 max-w-[65%]"
+      >
+        <label>
+          <div class="flex mb-2 items-center">
+            <span class="mr-2 text-sm">
+              {{ $t(`${fieldKey(field)}.LABEL`) }}
+            </span>
+            <Switch :id="field.name" v-model="fieldValues[field.name]" />
+          </div>
+        </label>
+      </div>
+    </template>
+
+    <div class="w-full">
+      <NextButton
+        :is-loading="uiFlags.isCreating || uiFlags.isUpdating"
+        type="submit"
+        solid
+        blue
+        :label="
+          isConvertMode
+            ? $t('INBOX_MGMT.CONVERT.SUBMIT_BUTTON')
+            : $t('INBOX_MGMT.ADD.WHATSAPP.SUBMIT_BUTTON')
+        "
+      />
+    </div>
+  </form>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/specs/Whatsapp.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/specs/Whatsapp.spec.js
@@ -1,7 +1,20 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { defineComponent, h, nextTick, reactive, ref } from 'vue';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import Whatsapp from '../Whatsapp.vue';
+import WhatsappChannel from 'dashboard/api/channel/whatsappChannel';
+
+// The picker fetches the session catalog on mount. Without this the real module reaches
+// for axios and the composable's own catch swallows it, so every session provider would
+// silently be missing from the picker rather than the test saying so.
+vi.mock('dashboard/api/channel/whatsappChannel', () => ({
+  default: { getSessionProviders: vi.fn() },
+}));
+
+const SESSION_CATALOG = [
+  { key: 'uazapi', creatable: true, beta: true, fields: [] },
+  { key: 'baileys', creatable: true, beta: false, legacy: true, fields: [] },
+];
 
 // Mutable reactive route — tests drive route.query / route.name through it
 // to exercise how the parent reacts to navigation events.
@@ -58,6 +71,15 @@ const stubComponent = name =>
     template: `<div class="${name}-stub" />`,
   });
 
+const ChannelSelectorStub = defineComponent({
+  name: 'ChannelSelector',
+  // Declared so the assertion can read it back with `props()`. eslint cannot see into a
+  // string template, so it reads the prop as unused.
+  // eslint-disable-next-line vue/no-unused-properties
+  props: { isBeta: { type: Boolean, default: false } },
+  template: '<div class="ChannelSelector-stub" />',
+});
+
 const WhatsappEmbeddedSignupStub = defineComponent({
   name: 'WhatsappEmbeddedSignup',
   // eslint-disable-next-line vue/no-unused-emit-declarations
@@ -86,7 +108,7 @@ const mountWhatsapp = (overrides = {}) => {
         Twilio: stubComponent('Twilio'),
         ThreeSixtyDialogWhatsapp: stubComponent('ThreeSixtyDialogWhatsapp'),
         CloudWhatsapp: stubComponent('CloudWhatsapp'),
-        ChannelSelector: stubComponent('ChannelSelector'),
+        ChannelSelector: ChannelSelectorStub,
         BaileysWhatsapp: stubComponent('BaileysWhatsapp'),
         ZapiWhatsapp: stubComponent('ZapiWhatsapp'),
       },
@@ -107,6 +129,9 @@ describe('Whatsapp.vue (convert mode)', () => {
     originalChatwootConfig = window.chatwootConfig;
     mockPush.mockReset();
     mockReplace.mockReset();
+    WhatsappChannel.getSessionProviders.mockResolvedValue({
+      data: { payload: SESSION_CATALOG },
+    });
     mockRoute = reactive({
       name: 'settings_inbox_convert',
       params: { inboxId: 30 },
@@ -130,6 +155,22 @@ describe('Whatsapp.vue (convert mode)', () => {
     await nextTick();
     expect(wrapper.find('.WhatsappEmbeddedSignup-stub').exists()).toBe(true);
     expect(wrapper.find('.ChannelSelector-stub').exists()).toBe(false);
+  });
+
+  // The badge is what tells the admin a provider is not settled yet, and it follows the
+  // catalog rather than the label, so a provider leaving beta is a server-side change.
+  it('badges the session providers the catalog reports as beta', async () => {
+    const wrapper = mountWhatsapp();
+    await flushPromises();
+
+    const badged = wrapper
+      .findAllComponents(ChannelSelectorStub)
+      .filter(selector => selector.props('isBeta'));
+
+    expect(
+      wrapper.findAllComponents(ChannelSelectorStub).length
+    ).toBeGreaterThan(badged.length);
+    expect(badged).toHaveLength(1);
   });
 
   // Reproduces the "flash" bug: a successful embedded signup runs

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/ChannelName.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/ChannelName.vue
@@ -2,6 +2,7 @@
 import { useI18n } from 'vue-i18n';
 import { useStoreGetters } from 'dashboard/composables/store';
 import { computed } from 'vue';
+import { isSessionProvider } from 'dashboard/helper/whatsappSession';
 
 const props = defineProps({
   channelType: {
@@ -48,11 +49,8 @@ const twilioChannelName = () => {
 };
 
 const whatsappChannelName = () => {
-  if (props.provider === 'baileys') {
-    return t(`INBOX_MGMT.CHANNELS.WHATSAPP_BAILEYS`);
-  }
-  if (props.provider === 'zapi') {
-    return t(`INBOX_MGMT.CHANNELS.WHATSAPP_ZAPI`);
+  if (isSessionProvider(props.provider)) {
+    return t(`INBOX_MGMT.CHANNELS.WHATSAPP_${props.provider.toUpperCase()}`);
   }
   return t(`INBOX_MGMT.CHANNELS.WHATSAPP`);
 };

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/ConfigurationPage.vue
@@ -17,6 +17,7 @@ import TextArea from 'next/textarea/TextArea.vue';
 import { sanitizeAllowedDomains, isValidURL } from 'dashboard/helper/URLHelper';
 import { requiredIf } from '@vuelidate/validators';
 import WhatsappLinkDeviceModal from '../components/WhatsappLinkDeviceModal.vue';
+import SessionProviderConfiguration from './SessionProviderConfiguration.vue';
 import WhatsappBusinessManagementToken from './WhatsappBusinessManagementToken.vue';
 import InboxName from 'dashboard/components/widgets/InboxName.vue';
 import Switch from 'dashboard/components-next/switch/Switch.vue';
@@ -32,6 +33,7 @@ export default {
     NextButton,
     TextArea,
     WhatsappLinkDeviceModal,
+    SessionProviderConfiguration,
     WhatsappBusinessManagementToken,
     InboxName,
     // eslint-disable-next-line vue/no-reserved-component-names
@@ -641,6 +643,14 @@ export default {
       </SettingsFieldSection>
     </div>
   </div>
+  <SessionProviderConfiguration
+    v-else-if="
+      isASessionWhatsAppChannel &&
+      !isAWhatsAppBaileysChannel &&
+      !isAWhatsAppZapiChannel
+    "
+    :inbox="inbox"
+  />
   <div v-else-if="isAWhatsAppBaileysChannel">
     <WhatsappLinkDeviceModal
       v-if="showLinkDeviceModal"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from 'vue-i18n';
 import { useAlert } from 'dashboard/composables';
-import { isValidURL } from 'dashboard/helper/URLHelper';
+import { isHttpUrl } from 'dashboard/helper/whatsappSession';
 import { useWhatsappSessionProviders } from 'dashboard/composables/useWhatsappSessionProviders';
 
 import SettingsSection from 'dashboard/components/SettingsSection.vue';
@@ -65,7 +65,7 @@ const isInvalid = field => {
   const value = values.value[field.name];
   if (field.required && field.secret) return false;
   if (field.required && !value) return true;
-  return field.type === 'url' && value && !isValidURL(value);
+  return field.type === 'url' && value && !isHttpUrl(value);
 };
 
 const save = async field => {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
@@ -1,0 +1,168 @@
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue';
+import { useStore } from 'vuex';
+import { useI18n } from 'vue-i18n';
+import { useAlert } from 'dashboard/composables';
+import { isValidURL } from 'dashboard/helper/URLHelper';
+import { useWhatsappSessionProviders } from 'dashboard/composables/useWhatsappSessionProviders';
+
+import SettingsSection from 'dashboard/components/SettingsSection.vue';
+import WhatsappLinkDeviceModal from '../components/WhatsappLinkDeviceModal.vue';
+import InboxName from 'dashboard/components/widgets/InboxName.vue';
+import NextButton from 'dashboard/components-next/button/Button.vue';
+import Switch from 'dashboard/components-next/switch/Switch.vue';
+
+const props = defineProps({
+  inbox: { type: Object, required: true },
+});
+
+const store = useStore();
+const { t } = useI18n();
+const { descriptorFor, fetchProviders } = useWhatsappSessionProviders();
+onMounted(fetchProviders);
+
+const descriptor = computed(() => descriptorFor(props.inbox.provider));
+const credentialFields = computed(
+  () => descriptor.value?.fields?.filter(f => f.type !== 'boolean') ?? []
+);
+const preferenceFields = computed(
+  () => descriptor.value?.fields?.filter(f => f.type === 'boolean') ?? []
+);
+
+// Edited values live apart from the inbox so a failed save leaves the record showing
+// what the server still holds.
+const values = ref({});
+watch(
+  [descriptor, () => props.inbox.provider_config],
+  ([shape, config]) => {
+    if (!shape) return;
+    values.value = Object.fromEntries(
+      shape.fields.map(field => [
+        field.name,
+        // A secret is never served back, so its input starts empty and an untouched one
+        // is left alone on save rather than overwriting the stored credential with ''.
+        field.secret
+          ? ''
+          : (config?.[field.name] ??
+            field.default ??
+            (field.type === 'boolean' ? false : '')),
+      ])
+    );
+  },
+  { immediate: true }
+);
+
+const showLinkDeviceModal = ref(false);
+
+const fieldKey = field =>
+  `INBOX_MGMT.ADD.WHATSAPP.SESSION.FIELDS.${field.name.toUpperCase()}`;
+
+const isInvalid = field => {
+  const value = values.value[field.name];
+  if (field.required && field.secret) return false;
+  if (field.required && !value) return true;
+  return field.type === 'url' && value && !isValidURL(value);
+};
+
+const save = async field => {
+  if (isInvalid(field)) return;
+
+  const value = values.value[field.name];
+  // An untouched secret input means "leave it as it is", not "clear it".
+  if (field.secret && !value) return;
+
+  try {
+    await store.dispatch('inboxes/updateInbox', {
+      id: props.inbox.id,
+      formData: false,
+      channel: {
+        provider_config: {
+          ...props.inbox.provider_config,
+          [field.name]: value,
+        },
+      },
+    });
+    useAlert(t('INBOX_MGMT.EDIT.API.SUCCESS_MESSAGE'));
+  } catch (error) {
+    useAlert(t('INBOX_MGMT.EDIT.API.ERROR_MESSAGE'));
+  }
+};
+</script>
+
+<template>
+  <div>
+    <WhatsappLinkDeviceModal
+      v-if="showLinkDeviceModal"
+      :show="showLinkDeviceModal"
+      :on-close="() => (showLinkDeviceModal = false)"
+      :inbox="inbox"
+    />
+    <div class="mx-8">
+      <SettingsSection
+        :title="
+          $t(
+            'INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_MANAGE_PROVIDER_CONNECTION_TITLE'
+          )
+        "
+        :sub-title="
+          $t(
+            'INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_MANAGE_PROVIDER_CONNECTION_SUBHEADER'
+          )
+        "
+      >
+        <div class="flex flex-col gap-2">
+          <InboxName
+            :inbox="inbox"
+            class="!text-lg !m-0"
+            with-phone-number
+            with-provider-connection-status
+          />
+          <NextButton class="w-fit" @click="showLinkDeviceModal = true">
+            {{
+              $t(
+                'INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_MANAGE_PROVIDER_CONNECTION_BUTTON'
+              )
+            }}
+          </NextButton>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        v-for="field in credentialFields"
+        :key="field.name"
+        :title="$t(`${fieldKey(field)}.LABEL`)"
+        :sub-title="$t(`${fieldKey(field)}.PLACEHOLDER`)"
+      >
+        <div class="flex items-center justify-between flex-1 mt-2">
+          <woot-input
+            v-model="values[field.name]"
+            :type="field.type === 'password' ? 'password' : 'text'"
+            class="flex-1 mr-2 items-center"
+            :placeholder="$t(`${fieldKey(field)}.PLACEHOLDER`)"
+          />
+          <NextButton
+            :disabled="isInvalid(field)"
+            :label="$t('INBOX_MGMT.SETTINGS_POPUP.UPDATE')"
+            @click="save(field)"
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        v-for="field in preferenceFields"
+        :key="field.name"
+        :title="$t(`${fieldKey(field)}.LABEL`)"
+        :sub-title="$t(`${fieldKey(field)}.LABEL`)"
+      >
+        <div class="flex items-center gap-2">
+          <Switch
+            :id="field.name"
+            v-model="values[field.name]"
+            @change="save(field)"
+          />
+          <span class="text-sm">{{ $t(`${fieldKey(field)}.LABEL`) }}</span>
+        </div>
+      </SettingsSection>
+    </div>
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
@@ -11,6 +11,7 @@ import WhatsappLinkDeviceModal from '../components/WhatsappLinkDeviceModal.vue';
 import InboxName from 'dashboard/components/widgets/InboxName.vue';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 import Switch from 'dashboard/components-next/switch/Switch.vue';
+import Label from 'dashboard/components-next/label/Label.vue';
 
 const props = defineProps({
   inbox: { type: Object, required: true },
@@ -22,6 +23,9 @@ const { descriptorFor, fetchProviders } = useWhatsappSessionProviders();
 onMounted(fetchProviders);
 
 const descriptor = computed(() => descriptorFor(props.inbox.provider));
+// Said where the inbox is managed, not only where it was picked: whoever inherits an
+// inbox never saw the picker, and this is the page they change its credentials on.
+const isBeta = computed(() => Boolean(descriptor.value?.beta));
 const credentialFields = computed(
   () => descriptor.value?.fields?.filter(f => f.type !== 'boolean') ?? []
 );
@@ -111,12 +115,21 @@ const save = async field => {
         "
       >
         <div class="flex flex-col gap-2">
-          <InboxName
-            :inbox="inbox"
-            class="!text-lg !m-0"
-            with-phone-number
-            with-provider-connection-status
-          />
+          <div class="flex items-center gap-2">
+            <InboxName
+              :inbox="inbox"
+              class="!text-lg !m-0"
+              with-phone-number
+              with-provider-connection-status
+            />
+            <Label
+              v-if="isBeta"
+              v-tooltip.top="t('GENERAL.BETA_DESCRIPTION')"
+              :label="t('GENERAL.BETA')"
+              color="blue"
+              compact
+            />
+          </div>
           <NextButton class="w-fit" @click="showLinkDeviceModal = true">
             {{
               $t(

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/specs/SessionProviderConfiguration.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/specs/SessionProviderConfiguration.spec.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { defineComponent, nextTick } from 'vue';
+import { flushPromises, mount } from '@vue/test-utils';
+import SessionProviderConfiguration from '../SessionProviderConfiguration.vue';
+import WhatsappChannel from 'dashboard/api/channel/whatsappChannel';
+
+vi.mock('dashboard/api/channel/whatsappChannel', () => ({
+  default: { getSessionProviders: vi.fn() },
+}));
+
+const mockDispatch = vi.fn();
+vi.mock('vuex', () => ({ useStore: () => ({ dispatch: mockDispatch }) }));
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual('vue-i18n');
+  return { ...actual, useI18n: () => ({ t: key => key }) };
+});
+
+const mockAlert = vi.fn();
+vi.mock('dashboard/composables', () => ({
+  useAlert: (...args) => mockAlert(...args),
+}));
+
+const stub = name =>
+  defineComponent({ name, template: `<div class="${name}-stub" />` });
+
+const FIELDS = [
+  {
+    name: 'base_url',
+    type: 'url',
+    required: true,
+    default: null,
+    secret: false,
+  },
+  {
+    name: 'token',
+    type: 'password',
+    required: true,
+    default: null,
+    secret: true,
+  },
+  {
+    name: 'mark_as_read',
+    type: 'boolean',
+    required: false,
+    default: true,
+    secret: false,
+  },
+];
+
+const catalog = ({ beta }) => [
+  { key: 'uazapi', creatable: true, beta, legacy: false, fields: FIELDS },
+];
+
+const INBOX = {
+  id: 7,
+  provider: 'uazapi',
+  name: 'Suporte',
+  // The server never serves the token back, which is what the save path has to survive.
+  provider_config: { base_url: 'https://uaz.example', mark_as_read: true },
+};
+
+const mountPage = async ({ beta = true } = {}) => {
+  WhatsappChannel.getSessionProviders.mockResolvedValue({
+    data: { payload: catalog({ beta }) },
+  });
+
+  const wrapper = mount(SessionProviderConfiguration, {
+    props: { inbox: INBOX },
+    global: {
+      stubs: {
+        WhatsappLinkDeviceModal: stub('WhatsappLinkDeviceModal'),
+        InboxName: stub('InboxName'),
+        // Rendered rather than stubbed away: the badge lives in its slot.
+        SettingsSection: defineComponent({
+          name: 'SettingsSection',
+          inheritAttrs: false,
+          template: '<div class="SettingsSection-stub"><slot /></div>',
+        }),
+        NextButton: stub('NextButton'),
+        Switch: stub('Switch'),
+        'woot-input': stub('woot-input'),
+      },
+    },
+  });
+
+  await flushPromises();
+  await nextTick();
+  return wrapper;
+};
+
+describe('SessionProviderConfiguration', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Whoever inherits an inbox never saw the picker, so the beta warning has to survive
+  // on the page they manage it from.
+  it('badges an inbox whose provider the catalog reports as beta', async () => {
+    const wrapper = await mountPage({ beta: true });
+
+    expect(wrapper.findComponent({ name: 'Label' }).exists()).toBe(true);
+  });
+
+  it('drops the badge once the provider leaves beta', async () => {
+    const wrapper = await mountPage({ beta: false });
+
+    expect(wrapper.findComponent({ name: 'Label' }).exists()).toBe(false);
+  });
+
+  // A secret is never served back, so its input starts empty. Saving that empty input
+  // would replace the stored credential with '' and silently disconnect the inbox.
+  it('leaves an untouched secret alone instead of clearing it', async () => {
+    const wrapper = await mountPage();
+    const token = FIELDS.find(field => field.secret);
+
+    await wrapper.vm.save(token);
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('sends a secret the operator actually typed', async () => {
+    const wrapper = await mountPage();
+    const token = FIELDS.find(field => field.secret);
+    wrapper.vm.values[token.name] = 'new-token';
+
+    await wrapper.vm.save(token);
+
+    expect(mockDispatch).toHaveBeenCalledWith('inboxes/updateInbox', {
+      id: INBOX.id,
+      formData: false,
+      channel: {
+        provider_config: { ...INBOX.provider_config, token: 'new-token' },
+      },
+    });
+  });
+});

--- a/app/services/whatsapp/session/channel_extension.rb
+++ b/app/services/whatsapp/session/channel_extension.rb
@@ -4,12 +4,12 @@
 #
 # Each override answers for the session providers and falls straight back to `super` for
 # the legacy and cloud ones, so no existing provider changes behavior.
-module Whatsapp::Session::ChannelExtension
+module Whatsapp::Session::ChannelExtension # rubocop:disable Metrics/ModuleLength
   # Registers the rollout gate as a real validation so it covers both paths that can
   # put an inbox on a session provider: creating one and converting an existing one
   # (`convert_provider!` pre-validates with `valid?` before it persists anything).
   def self.prepended(base)
-    base.validate :validate_session_provider_enabled
+    base.validate :validate_provider_eligible
     base.after_update_commit :handle_provider_config_change, if: :saved_change_to_provider_config?
   end
 
@@ -163,16 +163,30 @@ module Whatsapp::Session::ChannelExtension
     session_backend.ensure_registration
   end
 
-  # The account toggles are the rollout switch, and a picker that hides a provider is
-  # not a gate: the API would happily create a `native` inbox for any account. Only new
-  # records and provider changes are checked, so turning a toggle back off never makes
-  # an inbox that already exists unsaveable.
-  def validate_session_provider_enabled
-    return unless session_provider?
+  # Who may stand up an inbox on this provider: the account toggles while the new
+  # providers roll out, the deprecation switch once the frozen ones are withdrawn.
+  #
+  # Enforced where the record is written rather than where it is offered, because a
+  # picker that hides a provider is not a gate: the API, the rake conversion tasks and a
+  # `?provider=` URL all reach this code and none of them read the dashboard. Only new
+  # records and provider changes are checked, so flipping a switch back never makes an
+  # inbox that already exists unsaveable.
+  def validate_provider_eligible
     return unless new_record? || provider_changed?
-    return if account&.whatsapp_session_provider_enabled?(provider)
 
-    errors.add(:provider, I18n.t('errors.inboxes.channel.provider_not_enabled_for_account'))
+    reason = ineligible_reason
+    errors.add(:provider, I18n.t("errors.inboxes.channel.#{reason}")) if reason
+  end
+
+  def ineligible_reason
+    return 'provider_withdrawn' if legacy_provider? && !Whatsapp::Session::Registry.legacy_creatable?
+    return 'provider_not_enabled_for_account' if session_provider? && !account&.whatsapp_session_provider_enabled?(provider)
+
+    nil
+  end
+
+  def legacy_provider?
+    Whatsapp::Session::Registry.descriptor(provider)&.legacy? || false
   end
 
   # Session backends validate their config against the descriptor's field list, never

--- a/app/services/whatsapp/session/provider_descriptor.rb
+++ b/app/services/whatsapp/session/provider_descriptor.rb
@@ -42,6 +42,12 @@ class Whatsapp::Session::ProviderDescriptor < Data.define(
     family == 'session'
   end
 
+  # Frozen: still described so an existing inbox can be labelled and gated, never offered
+  # as a destination.
+  def legacy?
+    legacy
+  end
+
   # Served by this layer (as opposed to the legacy session providers, which keep their
   # own services).
   def served?

--- a/app/services/whatsapp/session/provider_descriptor.rb
+++ b/app/services/whatsapp/session/provider_descriptor.rb
@@ -3,7 +3,7 @@
 # fields its setup form asks for. The dashboard renders the form from this, instead of
 # carrying one hardcoded component and one literal check per provider.
 class Whatsapp::Session::ProviderDescriptor < Data.define(
-  :key, :family, :backend, :capabilities, :pairing_modes, :fields, :legacy
+  :key, :family, :backend, :capabilities, :pairing_modes, :fields, :legacy, :beta
 )
   # `session` pairs with a phone (QR / pairing code); `cloud` is the hosted Meta API
   # family (`default` = 360dialog, `whatsapp_cloud`), which this layer does not serve.
@@ -23,7 +23,9 @@ class Whatsapp::Session::ProviderDescriptor < Data.define(
     end
   end
 
-  DEFAULTS = { family: 'session', backend: nil, capabilities: [], pairing_modes: [], fields: [], legacy: false }.freeze
+  DEFAULTS = {
+    family: 'session', backend: nil, capabilities: [], pairing_modes: [], fields: [], legacy: false, beta: false
+  }.freeze
 
   def initialize(**attributes)
     attributes = DEFAULTS.merge(attributes.compact)
@@ -34,7 +36,7 @@ class Whatsapp::Session::ProviderDescriptor < Data.define(
       key: attributes[:key].to_s, family: family, backend: attributes[:backend],
       capabilities: Whatsapp::Session::Capabilities.validate!(attributes[:capabilities]),
       pairing_modes: attributes[:pairing_modes].map(&:to_s).freeze,
-      fields: attributes[:fields].freeze, legacy: attributes[:legacy]
+      fields: attributes[:fields].freeze, legacy: attributes[:legacy], beta: attributes[:beta]
     )
   end
 
@@ -46,6 +48,14 @@ class Whatsapp::Session::ProviderDescriptor < Data.define(
   # as a destination.
   def legacy?
     legacy
+  end
+
+  # Offered, but not yet trusted enough to be picked without being told so. The dashboard
+  # badges it; nothing gates on it. It is a property of the provider rather than of the
+  # account precisely so that ending the beta is one line here instead of a translation
+  # hunt across every label that names it.
+  def beta?
+    beta
   end
 
   # Served by this layer (as opposed to the legacy session providers, which keep their
@@ -75,7 +85,7 @@ class Whatsapp::Session::ProviderDescriptor < Data.define(
 
   def to_h
     {
-      'key' => key, 'family' => family, 'legacy' => legacy, 'available' => available?,
+      'key' => key, 'family' => family, 'legacy' => legacy, 'beta' => beta, 'available' => available?,
       'capabilities' => capabilities, 'pairing_modes' => pairing_modes, 'fields' => fields.map(&:to_h)
     }
   end

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -2,7 +2,11 @@
 # does its form look like" for every WhatsApp provider, including the legacy and cloud
 # ones it does not serve, so the dashboard can drive itself from capabilities instead of
 # provider-name literals.
-module Whatsapp::Session::Registry
+#
+# Most of the length below is the catalog literal itself, and it grows by a table entry
+# every time a provider is described, so the module-length metric is measuring the data
+# rather than the behavior.
+module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
   Descriptor = Whatsapp::Session::ProviderDescriptor
   Field = Whatsapp::Session::ProviderDescriptor::Field
 
@@ -13,6 +17,7 @@ module Whatsapp::Session::Registry
     Descriptor.new(
       key: 'native',
       backend: 'Whatsapp::Session::Backends::Connector::Backend',
+      beta: true,
       pairing_modes: %w[qr code],
       # No session_import: that is the Baileys credential import, which whatsmeow cannot
       # consume, and there is no such command in the contract. Its replacement for the
@@ -28,6 +33,7 @@ module Whatsapp::Session::Registry
     Descriptor.new(
       key: 'uazapi',
       backend: 'Whatsapp::Session::Backends::Uazapi::Backend',
+      beta: true,
       pairing_modes: %w[qr code],
       # No group_invites: the captured build answers 405 on `/group/invitelink`, and the
       # group snapshot it does serve carries no invite code either. A capability that is

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -149,6 +149,13 @@ module Whatsapp::Session::Registry
       value == 'true'
     end
 
+    # Whether the frozen providers are still offered when standing up a new inbox. They
+    # are frozen, not withdrawn: existing inboxes keep working either way, and this is
+    # what the deprecation flips when it starts.
+    def legacy_creatable?
+      ActiveModel::Type::Boolean.new.cast(ENV.fetch('WHATSAPP_LEGACY_PROVIDERS_CREATABLE', true))
+    end
+
     def available_providers
       descriptors.select(&:available?).map(&:key)
     end

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -31,6 +31,7 @@ en:
         provider_unavailable: This WhatsApp provider is not available on this installation yet.
         invalid_provider_config: 'Invalid configuration for: %{keys}'
         provider_not_enabled_for_account: This WhatsApp provider is not enabled for this account yet.
+        provider_withdrawn: This WhatsApp provider is no longer offered for new inboxes. Existing inboxes on it keep working.
         cannot_unpair: This provider cannot unlink the WhatsApp account paired with it, so connecting again would resume the same account. Reset the instance on the provider, point this inbox at another one, or correct the number configured here.
         provider_connection:
           wrong_phone_number: The phone number you are trying to link is not the same as the one you have configured. Please make sure the phone number is correct before scanning the QR code.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -31,6 +31,7 @@ es:
         provider_unavailable: Este proveedor de WhatsApp aún no está disponible en esta instalación.
         invalid_provider_config: 'Configuración inválida en: %{keys}'
         provider_not_enabled_for_account: Este proveedor de WhatsApp aún no está habilitado para esta cuenta.
+        provider_withdrawn: Este proveedor de WhatsApp ya no se ofrece para bandejas de entrada nuevas. Las que ya lo usan siguen funcionando.
         cannot_unpair: Este proveedor no puede desvincular la cuenta de WhatsApp emparejada con él, así que conectar de nuevo retomaría la misma cuenta. Reinicia la instancia en el proveedor, apunta esta bandeja de entrada a otra, o corrige el número configurado aquí.
         provider_connection:
           wrong_phone_number: El número de teléfono que intenta vincular no es el mismo que tiene configurado. Verifique que el número sea correcto antes de escanear el código QR.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -31,6 +31,7 @@ pt_BR:
         provider_unavailable: Este provedor de WhatsApp ainda não está disponível nesta instalação.
         invalid_provider_config: 'Configuração inválida em: %{keys}'
         provider_not_enabled_for_account: Este provedor de WhatsApp ainda não está habilitado para esta conta.
+        provider_withdrawn: Este provedor de WhatsApp não é mais oferecido para novas caixas de entrada. As caixas que já usam ele continuam funcionando.
         cannot_unpair: Este provedor não consegue desvincular a conta do WhatsApp pareada com ele, então conectar de novo retomaria a mesma conta. Reinicie a instância no provedor, aponte esta caixa de entrada para outra, ou corrija o número configurado aqui.
         provider_connection:
           wrong_phone_number: O número de telefone que você está tentando conectar não é o mesmo que o configurado. Certifique-se de que o número está correto antes de escanear o QR code.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -449,6 +449,7 @@ Rails.application.routes.draw do
 
           namespace :whatsapp do
             resource :authorization, only: [:create]
+            resources :session_providers, only: [:index]
           end
 
           resources :webhooks, only: [:index, :create, :update, :destroy]

--- a/spec/controllers/api/v1/accounts/whatsapp/session_providers_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/whatsapp/session_providers_controller_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe 'WhatsApp Session Providers API', type: :request do
         expect(uazapi['pairing_modes']).to contain_exactly('qr', 'code')
       end
 
+      it 'tells the picker which providers are still in beta' do
+        expect(payload.select { |p| p['beta'] }.pluck('key')).to contain_exactly('native', 'uazapi')
+      end
+
       it 'marks a provider creatable only once the account is opted in' do
         expect(payload.find { |p| p['key'] == 'uazapi' }['creatable']).to be(false)
 

--- a/spec/controllers/api/v1/accounts/whatsapp/session_providers_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/whatsapp/session_providers_controller_spec.rb
@@ -64,13 +64,19 @@ RSpec.describe 'WhatsApp Session Providers API', type: :request do
         end
       end
 
-      # Legacy providers are described so an existing inbox can be labelled, never
-      # offered as a destination for a new one.
-      it 'never marks a legacy provider creatable' do
+      # Frozen, not withdrawn: they are what most inboxes run on today, and the
+      # deprecation is what stops offering them.
+      it 'keeps the legacy providers on offer' do
         legacy = payload.select { |p| p['legacy'] }
 
         expect(legacy.pluck('key')).to contain_exactly('baileys', 'zapi')
-        expect(legacy.pluck('creatable')).to all(be(false))
+        expect(legacy.pluck('creatable')).to all(be(true))
+      end
+
+      it 'withdraws the legacy providers when the deprecation switch is thrown' do
+        with_modified_env WHATSAPP_LEGACY_PROVIDERS_CREATABLE: 'false' do
+          expect(payload.select { |p| p['legacy'] }.pluck('creatable')).to all(be(false))
+        end
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/whatsapp/session_providers_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/whatsapp/session_providers_controller_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe 'WhatsApp Session Providers API', type: :request do
+  let(:account) { create(:account) }
+  let(:url) { "/api/v1/accounts/#{account.id}/whatsapp/session_providers" }
+
+  describe 'GET /api/v1/accounts/{account.id}/whatsapp/session_providers' do
+    context 'when it is an unauthenticated user' do
+      it 'returns unauthorized' do
+        get url
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an agent' do
+      let(:agent) { create(:user, account: account, role: :agent) }
+
+      it 'returns unauthorized' do
+        get url, headers: agent.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when it is an administrator' do
+      let(:administrator) { create(:user, account: account, role: :administrator) }
+
+      def payload
+        get url, headers: administrator.create_new_auth_token, as: :json
+        response.parsed_body['payload']
+      end
+
+      it 'describes every session provider and no cloud one' do
+        expect(payload.pluck('key')).to contain_exactly('native', 'uazapi', 'baileys', 'zapi')
+      end
+
+      it 'carries the form and the capabilities the dashboard renders from' do
+        uazapi = payload.find { |p| p['key'] == 'uazapi' }
+
+        expect(uazapi['fields'].pluck('name')).to include('base_url', 'token')
+        expect(uazapi['fields'].find { |f| f['name'] == 'token' }).to include('required' => true, 'secret' => true)
+        expect(uazapi['capabilities']).to include('reactions')
+        expect(uazapi['pairing_modes']).to contain_exactly('qr', 'code')
+      end
+
+      it 'marks a provider creatable only once the account is opted in' do
+        expect(payload.find { |p| p['key'] == 'uazapi' }['creatable']).to be(false)
+
+        account.update!(whatsapp_uazapi_enabled: true)
+
+        expect(payload.find { |p| p['key'] == 'uazapi' }['creatable']).to be(true)
+      end
+
+      # The connector is what serves `native`, so an installation without one must not
+      # offer it however the account is configured.
+      it 'keeps native uncreatable while no connector is deployed' do
+        account.update!(whatsapp_native_enabled: true)
+
+        expect(payload.find { |p| p['key'] == 'native' }).to include('available' => false, 'creatable' => false)
+
+        with_modified_env WHATSAPP_CONNECTOR_ENABLED: 'true' do
+          expect(payload.find { |p| p['key'] == 'native' }).to include('available' => true, 'creatable' => true)
+        end
+      end
+
+      # Legacy providers are described so an existing inbox can be labelled, never
+      # offered as a destination for a new one.
+      it 'never marks a legacy provider creatable' do
+        legacy = payload.select { |p| p['legacy'] }
+
+        expect(legacy.pluck('key')).to contain_exactly('baileys', 'zapi')
+        expect(legacy.pluck('creatable')).to all(be(false))
+      end
+    end
+  end
+end

--- a/spec/services/whatsapp/session/channel_extension_spec.rb
+++ b/spec/services/whatsapp/session/channel_extension_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Whatsapp::Session::ChannelExtension do
   # The real descriptors stay unavailable until their backends ship, so the validation
   # examples stand in a descriptor that is already serving.
   def stub_descriptor(provider, backend)
-    descriptor = instance_double(Whatsapp::Session::ProviderDescriptor, available?: true, backend_class: backend)
+    descriptor = instance_double(Whatsapp::Session::ProviderDescriptor, available?: true, backend_class: backend, legacy?: false)
     allow(Whatsapp::Session::Registry).to receive(:descriptor).and_call_original
     allow(Whatsapp::Session::Registry).to receive(:descriptor).with(provider).and_return(descriptor)
   end
@@ -63,6 +63,30 @@ RSpec.describe Whatsapp::Session::ChannelExtension do
 
       expect(channel).not_to be_valid
       expect(channel.errors[:provider_config].first).to include('base_url', 'token')
+    end
+
+    # The picker is not the gate: the API, the rake conversion tasks and a `?provider=`
+    # URL all reach the record without reading the dashboard.
+    it 'refuses a frozen provider once the deprecation switch is thrown' do
+      with_modified_env WHATSAPP_LEGACY_PROVIDERS_CREATABLE: 'false' do
+        channel = build(:channel_whatsapp, account: account, provider: 'baileys', provider_config: {})
+        # The factory's bypass runs on create; this example never gets that far, and the
+        # legacy validation reaches for the provider over the network.
+        channel.define_singleton_method(:validate_provider_config) { nil }
+
+        expect(channel).not_to be_valid
+        expect(channel.errors[:provider]).to include(I18n.t('errors.inboxes.channel.provider_withdrawn'))
+      end
+    end
+
+    it 'leaves an existing inbox on a frozen provider saveable after the switch is thrown' do
+      channel = build_channel('baileys')
+
+      with_modified_env WHATSAPP_LEGACY_PROVIDERS_CREATABLE: 'false' do
+        channel.provider_config = { 'mark_as_read' => false }
+
+        expect(channel.valid?).to be(true)
+      end
     end
 
     it 'accepts a config the backend approves' do

--- a/spec/services/whatsapp/session/registry_spec.rb
+++ b/spec/services/whatsapp/session/registry_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe Whatsapp::Session::Registry do
     expect(described_class.descriptor('baileys').served?).to be(false)
   end
 
+  # The badge follows the descriptor, so this is what decides whether the picker warns the
+  # admin. Ending the beta is flipping these two, and the frozen providers were never in
+  # one.
+  it 'marks the new session providers as beta and nothing else' do
+    beta = described_class.descriptors.select(&:beta?).map(&:key)
+
+    expect(beta).to contain_exactly('native', 'uazapi')
+  end
+
   it 'reports a provider as unavailable while its backend class is missing' do
     descriptor = Whatsapp::Session::ProviderDescriptor.new(key: 'uazapi', backend: 'Whatsapp::Session::Backends::NotShippedYet')
 


### PR DESCRIPTION
A WhatsApp inbox can now be created on `native` or `uazapi` from the dashboard. The setup form, the picker entry and the inbox settings for either one are rendered from what the server declares about the provider, so neither has a component or a provider name of its own anywhere in the frontend.

`GET /whatsapp/session_providers` answers with the catalog: which providers this account may pick, the fields each one's form asks for, how it pairs, and what it can do once connected. `creatable` is computed there rather than in the browser, because the same rule already decides whether the channel accepts the create.

## Closes

Part of the WhatsApp session layer (slice 8 of 9). Stacked on #383.

## How to test

`native` needs a connector deployed (`WHATSAPP_CONNECTOR_ENABLED`); `uazapi` needs an instance and its token. Both are opted in per account: super admin, or `account.update!(whatsapp_uazapi_enabled: true)`.

1. With the account opted out, open **Add inbox → WhatsApp** and confirm neither provider is offered. Opt in and confirm the one you enabled appears.
2. Pick it. The form asks for the inbox name, the phone number, and exactly the fields the provider declares — for uazapi that is the instance URL and its token, with the preferences behind **Advanced options**.
3. Save with a wrong token and confirm the inbox is created without the setup touching the network; connecting is what fails.
4. Open the inbox's **Configuration** tab and confirm the connection panel and one section per provider field. Change a preference and confirm it saves; retype the token and confirm it saves; leave the token untouched and save something else, then confirm the stored token still works.
5. Convert an existing WhatsApp inbox to the provider and back, and confirm the conversation history survives.
6. Confirm Baileys and Z-API are still offered in the picker and still work, unchanged.
7. Set `WHATSAPP_LEGACY_PROVIDERS_CREATABLE=false` and confirm they disappear from both pickers while existing inboxes keep working.
8. Confirm `native` and `uazapi` carry a **Beta** badge in the picker and on the inbox's Configuration tab, and that no other provider does.
9. With `SAFE_FETCH_ALLOW_PRIVATE_NETWORK=true`, enter an instance URL on the deployment's own network (`http://uazapi:3000`) and confirm the form accepts it and the inbox saves.

## What changed

**The catalog endpoint.** `Api::V1::Accounts::Whatsapp::SessionProvidersController#index` serves the session-family descriptors, each with the `creatable` answer for this account. Administrators only: it exists to drive the two forms only an administrator can reach.

**One form for both providers.** `SessionWhatsapp.vue` takes a descriptor and renders it: non-boolean fields are what the inbox cannot connect without, booleans are preferences with a default and sit behind the advanced toggle. `SessionProviderConfiguration.vue` does the same for an existing inbox, with one detail worth knowing: a secret is never served back, so its input starts empty and an untouched one is left alone on save rather than overwriting the stored credential with an empty string.

**The new providers say they are new.** `native` and `uazapi` are offered before they have earned the trust of the providers beside them, so both carry a Beta badge: in the picker, where the choice is made, and on the inbox's Configuration tab, since whoever inherits an inbox never saw the picker and that is where they change its credentials. The marker is a `beta` field on the descriptor rather than "(BETA)" in the labels — the badge and its tooltip already exist on `ChannelSelector`, and ending the beta becomes two lines in the registry instead of twelve strings across three languages. The shared tooltip is now rendered by our own providers, so the fork overrides it where upstream got it wrong: pt_BR was ungrammatical, es was untranslated English.

**Legacy providers stay in the picker.** The plan had them leaving with this change. They are frozen, not withdrawn, and they are what most inboxes run on today — pulling them before `native` and `uazapi` have run in production would take the fork's main path with them. `WHATSAPP_LEGACY_PROVIDERS_CREATABLE` is the switch, on the server, so the deprecation is one env var rather than a dashboard change.

**Also here**: the advanced-options toggle in the Baileys form had no `type`, so the browser treated it as a submit button. With the required fields already valid, revealing the preference switches created the inbox. Same one-attribute fix, found by the review of the new form.

**And one the review caught late**: the provider URL field validated with `isValidURL`, whose regex needs a dot in the host, while `Backend.validate_config` takes any http(s) URI that has a host. So `http://uazapi:3000` — an instance self-hosted next to Chatwoot, which is what `use_internal_host` exists for and what `SAFE_FETCH_ALLOW_PRIVATE_NETWORK` already permits server-side — could not be typed into the form at all. The client now checks shape and leaves the network policy to the server, the only side that knows it. The trade-off is deliberate: a private address on a deployment that has not opened its private network now fails on save instead of inline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/384)
<!-- Reviewable:end -->

