### PR TITLE
refactor(whatsapp): drop the uazapi internal-host field

### DIFF
--- a/app/javascript/dashboard/helper/specs/whatsappSession.spec.js
+++ b/app/javascript/dashboard/helper/specs/whatsappSession.spec.js
@@ -45,7 +45,7 @@ describe('whatsappSession', () => {
     });
 
     // The reason this helper exists: `isValidURL` needs a dot in the host, so it refused
-    // the compose-network address that `use_internal_host` is for.
+    // the private address an operator who set `SAFE_FETCH_ALLOW_PRIVATE_NETWORK` may enter.
     it('accepts an address on the deployment own network', () => {
       expect(isHttpUrl('http://uazapi:3000')).toBe(true);
       expect(isHttpUrl('http://localhost:3000')).toBe(true);

--- a/app/javascript/dashboard/helper/whatsappSession.js
+++ b/app/javascript/dashboard/helper/whatsappSession.js
@@ -81,9 +81,9 @@ export const hasCapability = (inbox, capability) =>
  * dashboard cannot know that policy, so it checks shape only.
  *
  * `isValidURL` is stricter than that: its regex needs a dot in the host, which refuses
- * `http://uazapi:3000` and `http://localhost:3000` (the compose-network addresses the
- * `use_internal_host` field exists for) and every IPv6 literal. A form that refuses more
- * than the server does is a provider the operator cannot enter at all.
+ * `http://uazapi:3000` and `http://localhost:3000` (the addresses an operator who has set
+ * `SAFE_FETCH_ALLOW_PRIVATE_NETWORK` is entitled to enter) and every IPv6 literal. A form
+ * that refuses more than the server does is a provider the operator cannot enter at all.
  *
  * @param {string} value
  * @returns {boolean}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -10,8 +10,8 @@
           "ZAPI_DESC": "Connect via non-official API Z-API",
           "NATIVE": "WhatsApp (native)",
           "NATIVE_DESC": "Pair a phone through the connector that ships with this installation",
-          "UAZAPI": "uazapi",
-          "UAZAPI_DESC": "Pair a phone through your own uazapi instance"
+          "UAZAPI": "Uazapi",
+          "UAZAPI_DESC": "Pair a phone through your own Uazapi instance"
         },
         "PROVIDER_URL": {
           "LABEL": "Provider URL",
@@ -165,7 +165,7 @@
       "WHATSAPP_BAILEYS": "WhatsApp - Baileys",
       "WHATSAPP_ZAPI": "WhatsApp - Z-API",
       "WHATSAPP_NATIVE": "WhatsApp - native",
-      "WHATSAPP_UAZAPI": "WhatsApp - uazapi"
+      "WHATSAPP_UAZAPI": "WhatsApp - Uazapi"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -69,9 +69,6 @@
               "PLACEHOLDER": "Paste the token of the instance you want to use",
               "ERROR": "The instance token is required"
             },
-            "USE_INTERNAL_HOST": {
-              "LABEL": "Instance runs on this server’s network"
-            },
             "MARK_AS_READ": {
               "LABEL": "Mark messages as read on WhatsApp"
             },

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -69,9 +69,6 @@
               "PLACEHOLDER": "Pega el token de la instancia que quieres usar",
               "ERROR": "El token de la instancia es obligatorio"
             },
-            "USE_INTERNAL_HOST": {
-              "LABEL": "La instancia corre en la red de este servidor"
-            },
             "MARK_AS_READ": {
               "LABEL": "Marcar mensajes como leídos en WhatsApp"
             },

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -10,8 +10,8 @@
           "ZAPI_DESC": "Conectar mediante la API no oficial Z-API",
           "NATIVE": "WhatsApp (nativo)",
           "NATIVE_DESC": "Conecta un teléfono con el conector que ya viene en esta instalación",
-          "UAZAPI": "uazapi",
-          "UAZAPI_DESC": "Conecta un teléfono con tu propia instancia de uazapi"
+          "UAZAPI": "Uazapi",
+          "UAZAPI_DESC": "Conecta un teléfono con tu propia instancia de Uazapi"
         },
         "PROVIDER_URL": {
           "LABEL": "URL del proveedor",
@@ -165,7 +165,7 @@
       "WHATSAPP_BAILEYS": "WhatsApp - Baileys",
       "WHATSAPP_ZAPI": "WhatsApp - Z-API",
       "WHATSAPP_NATIVE": "WhatsApp - nativo",
-      "WHATSAPP_UAZAPI": "WhatsApp - uazapi"
+      "WHATSAPP_UAZAPI": "WhatsApp - Uazapi"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -69,9 +69,6 @@
               "PLACEHOLDER": "Cole o token da instância que você quer usar",
               "ERROR": "O token da instância é obrigatório"
             },
