### PR TITLE
feat(whatsapp): session layer 9/9, tooling to move an inbox off a frozen provider

### DIFF
--- a/.claude/skills/sync-fork/SKILL.md
+++ b/.claude/skills/sync-fork/SKILL.md
@@ -195,6 +195,62 @@ Upstream 4.16.0 rearchitected `Featurable`: `FEATURE_FLAG_COLUMNS = ['feature_fl
 - Controller gate: `can_reconfigure_channel?` (upstream name, our body) accepts any `Channel::Whatsapp` (fork conversion flow) and requires the `whatsapp_reconfigure` feature flag only when `provider_config['source'] == 'embedded_signup'`. Keep that shape.
 - Enterprise's new `Inbox#ensure_create_permitted` runs `account.inboxes.count` in `before_create` — fork specs that `instance_double` the `account.inboxes` relation must materialize factory records BEFORE installing the double (lazy `let` inside the `allow(...).with(baileys_inbox.id)` line fires mid-stub otherwise).
 
+### WhatsApp session providers (`native`, `uazapi`)
+
+The provider-neutral layer for the QR/pairing family. Nearly all of it is fork-only code in
+paths upstream has never had, so it does not conflict: `app/services/whatsapp/session/**`,
+`app/jobs/whatsapp/session/**`, `app/controllers/webhooks/whatsapp/**`,
+`app/controllers/api/v1/accounts/whatsapp/**`, `app/javascript/dashboard/helper/whatsappSession.js`,
+`.../inbox/channels/session/**`, `.../inbox/settingsPage/SessionProviderConfiguration.vue`,
+`lib/tasks/whatsapp_session.rake`. Merge conflicts there mean someone edited our tree, not upstream.
+
+What it *does* touch upstream is deliberately small, and every one is **KC** on a CE merge
+(upstream has no idea these providers exist):
+
+| File | Ours |
+|---|---|
+| `app/models/channel/whatsapp.rb` | `prepend Whatsapp::Session::ChannelExtension` and `PROVIDERS = (%w[...] + Whatsapp::Session::PROVIDERS)`. Every behavior override lives in the module, so upstream changing a method body usually merges clean. |
+| `app/services/whatsapp/send_on_whatsapp_service.rb` | `persist_source_id` goes through `Session::Outbound::SourceIdReservation.assign`, and `recipient_id` branches on `channel.session_family?`. |
+| `app/services/conversations/message_window_service.rb` | one line: `session_family?` instead of a provider list. |
+| `app/views/api/v1/models/_inbox.json.jbuilder` | `json.capabilities resource.channel.try(:session_capabilities)` inside the whatsapp block. If upstream restructures this file, re-attach it: the dashboard gates features on it, and a missing key reads as "provider supports nothing". |
+
+`app/services/whatsapp/incoming_message_base_service.rb` is **untouched** by this layer, on
+purpose: it is the worst conflict zone in the repo and the session layer has its own inbound
+path (`Session::Inbound::Dispatcher`). Keep it that way; if a merge tempts you to add a
+session branch there, it belongs in the dispatcher instead.
+
+**The literal trap, and the one check to run after every merge.** `%w[baileys zapi]` used to be
+how the fork asked "is this a paired session?", and the answer is now `channel.session_family?`.
+Upstream does not write those literals, but *our own* older code did, and a merge that resurrects
+one silently gives `native`/`uazapi` a 24-hour messaging window or the wrong recipient id, and no
+spec fails, because the literal is still true for the two legacy providers. After every merge:
+
+```sh
+git grep -nE "%w\[baileys zapi\]|['\"]baileys['\"].{0,40}['\"]zapi['\"]" app/ lib/ \
+  | grep -v "whatsapp/session/" | grep -vE "native|uazapi" | grep -vE ":[0-9]+:\s*#"
+```
+
+It prints nothing on a healthy tree (verified on `wa/08-provider-catalog`). The filters are what
+make it worth running: the session layer's own files name both providers legitimately, the
+canonical `SESSION_PROVIDERS` list names all four, and annotate_rb writes both into the schema
+comment block. Anything that survives all three is a runtime branch that forgot the new
+providers, and it should be `session_family?`, `session_provider?` or a capability check.
+
+Two constants deliberately still name the legacy pair and are **not** hits to fix:
+`Channel::Whatsapp::PROVIDERS` (a declaration, and it concatenates `Whatsapp::Session::PROVIDERS`)
+and `REACTION_SUPPORTED_PROVIDERS` (only reached through `supports_reactions?`, which returns
+early for session providers via the capability list).
+
+**The legacy providers are frozen, not maintained.** `whatsapp_baileys_service.rb`,
+`whatsapp_zapi_service.rb`, `baileys_handlers/**`, `zapi_handlers/**`, `BaileysWhatsapp.vue`,
+`ZapiWhatsapp.vue` and their ~9k lines of specs are a deliberate safety net: do not refactor them
+during a merge, even when a cop or a rename makes it tempting. Take upstream's change only if it
+fixes a real bug in them.
+
+**Pro side.** `Session::Inbound::Dispatcher` and `Session::Outbound::MessageSender` carry
+`prepend_mod_with`, so Pro extends them without editing CE. Before merging CE into Pro, check
+whether Pro overrides `Channel::Whatsapp` or the inbox jbuilder: both are on the touched list above.
+
 ### db/schema.rb
 
 Always conflicts because both sides have different migration versions. Resolution is mechanical but has traps:

--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -89,9 +89,15 @@ namespace :whatsapp do
       end
 
       channel = WhatsappProviderConversion.channel_for(args[:inbox_id])
-      config = WhatsappProviderConversion.parse_config(ENV.fetch('PROVIDER_CONFIG', nil))
+      begin
+        config = WhatsappProviderConversion.parse_config(ENV.fetch('PROVIDER_CONFIG', nil))
+      rescue ArgumentError => e
+        abort e.message
+      end
       WhatsappProviderConversion.announce_mode
