### PR TITLE
fix(whatsapp): close the ordering holes deferring alone cannot cover

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -121,12 +121,13 @@ class Message < ApplicationRecord
   # [:rich] : Structured WhatsApp "rich" message (template/interactive/buttons/list) with title/body/footer/buttons rendered as a card
   # [:deleted_by_contact] : The contact deleted/revoked the message on WhatsApp; we keep the content visible and only flag it
   # [:pending_source_id] : Provider message id reserved before the send (Baileys), used to match the provider echo back to this row
+  # [:edited_at] : Provider timestamp (ms) of the edit currently stored, so an edit that arrives out of order is refused
 
   store :content_attributes, accessors: [:submitted_email, :items, :submitted_values, :email, :in_reply_to, :deleted,
                                          :external_created_at, :story_sender, :story_id, :external_error,
                                          :translations, :in_reply_to_external_id, :is_unsupported, :data,
                                          :is_reaction, :is_edited, :previous_content, :zapi_args, :referral, :rich,
-                                         :deleted_by_contact, :pending_source_id], coder: JSON
+                                         :deleted_by_contact, :pending_source_id, :edited_at], coder: JSON
 
   store :external_source_ids, accessors: [:slack], coder: JSON, prefix: :external_source_id
 

--- a/app/services/whatsapp/session/inbound/handlers/message_edited.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_edited.rb
@@ -4,31 +4,53 @@ class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::I
     target = find_message(payload.message_id)
     # Not stored yet, as far as this transport can tell. On an ordered one it never was.
     return :deferred if target.nil?
+    return :ignored if revoked?(target)
 
     content = edited_content
     # nil is a content type this layer cannot render as text; an empty string is a real
     # edit that removed the caption, and dropping it would leave the old one on screen.
     return :ignored if content.nil?
+    return :ignored unless apply(target, content)
 
-    apply(target, content)
     inbound::ChatList.refresh(target.conversation)
     :handled
   end
 
   private
 
-  # Both the read and the write happen under the row lock: `is_edited` and
-  # `previous_content` live in the content_attributes JSON, so an edit applied off an
-  # instance loaded before a concurrent revoke would serialize the pre-revoke hash and
-  # bring a deleted message back, and the "what did it say before" read has to see the
-  # same row it is about to write.
+  # The message was deleted for everyone before this edit was applied. Editing it now
+  # writes the edited text back onto a bubble the UI shows as deleted, which on a
+  # delete-for-everyone also means restoring text WhatsApp has already taken off the
+  # contact's phone. Nobody edits a message they have deleted, so this only ever happens
+  # when the two arrive out of order.
+  def revoked?(target)
+    target.deleted? || target.deleted_by_contact
+  end
+
+  # Both the read and the write happen under the row lock: `is_edited`,
+  # `previous_content` and `edited_at` live in the content_attributes JSON, so an edit
+  # applied off an instance loaded before a concurrent revoke would serialize the
+  # pre-revoke hash and bring a deleted message back, and the "what did it say before"
+  # read has to see the same row it is about to write.
+  #
+  # False when this edit is older than the one already stored, which is what keeps two
+  # edits of the same message from depending on which job ran last. The comparison is on
+  # the provider's own clock rather than on arrival, since arrival is the thing that is
+  # out of order; ties pass, because equal timestamps carry no order to respect.
   def apply(target, content)
     target.with_lock do
+      next false if stale?(target)
+
       # The first edit is what the reader wants to compare against, so a second edit
       # does not overwrite the original.
       previous = target.is_edited ? target.previous_content : target.content
-      target.update!(content: content, is_edited: true, previous_content: previous)
+      target.update!(content: content, is_edited: true, previous_content: previous, edited_at: payload.timestamp)
+      true
     end
+  end
+
+  def stale?(target)
+    payload.timestamp.present? && target.edited_at.present? && payload.timestamp < target.edited_at
   end
 
   # By wire type, not by class: a class captured before a reload stops matching and the