-            "USE_INTERNAL_HOST": {
-              "LABEL": "A instância roda na rede deste servidor"
-            },
             "MARK_AS_READ": {
               "LABEL": "Marcar mensagens como lidas no WhatsApp"
             },

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -10,8 +10,8 @@
           "ZAPI_DESC": "Conectar via API não-oficial Z-API",
           "NATIVE": "WhatsApp (nativo)",
           "NATIVE_DESC": "Conecte um telefone pelo conector que já vem nesta instalação",
-          "UAZAPI": "uazapi",
-          "UAZAPI_DESC": "Conecte um telefone pela sua própria instância da uazapi"
+          "UAZAPI": "Uazapi",
+          "UAZAPI_DESC": "Conecte um telefone pela sua própria instância da Uazapi"
         },
         "PROVIDER_URL": {
           "LABEL": "URL do provedor",
@@ -165,7 +165,7 @@
       "WHATSAPP_BAILEYS": "WhatsApp - Baileys",
       "WHATSAPP_ZAPI": "WhatsApp - Z-API",
       "WHATSAPP_NATIVE": "WhatsApp - nativo",
-      "WHATSAPP_UAZAPI": "WhatsApp - uazapi"
+      "WHATSAPP_UAZAPI": "WhatsApp - Uazapi"
     }
   }
 }

--- a/app/services/whatsapp/session/backend.rb
+++ b/app/services/whatsapp/session/backend.rb
@@ -48,8 +48,9 @@ class Whatsapp::Session::Backend
     # INTERNAL_HOST_URL, while one sitting next to Rails on a closed installation can
     # resolve nothing else.
     #
-    # Asked per inbox rather than per provider, because a provider that is normally a
-    # hosted service can also be self-hosted, and then it is a neighbour.
+    # Takes the inbox rather than nothing so a provider that ships both a hosted service
+    # and a build to run next to Rails can answer per inbox. None does today: every
+    # provider here answers the same for all of its inboxes.
     def hosted?(_channel)
       false
     end

--- a/app/services/whatsapp/session/backends/uazapi/backend.rb
+++ b/app/services/whatsapp/session/backends/uazapi/backend.rb
@@ -75,14 +75,13 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
     # answer. A self-hosted one is reached by whatever name the network gives it, from a
     # compose service to an internal FQDN to a plain address, and reading any of those as
     # a signal gets a deployment wrong in one direction or the other. Only whoever set it
-    # up knows, so the inbox is asked and its answer is a field on the form.
-    #
-    # Not the same switch that opens the private network to the SSRF filter: that one is
-    # the operator's, in the environment, and this one sits in a form an account
-    # administrator can edit. Saying an instance is a neighbour must not be a way of
-    # authorizing calls into the deployment.
-    def hosted?(channel)
-      !ActiveModel::Type::Boolean.new.cast(channel.provider_config['use_internal_host'])
+    # up knows, and for this provider the answer is fixed: uazapi is sold as a service and
+    # the customer points an inbox at an instance it runs, so it is always on the far side
+    # of the deployment's network and always reachable at the public address. There is no
+    # build of it to stand up next to Rails, which is what an internal address would be
+    # for.
+    def hosted?(_channel)
+      true
     end
 
     # The token is what tells two instances apart: on the hosted service they share a base
@@ -285,18 +284,16 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
     }
   end
 
-  # The address this instance can reach us at, which for a hosted one is the public
-  # FRONTEND_URL and for a self-hosted neighbour is INTERNAL_HOST_URL: on a closed
-  # installation the public address does not resolve there, and an inbox would pair and
-  # then never receive an event.
+  # The address this instance can reach us at. Always the public one: the instance runs on
+  # the provider's infrastructure, so an address that only resolves inside this deployment
+  # would leave the inbox paired and never receiving an event.
   #
   # The path carries a secret of its own, generated per inbox and never shown. It is not
   # the only check: the body carries the instance token, which the controller compares
   # too, so a URL leaked through a proxy log is not on its own enough to post events into
   # an inbox.
   def webhook_url
-    host = ENV.fetch('INTERNAL_HOST_URL', nil) if channel.use_internal_host?
-    host = ENV.fetch('FRONTEND_URL', nil) if host.blank?
+    host = ENV.fetch('FRONTEND_URL', nil)
     "#{host.to_s.chomp('/')}/webhooks/whatsapp/session/uazapi/#{channel.id}/#{provider_config['webhook_verify_token']}"
   end
 