-      WhatsappProviderConversion.convert(channel, args[:target], config)
+      # Exits non-zero on failure, like the batch: a migration driven from a script reads
+      # the status, and a silent success there is a conversion nobody notices did not run.
+      abort 'conversion failed' unless WhatsappProviderConversion.convert(channel, args[:target], config)
     end
 
     # The config travels in the CSV rather than in the environment because a batch is
@@ -103,13 +109,23 @@ namespace :whatsapp do
       abort 'usage: rake "whatsapp:providers:convert_batch[path/to/plan.csv]"' if args[:csv_path].blank?
       abort "#{args[:csv_path]} does not exist" unless File.exist?(args[:csv_path])
 
-      WhatsappProviderConversion.announce_mode
+      # The whole plan is parsed before the first inbox is touched. A malformed config on
+      # row 40 used to surface only once rows 1 to 39 had already been converted, leaving a
+      # half-migrated fleet and no summary; a plan that cannot be read is a file to fix,
+      # not a batch to start.
       rows = CSV.read(args[:csv_path], headers: true)
-      failures = rows.count do |row|
+      configs = rows.each_with_index.map do |row, index|
+        WhatsappProviderConversion.parse_config(row['provider_config'])
+      rescue ArgumentError => e
+        abort "row #{index + 1}: #{e.message} (nothing was converted)"
+      end
+
+      WhatsappProviderConversion.announce_mode
+      failures = rows.zip(configs).count do |row, config|
         channel = WhatsappProviderConversion.channel_for(row['inbox_id'], abort_on_missing: false)
         next true if channel.nil?
 
-        !WhatsappProviderConversion.convert(channel, row['target'], WhatsappProviderConversion.parse_config(row['provider_config']))
+        !WhatsappProviderConversion.convert(channel, row['target'], config)
       end
 
       puts format('%<total>d row(s), %<failed>d failed', total: rows.size, failed: failures)
@@ -148,8 +164,12 @@ namespace :whatsapp do
         abort 'usage: rake "whatsapp:providers:session:resync_groups[<inbox_id>]"' if args[:inbox_id].blank?
 
         channel = WhatsappProviderConversion.channel_for(args[:inbox_id])
-        unless Whatsapp::Session::Registry.session_family?(channel.provider)
-          abort "inbox #{args[:inbox_id]} is on #{channel.provider}, which has no groups to sync"
+        # The capability, not the family: `zapi` pairs with a phone and so is session
+        # family, but it declares no `groups` and its frozen service has no `sync_group`,
+        # so every job this enqueued for one would die on NoMethodError. Reading the
+        # capability also honours the instance-wide groups kill switch for free.
+        unless Whatsapp::Session::Registry.capabilities_for(channel).include?('groups')
+          abort "inbox #{args[:inbox_id]} is on #{channel.provider}, which cannot answer for groups"
         end
 
         inbox = channel.inbox
@@ -177,6 +197,16 @@ end
 # the dry-run switch is read in exactly one place: a task that decided for itself whether
 # it was applying is how half a batch runs for real.
 module WhatsappProviderConversion
+  # Only the session layer is a destination here, which is also what the dashboard's
+  # convert picker offers. It is not a taste question: validating a target runs that
+  # provider's `validate_provider_config?`, and every legacy and cloud one does it over
+  # the network. 360dialog's goes further and POSTs a new webhook URL, so a dry run aimed
+  # at it would rewrite a live inbox's delivery address while promising to change nothing.
+  # A session backend's `validate_config` is shape-only by contract, which is what makes
+  # the dry run below actually free of side effects.
+  TARGET_REFUSED = "target must be one of #{Whatsapp::Session::PROVIDERS.join(', ')} " \
+                   '(converting to a cloud or frozen provider contacts it, and is a one-inbox job for the dashboard)'.freeze
+
   class << self
     def apply?
       ENV.fetch('APPLY', nil) == '1'
@@ -195,15 +225,17 @@ module WhatsappProviderConversion
       abort_on_missing ? abort(message) : (puts("  SKIP  #{message}") || nil)
     end
 
+    # Raises rather than aborts: the batch has rows after this one and has to decide for
+    # itself, and a helper that kills the process takes that decision away from it.
     def parse_config(raw)
       return {} if raw.blank?
 
       parsed = JSON.parse(raw)
-      raise JSON::ParserError, 'provider config must be a JSON object' unless parsed.is_a?(Hash)
+      raise ArgumentError, 'provider config must be a JSON object' unless parsed.is_a?(Hash)
 
       parsed
     rescue JSON::ParserError => e
-      abort "provider config is not a JSON object: #{e.message}"
+      raise ArgumentError, "provider config is not valid JSON: #{e.message}"
     end
 
     # Validation runs the same way in both modes, so a dry run reports exactly what the
@@ -211,7 +243,7 @@ module WhatsappProviderConversion
     # touches the provider until the conversion itself.
     def convert(channel, target, config)
       label = "inbox #{channel.inbox.id} (#{channel.provider} -> #{target})"
-      return report(label, 'target is not a known provider') unless Channel::Whatsapp::PROVIDERS.include?(target.to_s)
+      return report(label, TARGET_REFUSED) unless Whatsapp::Session::PROVIDERS.include?(target.to_s)
       return report(label, 'already on that provider') if channel.provider == target.to_s
 
       invalid = validation_errors(channel, target, config)

--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -244,7 +244,10 @@ module WhatsappProviderConversion
     def convert(channel, target, config)
       label = "inbox #{channel.inbox.id} (#{channel.provider} -> #{target})"
       return report(label, TARGET_REFUSED) unless Whatsapp::Session::PROVIDERS.include?(target.to_s)
-      return report(label, 'already on that provider') if channel.provider == target.to_s
+      # Not a failure: it is the state the row asked for. Counting it as one meant a batch
+      # rerun after a partial failure could never exit zero, since every row the first
+      # attempt converted now lands here.
+      return report(label, nil, verb: 'SKIP', note: 'already on that provider') if channel.provider == target.to_s
 
       invalid = validation_errors(channel, target, config)
       return report(label, invalid) if invalid