--- a/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_reaction.rb
@@ -21,13 +21,28 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
   # and an avatar job, and a removal aimed at a reaction this sender never made has
   # nothing to remove. Without this, every stray removal leaves a contact behind, which
   # is why the lookup here is the non-creating one.
+  #
+  # Nothing recorded at all is the out-of-order case rather than the stray one, and it is
+  # the half of it that deferring the *add* cannot cover: a removal that ran first would
+  # be dropped here, and the add behind it would then write a reaction the sender has
+  # already taken back, which nothing later corrects. A row that exists and is already
+  # gone is the ordinary echo of a removal made here, and answers itself.
   def remove
     known = payload.from_me ? nil : inbound::ContactLookup.contact(inbox: inbox, party: peer_party)
-    return :ignored if known.nil? && !payload.from_me
+    return :deferred unless recorded?(known)
     return :ignored unless inbound::ReactionStore.active?(inbox: inbox, target_id: payload.target_id,
                                                           sender: known, from_me: payload.from_me)
 
     store(sender_contact).remove ? :handled : :ignored
+  end
+
+  # No contact says the same thing as no row: the add is what resolves one, so a removal
+  # that finds nobody arrived before the reaction it takes back.
+  def recorded?(known)
+    return false if known.nil? && !payload.from_me
+
+    inbound::ReactionStore.recorded?(inbox: inbox, target_id: payload.target_id,
+                                     sender: known, from_me: payload.from_me)
   end
 
   def add
@@ -50,8 +65,10 @@ class Whatsapp::Session::Inbound::Handlers::MessageReaction < Whatsapp::Session:
     contact_inbox = resolve_contact_inbox
     return :ignored if contact_inbox.nil?
 
-    store(payload.chat.group? ? sender_contact : contact_inbox.contact).write(target.conversation)
-    :handled
+    written = store(payload.chat.group? ? sender_contact : contact_inbox.contact).write(target.conversation)
+    # nil when a newer reaction from the same sender is already on the bubble, which is
+    # what an emoji swap looks like when its two halves arrive the wrong way round.
+    written.nil? ? :ignored : :handled
   end
 
   def store(sender)

--- a/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_receipt.rb
@@ -4,6 +4,11 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceipt < Whatsapp::Session::
   # habit: opening a chat produced a single read event naming 246 messages, most of them
   # from before the inbox existed, and a lookup per id put hundreds of round trips on the
   # queue that inbound messages share.
+  #
+  # Never deferred, unlike the events that mutate one message. Waiting for the ids it
+  # names would replay that whole batch five times over the ones that are never coming,
+  # and losing a receipt is self-correcting in a way that losing a revoke is not: the
+  # next one on the chat carries the same marker forward.
   def perform
     messages = find_messages(Array(payload.message_ids).compact_blank).to_a
     return :ignored if messages.empty?

--- a/app/services/whatsapp/session/inbound/reaction_store.rb
+++ b/app/services/whatsapp/session/inbound/reaction_store.rb
@@ -2,6 +2,10 @@
 # (target, sender), toggled instead of duplicated. This holds both halves of that:
 # writing a new reaction and marking an existing one removed.
 class Whatsapp::Session::Inbound::ReactionStore
+  # `content_attributes` is a `store`, so it reaches Postgres as json rather than jsonb
+  # and every predicate below has to cast before it can index into it.
+  JSON_COLUMN = "(content_attributes#>>'{}')::jsonb".freeze
+
   attr_reader :inbox, :reaction, :sender
 
   # `sender` is the Contact that reacted, nil for a reaction sent from the phone.
@@ -20,20 +24,35 @@ class Whatsapp::Session::Inbound::ReactionStore
   # one author on the WhatsApp side whether an agent or the phone wrote it. The caller
   # finds the Contact without creating one.
   def self.active?(inbox:, target_id:, sender:, from_me: false)
