### PR TITLE
feat(whatsapp): let a session inbox pair with a code

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -4,7 +4,8 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
   before_action :fetch_agent_bot, only: [:set_agent_bot]
   # we are already handling the authorization in fetch inbox
   # rubocop:disable Rails/LexicallyScopedActionFilter -- health is defined in WhatsappHealthManagement concern
-  before_action :check_authorization, except: [:show, :health, :setup_channel_provider, :import_whatsapp_session]
+  before_action :check_authorization,
+                except: [:show, :health, :setup_channel_provider, :import_whatsapp_session, :request_pairing_code]
   before_action :validate_whatsapp_cloud_channel, only: [:health]
   # rubocop:enable Rails/LexicallyScopedActionFilter
   include Api::V1::Accounts::Concerns::WhatsappHealthManagement
@@ -92,6 +93,26 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
     end
 
     channel.setup_channel_provider
+    head :ok
+  rescue Whatsapp::Session::Errors::Error => e
+    render_session_error(e)
+  end
+
+  # The other way into the same pairing, for an operator who cannot scan the QR.
+  # Authorized exactly like setup_channel_provider, and for the same reason: both link a
+  # WhatsApp account to an inbox this agent is already assigned to.
+  #
+  # No phone in the request. The number is the inbox's own, because pairing links
+  # whatever phone the code is typed on and the layer quarantines a session whose account
+  # is not the inbox's.
+  def request_pairing_code
+    channel = @inbox.channel
+
+    unless channel.respond_to?(:request_pairing_code)
+      render json: { error: 'Channel does not support pairing by code' }, status: :unprocessable_entity and return
+    end
+
+    channel.request_pairing_code
     head :ok
   rescue Whatsapp::Session::Errors::Error => e
     render_session_error(e)

--- a/app/javascript/dashboard/api/inboxes.js
+++ b/app/javascript/dashboard/api/inboxes.js
@@ -114,6 +114,10 @@ class Inboxes extends CacheEnabledApiClient {
     return axios.post(`${this.url}/${inboxId}/setup_channel_provider`);
   }
 