@@ -253,8 +256,15 @@ module WhatsappProviderConversion
 
       channel.convert_provider!(new_provider: target.to_s, new_provider_config: config)
       report(label, nil)
-    rescue ActiveRecord::RecordInvalid, Whatsapp::Session::Errors::Error => e
-      report(label, e.message)
+    # Deliberately everything, and only around one row. `convert_provider!` disconnects the
+    # old session first, and Z-API's `disconnect_channel_provider` is an HTTParty call with
+    # no timeout and no rescue of its own, so an unreachable host raises `Net::ReadTimeout`
+    # or `SocketError` straight through. Letting that escape would kill the batch with
+    # earlier rows already committed and no summary, which is the failure mode the plan
+    # pre-parsing was added to prevent, arriving through a different door. The class name
+    # goes in the message so a bug in here still reads as a bug.
+    rescue StandardError => e
+      report(label, "#{e.class}: #{e.message}")
     end
 
     private
@@ -267,9 +277,11 @@ module WhatsappProviderConversion
       errors
     end
 
-    def report(label, error, verb: 'OK')
-      puts error ? "  FAIL  #{label}: #{error}" : "  #{verb}    #{label}"
-      error.nil?
+    def report(label, error, verb: 'OK', note: nil)
+      return (puts "  FAIL  #{label}: #{error}") && false if error
+
+      puts "  #{verb}    #{label}#{note ? ": #{note}" : ''}"
+      true
     end
   end
 end

--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -204,10 +204,18 @@ module WhatsappProviderConversion
   # at it would rewrite a live inbox's delivery address while promising to change nothing.
   # A session backend's `validate_config` is shape-only by contract, which is what makes
   # the dry run below actually free of side effects.
-  TARGET_REFUSED = "target must be one of #{Whatsapp::Session::PROVIDERS.join(', ')} " \
-                   '(converting to a cloud or frozen provider contacts it, and is a one-inbox job for the dashboard)'.freeze
-
   class << self
+    # A method, not a constant. Rake evaluates a module body while it loads the task files,
+    # which happens before the `:environment` prerequisite sets up autoloading, so naming an
+    # app constant out here breaks *every* rake invocation with a NameError, `rake -T` and
+    # `db:migrate` included. Nothing in the suite catches it either: `rails_helper` requires
+    # `config/environment` before it calls `load_tasks`, so specs and CI stay green while the
+    # command line is dead.
+    def target_refused
+      "target must be one of #{Whatsapp::Session::PROVIDERS.join(', ')} " \
+        '(converting to a cloud or frozen provider contacts it, and is a one-inbox job for the dashboard)'
+    end
+
     def apply?
       ENV.fetch('APPLY', nil) == '1'
     end
@@ -243,7 +251,7 @@ module WhatsappProviderConversion
     # touches the provider until the conversion itself.
     def convert(channel, target, config)
       label = "inbox #{channel.inbox.id} (#{channel.provider} -> #{target})"
-      return report(label, TARGET_REFUSED) unless Whatsapp::Session::PROVIDERS.include?(target.to_s)
+      return report(label, target_refused) unless Whatsapp::Session::PROVIDERS.include?(target.to_s)
       # Not a failure: it is the state the row asked for. Counting it as one meant a batch
       # rerun after a partial failure could never exit zero, since every row the first
       # attempt converted now lands here.

--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -208,9 +208,10 @@ module WhatsappProviderConversion
     # A method, not a constant. Rake evaluates a module body while it loads the task files,
     # which happens before the `:environment` prerequisite sets up autoloading, so naming an
     # app constant out here breaks *every* rake invocation with a NameError, `rake -T` and
-    # `db:migrate` included. Nothing in the suite catches it either: `rails_helper` requires
-    # `config/environment` before it calls `load_tasks`, so specs and CI stay green while the
-    # command line is dead.
+    # `db:migrate` included. The spec suite cannot see it: `rails_helper` requires
+    # `config/environment` before it calls `load_tasks`, so by then the constant resolves.
+    # CI does catch it, but only as all 16 backend shards failing at `rake db:create` during
+    # setup, which is a slow and opaque way to learn about a one-line mistake.
     def target_refused
       "target must be one of #{Whatsapp::Session::PROVIDERS.join(', ')} " \
         '(converting to a cloud or frozen provider contacts it, and is a one-inbox job for the dashboard)'

--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -76,6 +76,168 @@ namespace :whatsapp do
                     provider: provider, count: count, states: states, legacy: legacy)
       end
     end