-    json = "(content_attributes#>>'{}')::jsonb"
-    scope = Message.where(inbox_id: inbox.id)
-                   .where("#{json}->>'is_reaction' = 'true'")
-                   .where("#{json}->>'in_reply_to_external_id' = ?", target_id)
-                   .where.not(content: '')
-                   .where("COALESCE(#{json}->>'deleted', 'false') != 'true'")
-    scope = if from_me
-              scope.where(message_type: Message.message_types[:outgoing])
-            else
-              scope.where(sender: sender)
-            end
-    scope.exists?
+    live(rows(inbox: inbox, target_id: target_id, sender: sender, from_me: from_me)).exists?
   end
 
+  # The same pair, deleted rows included. What tells a removal that arrived before its
+  # reaction apart from one with nothing to do: the first has no row at all, the second
+  # has one that is already gone.
+  def self.recorded?(inbox:, target_id:, sender:, from_me: false)
+    rows(inbox: inbox, target_id: target_id, sender: sender, from_me: from_me).exists?
+  end
+
+  # Every reaction row this (target, sender) pair has, in any state. The one scope the
+  # three questions below are asked of, so "which rows are this pair's" is answered in a
+  # single place: `sender` decides it for a contact's reaction, and `message_type` for
+  # one from the connected number, which has a single author on the WhatsApp side
+  # whether an agent or the phone wrote it.
+  def self.rows(inbox:, target_id:, sender:, from_me:)
+    scope = Message.where(inbox_id: inbox.id)
+                   .where("#{JSON_COLUMN}->>'is_reaction' = 'true'")
+                   .where("#{JSON_COLUMN}->>'in_reply_to_external_id' = ?", target_id)
+    from_me ? scope.where(message_type: Message.message_types[:outgoing]) : scope.where(sender: sender)
+  end
+
+  # The subset that still shows an emoji on the bubble.
+  def self.live(scope)
+    scope.where.not(content: '').where("COALESCE(#{JSON_COLUMN}->>'deleted', 'false') != 'true'")
+  end
+
+  # nil when there was nothing to do: this reaction is older than the one already stored,
+  # so applying it would put the emoji the sender swapped away from back on the bubble.
   def write(conversation)
     existing = find_existing
     return replace(existing) if existing
@@ -48,7 +67,7 @@ class Whatsapp::Session::Inbound::ReactionStore
     {
       is_reaction: true,
       in_reply_to_external_id: reaction.target_id,
-      external_created_at: reaction.timestamp && (reaction.timestamp / 1000),
+      external_created_at: created_at,
       external_sender_name: ('WhatsApp' if reaction.from_me)
     }.compact
   end
@@ -79,45 +98,48 @@ class Whatsapp::Session::Inbound::ReactionStore
   # for another arrives as a fresh event rather than as an edit. One row per (target,
   # sender) is the invariant the removal path depends on: a second row would show both
   # emojis on the bubble and leave one of them behind when the reaction is taken back.
+  #
+  # Refused when this reaction is older than the stored one, on the provider's clock
+  # rather than on arrival: arrival is the thing that is out of order. Ties pass, since
+  # equal timestamps carry no order to respect, which is also what the second half of a
+  # swap looks like when the provider stamps both in the same second.
   def replace(existing)
-    existing.with_lock do
+    replaced = existing.with_lock do
+      next false if stale?(existing)
+
       existing.update!(
         source_id: reaction.id,
         content: reaction.emoji,
         content_attributes: existing.content_attributes.merge(
-          { 'external_created_at' => reaction.timestamp && (reaction.timestamp / 1000) }.compact
+          { 'external_created_at' => created_at }.compact
         )
       )
+      true
     end
+    return nil unless replaced
+
     Whatsapp::Session::Inbound::ChatList.refresh(existing.conversation)
     existing
   end
 
+  def stale?(existing)
+    stored = existing.external_created_at
+    created_at.present? && stored.present? && created_at < stored.to_i
+  end
+
+  def created_at
+    reaction.timestamp && (reaction.timestamp / 1000)
+  end
+
   # Deliberately not scoped to any conversation: the original reaction may live in an
   # older or resolved thread while the inbound flow picked a different one.