--- a/app/services/whatsapp/session/channel_extension.rb
+++ b/app/services/whatsapp/session/channel_extension.rb
@@ -144,7 +144,7 @@ module Whatsapp::Session::ChannelExtension # rubocop:disable Metrics/ModuleLengt
 
     previous = self.class.find(id)
     previous.provider_config = saved_change_to_provider_config.first || {}
-    moved_instance?(previous) ? let_go_of(previous) : refresh_registration(previous)
+    let_go_of(previous) if moved_instance?(previous)
   rescue Whatsapp::Session::Errors::Error => e
     # This runs after the commit, so raising would answer a save that already succeeded
     # with a 500, and neither half of this is something the save depended on.
@@ -171,18 +171,6 @@ module Whatsapp::Session::ChannelExtension # rubocop:disable Metrics/ModuleLengt
   def let_go_of(previous)
     with_lock { update_provider_connection!({}) }
     Whatsapp::Session::Registry.backend_for(previous).release_registration
-  end
-
-  # The same instance, at an address it was never told about: `use_internal_host` is what
-  # decides between the public frontend URL and the one that works inside the deployment's
-  # own network, and the provider has no way to learn that a form was edited. Outbound media
-  # follows the new choice on the next message, while the webhook would go on arriving at the
-  # old address, or stop arriving at all, which on the closed network this option exists for
-  # is the whole of the inbox's inbound traffic.
-  def refresh_registration(previous)
-    return if previous.use_internal_host? == use_internal_host?
-
-    session_backend.ensure_registration
   end
 
   # Who may stand up an inbox on this provider: the account toggles while the new

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -46,10 +46,6 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
       fields: [
         Field.new(name: 'base_url', type: 'url', required: true),
         Field.new(name: 'token', type: 'password', required: true, secret: true),
-        # An instance the operator runs on this deployment's own network, which is offered
-        # INTERNAL_HOST_URL instead of the public address for its webhook and for the
-        # attachments it fetches.
-        Field.new(name: 'use_internal_host', type: 'boolean', default: false),
         MARK_AS_READ,
         PRESENCE_SUBSCRIBE
       ]

--- a/spec/services/whatsapp/session/backends/uazapi/backend_spec.rb
+++ b/spec/services/whatsapp/session/backends/uazapi/backend_spec.rb
@@ -97,22 +97,6 @@ RSpec.describe Whatsapp::Session::Backends::Uazapi::Backend do
       end)
     end
 
-    # An instance the operator runs next to Chatwoot cannot resolve the public address, so
-    # an inbox would pair and then never receive an event.
-    it 'points a neighbouring instance at the internal host' do
-      neighbour = create(:channel_whatsapp, provider: 'uazapi', validate_provider_config: false, sync_templates: false,
-                                            provider_config: { 'base_url' => base, 'token' => 'x', 'use_internal_host' => true,
-                                                               'webhook_verify_token' => 'secret' })
-
-      with_modified_env INTERNAL_HOST_URL: 'http://rails:3000' do
-        described_class.new(neighbour).connect(commands::SessionConnect.new(pairing: 'qr'))
-      end
-
-      expect(WebMock).to(have_requested(:post, "#{base}/webhook").with do |request|
-        JSON.parse(request.body)['url'].start_with?('http://rails:3000/webhooks/whatsapp/session/uazapi/')
-      end)
-    end
-
     it 'answers with the QR the operator has to scan' do
       state = backend.connect(commands::SessionConnect.new(pairing: 'qr'))
 

--- a/spec/services/whatsapp/session/channel_extension_spec.rb
+++ b/spec/services/whatsapp/session/channel_extension_spec.rb
@@ -282,41 +282,6 @@ RSpec.describe Whatsapp::Session::ChannelExtension do
     end
   end
 
-  # The webhook URL is not derived from anything the instance knows: it is handed one, and
-  # the choice between the public address and the one that only resolves inside the
-  # deployment is a field on the inbox form. Outbound media follows a change to it on the
-  # next message; the webhook would go on arriving at the old address, or stop arriving at
-  # all, which on the closed network this option exists for is all of the inbound traffic.
-  describe 'an inbox whose webhook host changes' do
-    let(:channel) { build_channel('uazapi', { 'base_url' => 'https://uazapi.test', 'token' => 'first' }) }
-
-    before do
-      allow(Resolv).to receive(:getaddresses).and_call_original
-      allow(Resolv).to receive(:getaddresses).with('uazapi.test').and_return(['93.184.216.34'])
-      stub_request(:post, 'https://uazapi.test/webhook').to_return(status: 200, body: '{}',
-                                                                   headers: { 'Content-Type' => 'application/json' })
-    end
-
-    it 'hands the instance the address the inbox now asks for' do
-      internal = 'http://rails.internal/webhooks/whatsapp/session/uazapi/'
-      with_modified_env INTERNAL_HOST_URL: 'http://rails.internal' do
-        channel.update!(provider_config: channel.provider_config.merge('use_internal_host' => true))
-      end
-
-      expect(WebMock).to(
-        have_requested(:post, 'https://uazapi.test/webhook').with { |request| JSON.parse(request.body)['url'].start_with?(internal) }
-      )
-    end
-
-    # The field only chooses between two addresses, and an installation that never set the
-    # internal one has a single address to hand out either way.
-    it 'says nothing to the instance when the deployment has no internal address' do
-      channel.update!(provider_config: channel.provider_config.merge('use_internal_host' => true))
-
-      expect(WebMock).not_to have_requested(:post, 'https://uazapi.test/webhook')
-    end
-  end
-
   # The connector keys its whatsmeow store by this id, and provider_config is permitted
   # wholesale by the inbox API, so an update that left the key out used to mint a new one
   # and orphan the session the connector was still holding under the old one.