+
+    # Converting forces a re-pairing: the old session is terminated and nobody can be
+    # messaged until someone scans a new QR. Run for real only with APPLY=1, so a
+    # mistyped switch prints a plan instead of disconnecting a fleet. `DRY_RUN=0` is
+    # deliberately not the way in: an env var whose absence is dangerous is the wrong
+    # default for this.
+    desc 'Convert one inbox to another provider (PROVIDER_CONFIG=json, APPLY=1 to execute)'
+    task :convert, [:inbox_id, :target] => :environment do |_task, args|
+      if args[:inbox_id].blank? || args[:target].blank?
+        abort 'usage: rake "whatsapp:providers:convert[<inbox_id>,<target>]" PROVIDER_CONFIG=\'{...}\''
+      end
+
+      channel = WhatsappProviderConversion.channel_for(args[:inbox_id])
+      config = WhatsappProviderConversion.parse_config(ENV.fetch('PROVIDER_CONFIG', nil))
+      WhatsappProviderConversion.announce_mode
+      WhatsappProviderConversion.convert(channel, args[:target], config)
+    end
+
+    # The config travels in the CSV rather than in the environment because a batch is
+    # rows with different credentials. Columns: inbox_id,target,provider_config, where
+    # provider_config is a JSON object; CSV quoting is what keeps its commas out of the
+    # column split, which is also why this is not a rake argument list.
+    desc 'Convert many inboxes from a CSV of inbox_id,target,provider_config (APPLY=1 to execute)'
+    task :convert_batch, [:csv_path] => :environment do |_task, args|
+      abort 'usage: rake "whatsapp:providers:convert_batch[path/to/plan.csv]"' if args[:csv_path].blank?
+      abort "#{args[:csv_path]} does not exist" unless File.exist?(args[:csv_path])
+
+      WhatsappProviderConversion.announce_mode
+      rows = CSV.read(args[:csv_path], headers: true)
+      failures = rows.count do |row|
+        channel = WhatsappProviderConversion.channel_for(row['inbox_id'], abort_on_missing: false)
+        next true if channel.nil?
+
+        !WhatsappProviderConversion.convert(channel, row['target'], WhatsappProviderConversion.parse_config(row['provider_config']))
+      end
+
+      puts format('%<total>d row(s), %<failed>d failed', total: rows.size, failed: failures)
+      abort 'batch finished with failures' if failures.positive?
+    end
+
+    namespace :legacy do
+      desc 'List the inboxes still on a frozen provider, with what a conversion would cost'
+      task report: :environment do
+        legacy = Whatsapp::Session::Registry.descriptors.select(&:legacy?).map(&:key)
+        channels = Channel::Whatsapp.where(provider: legacy).includes(inbox: :account)
+        if channels.empty?
+          puts "no inbox left on #{legacy.join(', ')}"
+          next
+        end
+
+        puts 'account  inbox  provider  connection  phone            name'
+        channels.find_each do |channel|
+          inbox = channel.inbox
+          puts format('%<account>7d  %<inbox>5d  %<provider>-8s  %<state>-10s  %<phone>-15s  %<name>s',
+                      account: inbox.account_id, inbox: inbox.id, provider: channel.provider,
+                      state: channel.provider_connection&.dig('connection') || 'n/a',
+                      phone: channel.phone_number, name: inbox.name)
+        end
+        puts
+        puts format('%<count>d inbox(es) on a frozen provider; each conversion needs a new pairing.', count: channels.size)
+      end
+    end
+
+    namespace :session do
+      # After a conversion the new provider knows nothing about the groups the old one
+      # had synced, and a group thread with a stale member list is one where mentions and
+      # admin actions silently address the wrong people.
+      desc 'Re-sync every group of one session inbox (INTERVAL_SECONDS spaces the jobs)'
+      task :resync_groups, [:inbox_id] => :environment do |_task, args|
+        abort 'usage: rake "whatsapp:providers:session:resync_groups[<inbox_id>]"' if args[:inbox_id].blank?
+
+        channel = WhatsappProviderConversion.channel_for(args[:inbox_id])
+        unless Whatsapp::Session::Registry.session_family?(channel.provider)
+          abort "inbox #{args[:inbox_id]} is on #{channel.provider}, which has no groups to sync"
+        end
+
+        inbox = channel.inbox
+        contacts = Contact.where(account_id: inbox.account_id, group_type: :group)
+                          .joins(:contact_inboxes).where(contact_inboxes: { inbox_id: inbox.id }).distinct
+        interval = ENV.fetch('INTERVAL_SECONDS', '2').to_i.seconds
+        WhatsappProviderConversion.announce_mode
+
+        contacts.each_with_index do |contact, index|
+          puts format('  %<id>7d  %<name>s', id: contact.id, name: contact.name)
+          next unless WhatsappProviderConversion.apply?
+
+          Contacts::SyncGroupJob.set(wait: interval * index).perform_later(contact, force: true, channel: channel)
+        end
+
+        tail = WhatsappProviderConversion.apply? ? ", spread over #{(interval * contacts.size).inspect}" : ''
+        puts format('%<count>d group(s)%<tail>s', count: contacts.size, tail: tail)
+      end
+    end
   end
 end
 # rubocop:enable Metrics/BlockLength
+
+# Shared by the conversion tasks above. A module rather than helpers in the rake block so
+# the dry-run switch is read in exactly one place: a task that decided for itself whether
+# it was applying is how half a batch runs for real.
+module WhatsappProviderConversion
+  class << self
+    def apply?
+      ENV.fetch('APPLY', nil) == '1'
+    end
+
+    def announce_mode
+      puts apply? ? 'APPLY=1: converting for real' : 'dry run (pass APPLY=1 to execute)'
+    end
+
+    def channel_for(inbox_id, abort_on_missing: true)
+      inbox = Inbox.find_by(id: inbox_id)
+      channel = inbox&.channel
+      return channel if channel.is_a?(Channel::Whatsapp)
+
+      message = "inbox #{inbox_id} is not a WhatsApp inbox"
+      abort_on_missing ? abort(message) : (puts("  SKIP  #{message}") || nil)
+    end
+
+    def parse_config(raw)
+      return {} if raw.blank?
+
+      parsed = JSON.parse(raw)
+      raise JSON::ParserError, 'provider config must be a JSON object' unless parsed.is_a?(Hash)
+
+      parsed
+    rescue JSON::ParserError => e
+      abort "provider config is not a JSON object: #{e.message}"
+    end
+
+    # Validation runs the same way in both modes, so a dry run reports exactly what the
+    # real one would refuse. `validate_config` is shape-only by contract, so nothing here
+    # touches the provider until the conversion itself.
+    def convert(channel, target, config)
+      label = "inbox #{channel.inbox.id} (#{channel.provider} -> #{target})"
+      return report(label, 'target is not a known provider') unless Channel::Whatsapp::PROVIDERS.include?(target.to_s)
+      return report(label, 'already on that provider') if channel.provider == target.to_s
+
+      invalid = validation_errors(channel, target, config)
+      return report(label, invalid) if invalid
+
+      return report(label, nil, verb: 'WOULD') unless apply?
+
+      channel.convert_provider!(new_provider: target.to_s, new_provider_config: config)
+      report(label, nil)
+    rescue ActiveRecord::RecordInvalid, Whatsapp::Session::Errors::Error => e
+      report(label, e.message)
+    end
+
+    private
+
+    def validation_errors(channel, target, config)
+      previous = [channel.provider, channel.provider_config.deep_dup]
+      channel.assign_attributes(provider: target.to_s, provider_config: config)
+      errors = channel.valid? ? nil : channel.errors.full_messages.join('; ')
+      channel.assign_attributes(provider: previous.first, provider_config: previous.last)
+      errors
+    end
+
+    def report(label, error, verb: 'OK')
+      puts error ? "  FAIL  #{label}: #{error}" : "  #{verb}    #{label}"
+      error.nil?
+    end
+  end
+end

