### PR TITLE
fix(whatsapp): let the provider picker wrap instead of squeezing

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -305,7 +305,9 @@ const requestEmbeddedSignupAccess = () => {
         </p>
       </div>
 
-      <div class="flex gap-6 justify-start">
+      <div
+        class="grid max-w-3xl grid-cols-1 gap-6 xs:grid-cols-2 sm:grid-cols-3"
+      >
         <ChannelSelector
           v-for="provider in availableProviders"
           :key="provider.key"


### PR DESCRIPTION
## O que

O picker de provedores do WhatsApp era a única grade de canais do dashboard ainda num `flex` sem wrap, então cada provedor adicionado desde então deixou os cartões mais estreitos em vez de começar uma segunda linha. Cinco já passa do que cabe confortavelmente, e o picker de conversão pode mostrar seis.

Passa a usar a mesma grade responsiva que a lista principal de canais (`ChannelList.vue`) já usa, então os dois pickers quebram do mesmo jeito e os cartões mantêm a largura.

## Verificação

Medido no navegador (`getBoundingClientRect` por cartão):

| Viewport | Distribuição | Largura do cartão |
|---|---|---|
| 1440px | 3 + 2 | 242px |
| 820px | 3 + 2 | 160px, sem scroll horizontal |

Abaixo disso cai para 2 colunas no breakpoint `xs` e 1 no mobile.

O modo de conversão usa a mesma `div`: partindo de uma inbox `uazapi`, oferece Cloud, 360dialog, Baileys e Z-API (4 cartões, 3 + 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/392)
<!-- Reviewable:end -->