--- a/spec/services/whatsapp/session/outbound/attachment_adapter_spec.rb
+++ b/spec/services/whatsapp/session/outbound/attachment_adapter_spec.rb
@@ -56,19 +56,6 @@ RSpec.describe Whatsapp::Session::Outbound::AttachmentAdapter do
       end
     end
 
-    # The other side of the same rule: an instance the operator runs next to Chatwoot is a
-    # neighbour, and on a closed installation the public URL is the one it cannot reach.
-    it 'uses the internal host for an instance that is inside the deployment' do
-      neighbour = create(:channel_whatsapp, provider: 'uazapi', validate_provider_config: false, sync_templates: false,
-                                            provider_config: { 'base_url' => 'https://uazapi.test', 'token' => 'x',
-                                                               'use_internal_host' => true })
-
-      with_modified_env INTERNAL_HOST_URL: 'http://rails:3000' do
-        expect(described_class.new(attachment, channel: neighbour).media_url)
-          .to eq('http://rails:3000/rails/active_storage/disk/TOKEN/avatar.png')
-      end
-    end
-
     # With S3, GCS or any other cloud service the blob answers a presigned URL of its
     # own. Its path is not one Rails serves and its signature is bound to the host it was
     # made for, so moving it to the internal host is a 404 on every attachment the inbox


### PR DESCRIPTION
The uazapi form carried a switch, "Instance runs on this server's network", that
chose between the public address and `INTERNAL_HOST_URL` for the webhook it
registers and the attachments it hands over. That choice only makes sense for a
provider you can stand up next to Rails, and uazapi is sold as a service: the
customer points an inbox at an instance the provider runs, always on the far side
of this deployment's network, always reachable at the public address. The only
self-hostable build under their GitHub org is v1, which its own README calls
discontinued and unsupported, replaced by v2 in September 2024.

So the field switched between two addresses when only one could ever work, and
picking the wrong one produced an inbox that pairs and then never receives an
event, with nothing about the failure pointing back at the setting.

## What goes

- The field itself, and its `USE_INTERNAL_HOST` label in the three locales.
- `Uazapi::Backend.hosted?` stops reading it and answers `true`, which is what
  the provider is.
- `webhook_url` stops choosing and always hands out `FRONTEND_URL`.
- `refresh_registration`, which existed only to re-register the webhook when that
  field was edited. With no mutable choice left, `use_internal_host?` cannot
  differ between two saves of one inbox, so the call was dead. Its caller
  collapses from a ternary to `let_go_of(previous) if moved_instance?(previous)`.
- The three specs that drove the removed paths.

## What stays, and why

`INTERNAL_HOST_URL` and everything `native` needs. The connector runs next to
Rails in the same compose and fetches outbound media from it, so on an
installation with local Active Storage behind a private network the public URL is
exactly the one it cannot reach. That path is the operator's env var plus the
base `Backend.hosted?` returning false; no form field is involved, and none of it
is touched here.

`Backend.hosted?` also keeps taking a channel, so a provider that ever ships both
a hosted service and a build to run next to Rails can answer per inbox. The
comment now says that none does today rather than claiming one might.

The SSRF guard is unchanged: a private `base_url` is still refused unless the
operator has set `SAFE_FETCH_ALLOW_PRIVATE_NETWORK`. The frontend comment that
justified `isHttpUrl` being laxer than `isValidURL` now cites that env var, which
is the reason that survives, instead of the field.

## Verification

`spec/services/whatsapp/session/` and `spec/models/channel/whatsapp_spec.rb`:
577 examples, 0 failures. `whatsappSession.spec.js`: 17 passing. Rubocop clean.
Checked in the browser that the uazapi form now ends at `mark_as_read` and
`presence_subscribe`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/390)
<!-- Reviewable:end -->