+  #
+  # Active-only: when every match is already deleted this returns nil, so an echoed
+  # removal does not re-delete the row and bump the conversation again.
   def find_existing
-    json = "(content_attributes#>>'{}')::jsonb"
-    base = Message.where(inbox_id: inbox.id)
-                  .where("#{json}->>'is_reaction' = 'true'")
-                  .where("#{json}->>'in_reply_to_external_id' = ?", reaction.target_id)
-    matches = if reaction.from_me
-                # Outgoing is the whole test. On the WhatsApp side there is one author of
-                # a `from_me` reaction, the connected number, whether it was written on the
-                # phone (no agent on the row) or by an agent here (the agent on the row).
-                # Asking for a sender-less row instead would miss the agent's, and the echo
-                # of what the agent just sent would become a second emoji on the bubble
-                # that no removal can take back.
-                base.where(message_type: Message.message_types[:outgoing])
-              else
-                base.where(sender: sender)
-              end
+    matches = self.class.rows(inbox: inbox, target_id: reaction.target_id, sender: sender, from_me: reaction.from_me)
 
-    # Active-only: when every match is already deleted this returns nil, so an echoed
-    # removal does not re-delete the row and bump the conversation again.
-    preferred(matches.where.not(content: '')
-                     .where("COALESCE(#{json}->>'deleted', 'false') != 'true'")
-                     .reorder(created_at: :desc)
-                     .to_a)
+    preferred(self.class.live(matches).reorder(created_at: :desc).to_a)
   end
 
   # Which of them the echo belongs to, for a provider that gives it neither our reserved

--- a/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
@@ -28,6 +28,38 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageEdited do
     expect(message.previous_content).to eq('oi')
   end
 
+  # Two edits of one message, delivered the wrong way round. The provider's own clock is
+  # what orders them, since arrival is the thing that is out of order.
+  it 'refuses an edit older than the one already applied' do
+    newer = model::Events::MessageEdited.new(
+      chat: model::Address.phone('5541999990000'), message_id: message.source_id,
+      content: model::Content::Text.new(body: 'a segunda'), timestamp: 1_755_440_002_000
+    )
+    older = newer.with(content: model::Content::Text.new(body: 'a primeira'), timestamp: 1_755_440_001_000)
+
+    expect(described_class.new(channel: channel, event: model::Event.build(newer)).perform).to eq(:handled)
+    expect(described_class.new(channel: channel, event: model::Event.build(older)).perform).to eq(:ignored)
+
+    expect(message.reload.content).to eq('a segunda')
+  end
+
+  # Nobody edits a message they have deleted for everyone, so this only happens when the
+  # two arrive out of order. Applying it would put the text back on a bubble WhatsApp has
+  # already taken off the contact's phone.
+  it 'refuses an edit for a message that was revoked' do
+    message.update!(content_attributes: message.content_attributes.merge('deleted' => true))
+
+    expect(dispatch).to eq(:ignored)
+    expect(message.reload.is_edited).to be_nil
+  end
+
+  it 'refuses an edit for a message the contact revoked' do
+    message.update!(content_attributes: message.content_attributes.merge('deleted_by_contact' => true))
+
+    expect(dispatch).to eq(:ignored)
+    expect(message.reload.content).to eq('oi')
+  end
+
   it 'keeps the first version across a second edit' do
     dispatch
     described_class.new(

--- a/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_reaction_spec.rb
@@ -143,9 +143,29 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReaction do
       )
     end
 
-    it 'leaves no contact behind' do
-      expect { expect(dispatch).to eq(:ignored) }.not_to change(Contact, :count)
+    # Deferred rather than dropped, and still without resolving anybody: nothing recorded
+    # for this sender is also what a removal that overtook its own reaction looks like,
+    # and this transport cannot tell the two apart. The job waits, and a removal that
+    # really is aimed at nothing is dropped once the retries are spent.
+    it 'waits for the reaction it takes back, leaving no contact behind' do
+      expect { expect(dispatch).to eq(:deferred) }.not_to change(Contact, :count)
     end