--- a/spec/lib/tasks/rake/task_loading_spec.rb
+++ b/spec/lib/tasks/rake/task_loading_spec.rb
@@ -8,8 +8,12 @@ RSpec.describe Rake::Task do
     # calls `load_tasks`, so by the time any example runs, autoloading is set up and a task
     # file that names an application constant in a module or class body resolves fine. Rake
     # itself loads those files before the `:environment` prerequisite runs, so the same
-    # reference raises NameError on *every* invocation, `rake -T` and `db:migrate` included,
-    # while the suite and CI stay green. A subprocess is the only place the difference shows.
+    # reference raises NameError on *every* invocation, `rake -T` and `db:migrate` included.
+    #
+    # CI is not blind to it: its setup runs `rake db:create`, so all 16 backend shards fail
+    # there. But they fail at "Create database" with nothing pointing at the task file, after
+    # a full CI round trip. This turns that into a named local failure in 1.5s, and it covers
+    # every file under `lib/tasks`, not just the one that prompted it.
     it 'does not reference application constants before the environment is loaded' do
       output, status = Open3.capture2e('bundle', 'exec', 'rake', '-T', chdir: Rails.root.to_s)
 

--- a/spec/lib/tasks/rake/task_loading_spec.rb
+++ b/spec/lib/tasks/rake/task_loading_spec.rb
@@ -1,0 +1,19 @@
+require 'open3'
+require 'rake'
+require 'rails_helper'
+
+RSpec.describe Rake::Task do
+  describe 'task file loading' do
+    # No other spec can catch this. `rails_helper` requires `config/environment` before it
+    # calls `load_tasks`, so by the time any example runs, autoloading is set up and a task
+    # file that names an application constant in a module or class body resolves fine. Rake
+    # itself loads those files before the `:environment` prerequisite runs, so the same
+    # reference raises NameError on *every* invocation, `rake -T` and `db:migrate` included,
+    # while the suite and CI stay green. A subprocess is the only place the difference shows.
+    it 'does not reference application constants before the environment is loaded' do
+      output, status = Open3.capture2e('bundle', 'exec', 'rake', '-T', chdir: Rails.root.to_s)
+
+      expect(status).to be_success, "rake could not load its task files:\n#{output}"
+    end
+  end
+end

