### PR TITLE
fix(whatsapp): surface sends that never went out instead of losing them

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -47,6 +47,7 @@ import WhatsappLinkDeviceModal from '../../../routes/dashboard/settings/inbox/co
 import { isInboxAdminInGroup } from 'dashboard/helper/phoneHelper';
 import {
   isReachoutRestricted,
+  isSendStalled,
   reachoutRestrictionDeadline,
   isMessageCapped,
   isMessageCapReached,
@@ -377,6 +378,36 @@ export default {
     },
     inboxReachoutLock() {
       return this.currentInbox.provider_connection?.reachout_time_lock;
+    },
+    showSendStallWarning() {
+      return isSendStalled(
+        this.currentInbox.provider_connection?.send_stall,
+        this.inboxProviderConnection
+      );
+    },
+    providerConnectionBannerMessage() {
+      if (this.showSendStallWarning) {
+        return this.isAdmin
+          ? this.$t(
+              'CONVERSATION.INBOX.WHATSAPP_PROVIDER_CONNECTION.SEND_STALL'
+            )
+          : this.$t(
+              'CONVERSATION.INBOX.WHATSAPP_PROVIDER_CONNECTION.SEND_STALL_CONTACT_ADMIN'
+            );
+      }
+      return this.isAdmin
+        ? this.$t(
+            'CONVERSATION.INBOX.WHATSAPP_PROVIDER_CONNECTION.NOT_CONNECTED'
+          )
+        : this.$t(
+            'CONVERSATION.INBOX.WHATSAPP_PROVIDER_CONNECTION.NOT_CONNECTED_CONTACT_ADMIN'
+          );
+    },
+    // The agent's shortcut is a reconnect, and on a stall it is worse than nothing: it
+    // reaches a provider that already considers this socket live, refreshes presence, and
+    // reports success while the inbox stays mute. Only an admin has an action here.
+    providerConnectionBannerHasAction() {
+      return this.isAdmin || !this.showSendStallWarning;
     },
     showReachoutRestriction() {
       return isReachoutRestricted(
@@ -864,19 +895,11 @@ export default {
           :inbox="currentInbox"
         />
         <Banner
-          v-if="inboxProviderConnection !== 'open'"
+          v-if="inboxProviderConnection !== 'open' || showSendStallWarning"
           color-scheme="alert"
           class="mt-2 mx-2 rounded-lg overflow-hidden"
-          :banner-message="
-            isAdmin
-              ? $t(
-                  'CONVERSATION.INBOX.WHATSAPP_PROVIDER_CONNECTION.NOT_CONNECTED'
-                )
-              : $t(
-                  'CONVERSATION.INBOX.WHATSAPP_PROVIDER_CONNECTION.NOT_CONNECTED_CONTACT_ADMIN'
-                )
-          "
-          has-action-button
+          :banner-message="providerConnectionBannerMessage"
+          :has-action-button="providerConnectionBannerHasAction"
           :action-button-label="
             isAdmin
               ? $t(

--- a/app/javascript/dashboard/helper/specs/whatsapp.spec.js
+++ b/app/javascript/dashboard/helper/specs/whatsapp.spec.js
@@ -1,5 +1,6 @@
 import {
   isReachoutRestricted,
+  isSendStalled,
   reachoutRestrictionDeadline,
   isMessageCapped,
   isMessageCapReached,
@@ -47,6 +48,29 @@ describe('#isReachoutRestricted', () => {
   it('keeps the restriction visible when the deadline is malformed (fail safe)', () => {
     const lock = { is_active: true, time_enforcement_ends: 'not-a-date' };
     expect(isReachoutRestricted(lock, 'open', now)).toBe(true);
+  });
+});
+
+describe('#isSendStalled', () => {
+  const stall = { consecutive_timeouts: 3, action: 'suppressed' };
+
+  // The pairing that IS the fault: everything else in the view reports a healthy inbox.
+  it('warns while the connection still reads open', () => {
+    expect(isSendStalled(stall, 'open')).toBe(true);
+  });
+
+  it('stays quiet with no stall recorded', () => {
+    expect(isSendStalled(undefined, 'open')).toBe(false);
+    expect(isSendStalled(null, 'open')).toBe(false);
+  });
+
+  // The stored stall outlives the episode on purpose (only a new socket reaching 'open'
+  // clears it), so a closed connection would otherwise show both banners at once — and
+  // the offline one is the accurate one.
+  it('yields to the offline banner once the connection is down', () => {
+    expect(isSendStalled(stall, 'close')).toBe(false);
+    expect(isSendStalled(stall, 'connecting')).toBe(false);
+    expect(isSendStalled(stall, undefined)).toBe(false);
   });
 });
 

--- a/app/javascript/dashboard/helper/whatsapp.js
+++ b/app/javascript/dashboard/helper/whatsapp.js
@@ -24,6 +24,22 @@ export const isReachoutRestricted = (lock, connection, now = Date.now()) => {
 };
 
 /**
+ * Whether a session inbox should surface the send-stall banner.
+ *
+ * Gated on `open` for the opposite reason to the reach-out lock: that pairing IS the
+ * fault. The connection receives, answers every health check, and reports 'open' while no
+ * outgoing message leaves, so nothing else in the conversation view would warn anyone.
+ * Once the connection is down the offline banner is both truer and more urgent, and the
+ * stall value lingers by design (it is cleared only by a new socket reaching 'open').
+ *
+ * @param {{consecutive_timeouts?: number, action?: string, until?: string}|null|undefined} sendStall
+ * @param {string|undefined} connection - the provider_connection.connection value
+ * @returns {boolean}
+ */
+export const isSendStalled = (sendStall, connection) =>
+  connection === 'open' && Boolean(sendStall);
+
+/**
  * Local-timezone deadline label for the restriction banner, or '' when no deadline is set.
  * `new Date(isoUtc)` parses the UTC instant and `format` renders it in the browser's
  * timezone automatically.

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
@@ -60,7 +60,9 @@
         "NOT_CONNECTED": "WhatsApp is not connected. Please link your device again.",
         "NOT_CONNECTED_CONTACT_ADMIN": "WhatsApp is not connected. Click this button to try to reconnect, or please contact your administrator to link your device again.",
         "LINK_DEVICE": "Link device",
-        "RECONNECT_FAILED": "Failed to reconnect. Please contact your administrator to link your device again."
+        "RECONNECT_FAILED": "Failed to reconnect. Please contact your administrator to link your device again.",
+        "SEND_STALL": "WhatsApp is connected but cannot send messages. Link the device again to restore sending.",
+        "SEND_STALL_CONTACT_ADMIN": "WhatsApp is connected but cannot send messages. Your replies will not be delivered until an administrator links the device again."
       },
       "WHATSAPP_REACHOUT_RESTRICTION": {
         "RESTRICTED": "WhatsApp has temporarily restricted starting new conversations from this number.",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
@@ -60,7 +60,9 @@
         "NOT_CONNECTED": "WhatsApp no está conectado. Vincule su dispositivo de nuevo.",
         "NOT_CONNECTED_CONTACT_ADMIN": "WhatsApp no está conectado. Haga clic en este botón para intentar reconectar o contacte a su administrador para vincular el dispositivo de nuevo.",
         "LINK_DEVICE": "Vincular dispositivo",
-        "RECONNECT_FAILED": "No se pudo reconectar. Contacte a su administrador para vincular el dispositivo de nuevo."
+        "RECONNECT_FAILED": "No se pudo reconectar. Contacte a su administrador para vincular el dispositivo de nuevo.",
+        "SEND_STALL": "WhatsApp está conectado, pero no puede enviar mensajes. Vincule el dispositivo de nuevo para restablecer el envío.",
+        "SEND_STALL_CONTACT_ADMIN": "WhatsApp está conectado, pero no puede enviar mensajes. Sus respuestas no se entregarán hasta que un administrador vincule el dispositivo de nuevo."
       },
       "WHATSAPP_REACHOUT_RESTRICTION": {
         "RESTRICTED": "WhatsApp ha restringido temporalmente el inicio de conversaciones nuevas desde este número.",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
@@ -60,7 +60,9 @@
         "NOT_CONNECTED": "O WhatsApp não está conectado. Por favor conecte o seu dispositivo novamente.",
         "NOT_CONNECTED_CONTACT_ADMIN": "O WhatsApp não está conectado. Clique no botão ao lado para tentar reconectar, ou contate o seu administrador para conectar o dispositivo novamente.",
         "LINK_DEVICE": "Conectar dispositivo",
-        "RECONNECT_FAILED": "Falha ao reconectar. Por favor, contate o seu administrador para conectar o dispositivo novamente."
+        "RECONNECT_FAILED": "Falha ao reconectar. Por favor, contate o seu administrador para conectar o dispositivo novamente.",
+        "SEND_STALL": "O WhatsApp está conectado, mas não consegue enviar mensagens. Conecte o dispositivo novamente para restabelecer o envio.",
+        "SEND_STALL_CONTACT_ADMIN": "O WhatsApp está conectado, mas não consegue enviar mensagens. Suas respostas não serão entregues até que um administrador conecte o dispositivo novamente."
       },
       "WHATSAPP_REACHOUT_RESTRICTION": {
         "RESTRICTED": "O WhatsApp restringiu temporariamente o início de novas conversas a partir deste número.",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
@@ -34,6 +34,12 @@ const supportsCodePairing = computed(() =>
   hasCapability(props.inbox, CAPABILITIES.CODE_PAIRING)
 );
 
+// A send stall is the one failure that leaves `connection` reading 'open' while the
+// inbox cannot answer anyone. That combination breaks the usual reading of this modal:
+// setup() only refreshes presence on a connection the provider already considers live,
+// so the recovery is re-pairing, and the button for it lives in the open branch below.
+const sendStall = computed(() => providerConnection.value?.send_stall);
+
 // Alternative onboarding when WhatsApp's extra device-linking verification blocks
 // the QR: install the browser extension and import an already-linked session.
 //
@@ -131,7 +137,13 @@ watchEffect(() => {
             with-provider-connection-status
           />
 
-          <template v-if="!connection || connection === 'close' || error">
+          <template
+            v-if="
+              !connection ||
+              connection === 'close' ||
+              (error && connection !== 'open')
+            "
+          >
             <p v-if="error" class="text-red-500 text-center">
               {{ error }}
             </p>
@@ -234,7 +246,10 @@ watchEffect(() => {
           </template>
 
           <template v-else-if="connection === 'open'">
-            <p v-if="isSetup" class="text-center">
+            <p v-if="error" class="text-center text-red-500">
+              {{ error }}
+            </p>
+            <p v-else-if="isSetup" class="text-center">
               {{
                 $t(
                   'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.CONNECTED'
@@ -242,7 +257,14 @@ watchEffect(() => {
               }}
             </p>
             <div class="flex gap-2">
-              <Button ghost :is-loading="loading" @click="disconnect">
+              <!-- Promoted from ghost while a stall is open: re-pairing stops being the
+                   way out of the modal and becomes the only thing that clears the fault. -->
+              <Button
+                :variant="sendStall ? 'solid' : 'ghost'"
+                :color="sendStall ? 'ruby' : 'blue'"
+                :is-loading="loading"
+                @click="disconnect"
+              >
                 {{
                   $t(
                     'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.DISCONNECT'

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/WhatsappLinkDeviceModal.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/WhatsappLinkDeviceModal.spec.js
@@ -7,6 +7,9 @@ const USE_PAIRING_CODE_KEY = `${KEY}.USE_PAIRING_CODE`;
 const USE_QRCODE_KEY = `${KEY}.USE_QRCODE`;
 const LOADING_PAIRING_CODE_KEY = `${KEY}.LOADING_PAIRING_CODE`;
 
+const DISCONNECT_KEY = `${KEY}.DISCONNECT`;
+const LINK_DEVICE_KEY = `${KEY}.LINK_DEVICE`;
+
 const dispatch = vi.fn(() => Promise.resolve());
 
 vi.mock('vuex', () => ({
@@ -33,7 +36,13 @@ const mountModal = (
       stubs: {
         'woot-modal': { template: '<div><slot /></div>' },
         'router-link': true,
-        Button: { props: ['label'], template: '<button>{{ label }}</button>' },
+        // The default stub swallows the slot, and the slot is where the button's
+        // label lives — which is the whole thing these examples assert on.
+        Button: {
+          props: ['label', 'variant', 'color'],
+          template:
+            '<button :data-variant="variant" :data-color="color">{{ label }}<slot /></button>',
+        },
       },
     },
   });
@@ -99,5 +108,35 @@ describe('WhatsappLinkDeviceModal', () => {
       expect(wrapper.html()).toContain('K7QP-2M4X');
       expect(wrapper.html()).toContain(USE_QRCODE_KEY);
     });
+  });
+
+  // A send stall leaves the connection reading 'open'. The error branch used to win
+  // regardless, which hid Disconnect and offered a setup call that only refreshes
+  // presence on a socket the provider already considers live: the one action that
+  // cannot repair the fault was the only one on offer.
+  it('offers disconnect, not setup, when an open connection is stalled', () => {
+    const wrapper = mountModal(['qr_pairing'], {
+      connection: 'open',
+      error: 'This connection cannot send messages.',
+      send_stall: { consecutive_timeouts: 3, action: 'suppressed' },
+    });
+
+    const html = wrapper.html();
+    expect(html).toContain(DISCONNECT_KEY);
+    expect(html).not.toContain(LINK_DEVICE_KEY);
+    expect(html).toContain('This connection cannot send messages.');
+  });
+
+  // The error is still the whole story when the connection is genuinely down:
+  // re-pairing from scratch is the action, and Disconnect would be a no-op.
+  it('keeps offering setup when the connection is closed with an error', () => {
+    const wrapper = mountModal(['qr_pairing'], {
+      connection: 'close',
+      error: 'Wrong phone number.',
+    });
+
+    const html = wrapper.html();
+    expect(html).toContain(LINK_DEVICE_KEY);
+    expect(html).not.toContain(DISCONNECT_KEY);
   });
 });

--- a/app/jobs/channels/whatsapp/baileys_connection_check_job.rb
+++ b/app/jobs/channels/whatsapp/baileys_connection_check_job.rb
@@ -3,11 +3,34 @@ class Channels::Whatsapp::BaileysConnectionCheckJob < ApplicationJob
 
   def perform(whatsapp_channel)
     whatsapp_channel.setup_channel_provider
+    check_send_health(whatsapp_channel)
     refresh_reachout_time_lock(whatsapp_channel)
     refresh_new_chat_cap(whatsapp_channel)
   end
 
   private
+
+  # setup_channel_provider above does NOT prove this connection can send: for an
+  # already-registered connection it only sends a presence update, which does not go
+  # through the provider's keystore and therefore succeeds against a wedged socket. This
+  # is the part of the check that can actually tell.
+  #
+  # Reports rather than acts: the provider recovers a stall on its own, and a second
+  # actor racing it would only recreate sockets the provider had already replaced.
+  # 'unknown' is not a problem — it means no send has been observed on that connection.
+  def check_send_health(whatsapp_channel)
+    health = whatsapp_channel.provider_service.fetch_send_health
+    return if health.nil? || health[:send_state] != 'stalled'
+
+    Rails.logger.error(
+      "[WHATSAPP][BAILEYS] send stall on ##{whatsapp_channel.id}: " \
+      "consecutive_timeouts=#{health[:consecutive_send_timeouts]} " \
+      "last_send_completed_ago_ms=#{health[:last_send_completed_ago_ms] || 'never'} " \
+      "last_outgoing_ack_ago_ms=#{health[:last_outgoing_ack_ago_ms] || 'never'}"
+    )
+  rescue StandardError => e
+    Rails.logger.warn("[WHATSAPP][BAILEYS] send health check failed for ##{whatsapp_channel.id}: #{e.message}")
+  end
 
   # Best-effort: a failed time-lock fetch must not abort the connection check (which also
   # re-arms the session). nil means "unknown" (404/error) — skip so we never clear a banner

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -39,7 +39,7 @@ class SendReplyJob < ApplicationJob
     message = Message.find_by(id: message_id)
     return if message.blank?
 
-    Whatsapp::Session::Inbound::StatusTransition.apply(message, 'failed', error: reason)
+    Whatsapp::Session::Inbound::StatusTransition.fail_send(message, reason)
   rescue StandardError => e
     Rails.logger.error "SendReplyJob could not mark message #{message_id} as failed: #{e.message}"
   end

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -41,7 +41,13 @@ class SendReplyJob < ApplicationJob
 
     Whatsapp::Session::Inbound::StatusTransition.fail_send(message, reason)
   rescue StandardError => e
-    Rails.logger.error "SendReplyJob could not mark message #{message_id} as failed: #{e.message}"
+    # Logged AND re-raised. Returning normally from a retry_on block tells ActiveJob the
+    # original exception was handled, so Sidekiq neither retries nor buries the job — and
+    # the message stays on `sent` with a clock next to it, which is the exact silence this
+    # handler exists to end. A transient database failure here means the send is still
+    # unaccounted for, so the job has to die loudly and reach the dead-set handler.
+    Rails.logger.error "SendReplyJob could not mark message #{message_id} as failed (#{reason}): #{e.class}: #{e.message}"
+    raise
   end
 
   CHANNEL_SERVICES = {

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -26,7 +26,7 @@ class SendReplyJob < ApplicationJob
     Rails.logger.error(
       "SendReplyJob gave up on message #{job.arguments.first}: still processing elsewhere (#{error.message})"
     )
-    fail_message(job.arguments.first, 'The message was still being sent elsewhere and could not be confirmed.')
+    fail_message(job.arguments.first, I18n.t('errors.inboxes.channel.outgoing.still_processing'))
   end
 
   # Marks the message failed so the agent sees it and can resend. Through

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -1,6 +1,47 @@
 class SendReplyJob < ApplicationJob
   queue_as :high
 
+  # Declared BEFORE the MessageAlreadyProcessing handler below on purpose. retry_on is
+  # built on rescue_from, which matches handlers with reverse_each — the LAST matching
+  # declaration wins — so a broad class declared last would silently shadow every
+  # specific one above it.
+  #
+  # Everything else retryable: when the attempts run out the message must not be left
+  # sitting on "sent" with a clock next to it. Nobody is watching the dead set, so an
+  # exhausted job is the last chance to tell the agent it did not go.
+  retry_on Whatsapp::Session::Errors::Error, wait: :polynomially_longer, attempts: 4 do |job, error|
+    Rails.logger.error "SendReplyJob exhausted retries for message #{job.arguments.first}: #{error.message}"
+    fail_message(job.arguments.first, error.message)
+  end
+
+  # More specific than the handler above, so it has to come after it. A 409 from
+  # baileys-api means another worker holds the idempotency lock for this
+  # message. Sidekiq's default backoff (roughly 15s, 30s, 90s) used to burn all three
+  # retries well before that lock could clear, so the job always died in the dead set.
+  # Its own attempts, with a wait longer than a bounded send takes, keep the conflict
+  # from consuming the retries the real failure modes need.
+  retry_on Whatsapp::Session::Errors::MessageAlreadyProcessing,
+           wait: 60.seconds,
+           attempts: 3 do |job, error|
+    Rails.logger.error(
+      "SendReplyJob gave up on message #{job.arguments.first}: still processing elsewhere (#{error.message})"
+    )
+    fail_message(job.arguments.first, 'The message was still being sent elsewhere and could not be confirmed.')
+  end
+
+  # Marks the message failed so the agent sees it and can resend, mirroring
+  # Whatsapp::SendOnWhatsappService#fail_message. Never overwrites a reason already
+  # recorded there.
+  def self.fail_message(message_id, reason)
+    message = Message.find_by(id: message_id)
+    return if message.blank?
+    return if message.status == 'failed' && message.external_error.present?
+
+    message.update_under_lock!(status: :failed, external_error: reason)
+  rescue StandardError => e
+    Rails.logger.error "SendReplyJob could not mark message #{message_id} as failed: #{e.message}"
+  end
+
   CHANNEL_SERVICES = {
     'Channel::TwitterProfile' => '::Twitter::SendOnTwitterService',
     'Channel::TwilioSms' => '::Twilio::SendOnTwilioService',

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -29,15 +29,17 @@ class SendReplyJob < ApplicationJob
     fail_message(job.arguments.first, 'The message was still being sent elsewhere and could not be confirmed.')
   end
 
-  # Marks the message failed so the agent sees it and can resend, mirroring
-  # Whatsapp::SendOnWhatsappService#fail_message. Never overwrites a reason already
-  # recorded there.
+  # Marks the message failed so the agent sees it and can resend. Through
+  # StatusTransition because it owns the terminal-status rule and applies it under the
+  # row lock: an attempt that timed out may still have reached WhatsApp, so a receipt
+  # can mark this message delivered or read while its retries are still running out.
+  # Either status is proof it arrived, and walking one back to failed here is what
+  # would put a duplicate in front of the customer.
   def self.fail_message(message_id, reason)
     message = Message.find_by(id: message_id)
     return if message.blank?
-    return if message.status == 'failed' && message.external_error.present?
 
-    message.update_under_lock!(status: :failed, external_error: reason)
+    Whatsapp::Session::Inbound::StatusTransition.apply(message, 'failed', error: reason)
   rescue StandardError => e
     Rails.logger.error "SendReplyJob could not mark message #{message_id} as failed: #{e.message}"
   end

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -52,14 +52,15 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
     admin_tokens = account.administrators.pluck(:pubsub_token)
     agent_tokens = account.agents.pluck(:pubsub_token)
 
-    # reach-out lock and new-chat cap are not credential-sensitive (unlike qr_data_url), so they
+    # reach-out lock, new-chat cap and send-stall are not credential-sensitive (unlike qr_data_url), so they
     # ride the base hash shared by both agent and admin broadcasts. Without this, a connection.update
     # push would broadcast a provider_connection without them and the frontend mutation (wholesale
     # replace) would drop the restriction/cap banners. .presence + .compact keeps absent keys out.
     connection = {
       connection: provider_connection['connection'],
       reachout_time_lock: provider_connection['reachout_time_lock'].presence,
-      new_chat_cap: provider_connection['new_chat_cap'].presence
+      new_chat_cap: provider_connection['new_chat_cap'].presence,
+      send_stall: provider_connection['send_stall'].presence
     }.compact
     broadcast(account, agent_tokens, INBOX_PROVIDER_CONNECTION_UPDATED, { inbox_id: inbox.id, provider_connection: connection })
     broadcast(account, admin_tokens, INBOX_PROVIDER_CONNECTION_UPDATED, {

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -206,6 +206,11 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
     data = { connection: provider_connection['connection'] }
     data[:reachout_time_lock] = provider_connection['reachout_time_lock'] if provider_connection['reachout_time_lock'].present?
     data[:new_chat_cap] = provider_connection['new_chat_cap'] if provider_connection['new_chat_cap'].present?
+    # Agent-visible, unlike the QR and the error string: a stall carries no credential (a
+    # timeout count, a duration, what the provider decided to do and until when), and the
+    # agent is the one being told their reply went nowhere. Without it the conversation
+    # view has nothing to render, because `connection` still reads 'open' throughout.
+    data[:send_stall] = provider_connection['send_stall'] if provider_connection['send_stall'].present?
     data.merge!(provider_connection_admin_data) if Current.account_user&.administrator?
     data
   end

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -262,7 +262,15 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
   def disconnect_channel_provider
     provider_service.disconnect_channel_provider
   rescue StandardError => e
-    # NOTE: Don't prevent destruction if disconnect fails
+    # Two callers, opposite needs. A destroy must not be blocked by a provider that will
+    # not let go, so there the failure is logged and swallowed. An explicit disconnect is
+    # an operator waiting for an answer: reporting a session closed while it is still
+    # live leaves them with a connected number, a dashboard that disagrees, and no reason
+    # to try again — and for a send stall it also clears the warning that was the only
+    # thing telling anyone the inbox was mute. @session_teardown is set by the prepended
+    # before_destroy callback, so it means exactly "we are being destroyed".
+    raise unless @session_teardown
+
     Rails.logger.error "Failed to disconnect channel provider: #{e.message}"
   end
 

--- a/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
@@ -61,9 +61,19 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
   # Mirrors Whatsapp::SendOnWhatsappService#persist_source_id: the id the send never got to store is
   # what a revoke needs, so a message deleted while that send was in flight can only be taken off the
   # contact's phone once this echo supplies it.
+  # Through SourceIdReservation, exactly like the session layer's EchoMatcher, because
+  # filling source_id now means two things and not one: it decides who owes the revoke,
+  # and it retires a send failure recorded while the id was still blank. Writing the
+  # column directly here left a message that exhausted its retries before this echo
+  # arrived sitting on `failed` with a Retry button — and Retry clears the reservation and
+  # sends a fresh id, which is the duplicate the reservation exists to prevent.
   def confirm_source_id(reserved)
-    reserved.update_under_lock!(source_id: raw_message_id)
-    ::Messages::DeleteOnChannelJob.perform_later(reserved.id) if reserved.deleted?
+    return if raw_message_id.blank?
+    return unless ::Whatsapp::Session::Outbound::SourceIdReservation.assign(
+      reserved, { source_id: raw_message_id }
+    ) == :revoke
+
+    ::Messages::DeleteOnChannelJob.perform_later(reserved.id)
   end
 
   # Mirrors the Cloud provider (create_contact_messages): one message per shared

--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -25,12 +25,13 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
   #   - `reconnecting`: Connection has been established, but not open (i.e. device is being linked for the first time, or Baileys server restart)
   #   - `open`: Open and ready to send/receive messages
   def provider_connection_payload(data)
+    stall = send_stall_payload(data)
     {
       connection: data[:connection] || inbox.channel.provider_connection['connection'],
       qr_data_url: data[:qrDataUrl] || nil,
-      error: data[:error] ? I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}", default: data[:error].to_s.humanize) : nil,
+      error: connection_error(data, stall),
       quarantine: quarantine_payload(data),
-      send_stall: send_stall_payload(data),
+      send_stall: stall,
       reachout_time_lock: reachout_time_lock_payload(data),
       # new_chat_cap never rides a connection.update (it arrives via message-capping.update / the
       # poll). update_provider_connection! replaces provider_connection wholesale, so without
@@ -45,6 +46,21 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
   # health checks while every send times out. Worth surfacing on its own rather than as a
   # bare error string, because "action" is what tells an operator whether the provider
   # already recreated the socket or is holding off — and holding off is when a human has
+  # `error` is the only half of this warning an operator can actually see:
+  # provider_connection_admin_data serializes error and qr_data_url, and send_stall reaches
+  # no serializer and no frontend consumer (neither does quarantine — both are there for
+  # support and for the API). Preserving the detail without the string would preserve
+  # nothing anyone reads, so the two share a fate.
+  #
+  # Re-derived from the stall rather than copied from the stored error: copying would
+  # resurrect whatever unrelated error happened to be stored last.
+  def connection_error(data, stall)
+    return I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}", default: data[:error].to_s.humanize) if data[:error]
+    return I18n.t('errors.inboxes.channel.provider_connection.send_stall_detected') if stall.present?
+
+    nil
+  end
+
   # to step in.
   #
   # Unlike quarantine, this does NOT share the error's lifecycle. The provider reports a

--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -30,6 +30,7 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
       qr_data_url: data[:qrDataUrl] || nil,
       error: data[:error] ? I18n.t("errors.inboxes.channel.provider_connection.#{data[:error]}", default: data[:error].to_s.humanize) : nil,
       quarantine: quarantine_payload(data),
+      send_stall: send_stall_payload(data),
       reachout_time_lock: reachout_time_lock_payload(data),
       # new_chat_cap never rides a connection.update (it arrives via message-capping.update / the
       # poll). update_provider_connection! replaces provider_connection wholesale, so without
@@ -37,6 +38,24 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
       # off until the next cap push/poll. Preserve the existing value; .compact omits it when unset.
       new_chat_cap: inbox.channel.provider_connection['new_chat_cap'],
       epoch: data[:epoch]
+    }.compact
+  end
+
+  # Rides only the send_stall_detected webhook: the connection is receiving and answering
+  # health checks while every send times out. Worth surfacing on its own rather than as a
+  # bare error string, because "action" is what tells an operator whether the provider
+  # already recreated the socket or is holding off — and holding off is when a human has
+  # to step in. Shares the error's lifecycle, like quarantine: the next connection.update
+  # clears both, so a recovered inbox never keeps a stale warning.
+  def send_stall_payload(data)
+    raw = data[:sendStall]
+    return nil if raw.blank?
+
+    {
+      consecutive_timeouts: raw[:consecutiveTimeouts],
+      stalled_for_ms: raw[:stalledForMs],
+      action: raw[:action],
+      until: raw[:until]
     }.compact
   end
 

--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -42,15 +42,10 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
     }.compact
   end
 
-  # Rides only the send_stall_detected webhook: the connection is receiving and answering
-  # health checks while every send times out. Worth surfacing on its own rather than as a
-  # bare error string, because "action" is what tells an operator whether the provider
-  # already recreated the socket or is holding off — and holding off is when a human has
-  # `error` is the only half of this warning an operator can actually see:
-  # provider_connection_admin_data serializes error and qr_data_url, and send_stall reaches
-  # no serializer and no frontend consumer (neither does quarantine — both are there for
-  # support and for the API). Preserving the detail without the string would preserve
-  # nothing anyone reads, so the two share a fate.
+  # The human-readable half of the warning, and the half that survives serialization for a
+  # non-admin: provider_connection_data gives every agent `connection`, and only an admin
+  # also gets error and send_stall. Preserving the structured detail without the string
+  # would preserve nothing most viewers can read, so the two share a fate.
   #
   # Re-derived from the stall rather than copied from the stored error: copying would
   # resurrect whatever unrelated error happened to be stored last.
@@ -61,7 +56,12 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
     nil
   end
 
-  # to step in.
+  # Rides only the send_stall_detected webhook: the connection is receiving and answering
+  # health checks while every send times out. Worth surfacing on its own rather than as a
+  # bare error string, because "action" is what tells an operator whether the provider
+  # already recreated the socket or is holding off until `until` — and holding off is when
+  # a human has to step in, which is why it is serialized to admins rather than kept for
+  # support (quarantine, by contrast, still is).
   #
   # Unlike quarantine, this does NOT share the error's lifecycle. The provider reports a
   # stall once per episode, so an unrelated update in the meantime (a standalone

--- a/app/services/whatsapp/baileys_handlers/connection_update.rb
+++ b/app/services/whatsapp/baileys_handlers/connection_update.rb
@@ -45,11 +45,22 @@ module Whatsapp::BaileysHandlers::ConnectionUpdate
   # health checks while every send times out. Worth surfacing on its own rather than as a
   # bare error string, because "action" is what tells an operator whether the provider
   # already recreated the socket or is holding off — and holding off is when a human has
-  # to step in. Shares the error's lifecycle, like quarantine: the next connection.update
-  # clears both, so a recovered inbox never keeps a stale warning.
+  # to step in.
+  #
+  # Unlike quarantine, this does NOT share the error's lifecycle. The provider reports a
+  # stall once per episode, so an unrelated update in the meantime (a standalone
+  # reachoutTimeLock push carries no sendStall) would clear the warning for good while the
+  # connection is still mute — and nothing would ever say it again. So it is preserved,
+  # and cleared only by the one event that actually means recovery: the connection
+  # reaching `open` with nothing wrong, which is a NEW socket and therefore a new keystore
+  # mutex, whether the provider restarted it or WhatsApp dropped it.
   def send_stall_payload(data)
     raw = data[:sendStall]
-    return nil if raw.blank?
+    if raw.blank?
+      return nil if data[:connection] == 'open' && data[:error].blank?
+
+      return inbox.channel.provider_connection['send_stall']
+    end
 
     {
       consecutive_timeouts: raw[:consecutiveTimeouts],

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -130,17 +130,27 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # block a provider conversion or channel teardown — the only point of
   # calling this is to avoid leaving a dangling session, not to gate the
   # caller's flow on that cleanup succeeding.
+  # Reports the outcome instead of always claiming success. An explicit disconnect is an
+  # operator waiting for an answer, and it is now the recovery path for a send stall:
+  # returning true on a 500 or a read timeout meant the inbox was recorded as closed and
+  # the stall warning cleared while the wedged socket was still there, which is the one
+  # state where the UI stops telling anyone anything is wrong. The teardown callers that
+  # legitimately do not care are the ones that catch it (see Channel::Whatsapp).
   def disconnect_channel_provider
     response = HTTParty.delete(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}",
       headers: api_headers,
       timeout: 10
     )
-    Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider non-success status=#{response.code}") unless response.success?
-    true
+    return true if response.success?
+
+    Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider non-success status=#{response.code}")
+    raise ProviderUnavailableError, "The provider did not end the session (HTTP #{response.code})"
+  rescue Whatsapp::Session::Errors::Error
+    raise
   rescue StandardError => e
-    Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider failed (ignored): #{e.message}")
-    true
+    Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider failed: #{e.class}: #{e.message}")
+    raise ProviderUnavailableError, "Could not reach the provider to end the session (#{e.class})"
   end
 
   # Confirmed reconnect loop: the provider reported enough consecutive failed
@@ -817,17 +827,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     Rails.logger.error response.body
 
     case response.code
-    when 409
-      # Two different conflicts share this status; the header is what tells them apart.
-      raise SendOutcomeUnknownError, INDETERMINATE_SEND_MESSAGE if indeterminate_send?(response)
-
-      raise MessageAlreadyProcessingError
-    when 503
-      # Distinct from the generic 5xx below: this connection is known to be wedged, so it
-      # must not be marked 'close' (see NON_CHANNEL_DOWN_CODES) — that would drop it out
-      # of the very health-check cycle that detects the stall. It is also the status the
-      # whole episode settles on, since every send after the third timeout gets it.
-      raise SendStalledError, 'The WhatsApp connection is not accepting sends right now'
+    when 409 then raise_conflict_send_error(response)
+    when 503 then raise_unavailable_send_error(response)
     when 504
       raise SendTimeoutError, 'The send timed out; it may or may not have reached WhatsApp'
     when 413
@@ -839,8 +840,31 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     end
   end
 
+  # The two statuses a send can come back with where the status alone is not the answer:
+  # each covers two conditions that need opposite handling, and a header tells them apart.
+  def raise_conflict_send_error(response)
+    raise SendOutcomeUnknownError, INDETERMINATE_SEND_MESSAGE if indeterminate_send?(response)
+
+    raise MessageAlreadyProcessingError
+  end
+
+  # A wedged connection must NOT be marked 'close' (see NON_CHANNEL_DOWN_CODES): that
+  # would drop it out of the very health-check cycle that detects the stall, and 503 is
+  # where the whole episode settles, since every send after the third timeout gets it.
+  # But an outage and a draining proxy answer 503 too, and reading those as a stall leaves
+  # a genuinely dead channel recorded as open, skipping the reconnect it needed.
+  def raise_unavailable_send_error(response)
+    raise SendStalledError, 'The WhatsApp connection is not accepting sends right now' if stalled_send?(response)
+
+    raise ProviderUnavailableError
+  end
+
   def indeterminate_send?(response)
     response.headers['x-baileys-idempotency-state'] == 'indeterminate'
+  end
+
+  def stalled_send?(response)
+    response.headers['x-baileys-send-state'] == 'stalled'
   end
 
   # The WhatsApp message id this send will use, picked here instead of letting Baileys generate it.

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -744,7 +744,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   def send_message_request
     message_id = reserve_source_id
 
-    response = HTTParty.post(
+    response = post_send_message(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/send-message",
       headers: api_headers,
       body: {
@@ -771,30 +771,41 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
 
     update_external_created_at(response)
     response.parsed_response.dig('data', 'key', 'id')
-  rescue *TRANSPORT_ERRORS => e
-    raise_transport_error(e)
   end
 
   # A transport failure never reaches raise_send_error, because there is no response to
-  # classify — it escapes as Net::ReadTimeout or an Errno, which is not in the session
-  # hierarchy, so SendReplyJob's retry_on never sees it and the job dies in the dead set
-  # with the bubble still reading "sent". That is the exact silent failure this whole
-  # change exists to remove, so the transport gets translated too.
-  TRANSPORT_ERRORS = [
-    Net::ReadTimeout, Net::OpenTimeout, Net::HTTPBadResponse, EOFError, SocketError, IOError,
-    Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ETIMEDOUT
+  # classify — it escapes as itself, outside the session hierarchy, so SendReplyJob's
+  # retry_on never sees it and the job dies in the dead set with the bubble still reading
+  # "sent". That is the exact silent failure this change exists to remove.
+  #
+  # Rescued as a CLASS rather than as a list of exception types, which is why nothing but
+  # the HTTP call lives in here: an enumerated list is a promise to have thought of every
+  # way a socket can fail, and it will be wrong (Net::WriteTimeout on a large media body,
+  # OpenSSL::SSL::SSLError on a handshake, whatever the next TLS or HTTP gem raises).
+  # Anything StandardError can be here is a transport failure by construction.
+  def post_send_message(url, **)
+    HTTParty.post(url, **)
+  rescue StandardError => e
+    raise_transport_error(e)
+  end
+
+  # Failures that cannot have put a single byte of the request on the wire. Everything
+  # else defaults to indeterminate, and the asymmetry is deliberate: calling a
+  # possibly-delivered send "the provider is down" marks the channel closed, which drops
+  # the inbox out of the health-check cycle, while calling a never-sent one indeterminate
+  # costs one retry that the reserved message id makes duplicate-safe anyway.
+  NEVER_TRANSMITTED_ERRORS = [
+    Net::OpenTimeout, SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH
   ].freeze
 
   def raise_transport_error(error)
     Rails.logger.error "[WHATSAPP][BAILEYS] transport failure on send: #{error.class}: #{error.message}"
 
-    # A read timeout means the request went out and no answer came back, which is the same
-    # thing a 504 says: the send may or may not have reached WhatsApp. Everything else here
-    # failed before or during connect, so the send definitively did not happen and the
-    # provider really is unreachable — which is a channel-down signal, unlike the timeout.
-    raise SendTimeoutError, 'The send timed out; it may or may not have reached WhatsApp' if error.is_a?(Net::ReadTimeout)
+    if NEVER_TRANSMITTED_ERRORS.any? { |klass| error.is_a?(klass) }
+      raise ProviderUnavailableError, "Could not reach the WhatsApp provider (#{error.class})"
+    end
 
-    raise ProviderUnavailableError, "Could not reach the WhatsApp provider (#{error.class})"
+    raise SendTimeoutError, "The send did not complete (#{error.class}); it may or may not have reached WhatsApp"
   end
 
   # Every non-2xx used to collapse into a bare ProviderUnavailableError, which made it

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -1,13 +1,29 @@
 class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseService # rubocop:disable Metrics/ClassLength
   include BaileysHelper
 
-  class MessageContentTypeNotSupported < StandardError; end
   # Legacy errors inherit from the session hierarchy so every caller rescues a single
   # namespace, whatever the provider. Nothing else about this service changes: it is
   # frozen until baileys is removed.
   class ProviderUnavailableError < Whatsapp::Session::Errors::ProviderUnavailable; end
   class GroupParticipantNotAllowedError < Whatsapp::Session::Errors::GroupParticipantNotAllowed; end
   class MessageAlreadyProcessingError < Whatsapp::Session::Errors::MessageAlreadyProcessing; end
+  # The send reached its deadline. Retryable: the same send may well work next time.
+  class SendTimeoutError < Whatsapp::Session::Errors::Timeout; end
+
+  # A previous send timed out and may or may not have reached WhatsApp. NOT retryable:
+  # resending could deliver the message twice, and only the operator can tell. Reached
+  # only when the send did not reserve a message id, since with one a resend reuses the
+  # same WhatsApp key.id and WhatsApp itself dedupes it.
+  class SendOutcomeUnknownError < Whatsapp::Session::Errors::Error
+    CODE = 'send_outcome_unknown'.freeze
+  end
+
+  # The API knows this connection is not accepting sends at all (its send-stall circuit
+  # breaker is open) and refused without touching the socket. Retryable: the provider
+  # recreates the socket on its own, and the next attempt after that succeeds.
+  class SendStalledError < Whatsapp::Session::Errors::ProviderUnavailable
+    CODE = 'send_stalled'.freeze
+  end
 
   DEFAULT_CLIENT_NAME = ENV.fetch('BAILEYS_PROVIDER_DEFAULT_CLIENT_NAME', nil)
   DEFAULT_URL = ENV.fetch('BAILEYS_PROVIDER_DEFAULT_URL', nil)
@@ -17,6 +33,10 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # first. 3 full cycles span several minutes of backoff — a rejected
   # session, not a transient blip.
   RECONNECT_LOOP_RESET_STRIKES = 3
+  # Shown to the agent on a message whose send outcome cannot be determined. Says what
+  # to do, because "unknown" alone leaves them with no next step.
+  INDETERMINATE_SEND_MESSAGE = 'The send timed out and may have gone through. Check the ' \
+                               'conversation on WhatsApp before sending it again.'.freeze
 
   # One switch for the whole WhatsApp group subsystem, resolved in one place. Reading the
   # legacy variable here while the registry reads the new one would let an inbox advertise
@@ -571,6 +591,35 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     }.compact
   end
 
+  # Send-side health for this connection. The reason it exists: setup_channel_provider is
+  # not a health check for sending. On an already-registered connection it only sends a
+  # presence update, which does not go through the provider's keystore — so it succeeds
+  # against a socket whose sends are wedged, which is exactly the state we need to catch.
+  #
+  # nil means "unknown" (404 / error): the caller must leave the existing state alone
+  # rather than treat a failed lookup as healthy. Deliberately NOT wrapped in
+  # with_error_handling, matching the other diagnostic GETs — that helper marks the
+  # connection `close` on any error, which would be perverse for a health probe.
+  def fetch_send_health
+    response = HTTParty.get(
+      "#{provider_url}/connections/#{whatsapp_channel.phone_number}/health",
+      headers: api_headers,
+      format: :json,
+      timeout: 10
+    )
+
+    return nil if response.code == 404
+    return nil unless process_response(response)
+
+    data = response.parsed_response&.deep_symbolize_keys&.dig(:data) || {}
+    {
+      send_state: data[:sendState],
+      consecutive_send_timeouts: data[:consecutiveSendTimeouts],
+      last_send_completed_ago_ms: data[:lastSendCompletedAgoMs],
+      last_outgoing_ack_ago_ms: data[:lastOutgoingAckAgoMs]
+    }.compact
+  end
+
   # New-chat message cap (quota) for this connection. Read-only MEX query with the same 404
   # semantics as fetch_reachout_timelock (404 = not connected = unknown -> nil, don't clear the
   # banner). Returns the raw NewChatMessageCapInfo (already snake_case from the provider); the
@@ -709,14 +758,54 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         chatwootMessageId: "#{@message.id}:#{@message.updated_at.to_f}",
         messageId: message_id
       }.to_json,
-      timeout: 120
+      # Above the API's own 45s send deadline plus its slower paths (audio
+      # transcoding, media upload) and above a proxy's 75s cut, so we get its
+      # structured 504/503 rather than a bare Net::ReadTimeout. Below the old
+      # 120s because this request holds the per-channel outgoing lock
+      # (BaileysHelper::CHANNEL_LOCK_ON_OUTGOING_MESSAGE_TIMEOUT, 130s) and every
+      # other send on the inbox queues behind it.
+      timeout: 90
     )
 
-    raise MessageAlreadyProcessingError if response.code == 409
-    raise ProviderUnavailableError unless process_response(response)
+    raise_send_error(response) unless response.success?
 
     update_external_created_at(response)
     response.parsed_response.dig('data', 'key', 'id')
+  end
+
+  # Every non-2xx used to collapse into a bare ProviderUnavailableError, which made it
+  # impossible to tell "the connection is wedged" from "this message can never be sent"
+  # — so the job retried both and buried both in the dead set. Only the codes whose
+  # meaning is unambiguous are mapped; anything else keeps the old behaviour rather than
+  # risk marking a message permanently failed on a guess.
+  def raise_send_error(response)
+    Rails.logger.error response.body
+
+    case response.code
+    when 409
+      # Two different conflicts share this status; the header is what tells them apart.
+      raise SendOutcomeUnknownError, INDETERMINATE_SEND_MESSAGE if indeterminate_send?(response)
+
+      raise MessageAlreadyProcessingError
+    when 503
+      # Distinct from the generic 5xx below: this connection is known to be wedged, so it
+      # must not be marked 'close' (see NON_CHANNEL_DOWN_CODES) — that would drop it out
+      # of the very health-check cycle that detects the stall. It is also the status the
+      # whole episode settles on, since every send after the third timeout gets it.
+      raise SendStalledError, 'The WhatsApp connection is not accepting sends right now'
+    when 504
+      raise SendTimeoutError, 'The send timed out; it may or may not have reached WhatsApp'
+    when 413
+      raise Whatsapp::Session::Errors::MediaTooLarge, 'The attachment is too large to send'
+    when 422
+      raise Whatsapp::Session::Errors::InvalidPayload, 'WhatsApp rejected the message content'
+    else
+      raise ProviderUnavailableError
+    end
+  end
+
+  def indeterminate_send?(response)
+    response.headers['x-baileys-idempotency-state'] == 'indeterminate'
   end
 
   # The WhatsApp message id this send will use, picked here instead of letting Baileys generate it.
@@ -984,13 +1073,43 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
 
       define_method(method_name) do |*args, **kwargs, &block|
         original_method.bind_call(self, *args, **kwargs, &block)
-      rescue MessageAlreadyProcessingError
-        raise
       rescue StandardError => e
-        handle_channel_error
+        handle_channel_error unless channel_error_exempt?(e)
         raise e
       end
     end
+  end
+
+  # Errors that do NOT mean the connection is down, so they must not mark it 'close'.
+  # BaileysConnectionCheckSchedulerJob only enqueues channels whose connection is 'open',
+  # so marking it drops the channel out of the health-check cycle entirely, and only a
+  # webhook or a human puts it back.
+  #
+  # Two groups. The first says something about this message, not the connection: a
+  # rejected attachment or an unknown outcome tells us nothing about the socket. The
+  # second is the send stall itself — the connection is receiving and answering health
+  # checks, only sending is wedged, and marking it 'close' would remove it from the very
+  # cycle that detects that state while POST /connections cannot repair it anyway (on a
+  # registered connection it only sends a presence update, which does not touch the
+  # keystore). The provider recovers this on its own.
+  # Matched on the wire code, not on class identity, for the reason
+  # Whatsapp::Session::Errors::Error#retryable? gives: a constant holding another file's
+  # class keeps the object from before the last reload, and `is_a?` against it then
+  # answers false without saying why. Two of these classes live in errors.rb, so a list
+  # of classes frozen here would be exactly that trap.
+  NON_CHANNEL_DOWN_CODES = %w[
+    message_already_processing
+    send_outcome_unknown
+    send_stalled
+    timeout
+    media_too_large
+    invalid_payload
+  ].freeze
+
+  def channel_error_exempt?(error)
+    return false unless error.respond_to?(:code)
+
+    NON_CHANNEL_DOWN_CODES.include?(error.code)
   end
 
   def handle_channel_error

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -771,6 +771,30 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
 
     update_external_created_at(response)
     response.parsed_response.dig('data', 'key', 'id')
+  rescue *TRANSPORT_ERRORS => e
+    raise_transport_error(e)
+  end
+
+  # A transport failure never reaches raise_send_error, because there is no response to
+  # classify — it escapes as Net::ReadTimeout or an Errno, which is not in the session
+  # hierarchy, so SendReplyJob's retry_on never sees it and the job dies in the dead set
+  # with the bubble still reading "sent". That is the exact silent failure this whole
+  # change exists to remove, so the transport gets translated too.
+  TRANSPORT_ERRORS = [
+    Net::ReadTimeout, Net::OpenTimeout, Net::HTTPBadResponse, EOFError, SocketError, IOError,
+    Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ETIMEDOUT
+  ].freeze
+
+  def raise_transport_error(error)
+    Rails.logger.error "[WHATSAPP][BAILEYS] transport failure on send: #{error.class}: #{error.message}"
+
+    # A read timeout means the request went out and no answer came back, which is the same
+    # thing a 504 says: the send may or may not have reached WhatsApp. Everything else here
+    # failed before or during connect, so the send definitively did not happen and the
+    # provider really is unreachable — which is a channel-down signal, unlike the timeout.
+    raise SendTimeoutError, 'The send timed out; it may or may not have reached WhatsApp' if error.is_a?(Net::ReadTimeout)
+
+    raise ProviderUnavailableError, "Could not reach the WhatsApp provider (#{error.class})"
   end
 
   # Every non-2xx used to collapse into a bare ProviderUnavailableError, which made it

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -142,7 +142,11 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       headers: api_headers,
       timeout: 10
     )
-    return true if response.success?
+    # 404 is the state being asked for, not a failure: the session is already gone, so
+    # reporting it as one would abort a provider conversion, block the rejected-session
+    # path in setup_channel_provider, and leave the modal offering Disconnect forever for
+    # a connection that no longer exists.
+    return true if response.success? || response.code == 404
 
     Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider non-success status=#{response.code}")
     raise ProviderUnavailableError, "The provider did not end the session (HTTP #{response.code})"

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -844,7 +844,10 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     when 422
       raise Whatsapp::Session::Errors::InvalidPayload, outgoing_error(:invalid_payload)
     else
-      raise ProviderUnavailableError
+      # Reasoned, not bare: SendReplyJob persists this message as external_error when the
+      # retries run out, and a bare raise makes that message the Ruby class name. The
+      # agent then reads an internal constant where the reason should be.
+      raise ProviderUnavailableError, outgoing_error(:provider_error)
     end
   end
 
@@ -864,7 +867,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   def raise_unavailable_send_error(response)
     raise SendStalledError, outgoing_error(:send_stalled) if stalled_send?(response)
 
-    raise ProviderUnavailableError
+    raise ProviderUnavailableError, outgoing_error(:provider_error)
   end
 
   def outgoing_error(key)

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -35,8 +35,10 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   RECONNECT_LOOP_RESET_STRIKES = 3
   # Shown to the agent on a message whose send outcome cannot be determined. Says what
   # to do, because "unknown" alone leaves them with no next step.
-  INDETERMINATE_SEND_MESSAGE = 'The send timed out and may have gone through. Check the ' \
-                               'conversation on WhatsApp before sending it again.'.freeze
+  # Persisted as external_error and rendered to the agent, so it is translated like every
+  # other agent-facing string. Resolved at raise time rather than at load: I18n.locale is
+  # per-request, and a constant would freeze whichever locale booted the process.
+  OUTGOING_ERRORS_SCOPE = 'errors.inboxes.channel.outgoing'.freeze
 
   # One switch for the whole WhatsApp group subsystem, resolved in one place. Reading the
   # legacy variable here while the registry reads the new one would let an inbox advertise
@@ -149,12 +151,12 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     return true if response.success? || response.code == 404
 
     Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider non-success status=#{response.code}")
-    raise ProviderUnavailableError, "The provider did not end the session (HTTP #{response.code})"
+    raise ProviderUnavailableError, outgoing_error(:disconnect_refused)
   rescue Whatsapp::Session::Errors::Error
     raise
   rescue StandardError => e
     Rails.logger.warn("[WHATSAPP][BAILEYS] disconnect_channel_provider failed: #{e.class}: #{e.message}")
-    raise ProviderUnavailableError, "Could not reach the provider to end the session (#{e.class})"
+    raise ProviderUnavailableError, outgoing_error(:disconnect_unreachable)
   end
 
   # Confirmed reconnect loop: the provider reported enough consecutive failed
@@ -815,11 +817,13 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   def raise_transport_error(error)
     Rails.logger.error "[WHATSAPP][BAILEYS] transport failure on send: #{error.class}: #{error.message}"
 
-    if NEVER_TRANSMITTED_ERRORS.any? { |klass| error.is_a?(klass) }
-      raise ProviderUnavailableError, "Could not reach the WhatsApp provider (#{error.class})"
-    end
+    raise ProviderUnavailableError, outgoing_error(:provider_unreachable) if never_transmitted?(error)
 
-    raise SendTimeoutError, "The send did not complete (#{error.class}); it may or may not have reached WhatsApp"
+    raise SendTimeoutError, outgoing_error(:send_timed_out)
+  end
+
+  def never_transmitted?(error)
+    NEVER_TRANSMITTED_ERRORS.any? { |klass| error.is_a?(klass) }
   end
 
   # Every non-2xx used to collapse into a bare ProviderUnavailableError, which made it
@@ -834,11 +838,11 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     when 409 then raise_conflict_send_error(response)
     when 503 then raise_unavailable_send_error(response)
     when 504
-      raise SendTimeoutError, 'The send timed out; it may or may not have reached WhatsApp'
+      raise SendTimeoutError, outgoing_error(:send_timed_out)
     when 413
-      raise Whatsapp::Session::Errors::MediaTooLarge, 'The attachment is too large to send'
+      raise Whatsapp::Session::Errors::MediaTooLarge, outgoing_error(:media_too_large)
     when 422
-      raise Whatsapp::Session::Errors::InvalidPayload, 'WhatsApp rejected the message content'
+      raise Whatsapp::Session::Errors::InvalidPayload, outgoing_error(:invalid_payload)
     else
       raise ProviderUnavailableError
     end
@@ -847,7 +851,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # The two statuses a send can come back with where the status alone is not the answer:
   # each covers two conditions that need opposite handling, and a header tells them apart.
   def raise_conflict_send_error(response)
-    raise SendOutcomeUnknownError, INDETERMINATE_SEND_MESSAGE if indeterminate_send?(response)
+    raise SendOutcomeUnknownError, outgoing_error(:send_outcome_unknown) if indeterminate_send?(response)
 
     raise MessageAlreadyProcessingError
   end
@@ -858,9 +862,13 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # But an outage and a draining proxy answer 503 too, and reading those as a stall leaves
   # a genuinely dead channel recorded as open, skipping the reconnect it needed.
   def raise_unavailable_send_error(response)
-    raise SendStalledError, 'The WhatsApp connection is not accepting sends right now' if stalled_send?(response)
+    raise SendStalledError, outgoing_error(:send_stalled) if stalled_send?(response)
 
     raise ProviderUnavailableError
+  end
+
+  def outgoing_error(key)
+    I18n.t("#{OUTGOING_ERRORS_SCOPE}.#{key}")
   end
 
   def indeterminate_send?(response)

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -84,7 +84,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     # error.message, not the exception: StatusTransition appends the wire code when it
     # is handed an exception, and external_error is the sentence the agent reads on the
     # bubble. The code is already in the logs.
-    Whatsapp::Session::Inbound::StatusTransition.apply(message, 'failed', error: error.message)
+    Whatsapp::Session::Inbound::StatusTransition.fail_send(message, error.message)
     nil
   end
 

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -54,6 +54,29 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
 
       send_session_message
     end
+  rescue Whatsapp::Session::Errors::Error => e
+    # A refusal the provider will repeat, or a send whose outcome nobody can determine.
+    # Letting it escape leaves the bubble reading "sent" while the job retries something
+    # that cannot work and then dies in the dead set, so the reason goes on the message
+    # instead — the agent sees it and can act. Only an error that might answer
+    # differently next time is worth raising for. Mirrors
+    # Whatsapp::Session::Outbound::MessageSender, which already does this for the
+    # session providers.
+    raise if e.retryable?
+
+    fail_message(e)
+  end
+
+  # Never over a reason that is already there: a provider that already knows why it
+  # refused writes the specific sentence on the message before raising, and the
+  # exception's own message is the vaguer of the two. Same guard, same reason, as
+  # Whatsapp::Session::Outbound::MessageSender#fail_message.
+  def fail_message(error)
+    message.reload
+    return if message.status == 'failed' && message.external_error.present?
+
+    message.update_under_lock!(status: :failed, external_error: error.message)
+    nil
   end
 
   def validate_announcement_mode!

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -63,19 +63,28 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     # Whatsapp::Session::Outbound::MessageSender, which already does this for the
     # session providers.
     raise if e.retryable?
+    # A processing conflict is not retryable by the definition retryable? uses — the
+    # same command is not going to answer differently, because we are not the one
+    # running it. But the MESSAGE is still on its way out through the worker holding
+    # the lock, so failing it here would be a lie, and it would swallow the dedicated
+    # backoff SendReplyJob has for exactly this conflict.
+    raise if e.code == Whatsapp::Session::Errors::MessageAlreadyProcessing::CODE
 
     fail_message(e)
   end
 
-  # Never over a reason that is already there: a provider that already knows why it
-  # refused writes the specific sentence on the message before raising, and the
-  # exception's own message is the vaguer of the two. Same guard, same reason, as
-  # Whatsapp::Session::Outbound::MessageSender#fail_message.
+  # Through StatusTransition, which owns the rule and applies it under the row lock.
+  # Writing status/external_error directly here would be the third copy of that rule,
+  # and the two that already existed had drifted apart — but more concretely: a send
+  # that timed out may still have reached WhatsApp, so a receipt can mark this message
+  # delivered or read while we are deciding it failed. delivered/read are terminal, and
+  # walking one back to failed invites the agent to send a duplicate.
   def fail_message(error)
     message.reload
-    return if message.status == 'failed' && message.external_error.present?
-
-    message.update_under_lock!(status: :failed, external_error: error.message)
+    # error.message, not the exception: StatusTransition appends the wire code when it
+    # is handed an exception, and external_error is the sentence the agent reads on the
+    # bubble. The code is already in the logs.
+    Whatsapp::Session::Inbound::StatusTransition.apply(message, 'failed', error: error.message)
     nil
   end
 

--- a/app/services/whatsapp/session/channel_extension.rb
+++ b/app/services/whatsapp/session/channel_extension.rb
@@ -71,7 +71,7 @@ module Whatsapp::Session::ChannelExtension # rubocop:disable Metrics/ModuleLengt
     return super unless session_provider?
 
     unless @session_teardown
-      # The same teardown `super` performs, minus the rescue that swallows it. Not
+      # The same teardown `super` performs, minus its logging branch. Not
       # `backend.disconnect`: the facade deletes the session, and only disconnecting
       # leaves the pairing alive under a session id Chatwoot is about to stop using.
       provider_service.disconnect_channel_provider

--- a/app/services/whatsapp/session/inbound/status_transition.rb
+++ b/app/services/whatsapp/session/inbound/status_transition.rb
@@ -8,9 +8,17 @@ module Whatsapp::Session::Inbound::StatusTransition
   # which always implies read.
   RECEIPTS = { 'delivered' => 'delivered', 'read' => 'read', 'played' => 'read', 'failed' => 'failed' }.freeze
   RANK = { 'sent' => 0, 'delivered' => 1, 'read' => 2 }.freeze
-  # Nothing moves a message out of these. A failure reported after the message was
+  # No FAILURE moves a message out of these. A failure reported after the message was
   # delivered or read describes an earlier attempt, not the message coming undone:
   # either status is proof it arrived. A second failure has nothing left to say.
+  #
+  # The reverse is not symmetric, and that asymmetry is the point: a positive receipt
+  # after a failure is proof the message arrived, and proof outranks a verdict. The
+  # verdict may have been ours (a send we stopped waiting on, which says nothing about
+  # what WhatsApp did with it) or the provider's about ONE attempt — and with a
+  # caller-reserved id every attempt carries the same key, so a NACK on the first and a
+  # delivery on the second describe the same message. Leaving it failed would keep
+  # offering the agent a resend for a message the customer already has.
   TERMINAL = %w[delivered read failed].freeze
 
   module_function
@@ -53,14 +61,17 @@ module Whatsapp::Session::Inbound::StatusTransition
   end
 
   def failure_attributes(status, error)
-    return { status: status } unless status == 'failed'
+    return { status: :failed, external_error: error_message(error) } if status == 'failed'
 
-    { status: :failed, external_error: error_message(error) }
+    # Cleared, not just left behind: the dashboard decides between "resend" and "recreate"
+    # by whether a failed message carries an external_error, so a stale one on a message
+    # the receipt just confirmed would keep the resend button on a delivered message.
+    { status: status, external_error: nil }
   end
 
   def allowed?(current, new_status)
     return false if current.in?(TERMINAL) && new_status == 'failed'
-    return false if current.in?(%w[read failed])
+    return false if current == 'read'
     return true if new_status == 'failed'
 
     RANK.fetch(new_status, -1) > RANK.fetch(current, -1)

--- a/app/services/whatsapp/session/inbound/status_transition.rb
+++ b/app/services/whatsapp/session/inbound/status_transition.rb
@@ -33,6 +33,25 @@ module Whatsapp::Session::Inbound::StatusTransition
     end
   end
 
+  # The SEND side's failure writer, as opposed to `apply`, which records what the provider
+  # told us. The difference is source_id: it is only ever written by the provider
+  # confirming the message exists on WhatsApp — the send response, or the echo promoting a
+  # reservation — so a send WE could not confirm has nothing to say about a message the
+  # provider already confirmed, and saying it anyway invites the agent to resend a
+  # duplicate. Read under the row lock, because the echo can land while the last attempt
+  # is still unwinding.
+  #
+  # `apply` deliberately does NOT carry this rule: a provider-reported failure (a 463 NACK,
+  # say) is about a message that did reach the server, and suppressing that would hide a
+  # real delivery failure.
+  def fail_send(message, reason)
+    message.with_lock do
+      next false if message.source_id.present?
+
+      apply(message, 'failed', error: reason)
+    end
+  end
+
   def failure_attributes(status, error)
     return { status: status } unless status == 'failed'
 

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -152,7 +152,7 @@ class Whatsapp::Session::Outbound::MessageSender
   # one, and external_error is the sentence the agent reads on the bubble.
   def fail_message(error)
     message.reload
-    Whatsapp::Session::Inbound::StatusTransition.apply(message, 'failed', error: error.message)
+    Whatsapp::Session::Inbound::StatusTransition.fail_send(message, error.message)
     nil
   end
 

--- a/app/services/whatsapp/session/outbound/message_sender.rb
+++ b/app/services/whatsapp/session/outbound/message_sender.rb
@@ -140,14 +140,19 @@ class Whatsapp::Session::Outbound::MessageSender
     result.message_id
   end
 
-  # Never over a reason that is already there: the announcement guard writes a translated
-  # sentence before it raises, and the exception's own message would replace it with the
-  # English one meant for the log.
+  # Through StatusTransition, which owns the terminal-status rule and applies it under
+  # the row lock. It subsumes the reason it used to guard by hand — the announcement
+  # guard writes a translated sentence before raising and `failed` is terminal, so the
+  # English message meant for the log cannot replace it — and it adds the one this could
+  # not see: a send that timed out may still have arrived, so a receipt can mark the
+  # message delivered or read while we are deciding it failed, and walking that back is
+  # what puts a duplicate in front of the customer.
+  #
+  # error.message, not the exception: StatusTransition appends the wire code when handed
+  # one, and external_error is the sentence the agent reads on the bubble.
   def fail_message(error)
     message.reload
-    return if message.status == 'failed' && message.external_error.present?
-
-    message.update_under_lock!(status: :failed, external_error: error.message)
+    Whatsapp::Session::Inbound::StatusTransition.apply(message, 'failed', error: error.message)
     nil
   end
 

--- a/app/services/whatsapp/session/outbound/source_id_reservation.rb
+++ b/app/services/whatsapp/session/outbound/source_id_reservation.rb
@@ -69,7 +69,23 @@ module Whatsapp::Session::Outbound::SourceIdReservation
     return :stale if reservation.present? && message.pending_source_id != reservation
 
     assigned_here = message.source_id.blank? && attributes[:source_id].present?
-    message.update!(attributes)
+    message.update!(attributes.merge(assigned_here ? send_confirmation(message) : {}))
     assigned_here && message.deleted? ? :revoke : :written
+  end
+
+  # Filling source_id is proof the message exists on WhatsApp, so it also retires a
+  # failure recorded while it did not. StatusTransition.fail_send only ever writes one
+  # while source_id is blank, so a `failed` still standing here is exactly that: our
+  # verdict about a send we stopped waiting on, not WhatsApp's about the message.
+  #
+  # Atomic with the source_id write on purpose. Waiting for a delivery receipt to promote
+  # it (which StatusTransition does allow) leaves a window where the message is proven to
+  # exist and still shows Retry — and Retry clears the reservation and sends a fresh id,
+  # producing the duplicate this whole reservation exists to prevent. external_error goes
+  # with it, since that is what the dashboard reads to decide between resend and recreate.
+  def send_confirmation(message)
+    return {} unless message.status == 'failed'
+
+    { status: :sent, external_error: nil }
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,6 @@
 require Rails.root.join('lib/redis/config')
 require Rails.root.join('lib/captain_response_dequeued_logger')
+require Rails.root.join('lib/sidekiq_death_handler')
 
 schedule_file = 'config/schedule.yml'
 
@@ -18,6 +19,11 @@ end
 
 Sidekiq.configure_server do |config|
   config.redis = Redis::Config.app
+
+  # A job that exhausts its retries is otherwise silent: it lands in the dead set and
+  # nobody is told. For a reply that means the agent keeps seeing "sent" on a message
+  # that never went out.
+  config.death_handlers << SidekiqDeathHandler.method(:call)
 
   config.server_middleware do |chain|
     chain.add CaptainResponseDequeuedLogger

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -35,6 +35,7 @@ en:
         cannot_unpair: This provider cannot unlink the WhatsApp account paired with it, so connecting again would resume the same account. Reset the instance on the provider, point this inbox at another one, or correct the number configured here.
         code_pairing_unsupported: This WhatsApp provider cannot pair with a code. Scan the QR code instead.
         outgoing:
+          provider_error: WhatsApp could not send this message right now.
           provider_unreachable: Could not reach the WhatsApp provider.
           disconnect_refused: The provider did not end the session.
           disconnect_unreachable: Could not reach the provider to end the session.

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -34,6 +34,16 @@ en:
         provider_withdrawn: This WhatsApp provider is no longer offered for new inboxes. Existing inboxes on it keep working.
         cannot_unpair: This provider cannot unlink the WhatsApp account paired with it, so connecting again would resume the same account. Reset the instance on the provider, point this inbox at another one, or correct the number configured here.
         code_pairing_unsupported: This WhatsApp provider cannot pair with a code. Scan the QR code instead.
+        outgoing:
+          provider_unreachable: Could not reach the WhatsApp provider.
+          disconnect_refused: The provider did not end the session.
+          disconnect_unreachable: Could not reach the provider to end the session.
+          send_timed_out: The send timed out; it may or may not have reached WhatsApp.
+          send_outcome_unknown: The send timed out and may have gone through. Check the conversation on WhatsApp before sending it again.
+          send_stalled: The WhatsApp connection is not accepting sends right now.
+          media_too_large: The attachment is too large to send.
+          invalid_payload: WhatsApp rejected the message content.
+          still_processing: The message was still being sent elsewhere and could not be confirmed.
         provider_connection:
           wrong_phone_number: The phone number you are trying to link is not the same as the one you have configured. Please make sure the phone number is correct before scanning the QR code.
           reconnect_loop_detected: The connection could not be re-established after several attempts. Automatic retries continue at increasing intervals. If this persists, disconnect the inbox and pair it again by scanning a new QR code.

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -37,6 +37,7 @@ en:
         provider_connection:
           wrong_phone_number: The phone number you are trying to link is not the same as the one you have configured. Please make sure the phone number is correct before scanning the QR code.
           reconnect_loop_detected: The connection could not be re-established after several attempts. Automatic retries continue at increasing intervals. If this persists, disconnect the inbox and pair it again by scanning a new QR code.
+          send_stall_detected: This connection is receiving messages but cannot send them. If it does not clear on its own within a few minutes, disconnect the inbox and connect again by scanning a new QR code.
           invalid_credentials: The provider rejected the credentials for this inbox. Check the address and the token and try again.
           logged_out: This device was disconnected from WhatsApp on the phone. Pair it again to keep receiving messages.
           stream_replaced: This session was replaced by another connection to the same WhatsApp account. Pair it again to use it here.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -37,6 +37,7 @@ es:
         provider_connection:
           wrong_phone_number: El número de teléfono que intenta vincular no es el mismo que tiene configurado. Verifique que el número sea correcto antes de escanear el código QR.
           reconnect_loop_detected: No se pudo restablecer la conexión después de varios intentos. Los reintentos automáticos continúan a intervalos cada vez mayores. Si el problema persiste, desconecte la bandeja de entrada y vuelva a vincularla escaneando un código QR nuevo.
+          send_stall_detected: Esta conexión está recibiendo mensajes pero no puede enviarlos. Si no se resuelve por sí sola en unos minutos, desconecte la bandeja de entrada y conéctela de nuevo escaneando un nuevo código QR.
           invalid_credentials: El proveedor rechazó las credenciales de esta bandeja de entrada. Verifique la dirección y el token e inténtelo de nuevo.
           logged_out: Este dispositivo fue desconectado de WhatsApp desde el teléfono. Vuelva a vincularlo para seguir recibiendo mensajes.
           stream_replaced: Esta sesión fue reemplazada por otra conexión de la misma cuenta de WhatsApp. Vuelva a vincularla para usarla aquí.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -35,6 +35,7 @@ es:
         cannot_unpair: Este proveedor no puede desvincular la cuenta de WhatsApp emparejada con él, así que conectar de nuevo retomaría la misma cuenta. Reinicia la instancia en el proveedor, apunta esta bandeja de entrada a otra, o corrige el número configurado aquí.
         code_pairing_unsupported: Este proveedor de WhatsApp no puede emparejarse con un código. Escanea el código QR en su lugar.
         outgoing:
+          provider_error: WhatsApp no pudo enviar este mensaje en este momento.
           provider_unreachable: No se pudo contactar al proveedor de WhatsApp.
           disconnect_refused: El proveedor no finalizó la sesión.
           disconnect_unreachable: No se pudo contactar al proveedor para finalizar la sesión.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -34,6 +34,16 @@ es:
         provider_withdrawn: Este proveedor de WhatsApp ya no se ofrece para bandejas de entrada nuevas. Las que ya lo usan siguen funcionando.
         cannot_unpair: Este proveedor no puede desvincular la cuenta de WhatsApp emparejada con él, así que conectar de nuevo retomaría la misma cuenta. Reinicia la instancia en el proveedor, apunta esta bandeja de entrada a otra, o corrige el número configurado aquí.
         code_pairing_unsupported: Este proveedor de WhatsApp no puede emparejarse con un código. Escanea el código QR en su lugar.
+        outgoing:
+          provider_unreachable: No se pudo contactar al proveedor de WhatsApp.
+          disconnect_refused: El proveedor no finalizó la sesión.
+          disconnect_unreachable: No se pudo contactar al proveedor para finalizar la sesión.
+          send_timed_out: El envío superó el tiempo límite; puede o no haber llegado a WhatsApp.
+          send_outcome_unknown: El envío superó el tiempo límite y puede haberse completado. Revise la conversación en WhatsApp antes de enviarla de nuevo.
+          send_stalled: La conexión con WhatsApp no está aceptando envíos en este momento.
+          media_too_large: El archivo adjunto es demasiado grande para enviarlo.
+          invalid_payload: WhatsApp rechazó el contenido del mensaje.
+          still_processing: El mensaje aún se estaba enviando en otro lugar y no se pudo confirmar.
         provider_connection:
           wrong_phone_number: El número de teléfono que intenta vincular no es el mismo que tiene configurado. Verifique que el número sea correcto antes de escanear el código QR.
           reconnect_loop_detected: No se pudo restablecer la conexión después de varios intentos. Los reintentos automáticos continúan a intervalos cada vez mayores. Si el problema persiste, desconecte la bandeja de entrada y vuelva a vincularla escaneando un código QR nuevo.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -34,6 +34,16 @@ pt_BR:
         provider_withdrawn: Este provedor de WhatsApp não é mais oferecido para novas caixas de entrada. As caixas que já usam ele continuam funcionando.
         cannot_unpair: Este provedor não consegue desvincular a conta do WhatsApp pareada com ele, então conectar de novo retomaria a mesma conta. Reinicie a instância no provedor, aponte esta caixa de entrada para outra, ou corrija o número configurado aqui.
         code_pairing_unsupported: Este provedor do WhatsApp não consegue parear com código. Escaneie o QR Code no lugar.
+        outgoing:
+          provider_unreachable: Não foi possível alcançar o provedor do WhatsApp.
+          disconnect_refused: O provedor não encerrou a sessão.
+          disconnect_unreachable: Não foi possível alcançar o provedor para encerrar a sessão.
+          send_timed_out: O envio excedeu o tempo limite; pode ou não ter chegado ao WhatsApp.
+          send_outcome_unknown: O envio excedeu o tempo limite e pode ter sido concluído. Confira a conversa no WhatsApp antes de enviar novamente.
+          send_stalled: A conexão com o WhatsApp não está aceitando envios no momento.
+          media_too_large: O anexo é grande demais para ser enviado.
+          invalid_payload: O WhatsApp recusou o conteúdo da mensagem.
+          still_processing: A mensagem ainda estava sendo enviada em outro lugar e não foi possível confirmar.
         provider_connection:
           wrong_phone_number: O número de telefone que você está tentando conectar não é o mesmo que o configurado. Certifique-se de que o número está correto antes de escanear o QR code.
           reconnect_loop_detected: Não foi possível restabelecer a conexão após várias tentativas. Novas tentativas automáticas continuam em intervalos crescentes. Se o problema persistir, desconecte a caixa de entrada e conecte novamente escaneando um novo QR code.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -37,6 +37,7 @@ pt_BR:
         provider_connection:
           wrong_phone_number: O número de telefone que você está tentando conectar não é o mesmo que o configurado. Certifique-se de que o número está correto antes de escanear o QR code.
           reconnect_loop_detected: Não foi possível restabelecer a conexão após várias tentativas. Novas tentativas automáticas continuam em intervalos crescentes. Se o problema persistir, desconecte a caixa de entrada e conecte novamente escaneando um novo QR code.
+          send_stall_detected: Esta conexão está recebendo mensagens, mas não consegue enviá-las. Se não se resolver sozinha em alguns minutos, desconecte a caixa de entrada e conecte novamente escaneando um novo QR code.
           invalid_credentials: O provedor recusou as credenciais desta caixa de entrada. Confira o endereço e o token e tente novamente.
           logged_out: Este dispositivo foi desconectado do WhatsApp pelo celular. Conecte novamente para continuar recebendo mensagens.
           stream_replaced: Esta sessão foi substituída por outra conexão da mesma conta do WhatsApp. Conecte novamente para usar aqui.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -35,6 +35,7 @@ pt_BR:
         cannot_unpair: Este provedor não consegue desvincular a conta do WhatsApp pareada com ele, então conectar de novo retomaria a mesma conta. Reinicie a instância no provedor, aponte esta caixa de entrada para outra, ou corrija o número configurado aqui.
         code_pairing_unsupported: Este provedor do WhatsApp não consegue parear com código. Escaneie o QR Code no lugar.
         outgoing:
+          provider_error: O WhatsApp não conseguiu enviar esta mensagem no momento.
           provider_unreachable: Não foi possível alcançar o provedor do WhatsApp.
           disconnect_refused: O provedor não encerrou a sessão.
           disconnect_unreachable: Não foi possível alcançar o provedor para encerrar a sessão.

--- a/lib/sidekiq_death_handler.rb
+++ b/lib/sidekiq_death_handler.rb
@@ -1,0 +1,56 @@
+# Reports jobs that exhausted their retries and landed in the dead set.
+#
+# Until this existed nothing watched that set, so a send that failed every attempt was
+# discovered by the customer complaining rather than by monitoring — the dead set held
+# hundreds of SendReplyJob failures nobody had been told about. The handler runs for
+# every job class; SendReplyJob additionally resolves the message so the report names the
+# account, inbox and conversation instead of an opaque id.
+class SidekiqDeathHandler
+  def self.call(job, exception)
+    new(job, exception).report
+  end
+
+  def initialize(job, exception)
+    @job = job
+    @exception = exception
+  end
+
+  def report
+    Rails.logger.error(
+      "[SIDEKIQ][DEAD] #{job_class} args=#{job_args.inspect} error=#{@exception.class}: #{@exception.message}#{context_suffix}"
+    )
+    ChatwootExceptionTracker.new(@exception, account: account).capture_exception
+  rescue StandardError => e
+    # A death handler that raises takes the reporting down with the job it was reporting.
+    Rails.logger.error "[SIDEKIQ][DEAD] handler failed: #{e.message}"
+  end
+
+  private
+
+  # ActiveJob wraps the real class name; plain Sidekiq workers use 'class'.
+  def job_class
+    @job['wrapped'] || @job['class']
+  end
+
+  def job_args
+    payload = @job['args']&.first
+    payload.is_a?(Hash) ? payload['arguments'] : @job['args']
+  end
+
+  def message
+    return @message if defined?(@message)
+
+    @message = job_class.to_s == 'SendReplyJob' ? Message.find_by(id: job_args&.first) : nil
+  end
+
+  def account
+    message&.account
+  end
+
+  def context_suffix
+    return '' if message.blank?
+
+    " account_id=#{message.account_id} inbox_id=#{message.inbox_id} " \
+      "conversation_id=#{message.conversation_id} message_id=#{message.id}"
+  end
+end

--- a/lib/sidekiq_death_handler.rb
+++ b/lib/sidekiq_death_handler.rb
@@ -15,18 +15,31 @@ class SidekiqDeathHandler
     @exception = exception
   end
 
+  # The enrichment is best-effort and the report is not. Resolving the message hits the
+  # database, and the failures that fill the dead set are exactly the ones that come with a
+  # database in trouble: an exception raised while building the context used to take out
+  # the line reporting the original error AND the exception tracker call, so monitoring
+  # recorded "handler failed" and lost the terminal failure it exists to surface.
   def report
+    suffix = safely('context') { context_suffix } || ''
     Rails.logger.error(
       "[SIDEKIQ][DEAD] #{job_class} jid=#{@job['jid']} queue=#{@job['queue']} " \
-      "error=#{@exception.class}: #{@exception.message}#{context_suffix}"
+      "error=#{@exception.class}: #{@exception.message}#{suffix}"
     )
-    ChatwootExceptionTracker.new(@exception, account: account).capture_exception
+    ChatwootExceptionTracker.new(@exception, account: safely('account') { account }).capture_exception
   rescue StandardError => e
     # A death handler that raises takes the reporting down with the job it was reporting.
     Rails.logger.error "[SIDEKIQ][DEAD] handler failed: #{e.message}"
   end
 
   private
+
+  def safely(what)
+    yield
+  rescue StandardError => e
+    Rails.logger.warn "[SIDEKIQ][DEAD] could not resolve #{what}: #{e.class}: #{e.message}"
+    nil
+  end
 
   # ActiveJob wraps the real class name; plain Sidekiq workers use 'class'.
   def job_class

--- a/lib/sidekiq_death_handler.rb
+++ b/lib/sidekiq_death_handler.rb
@@ -17,7 +17,8 @@ class SidekiqDeathHandler
 
   def report
     Rails.logger.error(
-      "[SIDEKIQ][DEAD] #{job_class} args=#{job_args.inspect} error=#{@exception.class}: #{@exception.message}#{context_suffix}"
+      "[SIDEKIQ][DEAD] #{job_class} jid=#{@job['jid']} queue=#{@job['queue']} " \
+      "error=#{@exception.class}: #{@exception.message}#{context_suffix}"
     )
     ChatwootExceptionTracker.new(@exception, account: account).capture_exception
   rescue StandardError => e
@@ -32,6 +33,13 @@ class SidekiqDeathHandler
     @job['wrapped'] || @job['class']
   end
 
+  # NEVER logged, only used to resolve the message below. Arguments are job payloads:
+  # WebhookJob carries the customer's message body and `secret: webhook.secret`
+  # positionally, so dumping them here would put message content and a signing credential
+  # into the log aggregator on any unexpected terminal failure. Key-based filtering does
+  # not help with a bare secret in a positional array. The jid in the log line is enough to
+  # pull the full payload from the dead set, where access is already controlled, and
+  # ChatwootExceptionTracker ships it to Sentry with the same protection.
   def job_args
     payload = @job['args']&.first
     payload.is_a?(Hash) ? payload['arguments'] : @job['args']

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1927,10 +1927,19 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(channel.reload.provider_connection).to eq('connection' => 'close')
       end
 
-      it 'ensures provider connection is updated to close' do
-        channel.update_provider_connection!(connection: 'open')
-        service_double = instance_double(Whatsapp::Providers::WhatsappBaileysService, disconnect_channel_provider: true)
-        allow(service_double).to receive(:disconnect_channel_provider).and_raise(StandardError)
+      # Disconnect is the documented recovery for a send stall, and re-pairing is the only
+      # thing that replaces the wedged socket. Recording 'close' on a disconnect the
+      # provider refused would clear the stall warning without replacing anything: the
+      # operator is told it worked, the banner disappears, and the inbox is still mute
+      # with no signal left to say so.
+      it 'leaves the connection untouched when the provider refuses to end the session' do
+        channel.update_provider_connection!(
+          connection: 'open',
+          send_stall: { 'consecutive_timeouts' => 3, 'action' => 'suppressed' }
+        )
+        service_double = instance_double(Whatsapp::Providers::WhatsappBaileysService)
+        allow(service_double).to receive(:disconnect_channel_provider)
+          .and_raise(Whatsapp::Session::Errors::ProviderUnavailable.new('The provider did not end the session (HTTP 500)'))
         allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:new)
           .with(whatsapp_channel: channel)
           .and_return(service_double)
@@ -1939,8 +1948,11 @@ RSpec.describe 'Inboxes API', type: :request do
              headers: admin.create_new_auth_token,
              as: :json
 
-        expect(response).to have_http_status(:ok)
-        expect(channel.reload.provider_connection).to eq('connection' => 'close')
+        expect(response).to have_http_status(:service_unavailable)
+        expect(channel.reload.provider_connection).to include(
+          'connection' => 'open',
+          'send_stall' => { 'consecutive_timeouts' => 3, 'action' => 'suppressed' }
+        )
       end
     end
   end

--- a/spec/jobs/channels/whatsapp/baileys_connection_check_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/baileys_connection_check_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Channels::Whatsapp::BaileysConnectionCheckJob do
 
   before do
     allow(channel_whatsapp).to receive_messages(setup_channel_provider: true, provider_service: provider_service)
-    allow(provider_service).to receive_messages(fetch_reachout_timelock: nil, fetch_new_chat_cap: nil)
+    allow(provider_service).to receive_messages(fetch_reachout_timelock: nil, fetch_new_chat_cap: nil, fetch_send_health: nil)
   end
 
   it 'enqueues the job' do
@@ -53,6 +53,46 @@ RSpec.describe Channels::Whatsapp::BaileysConnectionCheckJob do
 
     it 'does not let a cap fetch error abort the connection check' do
       allow(provider_service).to receive(:fetch_new_chat_cap).and_raise(StandardError, 'boom')
+
+      expect { described_class.perform_now(channel_whatsapp) }.not_to raise_error
+      expect(channel_whatsapp).to have_received(:setup_channel_provider)
+    end
+
+    # setup_channel_provider only sends a presence update on an already-registered
+    # connection, which does not touch the provider's keystore — so it passes against a
+    # socket whose sends are wedged. This is the part of the check that can tell.
+    it 'reports a connection whose sends are stalled' do
+      allow(provider_service).to receive(:fetch_send_health).and_return(
+        { send_state: 'stalled', consecutive_send_timeouts: 3, last_outgoing_ack_ago_ms: 219_000 }
+      )
+      allow(Rails.logger).to receive(:error)
+
+      described_class.perform_now(channel_whatsapp)
+
+      expect(Rails.logger).to have_received(:error).with(/send stall on ##{channel_whatsapp.id}/)
+    end
+
+    it 'stays quiet for a healthy connection' do
+      allow(provider_service).to receive(:fetch_send_health).and_return({ send_state: 'ok' })
+      allow(Rails.logger).to receive(:error)
+
+      described_class.perform_now(channel_whatsapp)
+
+      expect(Rails.logger).not_to have_received(:error)
+    end
+
+    # 'unknown' means no send has been observed on that connection, which is not a problem.
+    it 'stays quiet when the send state is unknown' do
+      allow(provider_service).to receive(:fetch_send_health).and_return({ send_state: 'unknown' })
+      allow(Rails.logger).to receive(:error)
+
+      described_class.perform_now(channel_whatsapp)
+
+      expect(Rails.logger).not_to have_received(:error)
+    end
+
+    it 'does not let a health check error abort the connection check' do
+      allow(provider_service).to receive(:fetch_send_health).and_raise(StandardError, 'boom')
 
       expect { described_class.perform_now(channel_whatsapp) }.not_to raise_error
       expect(channel_whatsapp).to have_received(:setup_channel_provider)

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -149,6 +149,19 @@ RSpec.describe SendReplyJob do
       expect { described_class.fail_message(-1, 'gone') }.not_to raise_error
     end
 
+    # source_id is only ever written by the provider — the send response, or the echo
+    # promoting a reservation — so it is proof the message exists on WhatsApp even while
+    # the status is still 'sent'. A send WE could not confirm has nothing to say about
+    # one the provider already did.
+    it 'leaves a message the provider already echoed back alone' do
+      message.update_under_lock!(source_id: 'wa_msg_123')
+
+      described_class.fail_message(message.id, 'retries exhausted')
+
+      expect(message.reload.status).not_to eq('failed')
+      expect(message.external_error).to be_blank
+    end
+
     # A send that timed out may still have reached WhatsApp, so a receipt can mark this
     # message delivered while its retries are running out. Either status is proof it
     # arrived, and walking one back to failed is what puts a duplicate in front of the
@@ -187,8 +200,11 @@ RSpec.describe SendReplyJob do
       expect { described_class.perform_now(whatsapp_message.id) }
         .to have_enqueued_job(described_class)
 
+      # Asserted as a floor rather than a window: what this catches is the broad handler
+      # shadowing this one, which schedules the first retry ~3s out. Pinning the exact 60
+      # would only add flake from suite timing.
       scheduled_in = enqueued_jobs.last[:at] - Time.zone.now.to_f
-      expect(scheduled_in).to be_within(5).of(60)
+      expect(scheduled_in).to be > 30
     end
   end
 end

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -149,6 +149,21 @@ RSpec.describe SendReplyJob do
       expect { described_class.fail_message(-1, 'gone') }.not_to raise_error
     end
 
+    # A send that timed out may still have reached WhatsApp, so a receipt can mark this
+    # message delivered while its retries are running out. Either status is proof it
+    # arrived, and walking one back to failed is what puts a duplicate in front of the
+    # customer.
+    %w[delivered read].each do |terminal|
+      it "leaves a message already marked #{terminal} alone" do
+        message.update_under_lock!(status: terminal.to_sym)
+
+        described_class.fail_message(message.id, 'retries exhausted')
+
+        expect(message.reload.status).to eq(terminal)
+        expect(message.external_error).to be_blank
+      end
+    end
+
     # The idempotency lock clears in about the time a bounded send takes; the default
     # backoff burned all three retries well before that, so the conflict alone was enough
     # to kill the job every time.

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -149,6 +149,21 @@ RSpec.describe SendReplyJob do
       expect { described_class.fail_message(-1, 'gone') }.not_to raise_error
     end
 
+    # Returning normally from a retry_on block tells ActiveJob the original exception was
+    # handled, so Sidekiq neither retries nor buries the job — and the message stays on
+    # `sent` with a clock next to it, which is the exact silence this handler exists to
+    # end. If the write fails, the send is still unaccounted for and the job has to die
+    # loudly enough to reach the dead-set handler.
+    it 'raises when the failure could not be recorded' do
+      allow(Whatsapp::Session::Inbound::StatusTransition)
+        .to receive(:fail_send).and_raise(ActiveRecord::StatementInvalid, 'db down')
+      allow(Rails.logger).to receive(:error)
+
+      expect { described_class.fail_message(message.id, 'retries exhausted') }
+        .to raise_error(ActiveRecord::StatementInvalid)
+      expect(Rails.logger).to have_received(:error).with(/could not mark message #{message.id} as failed/)
+    end
+
     # source_id is only ever written by the provider — the send response, or the echo
     # promoting a reservation — so it is proof the message exists on WhatsApp even while
     # the status is still 'sent'. A send WE could not confirm has nothing to say about

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -123,4 +123,57 @@ RSpec.describe SendReplyJob do
       expect_mapped_service_to_perform(message, 'Tiktok::SendOnTiktokService')
     end
   end
+
+  # Until this existed an exhausted job died in the dead set in silence, leaving the
+  # bubble on "sent" with a clock next to it. Nobody watches the dead set, so the
+  # exhaustion handler is the last chance to tell the agent it did not go out.
+  describe 'when retries run out' do
+    let(:message) { create(:message, message_type: :outgoing) }
+
+    it 'marks the message failed with the reason' do
+      described_class.fail_message(message.id, 'the provider never answered')
+
+      expect(message.reload.status).to eq('failed')
+      expect(message.external_error).to eq('the provider never answered')
+    end
+
+    it 'does not overwrite a reason already recorded on the message' do
+      message.update_under_lock!(status: :failed, external_error: 'already recorded')
+
+      described_class.fail_message(message.id, 'the later reason')
+
+      expect(message.reload.external_error).to eq('already recorded')
+    end
+
+    it 'ignores a message that no longer exists' do
+      expect { described_class.fail_message(-1, 'gone') }.not_to raise_error
+    end
+
+    # The idempotency lock clears in about the time a bounded send takes; the default
+    # backoff burned all three retries well before that, so the conflict alone was enough
+    # to kill the job every time.
+    #
+    # Asserted on the scheduled retry rather than on the handler list, because being
+    # registered is not the same as being reached: retry_on is built on rescue_from,
+    # which matches with reverse_each, so the broad Errors::Error handler shadows this
+    # one unless it is declared first. A membership check passes either way.
+    it 'gives a processing conflict its own, longer backoff' do
+      whatsapp_channel = create(:channel_whatsapp, sync_templates: false, validate_provider_config: false)
+      whatsapp_message = create(
+        :message,
+        message_type: :outgoing,
+        conversation: create(:conversation, inbox: whatsapp_channel.inbox)
+      )
+      service = instance_double(Whatsapp::SendOnWhatsappService)
+      allow(Whatsapp::SendOnWhatsappService).to receive(:new).and_return(service)
+      allow(service).to receive(:perform)
+        .and_raise(Whatsapp::Providers::WhatsappBaileysService::MessageAlreadyProcessingError)
+
+      expect { described_class.perform_now(whatsapp_message.id) }
+        .to have_enqueued_job(described_class)
+
+      scheduled_in = enqueued_jobs.last[:at] - Time.zone.now.to_f
+      expect(scheduled_in).to be_within(5).of(60)
+    end
+  end
 end

--- a/spec/lib/sidekiq_death_handler_spec.rb
+++ b/spec/lib/sidekiq_death_handler_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SidekiqDeathHandler do
   it 'still reports the original failure when the context lookup blows up' do
     allow(Message).to receive(:find_by).and_raise(StandardError, 'db down')
     allow(ChatwootExceptionTracker).to receive(:new).and_return(instance_double(ChatwootExceptionTracker,
-                                                                               capture_exception: true))
+                                                                                capture_exception: true))
 
     described_class.call(job_for('SendReplyJob', [1]), exception)
 

--- a/spec/lib/sidekiq_death_handler_spec.rb
+++ b/spec/lib/sidekiq_death_handler_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe SidekiqDeathHandler do
+  let(:exception) { StandardError.new('the provider never answered') }
+
+  def job_for(class_name, arguments)
+    { 'class' => 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
+      'wrapped' => class_name,
+      'args' => [{ 'arguments' => arguments }] }
+  end
+
+  before { allow(Rails.logger).to receive(:error) }
+
+  # The dead set held hundreds of failed sends nobody had been told about, so the bug was
+  # found by the customer complaining rather than by monitoring.
+  it 'reports a dead job' do
+    described_class.call(job_for('SomeJob', [42]), exception)
+
+    expect(Rails.logger).to have_received(:error).with(/\[SIDEKIQ\]\[DEAD\] SomeJob/)
+  end
+
+  # An opaque message id is not actionable at 3am; the account and inbox are.
+  it 'names the account, inbox and conversation for a dead reply' do
+    message = create(:message, message_type: :outgoing)
+
+    described_class.call(job_for('SendReplyJob', [message.id]), exception)
+
+    expect(Rails.logger).to have_received(:error).with(
+      /account_id=#{message.account_id} inbox_id=#{message.inbox_id} conversation_id=#{message.conversation_id}/
+    )
+  end
+
+  it 'still reports when the message is already gone' do
+    described_class.call(job_for('SendReplyJob', [-1]), exception)
+
+    expect(Rails.logger).to have_received(:error).with(/\[SIDEKIQ\]\[DEAD\] SendReplyJob/)
+  end
+
+  it 'reads args from a plain Sidekiq worker payload' do
+    described_class.call({ 'class' => 'PlainWorker', 'args' => [7] }, exception)
+
+    expect(Rails.logger).to have_received(:error).with(/PlainWorker args=\[7\]/)
+  end
+
+  it 'sends the exception to the tracker with the account attached' do
+    message = create(:message, message_type: :outgoing)
+    tracker = instance_double(ChatwootExceptionTracker, capture_exception: nil)
+    allow(ChatwootExceptionTracker).to receive(:new).and_return(tracker)
+
+    described_class.call(job_for('SendReplyJob', [message.id]), exception)
+
+    expect(ChatwootExceptionTracker).to have_received(:new).with(exception, account: message.account)
+  end
+
+  # A death handler that raises takes down the reporting for the job it was reporting.
+  it 'never raises out of the handler' do
+    allow(Message).to receive(:find_by).and_raise(StandardError, 'db down')
+
+    expect { described_class.call(job_for('SendReplyJob', [1]), exception) }.not_to raise_error
+  end
+end

--- a/spec/lib/sidekiq_death_handler_spec.rb
+++ b/spec/lib/sidekiq_death_handler_spec.rb
@@ -36,10 +36,24 @@ RSpec.describe SidekiqDeathHandler do
     expect(Rails.logger).to have_received(:error).with(/\[SIDEKIQ\]\[DEAD\] SendReplyJob/)
   end
 
-  it 'reads args from a plain Sidekiq worker payload' do
-    described_class.call({ 'class' => 'PlainWorker', 'args' => [7] }, exception)
+  it 'reports a plain Sidekiq worker payload by class and jid' do
+    described_class.call({ 'class' => 'PlainWorker', 'args' => [7], 'jid' => 'abc123', 'queue' => 'low' }, exception)
 
-    expect(Rails.logger).to have_received(:error).with(/PlainWorker args=\[7\]/)
+    expect(Rails.logger).to have_received(:error).with(/PlainWorker jid=abc123 queue=low/)
+  end
+
+  # Arguments are job payloads: WebhookJob carries the customer's message body and its
+  # signing secret positionally, so dumping them here would put message content and a
+  # credential into the log aggregator on any unexpected terminal failure. The jid is
+  # enough to pull the full payload from the dead set, where access is already controlled.
+  it 'never writes job arguments to the log' do
+    described_class.call(
+      { 'class' => 'WebhookJob', 'args' => ['https://hook.example', { 'content' => 'private' }, 's3cr3t'], 'jid' => 'abc123' },
+      exception
+    )
+
+    expect(Rails.logger).not_to have_received(:error).with(/s3cr3t|private/)
+    expect(Rails.logger).to have_received(:error).with(/WebhookJob jid=abc123/)
   end
 
   it 'sends the exception to the tracker with the account attached' do

--- a/spec/lib/sidekiq_death_handler_spec.rb
+++ b/spec/lib/sidekiq_death_handler_spec.rb
@@ -72,4 +72,20 @@ RSpec.describe SidekiqDeathHandler do
 
     expect { described_class.call(job_for('SendReplyJob', [1]), exception) }.not_to raise_error
   end
+
+  # Enrichment is best-effort; the report is not. Resolving the message hits the database,
+  # and the failures that fill the dead set come with a database in trouble — so an
+  # exception there used to take out the line reporting the ORIGINAL error and the tracker
+  # call with it, leaving monitoring with "handler failed" and nothing else.
+  it 'still reports the original failure when the context lookup blows up' do
+    allow(Message).to receive(:find_by).and_raise(StandardError, 'db down')
+    allow(ChatwootExceptionTracker).to receive(:new).and_return(instance_double(ChatwootExceptionTracker,
+                                                                               capture_exception: true))
+
+    described_class.call(job_for('SendReplyJob', [1]), exception)
+
+    expect(Rails.logger).to have_received(:error).with(/the provider never answered/)
+    expect(Rails.logger).not_to have_received(:error).with(/handler failed/)
+    expect(ChatwootExceptionTracker).to have_received(:new).with(exception, account: nil)
+  end
 end

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -630,6 +630,32 @@ describe ActionCableListener do
       end
     end
 
+    context 'when a send stall is present' do
+      let(:provider_connection) do
+        { 'connection' => 'open', 'send_stall' => { 'consecutive_timeouts' => 3, 'action' => 'suppressed' } }
+      end
+
+      # The push is the only thing that reaches an agent already sitting in the
+      # conversation: the REST payload was fetched before the stall started.
+      it 'includes the stall in the agent broadcast' do
+        expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+          [agent.pubsub_token],
+          'inbox.provider_connection_updated',
+          {
+            inbox_id: inbox.id,
+            provider_connection: {
+              connection: 'open',
+              send_stall: { 'consecutive_timeouts' => 3, 'action' => 'suppressed' }
+            },
+            account_id: account.id
+          }
+        )
+        allow(ActionCableBroadcastJob).to receive(:perform_later).with([admin.pubsub_token], anything, anything)
+
+        listener.inbox_provider_connection_updated(event)
+      end
+    end
+
     context 'when a new-chat cap is present' do
       let(:provider_connection) do
         { 'connection' => 'open', 'new_chat_cap' => { 'capping_status' => 'CAPPED', 'total_quota' => 100, 'used_quota' => 100 } }

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -795,6 +795,31 @@ RSpec.describe Channel::Whatsapp do
       end
     end
 
+    context 'when a send stall is present' do
+      let(:channel) do
+        create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,
+                                  provider_connection: {
+                                    'connection' => 'open',
+                                    'send_stall' => { 'consecutive_timeouts' => 3, 'action' => 'suppressed' }
+                                  })
+      end
+
+      # The agent is the one whose replies are silently going nowhere, and the connection
+      # still reads 'open', so without this there is nothing in their view to warn them.
+      # Nothing in the payload is credential-sensitive, unlike the QR.
+      it 'exposes the stall to non-administrators' do
+        account_user = create(:account_user, account: channel.account, role: :agent)
+        allow(Current).to receive(:account_user).and_return(account_user)
+
+        data = channel.provider_connection_data
+
+        expect(data).to eq({
+                             connection: 'open',
+                             send_stall: { 'consecutive_timeouts' => 3, 'action' => 'suppressed' }
+                           })
+      end
+    end
+
     context 'when a new-chat cap is present' do
       let(:channel) do
         create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -968,6 +968,23 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       expect(sent.reload.source_id).to eq('RESERVED_4')
     end
 
+    # The retries ran out before this echo arrived, so the message was marked failed. The
+    # echo proves it reached WhatsApp, and leaving it failed puts a Retry button on it —
+    # Retry clears the reservation and sends a fresh id, which is the duplicate the
+    # reservation exists to prevent.
+    it 'retires the send failure of a message the echo proves arrived' do
+      sent = create(:message, inbox: inbox, conversation: conversation, message_type: :outgoing,
+                              content: '**John** olá', source_id: nil, status: :failed,
+                              external_error: 'send timed out',
+                              content_attributes: { pending_source_id: 'RESERVED_5' })
+
+      Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: echo_params('RESERVED_5')).perform
+
+      expect(sent.reload.source_id).to eq('RESERVED_5')
+      expect(sent.status).to eq('sent')
+      expect(sent.external_error).to be_blank
+    end
+
     it 'keeps the source_id already confirmed by the send response' do
       sent = create(:message, inbox: inbox, conversation: conversation, message_type: :outgoing,
                               content: '**John** olá', source_id: 'RESERVED_2',

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -219,7 +219,7 @@ describe Whatsapp::IncomingMessageBaileysService do
       # out, so this webhook is the only thing that says so. `action` is what tells an
       # operator whether the provider already recreated the socket or is holding off —
       # and holding off is when a human has to step in.
-      it 'persists a reported send stall and clears it on the next update' do
+      it 'persists a reported send stall and clears it only when the connection reopens' do
         params = base_params.merge(
           {
             data: {
@@ -246,6 +246,21 @@ describe Whatsapp::IncomingMessageBaileysService do
           }
         )
 
+        # The provider reports a stall once per episode. An unrelated update in the
+        # meantime — a standalone reachoutTimeLock push carries no sendStall — must not
+        # clear the warning, because nothing would ever say it again while the connection
+        # is still mute.
+        unrelated = base_params.merge(
+          { data: { reachoutTimeLock: { isActive: false } } }
+        )
+        described_class.new(inbox: inbox, params: unrelated).perform
+
+        expect(inbox.channel.reload.provider_connection['send_stall']).to include(
+          'consecutive_timeouts' => 3
+        )
+
+        # `open` is a NEW socket, hence a new keystore mutex, whether the provider
+        # restarted it or WhatsApp dropped it. That is the one event that means recovery.
         next_update = base_params.merge({ data: { connection: 'open' } })
         described_class.new(inbox: inbox, params: next_update).perform
 

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -258,6 +258,13 @@ describe Whatsapp::IncomingMessageBaileysService do
         expect(inbox.channel.reload.provider_connection['send_stall']).to include(
           'consecutive_timeouts' => 3
         )
+        # The error string is the only half of this warning an operator can see:
+        # provider_connection_admin_data serializes error and qr_data_url, and send_stall
+        # reaches no serializer. Preserving the detail without the string preserves nothing
+        # anyone reads.
+        expect(inbox.channel.provider_connection['error']).to eq(
+          I18n.t('errors.inboxes.channel.provider_connection.send_stall_detected')
+        )
 
         # `open` is a NEW socket, hence a new keystore mutex, whether the provider
         # restarted it or WhatsApp dropped it. That is the one event that means recovery.
@@ -265,6 +272,7 @@ describe Whatsapp::IncomingMessageBaileysService do
         described_class.new(inbox: inbox, params: next_update).perform
 
         expect(inbox.channel.reload.provider_connection['send_stall']).to be_nil
+        expect(inbox.channel.provider_connection['error']).to be_nil
       end
 
       context 'with reach-out time-lock (error 463 / account restriction)' do

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -215,6 +215,43 @@ describe Whatsapp::IncomingMessageBaileysService do
         expect(inbox.channel.reload.provider_connection['quarantine']).to be_nil
       end
 
+      # The connection keeps receiving and passing health checks while every send times
+      # out, so this webhook is the only thing that says so. `action` is what tells an
+      # operator whether the provider already recreated the socket or is holding off —
+      # and holding off is when a human has to step in.
+      it 'persists a reported send stall and clears it on the next update' do
+        params = base_params.merge(
+          {
+            data: {
+              error: 'send_stall_detected',
+              sendStall: {
+                consecutiveTimeouts: 3,
+                stalledForMs: 120_000,
+                action: 'suppressed',
+                until: '2026-08-21T12:00:00.000Z'
+              }
+            }
+          }
+        )
+
+        described_class.new(inbox: inbox, params: params).perform
+
+        expect(inbox.channel.provider_connection).to include(
+          'error' => I18n.t('errors.inboxes.channel.provider_connection.send_stall_detected'),
+          'send_stall' => {
+            'consecutive_timeouts' => 3,
+            'stalled_for_ms' => 120_000,
+            'action' => 'suppressed',
+            'until' => '2026-08-21T12:00:00.000Z'
+          }
+        )
+
+        next_update = base_params.merge({ data: { connection: 'open' } })
+        described_class.new(inbox: inbox, params: next_update).perform
+
+        expect(inbox.channel.reload.provider_connection['send_stall']).to be_nil
+      end
+
       context 'with reach-out time-lock (error 463 / account restriction)' do
         let(:reachout_data) do
           { isActive: true, timeEnforcementEnds: '2026-06-19T21:52:39.000Z', enforcementType: 'RESTRICT_ALL_COMPANIONS' }

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -952,6 +952,21 @@ describe Whatsapp::Providers::WhatsappBaileysService do
       end
     end
 
+    # SendReplyJob persists error.message as external_error when the retries run out, so a
+    # bare raise puts the Ruby class name in front of the agent where the reason belongs.
+    it 'gives a generic provider failure a reason an agent can read' do
+      stub_request(:post, request_path).to_return(status: 500, body: 'Internal Server Error')
+      stub_request(:post, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
+        .to_return(status: 200)
+
+      expect do
+        service.send_message(test_send_phone_number, message)
+      end.to(raise_error do |error|
+        expect(error.message).to eq(I18n.t('errors.inboxes.channel.outgoing.provider_error'))
+        expect(error.message).not_to include('WhatsappBaileysService')
+      end)
+    end
+
     context 'when the provider is unavailable' do
       it 'raises a retryable provider error' do
         stub_request(:post, request_path)

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -277,19 +277,30 @@ describe Whatsapp::Providers::WhatsappBaileysService do
     # re-pairing, that also cleared the warning that was the only thing telling anyone the
     # inbox was mute. The teardown callers that genuinely do not care rescue it themselves
     # (Channel::Whatsapp#disconnect_channel_provider), which is where that decision belongs.
+    # 404 is the state being asked for, not a failure. Reporting it as one aborts a
+    # provider conversion and leaves the modal offering Disconnect forever for a session
+    # that is already gone.
+    context 'when the session is already absent' do
+      it 'returns true for HTTP 404' do
+        stub_request(:delete, disconnect_url)
+          .with(headers: stub_headers(whatsapp_channel))
+          .to_return(status: 404, body: 'not found')
+
+        expect(service.disconnect_channel_provider).to be(true)
+      end
+    end
+
     context 'when the Baileys API responds with an error status' do
-      [404, 500].each do |status|
-        it "raises and logs a warning for HTTP #{status}" do
-          stub_request(:delete, disconnect_url)
-            .with(headers: stub_headers(whatsapp_channel))
-            .to_return(status: status, body: 'baileys error')
+      it 'raises and logs a warning for HTTP 500' do
+        stub_request(:delete, disconnect_url)
+          .with(headers: stub_headers(whatsapp_channel))
+          .to_return(status: 500, body: 'baileys error')
 
-          allow(Rails.logger).to receive(:warn)
+        allow(Rails.logger).to receive(:warn)
 
-          expect { service.disconnect_channel_provider }
-            .to raise_error(Whatsapp::Session::Errors::ProviderUnavailable, /did not end the session/)
-          expect(Rails.logger).to have_received(:warn).with(/disconnect_channel_provider non-success status=#{status}/)
-        end
+        expect { service.disconnect_channel_provider }
+          .to raise_error(Whatsapp::Session::Errors::ProviderUnavailable, /did not end the session/)
+        expect(Rails.logger).to have_received(:warn).with(/disconnect_channel_provider non-success status=500/)
       end
     end
 

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -272,34 +272,37 @@ describe Whatsapp::Providers::WhatsappBaileysService do
       end
     end
 
-    # disconnect is best-effort: a missing session (404), a Baileys API error
-    # (5xx), or a transport failure shouldn't propagate. The caller (e.g.
-    # convert_provider!) just needs the cleanup attempt to be made, not to
-    # succeed.
+    # The outcome has to travel. Swallowing it let the caller record the inbox as closed
+    # while the session was still live — and for a send stall, whose only recovery is
+    # re-pairing, that also cleared the warning that was the only thing telling anyone the
+    # inbox was mute. The teardown callers that genuinely do not care rescue it themselves
+    # (Channel::Whatsapp#disconnect_channel_provider), which is where that decision belongs.
     context 'when the Baileys API responds with an error status' do
       [404, 500].each do |status|
-        it "returns true, logs a warning, and does not raise for HTTP #{status}" do
+        it "raises and logs a warning for HTTP #{status}" do
           stub_request(:delete, disconnect_url)
             .with(headers: stub_headers(whatsapp_channel))
             .to_return(status: status, body: 'baileys error')
 
           allow(Rails.logger).to receive(:warn)
 
-          expect(service.disconnect_channel_provider).to be(true)
+          expect { service.disconnect_channel_provider }
+            .to raise_error(Whatsapp::Session::Errors::ProviderUnavailable, /did not end the session/)
           expect(Rails.logger).to have_received(:warn).with(/disconnect_channel_provider non-success status=#{status}/)
         end
       end
     end
 
     context 'when the request itself fails' do
-      it 'returns true, logs a warning, and does not raise' do
+      it 'raises and logs a warning' do
         stub_request(:delete, disconnect_url)
           .with(headers: stub_headers(whatsapp_channel))
           .to_raise(Net::OpenTimeout)
 
         allow(Rails.logger).to receive(:warn)
 
-        expect(service.disconnect_channel_provider).to be(true)
+        expect { service.disconnect_channel_provider }
+          .to raise_error(Whatsapp::Session::Errors::ProviderUnavailable, /Could not reach the provider/)
         expect(Rails.logger).to have_received(:warn).with(/disconnect_channel_provider failed/)
       end
 
@@ -309,7 +312,7 @@ describe Whatsapp::Providers::WhatsappBaileysService do
           .to_raise(Net::OpenTimeout)
         reconnect_request = stub_request(:post, disconnect_url)
 
-        service.disconnect_channel_provider
+        expect { service.disconnect_channel_provider }.to raise_error(Whatsapp::Session::Errors::Error)
 
         expect(reconnect_request).not_to have_been_requested
       end
@@ -869,7 +872,8 @@ describe Whatsapp::Providers::WhatsappBaileysService do
     context 'when the connection is refusing sends outright' do
       it 'raises a retryable stall error and leaves the channel open' do
         stub_request(:post, request_path)
-          .to_return(status: 503, body: 'Connection is not accepting sends')
+          .to_return(status: 503, body: 'Connection is not accepting sends',
+                     headers: { 'x-baileys-send-state' => 'stalled' })
 
         setup_url = "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}"
 
@@ -882,6 +886,25 @@ describe Whatsapp::Providers::WhatsappBaileysService do
         end)
 
         expect(WebMock).not_to have_requested(:post, setup_url)
+      end
+
+      # The stall branch is the one that must NOT mark the channel down. An outage and a
+      # draining proxy answer the same 503, and applying the stall reading to them leaves
+      # a genuinely dead channel recorded as open, skipping the reconnect it needed and
+      # dropping it out of the health-check cycle for good.
+      it 'treats a 503 without the provider marker as an ordinary outage' do
+        stub_request(:post, request_path)
+          .to_return(status: 503, body: 'Service Unavailable')
+        setup_url = "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}"
+        stub_request(:post, setup_url).to_return(status: 200)
+
+        expect do
+          service.send_message(test_send_phone_number, message)
+        end.to(raise_error do |error|
+          expect(error.class.name).to eq('Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError')
+        end)
+
+        expect(WebMock).to have_requested(:post, setup_url)
       end
     end
 
@@ -918,10 +941,10 @@ describe Whatsapp::Providers::WhatsappBaileysService do
       end
     end
 
-    context 'when the connection is stalled' do
+    context 'when the provider is unavailable' do
       it 'raises a retryable provider error' do
         stub_request(:post, request_path)
-          .to_return(status: 503, body: 'Connection is not accepting sends')
+          .to_return(status: 503, body: 'Service Unavailable')
         stub_request(:post, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
           .to_return(status: 200)
 

--- a/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_baileys_service_spec.rb
@@ -808,6 +808,132 @@ describe Whatsapp::Providers::WhatsappBaileysService do
       end
     end
 
+    # Every non-2xx used to collapse into a bare ProviderUnavailableError, so the job
+    # retried "this message can never be sent" exactly as hard as "the connection is
+    # down", and buried both in the dead set.
+    context 'when the server reports the send outcome is unknown' do
+      it 'raises a non-retryable error and does not reconnect the channel' do
+        stub_request(:post, request_path)
+          .to_return(
+            status: 409,
+            headers: { 'x-baileys-idempotency-state' => 'indeterminate' },
+            body: 'Previous send timed out; outcome unknown'
+          )
+
+        setup_url = "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}"
+
+        expect do
+          service.send_message(test_send_phone_number, message)
+        end.to(raise_error do |error|
+          expect(error.class.name).to eq('Whatsapp::Providers::WhatsappBaileysService::SendOutcomeUnknownError')
+          # Resending could deliver the message twice, and only a human can tell.
+          expect(error.retryable?).to be(false)
+        end)
+
+        expect(WebMock).not_to have_requested(:post, setup_url)
+      end
+    end
+
+    context 'when the send times out' do
+      it 'raises a retryable timeout error' do
+        stub_request(:post, request_path)
+          .to_return(status: 504, body: 'Send timed out; outcome unknown')
+
+        expect do
+          service.send_message(test_send_phone_number, message)
+        end.to(raise_error do |error|
+          expect(error.class.name).to eq('Whatsapp::Providers::WhatsappBaileysService::SendTimeoutError')
+          expect(error.retryable?).to be(true)
+        end)
+      end
+
+      # The connection is receiving and answering health checks; only sending is wedged.
+      # Marking it closed would drop it out of the health-check cycle that detects
+      # exactly this, and POST /connections cannot repair it anyway.
+      it 'leaves the channel open so the health check keeps watching it' do
+        stub_request(:post, request_path)
+          .to_return(status: 504, body: 'Send timed out; outcome unknown')
+
+        setup_url = "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}"
+
+        expect { service.send_message(test_send_phone_number, message) }.to raise_error(StandardError)
+
+        expect(WebMock).not_to have_requested(:post, setup_url)
+      end
+    end
+
+    # 503 is where the whole episode settles: after the third timeout the API's circuit
+    # breaker refuses without touching the socket, so every later send gets this. Folding
+    # it into the generic ProviderUnavailableError would mark the channel closed for the
+    # entire stall and drop it out of the very cycle meant to detect it.
+    context 'when the connection is refusing sends outright' do
+      it 'raises a retryable stall error and leaves the channel open' do
+        stub_request(:post, request_path)
+          .to_return(status: 503, body: 'Connection is not accepting sends')
+
+        setup_url = "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}"
+
+        expect do
+          service.send_message(test_send_phone_number, message)
+        end.to(raise_error do |error|
+          expect(error.class.name).to eq('Whatsapp::Providers::WhatsappBaileysService::SendStalledError')
+          # The provider recreates the socket on its own; the next attempt after that works.
+          expect(error.retryable?).to be(true)
+        end)
+
+        expect(WebMock).not_to have_requested(:post, setup_url)
+      end
+    end
+
+    context 'when the attachment is rejected as too large' do
+      it 'raises a non-retryable error without marking the channel closed' do
+        stub_request(:post, request_path).to_return(status: 413, body: 'Payload Too Large')
+
+        setup_url = "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}"
+
+        expect do
+          service.send_message(test_send_phone_number, message)
+        end.to raise_error(Whatsapp::Session::Errors::MediaTooLarge)
+
+        # Marking the channel closed here would drop it out of the health-check cycle,
+        # which only enqueues channels whose connection is 'open'.
+        expect(WebMock).not_to have_requested(:post, setup_url)
+      end
+    end
+
+    context 'when the message content is rejected' do
+      it 'raises a non-retryable error' do
+        stub_request(:post, request_path).to_return(status: 422, body: 'Unprocessable')
+
+        setup_url = "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}"
+
+        expect do
+          service.send_message(test_send_phone_number, message)
+        end.to(raise_error do |error|
+          expect(error).to be_a(Whatsapp::Session::Errors::InvalidPayload)
+          expect(error.retryable?).to be(false)
+        end)
+
+        expect(WebMock).not_to have_requested(:post, setup_url)
+      end
+    end
+
+    context 'when the connection is stalled' do
+      it 'raises a retryable provider error' do
+        stub_request(:post, request_path)
+          .to_return(status: 503, body: 'Connection is not accepting sends')
+        stub_request(:post, "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}")
+          .to_return(status: 200)
+
+        expect do
+          service.send_message(test_send_phone_number, message)
+        end.to(raise_error do |error|
+          expect(error).to be_a(Whatsapp::Session::Errors::ProviderUnavailable)
+          expect(error.retryable?).to be(true)
+        end)
+      end
+    end
+
     context 'when server returns 409 (message already processing)' do
       it 'raises MessageAlreadyProcessingError without triggering channel reconnection' do
         stub_request(:post, request_path)

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -563,7 +563,7 @@ describe Whatsapp::SendOnWhatsappService do
         end
       end
 
-      describe 'duplicate send on Net::ReadTimeout retry' do
+      describe 'a read timeout on the send' do
         let(:send_message_url) do
           "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/send-message"
         end
@@ -578,22 +578,49 @@ describe Whatsapp::SendOnWhatsappService do
           stub_request(:post, setup_url).to_return(status: 200, body: '', headers: {})
         end
 
-        it 'sends the message twice when first attempt times out and job is retried' do
+        # A transport failure used to escape as Net::ReadTimeout, which is not in the session
+        # hierarchy, so SendReplyJob's retry_on never saw it: Sidekiq burned its native
+        # retries and the job died in the dead set with the bubble still reading 'sent'.
+        # That is the silent failure this whole change exists to remove, so the transport is
+        # translated too. A read timeout says the same thing a 504 does — the send may or may
+        # not have arrived — which is why it maps to the retryable timeout and not to a
+        # provider-down error.
+        it 'translates into the session hierarchy so the job can retry it' do
           message = create(:message, message_type: :outgoing, content: 'test', conversation: conversation, source_id: nil)
 
+          stub_request(:post, send_message_url)
+            .with { |req| JSON.parse(req.body)['chatwootMessageId'].to_s.start_with?("#{message.id}:") }
+            .to_raise(Net::ReadTimeout.new('Net::ReadTimeout'))
+
+          expect { described_class.new(message: message).perform }.to(raise_error do |e|
+            expect(e.class.name).to eq('Whatsapp::Providers::WhatsappBaileysService::SendTimeoutError')
+            expect(e.retryable?).to be(true)
+          end)
+
+          # Not failed: the send may still have arrived, and the retry reuses the reserved id
+          # so WhatsApp dedupes it rather than delivering twice.
+          expect(message.reload.status).not_to eq('failed')
+          expect(message.pending_source_id).to be_present
+        end
+
+        # The retry sends the same reserved WhatsApp id, which is what makes it safe: two
+        # requests, one message on the customer's phone.
+        it 'reuses the reserved id when the retry goes through' do
+          message = create(:message, message_type: :outgoing, content: 'test', conversation: conversation, source_id: nil)
+          sent_ids = []
+
           stub = stub_request(:post, send_message_url)
-                 .with { |req| JSON.parse(req.body)['chatwootMessageId'].to_s.start_with?("#{message.id}:") }
+                 .with { |req| sent_ids << JSON.parse(req.body)['messageId'] }
                  .to_raise(Net::ReadTimeout.new('Net::ReadTimeout'))
                  .then
                  .to_return(status: 200, body: success_body, headers: { 'Content-Type' => 'application/json' })
 
-          expect { SendReplyJob.perform_now(message.id) }.to(raise_error { |e| expect(e.class.name).to eq('Net::ReadTimeout') })
-          expect(message.reload.source_id).to be_nil
-
-          SendReplyJob.perform_now(message.id)
-          expect(message.reload.source_id).to eq('wa_msg_123')
+          expect { described_class.new(message: message).perform }.to raise_error(Whatsapp::Session::Errors::Timeout)
+          described_class.new(message: message).perform
 
           expect(stub).to have_been_requested.twice
+          expect(sent_ids.uniq.length).to eq(1)
+          expect(message.reload.source_id).to eq('wa_msg_123')
         end
       end
     end

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -489,6 +489,44 @@ describe Whatsapp::SendOnWhatsappService do
           expect(message.external_error).to eq('may have gone through')
         end
 
+        # retryable? is false for a processing conflict, but the message is NOT failed:
+        # another worker holds the idempotency lock and is sending it right now. Failing
+        # it here would both lie to the agent and swallow the dedicated backoff
+        # SendReplyJob has for exactly this conflict, which never runs if the exception
+        # does not reach the job.
+        it 'lets a processing conflict reach the job instead of failing the message' do
+          allow(whatsapp_channel).to receive(:send_message).and_raise(
+            Whatsapp::Providers::WhatsappBaileysService::MessageAlreadyProcessingError
+          )
+
+          expect { described_class.new(message: message).perform }.to raise_error(
+            Whatsapp::Session::Errors::MessageAlreadyProcessing
+          )
+
+          expect(message.reload.status).not_to eq('failed')
+        end
+
+        # A send that timed out may still have reached WhatsApp, so a receipt can mark
+        # this message delivered while we are deciding it failed. Walking that back is
+        # what puts a duplicate in front of the customer.
+        it 'leaves a message the provider already confirmed delivered alone' do
+          allow(whatsapp_channel).to receive(:send_message).and_raise(
+            Whatsapp::Providers::WhatsappBaileysService::SendOutcomeUnknownError, 'may have gone through'
+          )
+          delivered = create(
+            :message,
+            message_type: :outgoing,
+            content: 'test',
+            conversation: conversation,
+            status: :delivered
+          )
+
+          described_class.new(message: delivered).perform
+
+          expect(delivered.reload.status).to eq('delivered')
+          expect(delivered.external_error).to be_blank
+        end
+
         # The other half: a provider that is down answers differently once it is back, so
         # the job has to fail and be retried rather than bury a message the agent could
         # still send.

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -603,6 +603,39 @@ describe Whatsapp::SendOnWhatsappService do
           expect(message.pending_source_id).to be_present
         end
 
+        # An enumerated list of exception types is a promise to have thought of every way a
+        # socket can fail, and it will be wrong: Net::WriteTimeout on a large media body,
+        # OpenSSL::SSL::SSLError on a handshake, whatever the next gem raises. Rescued as a
+        # class instead, which is why nothing but the HTTP call is inside that rescue.
+        [
+          [Net::WriteTimeout, 'Whatsapp::Providers::WhatsappBaileysService::SendTimeoutError'],
+          [OpenSSL::SSL::SSLError, 'Whatsapp::Providers::WhatsappBaileysService::SendTimeoutError'],
+          [Net::OpenTimeout, 'Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError'],
+          [SocketError, 'Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError']
+        ].each do |raised, expected|
+          it "maps #{raised} into the session hierarchy" do
+            message = create(:message, message_type: :outgoing, content: 'test', conversation: conversation, source_id: nil)
+            stub_request(:post, send_message_url).to_raise(raised)
+
+            expect { described_class.new(message: message).perform }.to(raise_error do |e|
+              expect(e.class.name).to eq(expected)
+              expect(e.retryable?).to be(true)
+            end)
+          end
+        end
+
+        # A send that may already be on the wire must not mark the channel closed: that
+        # drops the inbox out of the health-check cycle. A connect that never left our
+        # socket is a real provider-down signal and should.
+        it 'leaves the channel open for a write that may already have been transmitted' do
+          message = create(:message, message_type: :outgoing, content: 'test', conversation: conversation, source_id: nil)
+          stub_request(:post, send_message_url).to_raise(Net::WriteTimeout)
+
+          expect { described_class.new(message: message).perform }.to raise_error(Whatsapp::Session::Errors::Timeout)
+
+          expect(WebMock).not_to have_requested(:post, setup_url)
+        end
+
         # The retry sends the same reserved WhatsApp id, which is what makes it safe: two
         # requests, one message on the customer's phone.
         it 'reuses the reserved id when the retry goes through' do

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -461,6 +461,70 @@ describe Whatsapp::SendOnWhatsappService do
         expect(message.reload.source_id).to eq('msg_group')
       end
 
+      # The bubble used to sit on "sent" with a clock next to it while Sidekiq retried a
+      # send that could never work, and then died in the dead set with nobody watching.
+      # The agent had no way to know it had not gone out.
+      describe 'a send the provider will refuse again' do
+        let(:message) { create(:message, message_type: :outgoing, content: 'test', conversation: conversation) }
+
+        it 'fails the message with the reason instead of raising' do
+          allow(whatsapp_channel).to receive(:send_message).and_raise(
+            Whatsapp::Session::Errors::MediaTooLarge, 'The attachment is too large to send'
+          )
+
+          expect { described_class.new(message: message).perform }.not_to raise_error
+
+          expect(message.reload.status).to eq('failed')
+          expect(message.external_error).to eq('The attachment is too large to send')
+        end
+
+        it 'fails the message when the send outcome cannot be determined' do
+          allow(whatsapp_channel).to receive(:send_message).and_raise(
+            Whatsapp::Providers::WhatsappBaileysService::SendOutcomeUnknownError, 'may have gone through'
+          )
+
+          expect { described_class.new(message: message).perform }.not_to raise_error
+
+          expect(message.reload.status).to eq('failed')
+          expect(message.external_error).to eq('may have gone through')
+        end
+
+        # The other half: a provider that is down answers differently once it is back, so
+        # the job has to fail and be retried rather than bury a message the agent could
+        # still send.
+        it 'lets a retryable error take the job down with it' do
+          allow(whatsapp_channel).to receive(:send_message).and_raise(
+            Whatsapp::Session::Errors::ProviderUnavailable
+          )
+
+          expect { described_class.new(message: message).perform }.to raise_error(
+            Whatsapp::Session::Errors::ProviderUnavailable
+          )
+
+          expect(message.reload.status).not_to eq('failed')
+        end
+
+        # validate_announcement_mode! writes its own translated sentence before raising;
+        # the exception's message is the English one meant for the log.
+        it 'does not overwrite a reason already recorded on the message' do
+          allow(whatsapp_channel).to receive(:send_message).and_raise(
+            Whatsapp::Session::Errors::MediaTooLarge, 'the later reason'
+          )
+          failed_message = create(
+            :message,
+            message_type: :outgoing,
+            content: 'test',
+            conversation: conversation,
+            status: :failed,
+            content_attributes: { external_error: 'already recorded' }
+          )
+
+          described_class.new(message: failed_message).perform
+
+          expect(failed_message.reload.external_error).to eq('already recorded')
+        end
+      end
+
       describe 'duplicate send on Net::ReadTimeout retry' do
         let(:send_message_url) do
           "#{whatsapp_channel.provider_config['provider_url']}/connections/#{whatsapp_channel.phone_number}/send-message"

--- a/spec/services/whatsapp/session/inbound/status_transition_spec.rb
+++ b/spec/services/whatsapp/session/inbound/status_transition_spec.rb
@@ -58,10 +58,26 @@ RSpec.describe Whatsapp::Session::Inbound::StatusTransition do
     expect(message.external_error).to eq('file is too big media_too_large')
   end
 
-  it 'leaves a failed message alone' do
-    message.update!(status: :failed)
+  # The asymmetry with the failure rules below, and it is deliberate. A failure is a
+  # verdict: ours when we stopped waiting on a send (which says nothing about what
+  # WhatsApp did with it), the provider's about ONE attempt otherwise — and with a
+  # caller-reserved id every attempt carries the same key, so a NACK on the first and a
+  # delivery on the second describe the same message. A receipt is proof, and proof wins.
+  # Leaving it failed keeps a resend button on a message the customer already has, which
+  # is how a stalled send turns into a duplicate days later.
+  it 'promotes a failed message when a receipt proves it arrived' do
+    message.update!(status: :failed, external_error: 'send timed out')
 
-    expect(described_class.apply(message, 'delivered')).to be(false)
+    expect(described_class.apply(message, 'delivered')).to be(true)
+    expect(message.reload.status).to eq('delivered')
+    expect(message.external_error).to be_blank
+  end
+
+  it 'refuses to fail a message twice' do
+    message.update!(status: :failed, external_error: 'send timed out')
+
+    expect(described_class.apply(message, 'failed', error: 'send timed out again')).to be(false)
+    expect(message.reload.external_error).to eq('send timed out')
   end
 
   # Receipts arrive out of order, so a failure can land after the read that followed a

--- a/spec/services/whatsapp/session/outbound/source_id_reservation_spec.rb
+++ b/spec/services/whatsapp/session/outbound/source_id_reservation_spec.rb
@@ -48,6 +48,30 @@ RSpec.describe Whatsapp::Session::Outbound::SourceIdReservation do
       expect(message.reload.source_id).to be_nil
     end
 
+    # The echo of a send we already gave up on. Waiting for a delivery receipt to promote
+    # it leaves a window where the message is proven to exist and still shows Retry — and
+    # Retry clears the reservation and sends a fresh id, producing exactly the duplicate
+    # this reservation exists to prevent.
+    it 'retires a local send failure when the id proves the message exists' do
+      message.update!(status: :failed, external_error: 'send timed out')
+
+      expect(described_class.assign(message, { source_id: '3EB0FIRST' })).to eq(:written)
+
+      expect(message.reload.status).to eq('sent')
+      expect(message.external_error).to be_blank
+    end
+
+    # Only the writer that fills the column, and only over a failure. A receipt that
+    # already moved the message forward must not be walked back to `sent`.
+    it 'leaves a message the provider already confirmed where it is' do
+      described_class.assign(message, { source_id: '3EB0FIRST' })
+      message.reload.update!(status: :delivered)
+
+      described_class.assign(message.reload, { source_id: '3EB0FIRST' })
+
+      expect(message.reload.status).to eq('delivered')
+    end
+
     # `update_all` would have written the id without changing the record, leaving
     # `previous_changes` empty: dashboards and webhooks never learn the provider id, and
     # the reaction toolbar stays hidden until something else touches the message.


### PR DESCRIPTION
## The problem

When a baileys connection stops being able to send, Chatwoot has no way to tell. The bubble reads "sent", `SendReplyJob` retries three times inside four minutes against a lock that is held for ten, dies in the dead set, and nobody is notified. 261 dead jobs accumulated that way, across 13 incidents since 28/05/2026.

Depends on fazer-ai/baileys-api#379, which is where the stall itself is fixed. This PR is the half that makes a send which did not go out **visible** — it stays useful whatever the cause.

## What this does

**Map HTTP status to the error taxonomy.** `process_response` collapsed every non-2xx into a bare `ProviderUnavailableError` across ~25 call sites, so "this connection is wedged" and "this message can never be sent" were indistinguishable and `retryable?` could not answer correctly. The fork already has the right hierarchy (`Whatsapp::Session::Errors`, with `retryable?` on the exception); the send path now uses it. Only unambiguous codes are mapped — anything else keeps the old behaviour rather than marking a message permanently failed on a guess.

| status | class | `retryable?` |
|---|---|---|
| 409 + `x-baileys-idempotency-state: indeterminate` | `SendOutcomeUnknownError` | no |
| 409 | `MessageAlreadyProcessingError` | own retry policy |
| 503 | `SendStalledError` | yes |
| 504 | `SendTimeoutError` | yes |
| 413 / 422 | `MediaTooLarge` / `InvalidPayload` | no |
| rest | `ProviderUnavailableError` | yes |

**Put the reason on the message.** `send_baileys_session_message` had no `rescue` at all. Now a non-retryable error marks the message `failed` with `external_error` and does not raise: the agent sees it and resends. A retryable one still raises so the job retries and the message is not failed prematurely. Same shape as `Whatsapp::Session::Outbound::MessageSender`, which already does this for the session providers. The frontend already distinguishes the two failure kinds, so nothing changes in the UI.

**Give `SendReplyJob` real retries, and an ending.** It had none — only Sidekiq's global default (3 tries, ~4 minutes total) against a 600s idempotency lock, so a 409 alone was enough to kill it every time. Two `retry_on` policies now, and both mark the message failed when they run out. Order is load-bearing: `retry_on` is built on `rescue_from`, which matches with `reverse_each`, so the broad handler is declared **first** or it silently shadows the specific one. There is a test on the scheduled retry's delay, not on the handler list, because being registered is not the same as being reached.

**Report dead jobs at all.** There was nothing: no `death_handlers`, no `sidekiq_retries_exhausted`, no dead-set metric. The new handler names the account, inbox and message for a `SendReplyJob`. This item stands on its own — while a reply can die unnoticed, any variant of this bug is discovered by the customer complaining.

**Stop marking the channel closed for errors that are not the channel.** `with_error_handling` set `connection: 'close'` on any `StandardError`, and `BaileysConnectionCheckSchedulerJob` only enqueues channels whose connection is `open`. A send error therefore removed the inbox from the very health-check cycle meant to watch it, and only a webhook or a human put it back. Exemptions are matched on the wire `code`, not on class identity, for the reason `Errors::Error#retryable?` documents: a constant holding another file's class keeps the object from before the last reload.

**Actually check whether sending works.** `setup_channel_provider` is not a send health check: on a registered connection it only sends a presence update, which does not touch the keystore and so succeeds against a wedged socket. The check job now reads `GET /connections/:phone/health`, and `send_stall_detected` arrives by webhook as its own payload on `provider_connection`. Both report; neither acts — the provider recovers on its own, and a second actor racing it would recreate sockets the provider had already replaced.

`timeout: 120` → `90`: above the API's 45s send deadline and a proxy's 75s cut, so we get a structured 504 rather than a bare `Net::ReadTimeout` (which triggers the reconnect path), and below it because the request holds the 130s per-channel outgoing lock that every other send on the inbox queues behind.

## Tests

2533 examples, 0 failures, 2 pending (both pre-existing). RuboCop clean across 2634 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oeXoEGNu94cVXEtMx1rut

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/391)
<!-- Reviewable:end -->