+  end
+
+  # A swap arriving the wrong way round: the emoji the sender moved away from must not
+  # land back on the bubble.
+  it 'refuses a reaction older than the one already on the bubble' do
+    newer = model::Events::MessageReaction.new(
+      id: '3EB0SWAP2', chat: model::Address.phone('5541999990000'), sender: sender, from_me: false,
+      target_id: target.source_id, emoji: '❤️', timestamp: 1_755_440_002_000
+    )
+    older = newer.with(id: '3EB0SWAP1', emoji: '👍', timestamp: 1_755_440_001_000)
+
+    expect(described_class.new(channel: channel, event: model::Event.build(newer)).perform).to eq(:handled)
+    expect(described_class.new(channel: channel, event: model::Event.build(older)).perform).to eq(:ignored)
+
+    stored = inbox.messages.find_by("(content_attributes#>>'{}')::jsonb->>'is_reaction' = 'true'")
+    expect(stored.content).to eq('❤️')
   end
 
   context 'when the contact takes the reaction back' do
@@ -197,7 +217,7 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReaction do
     end
 
     it 'leaves no contact behind' do
-      expect { expect(dispatch).to eq(:ignored) }.not_to change(Contact, :count)
+      expect { expect(dispatch).to eq(:deferred) }.not_to change(Contact, :count)
     end
   end
 


### PR DESCRIPTION
Num provedor WhatsApp que entrega por webhook (`uazapi`) os eventos de um mesmo chat chegam sem ordem garantida. A camada de sessão já esperava pelo evento cujo alvo ainda não foi armazenado (uma edição, um apagamento ou uma reação que chegou antes da mensagem), mas três casos não são "o alvo está faltando" e continuavam caindo onde a fila quisesse.

## Closes

- Closes #373

## How to reproduce

Com uma caixa de entrada `uazapi` sob carga, ou entregando dois webhooks do mesmo chat na ordem invertida:

1. **Duas edições da mesma mensagem.** Edite duas vezes seguidas no celular. Se os dois jobs invertem, o texto antigo é o que fica na tela, para sempre.
2. **Edição de uma mensagem apagada.** Edite e apague em seguida. Se o apagamento roda primeiro, a edição escreve o texto de volta num balão que a interface mostra como apagado, e no apagar-para-todos isso é restaurar o que o WhatsApp já tirou do celular do contato.
3. **Reação retirada antes de a reação chegar.** Reaja e retire em seguida. Se a retirada roda primeiro, ela não acha nada e é descartada; a reação atrás dela grava um emoji que a pessoa já tinha tirado, e nada depois corrige.

## What changed

**Duas edições.** O evento carrega o timestamp do provedor em milissegundos, o que basta para ordená-las. A edição aplicada carimba `edited_at` e uma mais antiga é recusada. Empates passam, porque timestamps iguais não carregam ordem a respeitar.

**Edição sobre mensagem apagada.** Recusada, nos dois tipos de apagamento.

**Retirada de reação que ultrapassou a própria reação.** É a metade que adiar o *add* não alcança, porque quem chegou cedo foi a retirada. Distinguir isso de uma retirada que não tem o que fazer é a própria linha que responde, então o `ReactionStore` ganha `recorded?`: nenhuma linha significa que o add ainda não chegou e o job espera; uma linha que já está apagada é o eco comum de uma retirada feita aqui e se resolve sozinha. A troca de emoji ganha a mesma comparação de relógio da edição.

**`message.receipt`** é o quarto evento que o #373 lista e fica como está, agora com o motivo escrito no código: esperar pelos ids que um recibo de leitura enumera replicaria um lote de centenas cinco vezes por causa de mensagens anteriores à caixa de entrada, e perder um recibo se autocorrige, ao contrário de perder um apagamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/395)
<!-- Reviewable:end -->