+  requestPairingCode(inboxId) {
+    return axios.post(`${this.url}/${inboxId}/request_pairing_code`);
+  }
+
   disconnectChannelProvider(inboxId) {
     return axios.post(`${this.url}/${inboxId}/disconnect_channel_provider`);
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -45,8 +45,12 @@
           "LINK_BUTTON": "Link device",
           "LINK_DEVICE_MODAL": {
             "TITLE": "Link your device",
-            "SUBTITLE": "Scan the QR code to link your device. Make sure the phone number is correct before scanning.",
+            "SUBTITLE": "Link your device to this inbox. Make sure the phone number is correct before you start.",
             "LOADING_QRCODE": "Loading QR code...",
+            "USE_PAIRING_CODE": "Link with a code instead",
+            "USE_QRCODE": "Use the QR code instead",
+            "LOADING_PAIRING_CODE": "Requesting a code...",
+            "PAIRING_CODE_HELP": "On the phone, open WhatsApp, go to Linked devices, tap \"Link with phone number instead\" and type this code. It expires in a few minutes.",
             "RECONNECTING": "Connecting...",
             "LINK_DEVICE": "Link device",
             "DISCONNECT": "Disconnect",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -45,8 +45,12 @@
           "LINK_BUTTON": "Vincular dispositivo",
           "LINK_DEVICE_MODAL": {
             "TITLE": "Vincule su dispositivo",
-            "SUBTITLE": "Escanee el código QR para vincular su dispositivo. Verifique que el número de teléfono sea correcto antes de escanear.",
+            "SUBTITLE": "Vincule su dispositivo a esta bandeja de entrada. Verifique que el número de teléfono sea correcto antes de empezar.",
             "LOADING_QRCODE": "Cargando el código QR...",
+            "USE_PAIRING_CODE": "Vincular con un código",
+            "USE_QRCODE": "Usar el código QR",
+            "LOADING_PAIRING_CODE": "Solicitando un código...",
+            "PAIRING_CODE_HELP": "En el teléfono, abra WhatsApp, vaya a Dispositivos vinculados, toque \"Vincular con número de teléfono\" e ingrese este código. Caduca en unos minutos.",
             "RECONNECTING": "Conectando...",
             "LINK_DEVICE": "Vincular dispositivo",
             "DISCONNECT": "Desconectar",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -45,8 +45,12 @@
           "LINK_BUTTON": "Conectar dispositivo",
           "LINK_DEVICE_MODAL": {
             "TITLE": "Conecte o seu dispositivo",
-            "SUBTITLE": "Escaneie o QR code para conectar seu dispositivo. Certifique-se de que o número de telefone esteja correto antes de escanear.",
+            "SUBTITLE": "Conecte o seu dispositivo a esta caixa de entrada. Confira se o número de telefone está correto antes de começar.",
             "LOADING_QRCODE": "Carregando QR code...",
+            "USE_PAIRING_CODE": "Conectar com um código",
+            "USE_QRCODE": "Usar o QR code",
+            "LOADING_PAIRING_CODE": "Pedindo um código...",
+            "PAIRING_CODE_HELP": "No telefone, abra o WhatsApp, vá em Dispositivos conectados, toque em \"Conectar com número de telefone\" e digite este código. Ele expira em alguns minutos.",
             "RECONNECTING": "Conectando...",
             "LINK_DEVICE": "Conectar dispositivo",
             "DISCONNECT": "Desconectar",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
@@ -22,7 +22,17 @@ const store = useStore();
 const providerConnection = computed(() => props.inbox.provider_connection);
 const connection = computed(() => providerConnection.value?.connection);
 const qrDataUrl = computed(() => providerConnection.value?.qr_data_url);
+const pairingCode = computed(() => providerConnection.value?.pairing_code);
 const error = computed(() => providerConnection.value?.error);
+
+// Which pairing the operator asked for, not which one the provider has answered with
+// yet: the code takes a moment to arrive, and the screen has to say what it is waiting
+// for in the meantime. Reset whenever the pairing ends, so the next one starts on the
+// QR again, which is the mode that needs nothing from them.
+const pairingMode = ref('qr');
+const supportsCodePairing = computed(() =>
+  hasCapability(props.inbox, CAPABILITIES.CODE_PAIRING)
+);
 
 // Alternative onboarding when WhatsApp's extra device-linking verification blocks
 // the QR: install the browser extension and import an already-linked session.
@@ -46,8 +56,24 @@ const handleError = e => {
 };
 const setup = () => {
   loading.value = true;
+  pairingMode.value = 'qr';
   store
     .dispatch('inboxes/setupChannelProvider', props.inbox.id)
+    .catch(handleError);
+};
+// Asking again is how a code that expired is replaced, so this stays reachable while one
+// is already on screen.
+const pairWithCode = () => {
+  loading.value = true;
+  pairingMode.value = 'code';
+  store
+    .dispatch('inboxes/requestPairingCode', props.inbox.id)
+    .then(() => {
+      // The connection was already `connecting` when the QR was on screen, so the watcher
+      // below never fires and nothing else would stop the button spinning. What comes
+      // next is the wait for the code, which the panel shows on its own.
+      loading.value = false;
+    })
     .catch(handleError);
 };
 const disconnect = () => {
@@ -73,6 +99,9 @@ onUnmounted(() => {
 watchEffect(() => {
   if (connection.value) {
     loading.value = false;
+  }
+  if (connection.value && connection.value !== 'connecting') {
+    pairingMode.value = 'qr';
   }
 });
 </script>
@@ -116,22 +145,81 @@ watchEffect(() => {
           </template>
 
           <template v-else-if="connection === 'connecting'">
-            <div v-if="!qrDataUrl" class="flex flex-col gap-4 items-center">
-              <p>
-                {{
+            <template v-if="pairingMode === 'code'">
+              <div v-if="!pairingCode" class="flex flex-col gap-4 items-center">
+                <p>
+                  {{
+                    $t(
+                      'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.LOADING_PAIRING_CODE'
+                    )
+                  }}
+                </p>
+                <Spinner />
+              </div>
+              <div v-else class="flex flex-col gap-2 items-center">
+                <p
+                  class="font-mono text-3xl font-semibold tracking-widest select-all text-n-slate-12"
+                >
+                  {{ pairingCode }}
+                </p>
+                <p class="max-w-xs text-sm text-center text-n-slate-11">
+                  {{
+                    $t(
+                      'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.PAIRING_CODE_HELP'
+                    )
+                  }}
+                </p>
+              </div>
+            </template>
+
+            <template v-else>
+              <div v-if="!qrDataUrl" class="flex flex-col gap-4 items-center">
+                <p>
+                  {{
+                    $t(
+                      'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.LOADING_QRCODE'
+                    )
+                  }}
+                </p>
+                <Spinner />
+              </div>
+              <img
+                v-else
+                :src="qrDataUrl"
+                alt="QR Code"
+                class="w-[276px] h-[276px]"
+              />
+            </template>
+
+            <!-- The way in for an operator who cannot scan: the phone being linked is
+                 rarely in the same room as the person doing the setup. Asking again is
+                 also how a code that expired is replaced. -->
+            <template v-if="supportsCodePairing">
+              <Button
+                v-if="pairingMode === 'code'"
+                link
+                blue
+                :is-loading="loading"
+                :label="
                   $t(
-                    'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.LOADING_QRCODE'
+                    'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.USE_QRCODE'
                   )
-                }}
-              </p>
-              <Spinner />
-            </div>
-            <img
-              v-else
-              :src="qrDataUrl"
-              alt="QR Code"
-              class="w-[276px] h-[276px]"
-            />
+                "
+                @click="setup"
+              />
+              <Button
+                v-else
+                link
+                blue
+                :is-loading="loading"
+                :label="
+                  $t(
+                    'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.USE_PAIRING_CODE'
+                  )
+                "
+                @click="pairWithCode"
+              />
+            </template>
           </template>
 
           <template v-else-if="connection === 'reconnecting'">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/WhatsappLinkDeviceModal.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/WhatsappLinkDeviceModal.spec.js
@@ -1,10 +1,22 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, flushPromises } from '@vue/test-utils';
 import WhatsappLinkDeviceModal from '../WhatsappLinkDeviceModal.vue';
 
-const IMPORT_TITLE_KEY =
-  'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.IMPORT_SESSION_TITLE';
+const KEY = 'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL';
+const IMPORT_TITLE_KEY = `${KEY}.IMPORT_SESSION_TITLE`;
+const USE_PAIRING_CODE_KEY = `${KEY}.USE_PAIRING_CODE`;
+const USE_QRCODE_KEY = `${KEY}.USE_QRCODE`;
+const LOADING_PAIRING_CODE_KEY = `${KEY}.LOADING_PAIRING_CODE`;
 
-const mountModal = capabilities =>
+const dispatch = vi.fn(() => Promise.resolve());
+
+vi.mock('vuex', () => ({
+  useStore: () => ({ dispatch: (...args) => dispatch(...args) }),
+}));
+
+const mountModal = (
+  capabilities,
+  providerConnection = { connection: 'close' }
+) =>
   shallowMount(WhatsappLinkDeviceModal, {
     props: {
       show: true,
@@ -13,7 +25,7 @@ const mountModal = capabilities =>
         id: 1,
         name: 'WhatsApp',
         capabilities,
-        provider_connection: { connection: 'close' },
+        provider_connection: providerConnection,
       },
     },
     global: {
@@ -21,13 +33,12 @@ const mountModal = capabilities =>
       stubs: {
         'woot-modal': { template: '<div><slot /></div>' },
         'router-link': true,
+        Button: { props: ['label'], template: '<button>{{ label }}</button>' },
       },
     },
   });
 
-vi.mock('vuex', () => ({
-  useStore: () => ({ dispatch: () => Promise.resolve() }),
-}));
+beforeEach(() => dispatch.mockClear());
 
 describe('WhatsappLinkDeviceModal', () => {
   // The extension hands over Baileys credentials, so a provider that cannot consume
@@ -42,5 +53,51 @@ describe('WhatsappLinkDeviceModal', () => {
     const wrapper = mountModal(['qr_pairing', 'session_import']);
 
     expect(wrapper.html()).toContain(IMPORT_TITLE_KEY);
+  });
+
+  describe('pairing by code', () => {
+    const connecting = {
+      connection: 'connecting',
+      qr_data_url: 'data:image/png;base64,x',
+    };
+
+    it('is not offered by a provider that cannot do it', () => {
+      const wrapper = mountModal(['qr_pairing'], connecting);
+
+      expect(wrapper.html()).not.toContain(USE_PAIRING_CODE_KEY);
+    });
+
+    it('is offered next to the QR when the provider declares it', () => {
+      const wrapper = mountModal(['qr_pairing', 'code_pairing'], connecting);
+
+      expect(wrapper.html()).toContain(USE_PAIRING_CODE_KEY);
+    });
+
+    // The code takes a moment to arrive, and the QR is still on the record until it
+    // does: leaving it up would put the operator back on the thing they just said they
+    // could not use.
+    it('waits for the code instead of falling back to the QR', async () => {
+      const wrapper = mountModal(['qr_pairing', 'code_pairing'], connecting);
+
+      await wrapper.find('button').trigger('click');
+      await flushPromises();
+
+      expect(dispatch).toHaveBeenCalledWith('inboxes/requestPairingCode', 1);
+      expect(wrapper.html()).toContain(LOADING_PAIRING_CODE_KEY);
+      expect(wrapper.html()).not.toContain('data:image/png;base64,x');
+    });
+
+    it('shows the code the provider issued, and the way back to the QR', async () => {
+      const wrapper = mountModal(['qr_pairing', 'code_pairing'], {
+        ...connecting,
+        pairing_code: 'K7QP-2M4X',
+      });
+
+      await wrapper.find('button').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.html()).toContain('K7QP-2M4X');
+      expect(wrapper.html()).toContain(USE_QRCODE_KEY);
+    });
   });
 });

--- a/app/javascript/dashboard/store/modules/inboxes.js
+++ b/app/javascript/dashboard/store/modules/inboxes.js
@@ -396,6 +396,13 @@ export const actions = {
       throwErrorMessage(error);
     }
   },
+  requestPairingCode: async (_, inboxId) => {
+    try {
+      await InboxesAPI.requestPairingCode(inboxId);
+    } catch (error) {
+      throwErrorMessage(error);
+    }
+  },
   disconnectChannelProvider: async (_, inboxId) => {
     try {
       await InboxesAPI.disconnectChannelProvider(inboxId);

--- a/app/services/whatsapp/session/backend.rb
+++ b/app/services/whatsapp/session/backend.rb
@@ -82,7 +82,6 @@ class Whatsapp::Session::Backend
   def logout = not_supported!(:logout)
   def delete_session = not_supported!(:delete_session)
   def fetch_connection_state = not_supported!(:fetch_connection_state)
-  def request_pairing_code(_command) = not_supported!(:request_pairing_code)
   def import_session(_payload) = not_supported!(:import_session)
 
   # Whatever the provider holds pointing at this inbox, released on its own. Called when

--- a/app/services/whatsapp/session/backends/connector/backend.rb
+++ b/app/services/whatsapp/session/backends/connector/backend.rb
@@ -68,13 +68,6 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
     model::ConnectionState.from_h(client.call(commands::SessionStatus.new))
   end
 
-  # The code itself arrives as a pairing.code event: WhatsApp takes its time issuing it,
-  # and the inbox screen is already listening for connection updates.
-  def request_pairing_code(command)
-    client.publish(command)
-    nil
-  end
-
   # The limits ride along with the session status, which is the only thing that knows
   # them: they are pushed as events the rest of the time.
   def fetch_account_limits

--- a/app/services/whatsapp/session/backends/fake.rb
+++ b/app/services/whatsapp/session/backends/fake.rb
@@ -9,6 +9,7 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
   def model = Whatsapp::Session::Model
 
   QR_DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='.freeze
+  PAIRING_CODE = 'K7QP-2M4X'.freeze
 
   class << self
     def provider_key
@@ -37,6 +38,7 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
     @connection_state = model::ConnectionState.new(
       connection: 'connecting',
       qr_data_url: (QR_DATA_URL if command.pairing == 'qr'),
+      pairing_code: (PAIRING_CODE if command.pairing == 'code'),
       epoch: (connection_state.epoch || 0) + 1
     )
   end
@@ -57,11 +59,6 @@ class Whatsapp::Session::Backends::Fake < Whatsapp::Session::Backend
 
   def fetch_connection_state
     connection_state
-  end
-
-  def request_pairing_code(command)
-    record(command)
-    model::Events::PairingCode.new(code: 'K7QP-2M4X', phone: command.phone)
   end
 
   def import_session(payload)

--- a/app/services/whatsapp/session/backends/uazapi/backend.rb
+++ b/app/services/whatsapp/session/backends/uazapi/backend.rb
@@ -187,14 +187,6 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
     connection_state(client.get('/instance/status'))
   end
 
-  # The code comes back in this same answer, but it is not returned: the pairing poll is
-  # already running and writes it, and a backend that also wrote state would be the second
-  # writer of a record that has exactly one.
-  def request_pairing_code(command)
-    client.post('/instance/connect', { phone: command.phone })
-    nil
-  end
-
   def fetch_account_limits
     limits = client.get('/instance/wa_messages_limits') || {}
     { 'reachout_time_lock' => reachout_time_lock(limits), 'new_chat_cap' => new_chat_cap(limits) }.compact

--- a/app/services/whatsapp/session/capabilities.rb
+++ b/app/services/whatsapp/session/capabilities.rb
@@ -28,12 +28,14 @@ module Whatsapp::Session::Capabilities
   ].freeze
 
   # Capability -> the Backend method it unlocks. Only capabilities that map to a single
-  # entry point are listed: `qr_pairing` is covered by `connect` (every backend has it),
-  # and `echo_by_reserved_id`, `history_sync` and `calls` describe behavior rather than a
-  # call. The shared examples use this map to assert that a declared capability is
-  # actually implemented, and that an undeclared one still raises NotSupported.
+  # entry point are listed. `qr_pairing` and `code_pairing` are not: both are `connect`,
+  # which every backend has, told which mode to pair in, and a code is issued by raising
+  # the session rather than on top of one, so there is no second call to make. Neither
+  # are `echo_by_reserved_id`, `history_sync` and `calls`, which describe behavior. The
+  # shared examples use this map to assert that a declared capability is actually
+  # implemented, and that an undeclared one still raises NotSupported; the pairing modes
+  # get an example of their own, against `connect`.
   METHODS = {
-    'code_pairing' => :request_pairing_code,
     'session_import' => :import_session,
     'edit' => :edit_message,
     'revoke' => :revoke_message,

--- a/app/services/whatsapp/session/channel_extension.rb
+++ b/app/services/whatsapp/session/channel_extension.rb
@@ -46,6 +46,14 @@ module Whatsapp::Session::ChannelExtension # rubocop:disable Metrics/ModuleLengt
     Whatsapp::Session::Registry.backend_for(self)
   end
 
+  # Not a delegate on the model, unlike `setup_channel_provider`: pairing by code is a
+  # session-family action, and the legacy services have nothing to answer it with.
+  def request_pairing_code
+    raise Whatsapp::Session::Errors::NotSupported, "#{provider} does not pair by code" unless session_provider?
+
+    provider_service.request_pairing_code
+  end
+
   # Two callers reach this, and they want opposite things. `convert_provider!` is neither:
   # it goes to the provider service directly.
   #

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -41,22 +41,22 @@ class Whatsapp::Session::Facade
 
   # "Make sure this session is up": resumes an existing pairing, or starts a new one.
   def setup_channel_provider
-    end_disowned_session
-    mode = pairing_mode
-    attempt = claim_pairing_attempt
-    # The inbox was converted while this was running, so it is not this backend's to
-    # connect: asking the old provider anyway leaves a session behind that no inbox owns.
-    return if attempt.nil?
+    start_pairing(pairing_mode)
+  end
 
-    state = connect(mode, attempt)
-    # The connect answer is the first state the dashboard has to show (it carries the QR
-    # for a provider that returns one), and for a polled backend it is also what starts
-    # the pairing poll: nothing else would refresh the code as it rotates. A resume that
-    # answers `open` has nothing left to poll, and a chain started over one would write
-    # `connect_failure` over a healthy connection the first time a request failed.
-    writer.apply(state.with_attempt(attempt), reset: true, attempt: attempt, provider: provider, instance: instance)
-    start_pairing_poll(mode, attempt) if state.connecting? && backend.class.state_polling?
-    state
+  # The operator saying they cannot scan the QR. `setup_channel_provider` picks QR for a
+  # session that has never paired because that is the mode needing nothing from them;
+  # this is the other way into the same pairing, and asking again is how a code that
+  # expired gets replaced.
+  #
+  # It pairs the inbox's own number, never one the request carries. Pairing links
+  # whatever phone the code is typed on, and this layer quarantines a session whose
+  # account is not the inbox's: letting the caller name a different number would spend a
+  # pairing to arrive at that quarantine.
+  def request_pairing_code
+    raise Whatsapp::Session::Errors::NotSupported, I18n.t('errors.inboxes.channel.code_pairing_unsupported') unless capability?('code_pairing')
+
+    start_pairing('code')
   end
 
   def import_session(session:, candidate_index: 0)
@@ -212,6 +212,27 @@ class Whatsapp::Session::Facade
 
   def capability?(capability)
     channel.session_capabilities.include?(capability)
+  end
+
+  # Both ways in share every step but the mode: the disowned-session guard, the claim
+  # that orders two clicks by the click, the write and the poll.
+  def start_pairing(mode)
+    end_disowned_session
+    attempt = claim_pairing_attempt
+    # The inbox was converted while this was running, so it is not this backend's to
+    # connect: asking the old provider anyway leaves a session behind that no inbox owns.
+    return if attempt.nil?
+
+    state = connect(mode, attempt)
+    # The connect answer is the first state the dashboard has to show (it carries the QR,
+    # or the code, for a provider that returns one), and for a polled backend it is also
+    # what starts the pairing poll: nothing else would refresh either as it rotates. A
+    # resume that answers `open` has nothing left to poll, and a chain started over one
+    # would write `connect_failure` over a healthy connection the first time a request
+    # failed.
+    writer.apply(state.with_attempt(attempt), reset: true, attempt: attempt, provider: provider, instance: instance)
+    start_pairing_poll(mode, attempt) if state.connecting? && backend.class.state_polling?
+    state
   end
 
   # An object in the contract, not a flag: the field says how calls are handled, and the

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -33,6 +33,7 @@ en:
         provider_not_enabled_for_account: This WhatsApp provider is turned off for this account.
         provider_withdrawn: This WhatsApp provider is no longer offered for new inboxes. Existing inboxes on it keep working.
         cannot_unpair: This provider cannot unlink the WhatsApp account paired with it, so connecting again would resume the same account. Reset the instance on the provider, point this inbox at another one, or correct the number configured here.
+        code_pairing_unsupported: This WhatsApp provider cannot pair with a code. Scan the QR code instead.
         provider_connection:
           wrong_phone_number: The phone number you are trying to link is not the same as the one you have configured. Please make sure the phone number is correct before scanning the QR code.
           reconnect_loop_detected: The connection could not be re-established after several attempts. Automatic retries continue at increasing intervals. If this persists, disconnect the inbox and pair it again by scanning a new QR code.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -33,6 +33,7 @@ es:
         provider_not_enabled_for_account: Este proveedor de WhatsApp está desactivado para esta cuenta.
         provider_withdrawn: Este proveedor de WhatsApp ya no se ofrece para bandejas de entrada nuevas. Las que ya lo usan siguen funcionando.
         cannot_unpair: Este proveedor no puede desvincular la cuenta de WhatsApp emparejada con él, así que conectar de nuevo retomaría la misma cuenta. Reinicia la instancia en el proveedor, apunta esta bandeja de entrada a otra, o corrige el número configurado aquí.
+        code_pairing_unsupported: Este proveedor de WhatsApp no puede emparejarse con un código. Escanea el código QR en su lugar.
         provider_connection:
           wrong_phone_number: El número de teléfono que intenta vincular no es el mismo que tiene configurado. Verifique que el número sea correcto antes de escanear el código QR.
           reconnect_loop_detected: No se pudo restablecer la conexión después de varios intentos. Los reintentos automáticos continúan a intervalos cada vez mayores. Si el problema persiste, desconecte la bandeja de entrada y vuelva a vincularla escaneando un código QR nuevo.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -33,6 +33,7 @@ pt_BR:
         provider_not_enabled_for_account: Este provedor de WhatsApp está desativado para esta conta.
         provider_withdrawn: Este provedor de WhatsApp não é mais oferecido para novas caixas de entrada. As caixas que já usam ele continuam funcionando.
         cannot_unpair: Este provedor não consegue desvincular a conta do WhatsApp pareada com ele, então conectar de novo retomaria a mesma conta. Reinicie a instância no provedor, aponte esta caixa de entrada para outra, ou corrija o número configurado aqui.
+        code_pairing_unsupported: Este provedor do WhatsApp não consegue parear com código. Escaneie o QR Code no lugar.
         provider_connection:
           wrong_phone_number: O número de telefone que você está tentando conectar não é o mesmo que o configurado. Certifique-se de que o número está correto antes de escanear o QR code.
           reconnect_loop_detected: Não foi possível restabelecer a conexão após várias tentativas. Novas tentativas automáticas continuam em intervalos crescentes. Se o problema persistir, desconecte a caixa de entrada e conecte novamente escaneando um novo QR code.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -358,6 +358,7 @@ Rails.application.routes.draw do
             get :message_templates, on: :member
             post :set_agent_bot, on: :member
             post :setup_channel_provider, on: :member
+            post :request_pairing_code, on: :member
             post :import_whatsapp_session, on: :member
             post :disconnect_channel_provider, on: :member
             post :convert_provider, on: :member

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1708,6 +1708,68 @@ RSpec.describe 'Inboxes API', type: :request do
     end
   end
 
+  describe 'POST /api/v1/accounts/:account_id/inboxes/:id/request_pairing_code' do
+    let(:session_channel) do
+      create(:channel_whatsapp, account: account, provider: 'uazapi', validate_provider_config: false, sync_templates: false)
+    end
+    let(:session_inbox) { session_channel.inbox }
+
+    it 'returns unauthorized when unauthenticated' do
+      post "/api/v1/accounts/#{account.id}/inboxes/#{session_inbox.id}/request_pairing_code"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    # Same privilege as scanning a QR for the inbox, and granted the same way: both link
+    # a WhatsApp account to an inbox this agent is already assigned to.
+    it 'lets an assigned agent ask for one' do
+      create(:inbox_member, user: agent, inbox: session_inbox)
+      allow_any_instance_of(Whatsapp::Session::Facade).to receive(:request_pairing_code) # rubocop:disable RSpec/AnyInstance
+
+      post "/api/v1/accounts/#{account.id}/inboxes/#{session_inbox.id}/request_pairing_code",
+           headers: agent.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns unauthorized for an agent who is not on the inbox' do
+      post "/api/v1/accounts/#{account.id}/inboxes/#{session_inbox.id}/request_pairing_code",
+           headers: agent.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    # The route is on every inbox, and only the session family can answer it. A provider
+    # that cannot pair by code has to say so as a sentence, not as a 500.
+    it 'refuses a provider that does not pair by code' do
+      legacy = create(:channel_whatsapp, account: account, provider: 'baileys', validate_provider_config: false)
+
+      post "/api/v1/accounts/#{account.id}/inboxes/#{legacy.inbox.id}/request_pairing_code",
+           headers: admin.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['code']).to eq('unsupported')
+    end
+
+    it 'refuses a channel that has no pairing at all' do
+      post "/api/v1/accounts/#{account.id}/inboxes/#{create(:inbox, account: account).id}/request_pairing_code",
+           headers: admin.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'answers a provider that is down with a 503, which is worth retrying' do
+      allow_any_instance_of(Whatsapp::Session::Facade) # rubocop:disable RSpec/AnyInstance
+        .to receive(:request_pairing_code)
+        .and_raise(Whatsapp::Session::Errors::ProviderUnavailable, 'the instance did not answer')
+
+      post "/api/v1/accounts/#{account.id}/inboxes/#{session_inbox.id}/request_pairing_code",
+           headers: admin.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:service_unavailable)
+    end
+  end
+
   describe 'POST /api/v1/accounts/:account_id/inboxes/:id/import_whatsapp_session' do
     let(:channel) { create(:channel_whatsapp, account: account, provider: 'baileys', validate_provider_config: false) }
     let(:inbox) { channel.inbox }

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -20,6 +20,34 @@ RSpec.describe Whatsapp::Session::Facade do
     expect(channel.session_backend).to eq(backend)
   end
 
+  describe 'pairing by code' do
+    it 'connects in code mode and puts the code on the record' do
+      channel.request_pairing_code
+
+      expect(backend.last_command).to have_attributes(pairing: 'code', phone: channel.phone_number.delete('+'))
+      expect(channel.reload.provider_connection).to include('connection' => 'connecting', 'pairing_code' => 'K7QP-2M4X')
+    end
+
+    # The mode is the only difference between the two ways in. Everything the QR path
+    # sets up for the screen has to be set up here too, or an operator pairing by code
+    # gets a session nobody is watching: no attempt token to order two clicks by, and no
+    # poll to notice that the code expired.
+    it 'claims the screen and polls, exactly like the QR path' do
+      allow(backend.class).to receive(:state_polling?).and_return(true)
+
+      expect { channel.request_pairing_code }.to have_enqueued_job(Whatsapp::Session::PairingPollJob)
+        .with(channel, hash_including(pairing: 'code'))
+      expect(channel.reload.provider_connection['pairing_attempt']).to be_present
+    end
+
+    it 'refuses a provider that does not declare the capability' do
+      allow(channel).to receive(:session_capabilities).and_return(%w[qr_pairing])
+
+      expect { channel.request_pairing_code }.to raise_error(Whatsapp::Session::Errors::NotSupported)
+      expect(backend.commands).to be_empty
+    end
+  end
+
   describe 'read receipts' do
     it 'marks the stored messages read on WhatsApp' do
       message = create(:message, conversation: conversation, inbox: inbox, account: channel.account, source_id: '3EB0AAAA')

--- a/spec/support/whatsapp/session/backend_shared_examples.rb
+++ b/spec/support/whatsapp/session/backend_shared_examples.rb
@@ -14,7 +14,6 @@ RSpec.shared_examples 'a whatsapp session backend' do
   # method is wired without knowing anything about the backend.
   let(:sample_calls) do
     {
-      request_pairing_code: [commands::PairingRequestCode.new(phone: '5541999991111')],
       import_session: [{ 'session' => { 'creds' => 'redacted' } }],
       edit_message: [commands::MessageEdit.new(target_id: '3EB0AAAA', to: phone_address, content: text_content)],
       revoke_message: [commands::MessageRevoke.new(target_id: '3EB0AAAA', to: phone_address)],
@@ -95,6 +94,21 @@ RSpec.shared_examples 'a whatsapp session backend' do
 
       expect(state).to be_a(model::ConnectionState)
       expect(state.connection).to be_in(model::ConnectionState::CONNECTIONS)
+    end
+
+    # The pairing modes are the one pair of capabilities `Capabilities::METHODS` cannot
+    # cover, because both are the same method told which mode to use. Declaring
+    # `code_pairing` and then refusing the mode is the failure that map exists to catch
+    # everywhere else, so it is caught here instead.
+    it 'pairs in every mode it declares' do
+      modes = { 'qr_pairing' => 'qr', 'code_pairing' => 'code' }.select { |capability, _| described_class.supports?(capability) }
+      states = modes.transform_values do |mode|
+        subject.connect(commands::SessionConnect.new(pairing: mode, phone: '5541999991111'))
+      rescue Whatsapp::Session::Errors::NotSupported
+        nil
+      end
+
+      expect(states.compact_blank.keys).to eq(modes.keys)
     end
 
     it 'reports the connection state' do


### PR DESCRIPTION
Uma caixa de entrada WhatsApp de sessão (`uazapi`, e `native` quando o conector existir) agora pode ser conectada digitando um código no celular, em vez de escanear o QR code. É o caminho que se usa quando o telefone não está na mesma sala de quem está fazendo a configuração.

O QR continua sendo o padrão. Ao lado dele aparece "Conectar com um código", e dentro do modo de código aparece a volta para o QR. Clicar de novo é como se pede um código novo quando o anterior expira.

## Closes

- Closes #388

## How to test

1. Numa caixa de entrada `uazapi`, vá em Configurações → Configuração → **Gerenciar conexão**.
2. O QR aparece como sempre, agora com **Conectar com um código** abaixo.
3. Clique. O QR sai e entra o código, com a instrução de onde digitá-lo no celular.
4. **Usar o QR code** volta ao QR.
5. Numa caixa de entrada Baileys ou Z-API, o link não aparece: nenhuma das duas declara `code_pairing`.

Validado no navegador contra um stub do uazapi: ida e volta entre os dois modos, e o registro do provedor terminando em `connection=connecting`, `pairing_code` preenchido, `pairing_attempt` presente e `qr_data_url` limpo.

## What changed

**O caminho é `connect` com o modo, não uma segunda chamada.** `Backend#request_pairing_code` saiu junto: no uazapi era o `connect` menos o registro do webhook, que é exatamente a janela que o `connect` documenta (uma sessão que abre sem ter para onde entregar), e no conector publicava um comando que o contrato não responde. Por consequência `Capabilities::METHODS` não mapeia mais `code_pairing`, pelo mesmo motivo que nunca mapeou `qr_pairing`, e as shared examples passam a fixar os dois modos contra o `connect`: declarar um modo e depois recusá-lo é a falha que aquele mapa existe para pegar.

**Os dois caminhos de entrada do facade agora compartilham `start_pairing`.** Assim o modo de código ganha o que o QR já tinha: a guarda de sessão desgarrada, o token de tentativa que ordena dois cliques pelo clique, e o poll. O poll é o que substitui um código expirado, e o `PairingPollJob` já conhecia o teto de cinco minutos desse modo desde que foi escrito.

**O número é o da própria caixa de entrada, nunca um que venha na requisição.** O pareamento vincula o telefone em que o código for digitado, e esta camada coloca em quarentena uma sessão cuja conta não é a da caixa de entrada: deixar quem chama escolher o número gastaria um pareamento para chegar nessa quarentena. Por isso a rota não recebe corpo.

Autorização igual à do `setup_channel_provider`, e pelo mesmo motivo: os dois vinculam uma conta do WhatsApp a uma caixa de entrada que o agente já atende.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/394)
<!-- Reviewable:end -->