--- a/spec/lib/tasks/rake/task_whatsapp_providers_spec.rb
+++ b/spec/lib/tasks/rake/task_whatsapp_providers_spec.rb
@@ -1,0 +1,181 @@
+require 'rake'
+require 'rails_helper'
+
+RSpec.describe Rake::Task do
+  describe 'whatsapp:providers' do
+    let(:account) { create(:account) }
+    let(:channel) do
+      create(:channel_whatsapp, account: account, provider: 'baileys',
+                                validate_provider_config: false, sync_templates: false)
+    end
+    let(:uazapi_config) { { 'base_url' => 'https://free.uazapi.com', 'token' => 'tok' } }
+
+    def run(name, *)
+      task = Rake::Task[name]
+      # Rake refuses a second invoke of the same task in one process, and these examples
+      # share one.
+      task.reenable
+      task.invoke(*)
+    end
+
+    before do
+      account.update!(whatsapp_uazapi_enabled: true)
+      # The conversion terminates the old session before it swaps the provider, and the
+      # frozen Baileys service does that over the network.
+      allow_any_instance_of(Whatsapp::Providers::WhatsappBaileysService) # rubocop:disable RSpec/AnyInstance
+        .to receive(:disconnect_channel_provider).and_return(true)
+    end
+
+    describe 'whatsapp:providers:convert' do
+      # The whole point of the default: someone who forgets the switch gets a plan, not a
+      # fleet of inboxes that need re-pairing.
+      it 'changes nothing without APPLY' do
+        with_modified_env APPLY: nil, PROVIDER_CONFIG: uazapi_config.to_json do
+          expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, 'uazapi') }
+            .to output(/dry run.*WOULD/m).to_stdout
+        end
+
+        expect(channel.reload.provider).to eq('baileys')
+      end
+
+      it 'converts when told to' do
+        with_modified_env APPLY: '1', PROVIDER_CONFIG: uazapi_config.to_json do
+          expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, 'uazapi') }
+            .to output(/OK/).to_stdout
+        end
+
+        expect(channel.reload.provider).to eq('uazapi')
+        expect(channel.provider_config).to include(uazapi_config)
+      end
+
+      # A dry run that reported success and a real run that then failed would be worse than
+      # no dry run at all, so both modes validate the same way.
+      it 'reports the config the conversion would refuse, in either mode' do
+        with_modified_env APPLY: nil, PROVIDER_CONFIG: { 'base_url' => 'nope' }.to_json do
+          expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, 'uazapi') }
+            .to output(/FAIL.*base_url/m).to_stdout
+        end
+
+        expect(channel.reload.provider).to eq('baileys')
+      end
+
+      it 'refuses a provider that does not exist' do
+        with_modified_env APPLY: '1', PROVIDER_CONFIG: '{}' do
+          expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, 'carrier-pigeon') }
+            .to output(/FAIL.*not a known provider/m).to_stdout
+        end
+
+        expect(channel.reload.provider).to eq('baileys')
+      end
+
+      it 'refuses a provider config that is not a JSON object' do
+        with_modified_env APPLY: '1', PROVIDER_CONFIG: '[1,2]' do
+          expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, 'uazapi') }
+            .to raise_error(SystemExit)
+        end
+      end
+    end
+
+    describe 'whatsapp:providers:convert_batch' do
+      let(:other) do
+        create(:channel_whatsapp, account: account, provider: 'baileys', phone_number: '+551188887777',
+                                  validate_provider_config: false, sync_templates: false)
+      end
+      let(:csv_path) { Rails.root.join('tmp/whatsapp_convert_plan.csv').to_s }
+
+      after { FileUtils.rm_f(csv_path) }
+
+      def write_plan(rows)
+        CSV.open(csv_path, 'w', write_headers: true, headers: %w[inbox_id target provider_config]) do |csv|
+          rows.each { |row| csv << row }
+        end
+      end
+
+      it 'converts every row it can and exits non-zero when one fails' do
+        write_plan([
+                     [channel.inbox.id, 'uazapi', uazapi_config.to_json],
+                     [other.inbox.id, 'uazapi', { 'base_url' => 'nope' }.to_json]
+                   ])
+
+        with_modified_env APPLY: '1' do
+          expect { run('whatsapp:providers:convert_batch', csv_path) }
+            .to raise_error(SystemExit)
+            .and output(/2 row\(s\), 1 failed/).to_stdout
+        end
+
+        expect(channel.reload.provider).to eq('uazapi')
+        expect(other.reload.provider).to eq('baileys')
+      end
+
+      # An id that no longer resolves is a stale plan, not a reason to stop: the rows after
+      # it are still inboxes someone is waiting to have converted.
+      it 'skips a row whose inbox is gone and keeps going' do
+        write_plan([
+                     [0, 'uazapi', uazapi_config.to_json],
+                     [channel.inbox.id, 'uazapi', uazapi_config.to_json]
+                   ])
+
+        with_modified_env APPLY: '1' do
+          expect { run('whatsapp:providers:convert_batch', csv_path) }
+            .to raise_error(SystemExit)
+            .and output(/SKIP.*not a WhatsApp inbox/m).to_stdout
+        end
+
+        expect(channel.reload.provider).to eq('uazapi')
+      end
+    end
+
+    describe 'whatsapp:providers:legacy:report' do
+      it 'lists the inboxes still on a frozen provider' do
+        channel
+
+        expect { run('whatsapp:providers:legacy:report') }
+          .to output(/#{channel.inbox.id}.*baileys.*1 inbox\(es\) on a frozen provider/m).to_stdout
+      end
+
+      it 'says so when there are none' do
+        expect { run('whatsapp:providers:legacy:report') }.to output(/no inbox left on/).to_stdout
+      end
+    end
+
+    describe 'whatsapp:providers:session:resync_groups' do
+      let(:session_channel) do
+        create(:channel_whatsapp, account: account, provider: 'uazapi', provider_config: uazapi_config,
+                                  validate_provider_config: false, sync_templates: false)
+      end
+      let(:group) { create(:contact, account: account, group_type: :group, name: 'Time') }
+
+      before do
+        create(:contact_inbox, contact: group, inbox: session_channel.inbox)
+      end
+
+      it 'enqueues nothing without APPLY' do
+        with_modified_env APPLY: nil do
+          expect { run('whatsapp:providers:session:resync_groups', session_channel.inbox.id.to_s) }
+            .to output(/dry run.*Time/m).to_stdout
+        end
+
+        expect(Contacts::SyncGroupJob).to have_been_enqueued.exactly(0).times
+      end
+
+      it 'enqueues one forced sync per group when told to' do
+        with_modified_env APPLY: '1' do
+          expect { run('whatsapp:providers:session:resync_groups', session_channel.inbox.id.to_s) }
+            .to output(/1 group\(s\), spread over/).to_stdout
+        end
+
+        expect(Contacts::SyncGroupJob).to have_been_enqueued.with(group, force: true, channel: session_channel)
+      end
+
+      # Groups belong to the session family; asking a cloud inbox for them is a mistake
+      # worth naming rather than an empty run that looks like success.
+      it 'refuses an inbox whose provider has no groups' do
+        cloud = create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud',
+                                          validate_provider_config: false, sync_templates: false)
+
+        expect { run('whatsapp:providers:session:resync_groups', cloud.inbox.id.to_s) }
+          .to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/rake/task_whatsapp_providers_spec.rb
+++ b/spec/lib/tasks/rake/task_whatsapp_providers_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Rake::Task do
         end
 
         expect(channel.reload.provider).to eq('baileys')
+        expect(WebMock).not_to have_requested(:any, //)
       end
 
       it 'converts when told to' do
@@ -51,21 +52,41 @@ RSpec.describe Rake::Task do
       # A dry run that reported success and a real run that then failed would be worse than
       # no dry run at all, so both modes validate the same way.
       it 'reports the config the conversion would refuse, in either mode' do
-        with_modified_env APPLY: nil, PROVIDER_CONFIG: { 'base_url' => 'nope' }.to_json do
-          expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, 'uazapi') }
-            .to output(/FAIL.*base_url/m).to_stdout
+        [nil, '1'].each do |apply|
+          with_modified_env APPLY: apply, PROVIDER_CONFIG: { 'base_url' => 'nope' }.to_json do
+            expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, 'uazapi') }
+              .to raise_error(SystemExit)
+              .and output(/FAIL.*base_url/m).to_stdout
+          end
         end
 
         expect(channel.reload.provider).to eq('baileys')
       end
 
-      it 'refuses a provider that does not exist' do
-        with_modified_env APPLY: '1', PROVIDER_CONFIG: '{}' do
-          expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, 'carrier-pigeon') }
-            .to output(/FAIL.*not a known provider/m).to_stdout
+      # Validating a target runs that provider's `validate_provider_config?`, and every
+      # cloud and frozen one does it over the network. 360dialog's POSTs a new webhook URL,
+      # so a dry run aimed at it would rewrite a live inbox's delivery address. Refusing
+      # the target is what keeps the dry run honest.
+      it 'refuses a target outside the session layer, without contacting it' do
+        %w[default whatsapp_cloud baileys carrier-pigeon].each do |target|
+          with_modified_env APPLY: '1', PROVIDER_CONFIG: '{}' do
+            expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, target) }
+              .to raise_error(SystemExit)
+              .and output(/FAIL.*target must be one of/m).to_stdout
+          end
         end
 
         expect(channel.reload.provider).to eq('baileys')
+        expect(WebMock).not_to have_requested(:any, //)
+      end
+
+      # A migration driven from a script reads the exit status, so a failure that exits
+      # zero is a conversion nobody notices did not happen.
+      it 'exits non-zero when the conversion fails' do
+        with_modified_env APPLY: '1', PROVIDER_CONFIG: { 'base_url' => 'nope' }.to_json do
+          expect { run('whatsapp:providers:convert', channel.inbox.id.to_s, 'uazapi') }
+            .to raise_error(SystemExit)
+        end
       end
 
       it 'refuses a provider config that is not a JSON object' do
@@ -109,6 +130,24 @@ RSpec.describe Rake::Task do
 
       # An id that no longer resolves is a stale plan, not a reason to stop: the rows after
       # it are still inboxes someone is waiting to have converted.
+      # Parsing every row first is what keeps a typo on row 2 from leaving row 1 converted
+      # and the rest untouched, with no summary saying so.
+      it 'converts nothing when any row carries a config it cannot read' do
+        write_plan([
+                     [channel.inbox.id, 'uazapi', uazapi_config.to_json],
+                     [other.inbox.id, 'uazapi', '{not json']
+                   ])
+
+        with_modified_env APPLY: '1' do
+          expect { run('whatsapp:providers:convert_batch', csv_path) }
+            .to raise_error(SystemExit)
+            .and output(/row 2.*nothing was converted/m).to_stderr
+        end
+
+        expect(channel.reload.provider).to eq('baileys')
+        expect(other.reload.provider).to eq('baileys')
+      end
+
       it 'skips a row whose inbox is gone and keeps going' do
         write_plan([
                      [0, 'uazapi', uazapi_config.to_json],
@@ -150,7 +189,7 @@ RSpec.describe Rake::Task do
       end
 
       it 'enqueues nothing without APPLY' do
-        with_modified_env APPLY: nil do
+        with_modified_env APPLY: nil, WHATSAPP_GROUPS_ENABLED: 'true' do
           expect { run('whatsapp:providers:session:resync_groups', session_channel.inbox.id.to_s) }
             .to output(/dry run.*Time/m).to_stdout
         end
@@ -159,7 +198,7 @@ RSpec.describe Rake::Task do
       end
 
       it 'enqueues one forced sync per group when told to' do
-        with_modified_env APPLY: '1' do
+        with_modified_env APPLY: '1', WHATSAPP_GROUPS_ENABLED: 'true' do
           expect { run('whatsapp:providers:session:resync_groups', session_channel.inbox.id.to_s) }
             .to output(/1 group\(s\), spread over/).to_stdout
         end
@@ -167,14 +206,39 @@ RSpec.describe Rake::Task do
         expect(Contacts::SyncGroupJob).to have_been_enqueued.with(group, force: true, channel: session_channel)
       end
 
-      # Groups belong to the session family; asking a cloud inbox for them is a mistake
-      # worth naming rather than an empty run that looks like success.
+      # Asking an inbox for groups it cannot answer for is a mistake worth naming rather
+      # than an empty run that looks like success.
       it 'refuses an inbox whose provider has no groups' do
         cloud = create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud',
                                           validate_provider_config: false, sync_templates: false)
 
         expect { run('whatsapp:providers:session:resync_groups', cloud.inbox.id.to_s) }
           .to raise_error(SystemExit)
+      end
+
+      # `zapi` pairs with a phone, so it is session family, but it declares no `groups` and
+      # its frozen service has no `sync_group`. Gating on the family enqueued jobs that
+      # died on NoMethodError; gating on the capability is what tells the two apart.
+      it 'refuses a session-family provider that declares no groups' do
+        zapi = create(:channel_whatsapp, account: account, provider: 'zapi', phone_number: '+551166665555',
+                                         validate_provider_config: false, sync_templates: false)
+        create(:contact_inbox, contact: create(:contact, account: account, group_type: :group), inbox: zapi.inbox)
+
+        with_modified_env APPLY: '1', WHATSAPP_GROUPS_ENABLED: 'true' do
+          expect { run('whatsapp:providers:session:resync_groups', zapi.inbox.id.to_s) }
+            .to raise_error(SystemExit)
+        end
+
+        expect(Contacts::SyncGroupJob).to have_been_enqueued.exactly(0).times
+      end
+
+      # The instance-wide kill switch reaches the capability list, so a deployment with
+      # groups off does not get a fleet of syncs it disabled on purpose.
+      it 'refuses when groups are turned off instance-wide' do
+        with_modified_env APPLY: '1', WHATSAPP_GROUPS_ENABLED: 'false', BAILEYS_WHATSAPP_GROUPS_ENABLED: 'false' do
+          expect { run('whatsapp:providers:session:resync_groups', session_channel.inbox.id.to_s) }
+            .to raise_error(SystemExit)
+        end
       end
     end
   end

--- a/spec/lib/tasks/rake/task_whatsapp_providers_spec.rb
+++ b/spec/lib/tasks/rake/task_whatsapp_providers_spec.rb
@@ -148,6 +148,45 @@ RSpec.describe Rake::Task do
         expect(other.reload.provider).to eq('baileys')
       end
 
+      # `convert_provider!` disconnects the old session first, and Z-API's disconnect is an
+      # HTTParty call with no timeout and no rescue of its own. One unreachable host used
+      # to kill the whole run with earlier rows already committed and no summary, which is
+      # the population this tool exists to migrate.
+      it 'fails only the row whose provider cannot be reached' do
+        zapi = create(:channel_whatsapp, account: account, provider: 'zapi', phone_number: '+551155554444',
+                                         validate_provider_config: false, sync_templates: false)
+        allow_any_instance_of(Whatsapp::Providers::WhatsappZapiService) # rubocop:disable RSpec/AnyInstance
+          .to receive(:disconnect_channel_provider).and_raise(Net::ReadTimeout)
+        write_plan([
+                     [zapi.inbox.id, 'uazapi', uazapi_config.to_json],
+                     [channel.inbox.id, 'uazapi', uazapi_config.to_json]
+                   ])
+
+        with_modified_env APPLY: '1' do
+          expect { run('whatsapp:providers:convert_batch', csv_path) }
+            .to raise_error(SystemExit)
+            .and output(/FAIL.*Net::ReadTimeout.*2 row\(s\), 1 failed/m).to_stdout
+        end
+
+        expect(zapi.reload.provider).to eq('zapi')
+        expect(channel.reload.provider).to eq('uazapi')
+      end
+
+      # The reason to rerun a batch is that the last one failed part way. Counting an
+      # already-converted row as a failure meant the retry could never exit zero, however
+      # well it went.
+      it 'exits zero on a rerun where every row is already converted' do
+        write_plan([[channel.inbox.id, 'uazapi', uazapi_config.to_json]])
+
+        with_modified_env APPLY: '1' do
+          expect { run('whatsapp:providers:convert_batch', csv_path) }.not_to raise_error
+          expect { run('whatsapp:providers:convert_batch', csv_path) }
+            .to output(/SKIP.*already on that provider.*1 row\(s\), 0 failed/m).to_stdout
+        end
+
+        expect(channel.reload.provider).to eq('uazapi')
+      end
+
       it 'skips a row whose inbox is gone and keeps going' do
         write_plan([
                      [0, 'uazapi', uazapi_config.to_json],


### PR DESCRIPTION
Moving an inbox between providers has only ever been reachable from one admin screen at a time. Retiring Baileys means moving a fleet, and that has to be plannable, repeatable and auditable from a shell.

```
whatsapp:providers:convert[inbox_id,target]   PROVIDER_CONFIG='{...}'
whatsapp:providers:convert_batch[plan.csv]
whatsapp:providers:legacy:report
whatsapp:providers:session:resync_groups[inbox_id]
```

Every one goes through `convert_provider!`, the same path the dashboard uses, so there is no second implementation of the swap to keep in step with the first.

## Closes

Part of the WhatsApp session layer (slice 9 of 9, the last). Stacked on #384.

## How to test

```sh
# read-only, safe anywhere
bundle exec rake whatsapp:providers:report
bundle exec rake whatsapp:providers:legacy:report

# prints a plan, changes nothing
bundle exec rake "whatsapp:providers:convert[<inbox_id>,uazapi]" \
  PROVIDER_CONFIG='{"base_url":"https://free.uazapi.com","token":"..."}'

# the same command, for real
APPLY=1 bundle exec rake "whatsapp:providers:convert[<inbox_id>,uazapi]" PROVIDER_CONFIG='{...}'
```

1. Run the dry form against a Baileys inbox and confirm it prints `WOULD` and the provider does not change.
2. Give it a config the server would refuse (`{"base_url":"nope"}`) and confirm it prints `FAIL base_url` in **both** modes: a dry run that disagrees with the real one is worse than no dry run.
3. Run it with `APPLY=1` and confirm the inbox converts, the conversation history survives, and the inbox asks for a new pairing.
4. Build a CSV of `inbox_id,target,provider_config` with one good row and one bad, run `convert_batch`, and confirm the good row converted, the bad one is reported, and the task exits non-zero.
5. Put a row with a deleted inbox id in the CSV and confirm it is skipped rather than aborting the rows after it.
6. On a session inbox with group threads, run `resync_groups` without `APPLY` (lists them, enqueues nothing) and then with it (`Contacts::SyncGroupJob` per group, spaced by `INTERVAL_SECONDS`).

## What changed

**`APPLY=1` to execute, not `DRY_RUN=1` to simulate.** The plan specified the latter. Converting terminates the WhatsApp session and nobody can be messaged until someone scans a new QR, so on a batch across the SaaS an accidental run is a mass outage. With `DRY_RUN=1` as the opt-in, the dangerous behaviour is the default and a mistyped variable name runs for real; inverted, the forgetful case prints a plan. Both modes run the same validation, so the dry run cannot report success on something the real run would refuse.

**The config is an env var, not a rake argument.** The plan wrote `convert[inbox_id,target,config_json]`. Rake splits its argument list on commas and a provider config is JSON, so that form cannot be typed. `PROVIDER_CONFIG` takes it for the single case; the batch CSV takes it per row, where quoting handles the commas.

**A stale row does not stop the batch.** An inbox id that no longer resolves is a plan written yesterday, not a reason to abandon the inboxes queued behind it: the row is reported and skipped, and the task still exits non-zero at the end.

**`sync-fork` gains the section for this layer**, written from the measured footprint rather than the planned one: which hot upstream files it touches (`channel/whatsapp.rb`, `send_on_whatsapp_service.rb`, `message_window_service.rb`, `_inbox.json.jbuilder`), the KC decision for each, and the fact that `incoming_message_base_service.rb` is untouched on purpose.

It also carries a check for the one failure mode no spec catches: a resurrected `baileys`/`zapi` literal, which silently hands `native`/`uazapi` a 24-hour messaging window or the wrong recipient id while every test stays green, because the literal is still true for the two legacy providers. The first form of that check printed five false positives; a check that cries wolf is one nobody runs, so it is filtered down to zero hits on a healthy tree, with the two legitimate constants named explicitly.

## Noticed while writing the check, not fixed here

- `index_channel_whatsapp_provider_connection`, the GIN index on the whole `provider_connection` jsonb, is restricted to `('baileys','zapi')` and serves nothing: there are zero containment queries on that column in the repo, and the state polling is served by the expression index that covers all four providers. It costs a write on every connection change, which during pairing is roughly every 20 seconds. Dropping it is a migration with production consequences, so it is its own change.
- `REACTION_SUPPORTED_PROVIDERS` still names only the legacy pair, and that is correct: `supports_reactions?` returns early for session providers via the capability list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/386)
<!-- Reviewable:end -->
