### PR TITLE
fix(whatsapp): perform a group action as the inbox the agent is on

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/group_admin_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_admin_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Accounts::Contacts::GroupAdminController < Api::V1::Accounts::Contacts::BaseController
+  include GroupChannelResolver
+
   VALID_PROPERTIES = %w[announce restrict join_approval_mode member_add_mode].freeze
 
   def leave
@@ -37,10 +39,6 @@ class Api::V1::Accounts::Contacts::GroupAdminController < Api::V1::Accounts::Con
 
   def property_params
     params.permit(:property, :enabled)
-  end
-
-  def channel
-    @channel ||= @contact.group_channel
   end
 
   def resolve_group_conversations

--- a/app/controllers/api/v1/accounts/contacts/group_invites_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_invites_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Accounts::Contacts::GroupInvitesController < Api::V1::Accounts::Contacts::BaseController
+  include GroupChannelResolver
+
   def show
     authorize @contact, :show?
     code = channel.group_invite_code(@contact.identifier)
@@ -16,10 +18,6 @@ class Api::V1::Accounts::Contacts::GroupInvitesController < Api::V1::Accounts::C
   end
 
   private
-
-  def channel
-    @channel ||= @contact.group_channel
-  end
 
   def invite_response(code)
     { invite_code: code, invite_url: "https://chat.whatsapp.com/#{code}" }

--- a/app/controllers/api/v1/accounts/contacts/group_join_requests_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_join_requests_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Accounts::Contacts::GroupJoinRequestsController < Api::V1::Accounts::Contacts::BaseController
+  include GroupChannelResolver
+
   def index
     authorize @contact, :show?
     requests = channel.group_join_requests(@contact.identifier)
@@ -20,10 +22,6 @@ class Api::V1::Accounts::Contacts::GroupJoinRequestsController < Api::V1::Accoun
 
   def handle_params
     params.permit(:request_action, participants: [])
-  end
-
-  def channel
-    @channel ||= @contact.group_channel
   end
 
   def remove_handled_requests(participants)

--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::Contacts::BaseController
+  include GroupChannelResolver
+
   DEFAULT_PER_PAGE = 10
 
   before_action :ensure_group_contact, only: %i[create update destroy]
@@ -85,10 +87,6 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     params.permit(:role)
   end
 
-  def channel
-    @channel ||= @contact.group_channel
-  end
-
   def inbox_phone_number
     channel&.phone_number
   end
@@ -120,8 +118,10 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     address.to_jid
   end
 
+  # Into the inbox the addition was performed as, which is the one that now has the new
+  # members in its copy of the group.
   def add_group_members(phone_numbers)
-    inbox = @contact.contact_inboxes.first&.inbox
+    inbox = group_contact_inbox&.inbox
     Array(phone_numbers).each do |phone|
       normalized = normalize_phone(phone)
       next if normalized.blank?

--- a/app/controllers/api/v1/accounts/contacts/group_metadata_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_metadata_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::Accounts::Contacts::GroupMetadataController < Api::V1::Accounts::Contacts::BaseController
+  include GroupChannelResolver
+
   def update
     authorize @contact, :update?
     update_subject if metadata_params[:subject].present?
@@ -31,9 +33,5 @@ class Api::V1::Accounts::Contacts::GroupMetadataController < Api::V1::Accounts::
     image_base64 = Base64.strict_encode64(avatar.read)
     channel.update_group_picture(@contact.identifier, image_base64)
     @contact.avatar.attach(avatar)
-  end
-
-  def channel
-    @channel ||= @contact.group_channel
   end
 end

--- a/app/controllers/api/v1/accounts/contacts_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController # rubocop:disable Metrics/ClassLength
+  include GroupChannelResolver
   include Sift
   sort_on :email, type: :string
   sort_on :name, internal_name: :order_on_name, type: :scope, scope_params: [:direction]
@@ -82,12 +83,15 @@ class Api::V1::Accounts::ContactsController < Api::V1::Accounts::BaseController 
     @contact.save!
   end
 
+  # Through the inbox the caller named, so a group that is in two of them is refreshed on
+  # the one the agent is looking at rather than on whichever came first, which can be a
+  # session that is not even connected.
   def sync_group
     authorize @contact, :sync_group?
     raise ActionController::BadRequest, I18n.t('contacts.sync_group.not_a_group') if @contact.group_type_individual?
     raise ActionController::BadRequest, I18n.t('contacts.sync_group.no_identifier') if @contact.identifier.blank?
 
-    Contacts::SyncGroupJob.perform_later(@contact)
+    Contacts::SyncGroupJob.perform_later(@contact, channel: channel)
     head :accepted
   end
 

--- a/app/controllers/concerns/group_channel_resolver.rb
+++ b/app/controllers/concerns/group_channel_resolver.rb
@@ -28,8 +28,15 @@ module GroupChannelResolver
   #
   # Left out, one inbox answers for itself. Left out on a group that is in two, there is
   # no answer to give, and picking one is the coin flip: the caller is asked to say which.
+  #
+  # Only inboxes this agent is on are candidates. `ContactPolicy` lets every agent of the
+  # account read and update a contact, which was harmless while the inbox was ours to
+  # pick; naming one is a request, and without this an agent on inbox A could leave the
+  # group, promote or remove members as inbox B by asking for it. An inbox they are not
+  # on reads as an inbox the group is not in: refusing it differently would answer
+  # whether that number is in the group.
   def resolve_group_contact_inbox
-    candidates = @contact.contact_inboxes.includes(:inbox)
+    candidates = @contact.contact_inboxes.includes(:inbox).where(inbox: Current.user.assigned_inboxes)
     return candidates.find_by!(inbox_id: params[:inbox_id]) if params[:inbox_id].present?
     return candidates.first if candidates.size <= 1
 

--- a/app/controllers/concerns/group_channel_resolver.rb
+++ b/app/controllers/concerns/group_channel_resolver.rb
@@ -1,0 +1,38 @@
+# Which WhatsApp number a group action is performed as.
+#
+# A group contact is account-scoped (its identifier is the group's own id), while a
+# contact inbox is per inbox, so one WhatsApp group can belong to two inboxes of the same
+# account. These requests used to resolve the channel by taking whichever contact inbox
+# came first, and the dashboard decides what an agent may do from the inbox they have
+# open, so the two could disagree: the panel granted the action using inbox A's
+# capabilities and admin status, and the server then performed it as inbox B. Leaving the
+# group is the worst of them, because it removes the wrong number from the group.
+module GroupChannelResolver
+  extend ActiveSupport::Concern
+
+  private
+
+  def channel
+    @channel ||= group_contact_inbox&.inbox&.channel
+  end
+
+  def group_contact_inbox
+    return @group_contact_inbox if defined?(@group_contact_inbox)
+
+    @group_contact_inbox = resolve_group_contact_inbox
+  end
+
+  # `inbox_id` is optional, because these endpoints are documented and shipped without it.
+  # What it may not be is wrong: an inbox this group does not belong to is refused rather
+  # than quietly replaced by another one, which is the substitution this exists to stop.
+  #
+  # Left out, one inbox answers for itself. Left out on a group that is in two, there is
+  # no answer to give, and picking one is the coin flip: the caller is asked to say which.
+  def resolve_group_contact_inbox
+    candidates = @contact.contact_inboxes.includes(:inbox)
+    return candidates.find_by!(inbox_id: params[:inbox_id]) if params[:inbox_id].present?
+    return candidates.first if candidates.size <= 1
+
+    raise ActionController::BadRequest, I18n.t('contacts.group.inbox_id_required')
+  end
+end

--- a/app/javascript/dashboard/api/groupMembers.js
+++ b/app/javascript/dashboard/api/groupMembers.js
@@ -1,70 +1,94 @@
 /* global axios */
 import ApiClient from './ApiClient';
 
+/**
+ * Every call here carries the inbox the action is for.
+ *
+ * A group contact is account-scoped, so one WhatsApp group can belong to two inboxes of
+ * the same account. Without the inbox the server resolved the channel by taking whichever
+ * contact inbox came first, which could be a different number from the one the agent has
+ * open: the panel decided what they may do from one inbox and the server acted as
+ * another. The server refuses an inbox the group is not in, and refuses to guess when a
+ * group is in two and none is named.
+ */
 class GroupMembersAPI extends ApiClient {
   constructor() {
     super('contacts', { accountScoped: true });
   }
 
-  getGroupMembers(contactId, page = 1) {
+  getGroupMembers(contactId, inboxId, page = 1) {
     return axios.get(`${this.url}/${contactId}/group_members`, {
-      params: { page },
+      params: { page, inbox_id: inboxId },
     });
   }
 
-  syncGroup(contactId) {
-    return axios.post(`${this.url}/${contactId}/sync_group`);
+  syncGroup(contactId, inboxId) {
+    return axios.post(`${this.url}/${contactId}/sync_group`, {
+      inbox_id: inboxId,
+    });
   }
 
   createGroup(params) {
     return axios.post(`${this.baseUrl()}/groups`, params);
   }
 
-  updateGroupMetadata(contactId, params) {
-    return axios.patch(`${this.url}/${contactId}/group_metadata`, params);
+  updateGroupMetadata(contactId, params, inboxId) {
+    return axios.patch(`${this.url}/${contactId}/group_metadata`, {
+      ...params,
+      inbox_id: inboxId,
+    });
   }
 
-  addMembers(contactId, participants) {
+  addMembers(contactId, participants, inboxId) {
     return axios.post(`${this.url}/${contactId}/group_members`, {
       participants,
+      inbox_id: inboxId,
     });
   }
 
-  removeMembers(contactId, memberId) {
-    return axios.delete(`${this.url}/${contactId}/group_members/${memberId}`);
+  removeMembers(contactId, memberId, inboxId) {
+    return axios.delete(`${this.url}/${contactId}/group_members/${memberId}`, {
+      params: { inbox_id: inboxId },
+    });
   }
 
-  updateMemberRole(contactId, memberId, role) {
+  updateMemberRole(contactId, memberId, role, inboxId) {
     return axios.patch(`${this.url}/${contactId}/group_members/${memberId}`, {
       role,
+      inbox_id: inboxId,
     });
   }
 
-  getInviteLink(contactId) {
-    return axios.get(`${this.url}/${contactId}/group_invite`);
+  getInviteLink(contactId, inboxId) {
+    return axios.get(`${this.url}/${contactId}/group_invite`, {
+      params: { inbox_id: inboxId },
+    });
   }
 
-  revokeInviteLink(contactId) {
-    return axios.post(`${this.url}/${contactId}/group_invite/revoke`);
+  revokeInviteLink(contactId, inboxId) {
+    return axios.post(`${this.url}/${contactId}/group_invite/revoke`, {
+      inbox_id: inboxId,
+    });
   }
 
-  getPendingRequests(contactId) {
-    return axios.get(`${this.url}/${contactId}/group_join_requests`);
+  handleJoinRequest(contactId, params, inboxId) {
+    return axios.post(`${this.url}/${contactId}/group_join_requests/handle`, {
+      ...params,
+      inbox_id: inboxId,
+    });
   }
 
-  handleJoinRequest(contactId, params) {
-    return axios.post(
-      `${this.url}/${contactId}/group_join_requests/handle`,
-      params
-    );
+  leaveGroup(contactId, inboxId) {
+    return axios.post(`${this.url}/${contactId}/group_admin/leave`, {
+      inbox_id: inboxId,
+    });
   }
 
-  leaveGroup(contactId) {
-    return axios.post(`${this.url}/${contactId}/group_admin/leave`);
-  }
-
-  updateGroupProperty(contactId, params) {
-    return axios.patch(`${this.url}/${contactId}/group_admin`, params);
+  updateGroupProperty(contactId, params, inboxId) {
+    return axios.patch(`${this.url}/${contactId}/group_admin`, {
+      ...params,
+      inbox_id: inboxId,
+    });
   }
 }
 

--- a/app/javascript/dashboard/api/groupMembers.js
+++ b/app/javascript/dashboard/api/groupMembers.js
@@ -32,11 +32,20 @@ class GroupMembersAPI extends ApiClient {
     return axios.post(`${this.baseUrl()}/groups`, params);
   }
 
+  // The avatar upload sends FormData, and spreading one copies no entry at all: the
+  // request would carry the inbox and nothing else, and the server would answer 200 to
+  // an upload with no file in it.
   updateGroupMetadata(contactId, params, inboxId) {
-    return axios.patch(`${this.url}/${contactId}/group_metadata`, {
-      ...params,
-      inbox_id: inboxId,
-    });
+    const url = `${this.url}/${contactId}/group_metadata`;
+
+    if (params instanceof FormData) {
+      // A missing inbox is left out rather than appended: FormData stringifies, so it
+      // would reach the server as the literal "undefined" and fail the lookup.
+      if (inboxId != null) params.append('inbox_id', inboxId);
+      return axios.patch(url, params);
+    }
+
+    return axios.patch(url, { ...params, inbox_id: inboxId });
   }
 
   addMembers(contactId, participants, inboxId) {

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -440,7 +440,10 @@ export default {
       immediate: true,
       handler(contactId) {
         if (contactId && !this.isGroupMembersLoaded) {
-          this.$store.dispatch('groupMembers/fetch', { contactId });
+          this.$store.dispatch('groupMembers/fetch', {
+            contactId,
+            inboxId: this.currentChat?.inbox_id,
+          });
         }
       },
     },

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -304,12 +304,15 @@ export default {
     isGroupConversation() {
       return this.currentChat?.group_type === 'group';
     },
+    // The inbox is part of the target, not only the contact. A group contact is
+    // account-scoped, so the same group can be open in two inboxes of one account, and
+    // what the panel may do there is answered per inbox. Keyed on the contact alone,
+    // switching between the two threads kept the first inbox's answer.
     groupMembersFetchTarget() {
       if (!this.groupContactId || !this.isGroupConversation) return null;
+      if (!this.hasInboxCapability(CAPABILITIES.GROUPS)) return null;
 
-      return this.hasInboxCapability(CAPABILITIES.GROUPS)
-        ? this.groupContactId
-        : null;
+      return `${this.groupContactId}:${this.currentChat?.inbox_id}`;
     },
     groupContactId() {
       return this.currentChat?.meta?.sender?.id || null;
@@ -326,7 +329,8 @@ export default {
       if (!this.groupContactId) return {};
       return (
         this.$store.getters['groupMembers/getGroupMembersMeta'](
-          this.groupContactId
+          this.groupContactId,
+          this.currentChat?.inbox_id
         ) || {}
       );
     },
@@ -438,10 +442,10 @@ export default {
     // thread stayed without members until the agent switched conversations.
     groupMembersFetchTarget: {
       immediate: true,
-      handler(contactId) {
-        if (contactId && !this.isGroupMembersLoaded) {
+      handler(target) {
+        if (target && !this.isGroupMembersLoaded) {
           this.$store.dispatch('groupMembers/fetch', {
-            contactId,
+            contactId: this.groupContactId,
             inboxId: this.currentChat?.inbox_id,
           });
         }

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -190,12 +190,15 @@ export default {
     isGroupConversation() {
       return this.currentChat?.group_type === 'group';
     },
+    // The inbox is part of the target, not only the contact. A group contact is
+    // account-scoped, so the same group can be open in two inboxes of one account, and
+    // what the panel may do there is answered per inbox. Keyed on the contact alone,
+    // switching between the two threads kept the first inbox's answer.
     groupMembersFetchTarget() {
       if (!this.groupContactId || !this.isGroupConversation) return null;
+      if (!this.hasInboxCapability(CAPABILITIES.GROUPS)) return null;
 
-      return this.hasInboxCapability(CAPABILITIES.GROUPS)
-        ? this.groupContactId
-        : null;
+      return `${this.groupContactId}:${this.currentChat?.inbox_id}`;
     },
     groupContactId() {
       return this.currentChat?.meta?.sender?.id || null;
@@ -215,7 +218,8 @@ export default {
       if (!this.groupContactId) return {};
       return (
         this.$store.getters['groupMembers/getGroupMembersMeta'](
-          this.groupContactId
+          this.groupContactId,
+          this.currentChat?.inbox_id
         ) || {}
       );
     },
@@ -668,10 +672,10 @@ export default {
     // thread stayed without members until the agent switched conversations.
     groupMembersFetchTarget: {
       immediate: true,
-      handler(contactId) {
-        if (contactId && !this.isGroupMembersLoaded) {
+      handler(target) {
+        if (target && !this.isGroupMembersLoaded) {
           this.$store.dispatch('groupMembers/fetch', {
-            contactId,
+            contactId: this.groupContactId,
             inboxId: this.currentChat?.inbox_id,
           });
         }

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -670,7 +670,10 @@ export default {
       immediate: true,
       handler(contactId) {
         if (contactId && !this.isGroupMembersLoaded) {
-          this.$store.dispatch('groupMembers/fetch', { contactId });
+          this.$store.dispatch('groupMembers/fetch', {
+            contactId,
+            inboxId: this.currentChat?.inbox_id,
+          });
         }
       },
     },

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -451,6 +451,7 @@ class ActionCableConnector extends BaseActionCableConnector {
       inboxPhoneNumber: data.inbox_phone_number,
       ownMemberId: data.own_member_id,
       isInboxAdmin: data.is_inbox_admin,
+      inboxId: data.inbox_id,
     });
     this.app.$store.dispatch('contacts/updateContact', data);
   };

--- a/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
@@ -126,7 +126,10 @@ const getContactDetails = () => {
 
 const triggerGroupSync = () => {
   if (showGroupInfo.value && supportsGroups.value && contactId.value) {
-    store.dispatch('groupMembers/sync', { contactId: contactId.value });
+    store.dispatch('groupMembers/sync', {
+      contactId: contactId.value,
+      inboxId: props.inboxId,
+    });
   }
 };
 

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/BaileysGroupOptions.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/BaileysGroupOptions.vue
@@ -13,6 +13,12 @@ const props = defineProps({
     type: Object,
     default: () => ({}),
   },
+  // Which WhatsApp number these actions are performed as: the same group can belong to
+  // two inboxes of one account, and the panel is scoped to the one the agent has open.
+  inboxId: {
+    type: Number,
+    default: null,
+  },
   isAdmin: {
     type: Boolean,
     default: false,
@@ -66,10 +72,11 @@ const toggleEditGroupSettings = async () => {
     // NOTE: restrict=true means members CANNOT edit; flip to the opposite of current
     const currentValue = props.contact.additional_attributes?.restrict === true;
     const newValue = !currentValue;
-    await GroupMembersAPI.updateGroupProperty(props.contact.id, {
-      property: 'restrict',
-      enabled: newValue,
-    });
+    await GroupMembersAPI.updateGroupProperty(
+      props.contact.id,
+      { property: 'restrict', enabled: newValue },
+      props.inboxId
+    );
     await updateContactAttribute('restrict', newValue);
     useAlert(t('GROUP.SETTINGS.UPDATE_SUCCESS'));
   } catch {
@@ -85,10 +92,11 @@ const toggleSendMessages = async () => {
     // NOTE: announce=true means only admins can send; flip to the opposite of current
     const currentValue = props.contact.additional_attributes?.announce === true;
     const newValue = !currentValue;
-    await GroupMembersAPI.updateGroupProperty(props.contact.id, {
-      property: 'announce',
-      enabled: newValue,
-    });
+    await GroupMembersAPI.updateGroupProperty(
+      props.contact.id,
+      { property: 'announce', enabled: newValue },
+      props.inboxId
+    );
     await updateContactAttribute('announce', newValue);
     useAlert(t('GROUP.SETTINGS.UPDATE_SUCCESS'));
   } catch {
@@ -101,7 +109,10 @@ const toggleSendMessages = async () => {
 const resetInviteLink = async () => {
   isResettingInviteLink.value = true;
   try {
-    const { data } = await GroupMembersAPI.revokeInviteLink(props.contact.id);
+    const { data } = await GroupMembersAPI.revokeInviteLink(
+      props.contact.id,
+      props.inboxId
+    );
     if (data.invite_code) {
       store.dispatch('contacts/updateContact', {
         ...props.contact,
@@ -133,16 +144,17 @@ const toggleAddMembers = async () => {
 
   isTogglingMemberAdd.value = true;
   try {
-    await GroupMembersAPI.updateGroupProperty(props.contact.id, {
-      property: 'member_add_mode',
-      enabled: newValue,
-    });
+    await GroupMembersAPI.updateGroupProperty(
+      props.contact.id,
+      { property: 'member_add_mode', enabled: newValue },
+      props.inboxId
+    );
 
     // Also revoke invite link when restricting member additions, where the provider
     // serves invites at all. Without the guard the revoke throws, the whole block lands
     // in the catch, and the toggle reports failure on a property it just changed.
     if (!newValue && props.canManageInvites) {
-      await GroupMembersAPI.revokeInviteLink(props.contact.id);
+      await GroupMembersAPI.revokeInviteLink(props.contact.id, props.inboxId);
     }
 
     await updateContactAttribute('member_add_mode', newValue);
@@ -161,10 +173,11 @@ const toggleJoinApproval = async () => {
     const currentValue =
       props.contact.additional_attributes?.join_approval_mode === true;
     const newValue = !currentValue;
-    await GroupMembersAPI.updateGroupProperty(props.contact.id, {
-      property: 'join_approval_mode',
-      enabled: newValue,
-    });
+    await GroupMembersAPI.updateGroupProperty(
+      props.contact.id,
+      { property: 'join_approval_mode', enabled: newValue },
+      props.inboxId
+    );
     await updateContactAttribute('join_approval_mode', newValue);
     useAlert(t('GROUP.SETTINGS.UPDATE_SUCCESS'));
   } catch {

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
@@ -64,7 +64,7 @@ const members = computed(() => {
 });
 
 const membersMeta = computed(
-  () => getGroupMembersMeta.value(props.contact.id) || {}
+  () => getGroupMembersMeta.value(props.contact.id, inboxId.value) || {}
 );
 
 // Prefer inbox_phone_number from the group members meta (always available on
@@ -670,12 +670,15 @@ const fetchGroupData = contactId => {
   }
 };
 
+// The inbox counts as much as the contact: the same group contact is account-scoped and
+// can be open in two inboxes, and this panel decides what the agent may do from the
+// answer the server gave for one of them.
 watch(
-  () => props.contact.id,
-  (newId, oldId) => {
-    if (newId && newId !== oldId) {
+  () => [props.contact.id, inboxId.value].join(':'),
+  (target, previous) => {
+    if (props.contact.id && target !== previous) {
       visibleRequestCount.value = REQUESTS_PAGE_SIZE;
-      fetchGroupData(newId);
+      fetchGroupData(props.contact.id);
     }
   }
 );

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
@@ -45,6 +45,11 @@ const inboxGetter = useMapGetter('inboxes/getInboxById');
 const inbox = computed(
   () => inboxGetter.value(currentChat.value?.inbox_id) || {}
 );
+// Which WhatsApp number every action on this panel is performed as. The same group can
+// belong to two inboxes of one account, and the panel decides what the agent may do from
+// the one they have open, so the server has to act as that one and not as whichever
+// contact inbox came first.
+const inboxId = computed(() => currentChat.value?.inbox_id);
 
 const contactProfileLink = computed(
   () => `/app/accounts/${route.params.accountId}/contacts/${props.contact.id}`
@@ -111,6 +116,7 @@ const loadMoreMembers = async () => {
   await store.dispatch('groupMembers/fetch', {
     contactId: props.contact.id,
     page: nextPage,
+    inboxId: inboxId.value,
   });
 };
 
@@ -208,6 +214,7 @@ const saveName = async () => {
     await store.dispatch('groupMembers/updateGroupMetadata', {
       contactId: props.contact.id,
       params: { subject: newName },
+      inboxId: inboxId.value,
     });
     useAlert(t('GROUP.METADATA.SAVE_SUCCESS'));
   } catch {
@@ -245,6 +252,7 @@ const saveDescription = async () => {
     await store.dispatch('groupMembers/updateGroupMetadata', {
       contactId: props.contact.id,
       params: { description: newDesc },
+      inboxId: inboxId.value,
     });
     useAlert(t('GROUP.METADATA.SAVE_SUCCESS'));
   } catch {
@@ -281,6 +289,7 @@ const onAvatarSelected = async event => {
     await store.dispatch('groupMembers/updateGroupMetadata', {
       contactId: props.contact.id,
       params: formData,
+      inboxId: inboxId.value,
     });
     useAlert(t('GROUP.METADATA.SAVE_SUCCESS'));
   } catch {
@@ -429,6 +438,7 @@ const addMember = async contact => {
     await store.dispatch('groupMembers/addMembers', {
       contactId: props.contact.id,
       participants: [contact.phone_number],
+      inboxId: inboxId.value,
     });
     dismiss();
     useAlert(t('GROUP.MEMBERS.ADD_SUCCESS'));
@@ -528,6 +538,7 @@ const handleMemberAction = async (member, { action }) => {
       await store.dispatch('groupMembers/removeMembers', {
         contactId: props.contact.id,
         memberId: member.id,
+        inboxId: inboxId.value,
       });
       dismiss();
       useAlert(t('GROUP.MEMBERS.REMOVE_SUCCESS'));
@@ -536,6 +547,7 @@ const handleMemberAction = async (member, { action }) => {
         contactId: props.contact.id,
         memberId: member.id,
         role: 'admin',
+        inboxId: inboxId.value,
       });
       dismiss();
       useAlert(t('GROUP.MEMBERS.PROMOTE_SUCCESS'));
@@ -544,6 +556,7 @@ const handleMemberAction = async (member, { action }) => {
         contactId: props.contact.id,
         memberId: member.id,
         role: 'member',
+        inboxId: inboxId.value,
       });
       dismiss();
       useAlert(t('GROUP.MEMBERS.DEMOTE_SUCCESS'));
@@ -570,7 +583,10 @@ const handleMemberAction = async (member, { action }) => {
 const fetchInviteLink = async () => {
   isFetchingInvite.value = true;
   try {
-    const { data } = await GroupMembersAPI.getInviteLink(props.contact.id);
+    const { data } = await GroupMembersAPI.getInviteLink(
+      props.contact.id,
+      inboxId.value
+    );
     inviteUrl.value = data.invite_url || '';
   } catch {
     inviteUrl.value = '';
@@ -599,10 +615,11 @@ const handleJoinRequest = async (request, action) => {
   loadingRequestJid.value = request.jid;
   const dismiss = usePendingAlert(t('GROUP.JOIN_REQUESTS.PROCESSING'));
   try {
-    await GroupMembersAPI.handleJoinRequest(props.contact.id, {
-      participants: [request.jid],
-      request_action: action,
-    });
+    await GroupMembersAPI.handleJoinRequest(
+      props.contact.id,
+      { participants: [request.jid], request_action: action },
+      inboxId.value
+    );
     // Optimistic local update — remove handled request from additional_attributes
     const updated = pendingRequests.value.filter(r => r.jid !== request.jid);
     await store.dispatch('contacts/update', {
@@ -632,7 +649,7 @@ const leaveGroup = async () => {
   isLeavingGroup.value = true;
   const dismiss = usePendingAlert(t('GROUP.SETTINGS.LEAVING'));
   try {
-    await GroupMembersAPI.leaveGroup(props.contact.id);
+    await GroupMembersAPI.leaveGroup(props.contact.id, inboxId.value);
     showLeaveConfirm.value = false;
     dismiss();
     useAlert(t('GROUP.SETTINGS.LEAVE_SUCCESS'));
@@ -646,7 +663,7 @@ const leaveGroup = async () => {
 
 const fetchGroupData = contactId => {
   if (!contactId) return;
-  store.dispatch('groupMembers/fetch', { contactId });
+  store.dispatch('groupMembers/fetch', { contactId, inboxId: inboxId.value });
   // Only fetch from API if we don't already have a stored invite code
   if (canManageInvites.value && !storedInviteCode.value) {
     fetchInviteLink();
@@ -1098,6 +1115,7 @@ useEventListener(sidebarScrollRef, 'scroll', closeMemberMenu);
       >
         <BaileysGroupOptions
           :contact="contact"
+          :inbox-id="inboxId"
           :is-admin="canEditGroup"
           :can-manage-invites="canManageInvites"
         />

--- a/app/javascript/dashboard/store/modules/groupMembers.js
+++ b/app/javascript/dashboard/store/modules/groupMembers.js
@@ -57,14 +57,18 @@ export const actions = {
     }
   },
 
-  async fetch({ commit }, { contactId, page = 1 }) {
+  async fetch({ commit }, { contactId, page = 1, inboxId }) {
     const isFirstPage = page === 1;
     commit(
       types.SET_GROUP_MEMBERS_UI_FLAG,
       isFirstPage ? { isFetching: true } : { isFetchingMore: true }
     );
     try {
-      const { data } = await GroupMembersAPI.getGroupMembers(contactId, page);
+      const { data } = await GroupMembersAPI.getGroupMembers(
+        contactId,
+        inboxId,
+        page
+      );
       if (isFirstPage) {
         commit(types.SET_GROUP_MEMBERS, { contactId, members: data.payload });
       } else {
@@ -82,10 +86,10 @@ export const actions = {
     }
   },
 
-  async sync({ commit }, { contactId }) {
+  async sync({ commit }, { contactId, inboxId }) {
     commit(types.SET_GROUP_MEMBERS_UI_FLAG, { isSyncing: true });
     try {
-      await GroupMembersAPI.syncGroup(contactId);
+      await GroupMembersAPI.syncGroup(contactId, inboxId);
     } catch (error) {
       // fire-and-forget: sync runs in background, results arrive via ActionCable
     } finally {
@@ -93,40 +97,48 @@ export const actions = {
     }
   },
 
-  async addMembers({ commit, dispatch }, { contactId, participants }) {
+  async addMembers({ commit, dispatch }, { contactId, participants, inboxId }) {
     commit(types.SET_GROUP_MEMBERS_UI_FLAG, { isUpdating: true });
     try {
-      await GroupMembersAPI.addMembers(contactId, participants);
-      await dispatch('fetch', { contactId });
+      await GroupMembersAPI.addMembers(contactId, participants, inboxId);
+      await dispatch('fetch', { contactId, inboxId });
     } finally {
       commit(types.SET_GROUP_MEMBERS_UI_FLAG, { isUpdating: false });
     }
   },
 
-  async removeMembers({ commit, dispatch }, { contactId, memberId }) {
+  async removeMembers({ commit, dispatch }, { contactId, memberId, inboxId }) {
     commit(types.SET_GROUP_MEMBERS_UI_FLAG, { isUpdating: true });
     try {
-      await GroupMembersAPI.removeMembers(contactId, memberId);
-      await dispatch('fetch', { contactId });
+      await GroupMembersAPI.removeMembers(contactId, memberId, inboxId);
+      await dispatch('fetch', { contactId, inboxId });
     } finally {
       commit(types.SET_GROUP_MEMBERS_UI_FLAG, { isUpdating: false });
     }
   },
 
-  async updateGroupMetadata({ commit }, { contactId, params }) {
+  async updateGroupMetadata({ commit }, { contactId, params, inboxId }) {
     commit(types.SET_GROUP_MEMBERS_UI_FLAG, { isUpdating: true });
     try {
-      await GroupMembersAPI.updateGroupMetadata(contactId, params);
+      await GroupMembersAPI.updateGroupMetadata(contactId, params, inboxId);
     } finally {
       commit(types.SET_GROUP_MEMBERS_UI_FLAG, { isUpdating: false });
     }
   },
 
-  async updateMemberRole({ commit, dispatch }, { contactId, memberId, role }) {
+  async updateMemberRole(
+    { commit, dispatch },
+    { contactId, memberId, role, inboxId }
+  ) {
     commit(types.SET_GROUP_MEMBERS_UI_FLAG, { isUpdating: true });
     try {
-      await GroupMembersAPI.updateMemberRole(contactId, memberId, role);
-      await dispatch('fetch', { contactId });
+      await GroupMembersAPI.updateMemberRole(
+        contactId,
+        memberId,
+        role,
+        inboxId
+      );
+      await dispatch('fetch', { contactId, inboxId });
     } finally {
       commit(types.SET_GROUP_MEMBERS_UI_FLAG, { isUpdating: false });
     }

--- a/app/javascript/dashboard/store/modules/groupMembers.js
+++ b/app/javascript/dashboard/store/modules/groupMembers.js
@@ -1,6 +1,14 @@
 import types from '../mutation-types';
 import GroupMembersAPI from '../../api/groupMembers';
 
+// The roster belongs to the group, so it is shared: the same members whoever is looking.
+// The meta does not. `inbox_phone_number`, `own_member_id` and `is_inbox_admin` answer
+// "who are we in this group", and a group contact is account-scoped, so the same group
+// can be open in two inboxes of one account with a different answer in each. Keyed by
+// contact alone, whichever fetch or sync event landed last decided what the panel
+// offered, for both of them.
+const metaKey = (contactId, inboxId) => `${contactId}:${inboxId ?? ''}`;
+
 export const state = {
   records: {},
   meta: {},
@@ -17,8 +25,8 @@ export const getters = {
   getGroupMembers: _state => contactId => {
     return _state.records[contactId] || [];
   },
-  getGroupMembersMeta: _state => contactId => {
-    return _state.meta[contactId] || {};
+  getGroupMembersMeta: _state => (contactId, inboxId) => {
+    return _state.meta[metaKey(contactId, inboxId)] || {};
   },
   getUIFlags(_state) {
     return _state.uiFlags;
@@ -28,11 +36,12 @@ export const getters = {
 export const actions = {
   setGroupMembers(
     { commit },
-    { contactId, members, inboxPhoneNumber, ownMemberId, isInboxAdmin }
+    { contactId, members, inboxPhoneNumber, ownMemberId, isInboxAdmin, inboxId }
   ) {
     commit(types.SET_GROUP_MEMBERS, { contactId, members });
     commit(types.SET_GROUP_MEMBERS_META, {
       contactId,
+      inboxId,
       meta: {
         total_count: members.length,
         page: 1,
@@ -77,7 +86,11 @@ export const actions = {
           members: data.payload,
         });
       }
-      commit(types.SET_GROUP_MEMBERS_META, { contactId, meta: data.meta });
+      commit(types.SET_GROUP_MEMBERS_META, {
+        contactId,
+        inboxId,
+        meta: data.meta,
+      });
     } finally {
       commit(
         types.SET_GROUP_MEMBERS_UI_FLAG,
@@ -168,10 +181,10 @@ export const mutations = {
     };
   },
 
-  [types.SET_GROUP_MEMBERS_META](_state, { contactId, meta }) {
+  [types.SET_GROUP_MEMBERS_META](_state, { contactId, inboxId, meta }) {
     _state.meta = {
       ..._state.meta,
-      [contactId]: meta,
+      [metaKey(contactId, inboxId)]: meta,
     };
   },
 };

--- a/app/javascript/dashboard/store/modules/groupMembers.spec.js
+++ b/app/javascript/dashboard/store/modules/groupMembers.spec.js
@@ -40,6 +40,25 @@ describe('groupMembers store', () => {
       expect(getters.getGroupMembers(localState)(99)).toEqual([]);
     });
 
+    // The roster is the group's and is shared, but `is_inbox_admin`, `own_member_id` and
+    // the phone number answer "who are we in this group", which is per inbox. Keyed by
+    // contact alone, the panel for one number showed the other one's answer.
+    it('getGroupMembersMeta answers per inbox', () => {
+      const localState = {
+        meta: {
+          '42:7': { is_inbox_admin: true },
+          '42:9': { is_inbox_admin: false },
+        },
+      };
+      expect(getters.getGroupMembersMeta(localState)(42, 7)).toEqual({
+        is_inbox_admin: true,
+      });
+      expect(getters.getGroupMembersMeta(localState)(42, 9)).toEqual({
+        is_inbox_admin: false,
+      });
+      expect(getters.getGroupMembersMeta(localState)(42, 11)).toEqual({});
+    });
+
     it('getUIFlags returns uiFlags', () => {
       const localState = {
         uiFlags: { isFetching: true, isSyncing: false, isUpdating: false },
@@ -64,6 +83,23 @@ describe('groupMembers store', () => {
         members: sampleMembers,
       });
       expect(localState.records[42]).toEqual(sampleMembers);
+    });
+
+    it('SET_GROUP_MEMBERS_META keeps one inbox from overwriting another', () => {
+      const localState = { meta: {} };
+      mutations[types.default.SET_GROUP_MEMBERS_META](localState, {
+        contactId: 42,
+        inboxId: 7,
+        meta: { is_inbox_admin: true },
+      });
+      mutations[types.default.SET_GROUP_MEMBERS_META](localState, {
+        contactId: 42,
+        inboxId: 9,
+        meta: { is_inbox_admin: false },
+      });
+
+      expect(localState.meta['42:7']).toEqual({ is_inbox_admin: true });
+      expect(localState.meta['42:9']).toEqual({ is_inbox_admin: false });
     });
   });
 
@@ -95,7 +131,10 @@ describe('groupMembers store', () => {
             types.default.SET_GROUP_MEMBERS,
             { contactId: 42, members: sampleMembers },
           ],
-          [types.default.SET_GROUP_MEMBERS_META, { contactId: 42, meta }],
+          [
+            types.default.SET_GROUP_MEMBERS_META,
+            { contactId: 42, inboxId: 7, meta },
+          ],
           [types.default.SET_GROUP_MEMBERS_UI_FLAG, { isFetching: false }],
         ]);
       });

--- a/app/javascript/dashboard/store/modules/groupMembers.spec.js
+++ b/app/javascript/dashboard/store/modules/groupMembers.spec.js
@@ -87,7 +87,8 @@ describe('groupMembers store', () => {
         GroupMembersAPI.getGroupMembers.mockResolvedValue({
           data: { payload: sampleMembers, meta },
         });
-        await actions.fetch({ commit }, { contactId: 42 });
+        await actions.fetch({ commit }, { contactId: 42, inboxId: 7 });
+        expect(GroupMembersAPI.getGroupMembers).toHaveBeenCalledWith(42, 7, 1);
         expect(commit.mock.calls).toEqual([
           [types.default.SET_GROUP_MEMBERS_UI_FLAG, { isFetching: true }],
           [
@@ -110,8 +111,8 @@ describe('groupMembers store', () => {
     describe('sync', () => {
       it('calls syncGroup without re-fetching (fire-and-forget)', async () => {
         GroupMembersAPI.syncGroup.mockResolvedValue({});
-        await actions.sync({ commit }, { contactId: 42 });
-        expect(GroupMembersAPI.syncGroup).toHaveBeenCalledWith(42);
+        await actions.sync({ commit }, { contactId: 42, inboxId: 7 });
+        expect(GroupMembersAPI.syncGroup).toHaveBeenCalledWith(42, 7);
         expect(dispatch).not.toHaveBeenCalled();
       });
     });
@@ -122,9 +123,17 @@ describe('groupMembers store', () => {
         dispatch.mockResolvedValue();
         await actions.addMembers(
           { commit, dispatch },
-          { contactId: 42, participants: ['+5511999'] }
+          { contactId: 42, participants: ['+5511999'], inboxId: 7 }
         );
-        expect(dispatch).toHaveBeenCalledWith('fetch', { contactId: 42 });
+        expect(GroupMembersAPI.addMembers).toHaveBeenCalledWith(
+          42,
+          ['+5511999'],
+          7
+        );
+        expect(dispatch).toHaveBeenCalledWith('fetch', {
+          contactId: 42,
+          inboxId: 7,
+        });
       });
     });
 
@@ -134,9 +143,13 @@ describe('groupMembers store', () => {
         dispatch.mockResolvedValue();
         await actions.removeMembers(
           { commit, dispatch },
-          { contactId: 42, memberId: 1 }
+          { contactId: 42, memberId: 1, inboxId: 7 }
         );
-        expect(dispatch).toHaveBeenCalledWith('fetch', { contactId: 42 });
+        expect(GroupMembersAPI.removeMembers).toHaveBeenCalledWith(42, 1, 7);
+        expect(dispatch).toHaveBeenCalledWith('fetch', {
+          contactId: 42,
+          inboxId: 7,
+        });
       });
     });
 
@@ -146,9 +159,18 @@ describe('groupMembers store', () => {
         dispatch.mockResolvedValue();
         await actions.updateMemberRole(
           { commit, dispatch },
-          { contactId: 42, memberId: 1, role: 'admin' }
+          { contactId: 42, memberId: 1, role: 'admin', inboxId: 7 }
         );
-        expect(dispatch).toHaveBeenCalledWith('fetch', { contactId: 42 });
+        expect(GroupMembersAPI.updateMemberRole).toHaveBeenCalledWith(
+          42,
+          1,
+          'admin',
+          7
+        );
+        expect(dispatch).toHaveBeenCalledWith('fetch', {
+          contactId: 42,
+          inboxId: 7,
+        });
       });
     });
   });

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -279,13 +279,19 @@ class ActionCableListener < BaseListener # rubocop:disable Metrics/ClassLength
 
   def contact_group_synced(event)
     contact, account = extract_contact_and_account(event)
-    channel = contact.group_channel
+    # The inbox the sync actually ran as. `Contact#group_channel` is the group contact's
+    # first contact inbox, which is an arbitrary pick as soon as the same group is in two
+    # inboxes of one account: it would answer "you administer this group" for a number
+    # that is not the one the agent has open. Kept as the fallback for an event queued by
+    # a version that did not name it.
+    channel = event.data[:channel] || contact.group_channel
     # The same answer the REST roster sends, from the same lookup. Two copies of it is how
     # an account known by LID alone was recognised by whichever ran last: the fetch said
     # "you administer this group" and the first sync event took it back.
     own_member = Whatsapp::Session::Owner.group_member(channel, contact)
     payload = contact.push_event_data.merge(
       group_members: group_members_data(contact, account),
+      inbox_id: channel&.inbox&.id,
       inbox_phone_number: channel&.phone_number,
       own_member_id: own_member&.id,
       is_inbox_admin: own_member&.role == 'admin'

--- a/app/services/contacts/sync_group_service.rb
+++ b/app/services/contacts/sync_group_service.rb
@@ -53,11 +53,15 @@ class Contacts::SyncGroupService
     raise ActionController::BadRequest, I18n.t('contacts.sync_group.no_identifier') if contact.identifier.blank?
   end
 
+  # The channel travels with the event because the payload it builds answers "who are we
+  # in this group", and that is per inbox. Without it the listener falls back to the
+  # contact's first contact inbox, which can be another number entirely.
   def dispatch_group_synced_event
     Rails.configuration.dispatcher.dispatch(
       Events::Types::CONTACT_GROUP_SYNCED,
       Time.zone.now,
-      contact: contact
+      contact: contact,
+      channel: channel || contact.group_channel
     )
   end
 end

--- a/app/services/whatsapp/baileys_handlers/concerns/group_event_helper.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/group_event_helper.rb
@@ -43,7 +43,8 @@ module Whatsapp::BaileysHandlers::Concerns::GroupEventHelper
     Rails.configuration.dispatcher.dispatch(
       Events::Types::CONTACT_GROUP_SYNCED,
       Time.zone.now,
-      contact: group_contact
+      contact: group_contact,
+      channel: inbox.channel
     )
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/group_joined.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_joined.rb
@@ -40,6 +40,8 @@ class Whatsapp::Session::Inbound::Handlers::GroupJoined < Whatsapp::Session::Inb
   # the group had before, until a reload or the next participant event.
   def broadcast_roster(group_contact)
     group_contact.reload
-    Rails.configuration.dispatcher.dispatch(Events::Types::CONTACT_GROUP_SYNCED, Time.zone.now, contact: group_contact)
+    Rails.configuration.dispatcher.dispatch(
+      Events::Types::CONTACT_GROUP_SYNCED, Time.zone.now, contact: group_contact, channel: channel
+    )
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -143,6 +143,8 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
 
   def dispatch_group_synced
     @group_contact.reload
-    Rails.configuration.dispatcher.dispatch(Events::Types::CONTACT_GROUP_SYNCED, Time.zone.now, contact: @group_contact)
+    Rails.configuration.dispatcher.dispatch(
+      Events::Types::CONTACT_GROUP_SYNCED, Time.zone.now, contact: @group_contact, channel: channel
+    )
   end
 end

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -89,6 +89,8 @@ en:
       recurring_message_cancelled: Recurring scheduled message has been stopped by %{agent}.
       unknown_agent: Unknown
   contacts:
+    group:
+      inbox_id_required: This group is in more than one inbox. Say which one the action is for by sending inbox_id.
     sync_group:
       not_a_group: Contact is not a group
       no_identifier: Contact does not have a group identifier

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -89,6 +89,8 @@ es:
       recurring_message_cancelled: "%{agent} detuvo el mensaje programado recurrente."
       unknown_agent: Desconocido
   contacts:
+    group:
+      inbox_id_required: Este grupo está en más de una bandeja de entrada. Indique por cuál vale la acción enviando inbox_id.
     sync_group:
       not_a_group: El contacto no es un grupo
       no_identifier: El contacto no tiene un identificador de grupo

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -89,6 +89,8 @@ pt_BR:
       recurring_message_cancelled: Recorrência de mensagem agendada foi interrompida por %{agent}.
       unknown_agent: Desconhecido
   contacts:
+    group:
+      inbox_id_required: Este grupo está em mais de uma caixa de entrada. Diga por qual delas a ação vale enviando inbox_id.
     sync_group:
       not_a_group: O contato não é um grupo
       no_identifier: O contato não possui um identificador de grupo

--- a/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe 'group actions and the inbox they run as', type: :request do
     expect(response).to have_http_status(:bad_request)
   end
 
+  # `ContactPolicy` lets every agent of the account read and update a contact, which was
+  # harmless while the inbox was ours to pick. Naming one is a request, so without this an
+  # agent on one inbox could leave the group, promote or remove members as another.
+  it 'refuses an inbox the agent is not on' do
+    agent = create(:user, account: account, role: :agent)
+    create(:inbox_member, user: agent, inbox: looking_at.inbox)
+
+    post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_admin/leave",
+         params: { inbox_id: other.inbox.id }, headers: agent.create_new_auth_token, as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+
   # The endpoints predate the parameter and are documented without it, so a group that is
   # in one inbox still answers on its own.
   it 'needs no inbox when the group is in only one' do

--- a/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+# A group contact is account-scoped, so one WhatsApp group can belong to two inboxes of
+# the same account. Every group action used to resolve its channel by taking whichever
+# contact inbox came first, while the dashboard decided what the agent may do from the
+# inbox they had open: the panel granted the action using one inbox's capabilities and
+# admin status, and the server performed it as another. Leaving is the worst of them,
+# because it removes the wrong number from the group.
+#
+# Asserted on `group_admin#leave`, which is the destructive one, and on the ambiguity
+# itself, which every group endpoint answers the same way through the shared concern.
+RSpec.describe 'group actions and the inbox they run as', type: :request do
+  let(:account) { create(:account) }
+  let(:admin) { create(:user, account: account, role: :administrator) }
+  let(:looking_at) do
+    create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false, account: account)
+  end
+  let(:other) do
+    create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false, account: account)
+  end
+  let(:group_contact) { create(:contact, account: account, group_type: :group, identifier: '120363041234567890@g.us') }
+
+  before do
+    # `other` first, so taking whichever comes first is the wrong answer.
+    create(:contact_inbox, contact: group_contact, inbox: other.inbox, source_id: '120363041234567890')
+    create(:contact_inbox, contact: group_contact, inbox: looking_at.inbox, source_id: '120363041234567890')
+  end
+
+  it 'leaves the group as the inbox the caller named' do
+    left_as = []
+    allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:new) do |whatsapp_channel:|
+      instance_double(Whatsapp::Providers::WhatsappBaileysService).tap do |service|
+        allow(service).to receive(:group_leave) { left_as << whatsapp_channel }
+      end
+    end
+
+    post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_admin/leave",
+         params: { inbox_id: looking_at.inbox.id }, headers: admin.create_new_auth_token, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(left_as).to eq([looking_at])
+  end
+
+  it 'refuses an inbox this group is not in' do
+    stranger = create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,
+                                         account: account)
+
+    post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_admin/leave",
+         params: { inbox_id: stranger.inbox.id }, headers: admin.create_new_auth_token, as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'refuses to guess when the caller names none' do
+    post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_admin/leave",
+         headers: admin.create_new_auth_token, as: :json
+
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  # The endpoints predate the parameter and are documented without it, so a group that is
+  # in one inbox still answers on its own.
+  it 'needs no inbox when the group is in only one' do
+    group_contact.contact_inboxes.where(inbox: other.inbox).destroy_all
+    service = instance_double(Whatsapp::Providers::WhatsappBaileysService, group_leave: true)
+    allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:new).and_return(service)
+
+    post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_admin/leave",
+         headers: admin.create_new_auth_token, as: :json
+
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -808,7 +808,36 @@ RSpec.describe 'Contacts API', type: :request do
              as: :json
 
         expect(response).to have_http_status(:accepted)
-        expect(Contacts::SyncGroupJob).to have_been_enqueued.with(contact)
+        expect(Contacts::SyncGroupJob).to have_been_enqueued.with(contact, channel: nil)
+      end
+
+      # A group contact is account-scoped, so the same WhatsApp group can sit in two
+      # inboxes. Syncing through whichever came first can run the refresh over a session
+      # that is not even connected, and it is not the one the agent is looking at.
+      context 'when the group is in two inboxes' do
+        let(:first) { create(:channel_whatsapp, account: account, validate_provider_config: false, sync_templates: false) }
+        let(:second) { create(:channel_whatsapp, account: account, validate_provider_config: false, sync_templates: false) }
+
+        before do
+          create(:contact_inbox, contact: contact, inbox: first.inbox, source_id: '12345678901234567890')
+          create(:contact_inbox, contact: contact, inbox: second.inbox, source_id: '12345678901234567890')
+        end
+
+        it 'syncs through the inbox the caller named' do
+          post "/api/v1/accounts/#{account.id}/contacts/#{contact.id}/sync_group",
+               params: { inbox_id: second.inbox.id }, headers: agent.create_new_auth_token, as: :json
+
+          expect(response).to have_http_status(:accepted)
+          expect(Contacts::SyncGroupJob).to have_been_enqueued.with(contact, channel: second)
+        end
+
+        it 'refuses to guess when the caller names none' do
+          post "/api/v1/accounts/#{account.id}/contacts/#{contact.id}/sync_group",
+               headers: agent.create_new_auth_token, as: :json
+
+          expect(response).to have_http_status(:bad_request)
+          expect(Contacts::SyncGroupJob).not_to have_been_enqueued
+        end
       end
 
       it 'returns bad request when contact is not a group' do

--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -821,6 +821,8 @@ RSpec.describe 'Contacts API', type: :request do
         before do
           create(:contact_inbox, contact: contact, inbox: first.inbox, source_id: '12345678901234567890')
           create(:contact_inbox, contact: contact, inbox: second.inbox, source_id: '12345678901234567890')
+          create(:inbox_member, user: agent, inbox: first.inbox)
+          create(:inbox_member, user: agent, inbox: second.inbox)
         end
 
         it 'syncs through the inbox the caller named' do
@@ -836,6 +838,28 @@ RSpec.describe 'Contacts API', type: :request do
                headers: agent.create_new_auth_token, as: :json
 
           expect(response).to have_http_status(:bad_request)
+          expect(Contacts::SyncGroupJob).not_to have_been_enqueued
+        end
+
+        # An agent on one of the two inboxes has no ambiguity to resolve: the other one
+        # is not theirs to act as, named or not.
+        it 'syncs an agent on one of them through their own inbox, unasked' do
+          InboxMember.find_by(user: agent, inbox: second.inbox).destroy!
+
+          post "/api/v1/accounts/#{account.id}/contacts/#{contact.id}/sync_group",
+               headers: agent.create_new_auth_token, as: :json
+
+          expect(response).to have_http_status(:accepted)
+          expect(Contacts::SyncGroupJob).to have_been_enqueued.with(contact, channel: first)
+        end
+
+        it 'refuses an inbox the agent is not on' do
+          InboxMember.find_by(user: agent, inbox: second.inbox).destroy!
+
+          post "/api/v1/accounts/#{account.id}/contacts/#{contact.id}/sync_group",
+               params: { inbox_id: second.inbox.id }, headers: agent.create_new_auth_token, as: :json
+
+          expect(response).to have_http_status(:not_found)
           expect(Contacts::SyncGroupJob).not_to have_been_enqueued
         end
       end

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -45,6 +45,24 @@ describe ActionCableListener do
 
       listener.contact_group_synced(event)
     end
+
+    # The panel decides what the agent may do from this payload, so it has to answer for
+    # the inbox the sync ran as. `Contact#group_channel` is the group contact's first
+    # contact inbox, which is another number entirely as soon as the group is in two.
+    it 'answers for the inbox the event names, not for whichever came first' do
+      other = create(:channel_whatsapp, account: account, provider: 'uazapi', phone_number: '+5541988887777',
+                                        validate_provider_config: false, sync_templates: false)
+      create(:contact_inbox, inbox: other.inbox, contact: group_contact)
+      create(:contact_inbox, inbox: channel.inbox, contact: group_contact)
+      event = Events::Base.new(:'contact.group_synced', Time.zone.now, contact: group_contact, channel: channel)
+
+      expect(ActionCableBroadcastJob).to receive(:perform_later).with(
+        anything, 'contact.group_synced',
+        hash_including(inbox_id: channel.inbox.id, inbox_phone_number: '+5541999990000')
+      )
+
+      listener.contact_group_synced(event)
+    end
   end
 
   describe '#account_cache_invalidated' do

--- a/spec/services/contacts/sync_group_service_spec.rb
+++ b/spec/services/contacts/sync_group_service_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Contacts::SyncGroupService do
       allow(contact).to receive(:group_channel).and_return(channel)
 
       expect(Rails.configuration.dispatcher).to receive(:dispatch)
-        .with(Events::Types::CONTACT_GROUP_SYNCED, anything, contact: contact)
+        .with(Events::Types::CONTACT_GROUP_SYNCED, anything, contact: contact, channel: channel)
 
       described_class.new(contact: contact).perform
     end

--- a/swagger/paths/application/contacts/group_admin.yml
+++ b/swagger/paths/application/contacts/group_admin.yml
@@ -15,8 +15,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 patch:
   tags:

--- a/swagger/paths/application/contacts/group_admin.yml
+++ b/swagger/paths/application/contacts/group_admin.yml
@@ -6,6 +6,17 @@ parameters:
     schema:
       type: number
     description: ID of the group contact
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 patch:
   tags:

--- a/swagger/paths/application/contacts/group_admin_leave.yml
+++ b/swagger/paths/application/contacts/group_admin_leave.yml
@@ -6,6 +6,17 @@ parameters:
     schema:
       type: number
     description: ID of the group contact
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 post:
   tags:

--- a/swagger/paths/application/contacts/group_admin_leave.yml
+++ b/swagger/paths/application/contacts/group_admin_leave.yml
@@ -15,8 +15,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 post:
   tags:

--- a/swagger/paths/application/contacts/group_invite.yml
+++ b/swagger/paths/application/contacts/group_invite.yml
@@ -15,8 +15,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 get:
   tags:

--- a/swagger/paths/application/contacts/group_invite.yml
+++ b/swagger/paths/application/contacts/group_invite.yml
@@ -6,6 +6,17 @@ parameters:
     schema:
       type: number
     description: ID of the group contact
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 get:
   tags:

--- a/swagger/paths/application/contacts/group_invite_revoke.yml
+++ b/swagger/paths/application/contacts/group_invite_revoke.yml
@@ -6,6 +6,17 @@ parameters:
     schema:
       type: number
     description: ID of the group contact
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 post:
   tags:

--- a/swagger/paths/application/contacts/group_invite_revoke.yml
+++ b/swagger/paths/application/contacts/group_invite_revoke.yml
@@ -15,8 +15,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 post:
   tags:

--- a/swagger/paths/application/contacts/group_join_requests.yml
+++ b/swagger/paths/application/contacts/group_join_requests.yml
@@ -15,8 +15,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 get:
   tags:

--- a/swagger/paths/application/contacts/group_join_requests.yml
+++ b/swagger/paths/application/contacts/group_join_requests.yml
@@ -6,6 +6,17 @@ parameters:
     schema:
       type: number
     description: ID of the group contact
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 get:
   tags:

--- a/swagger/paths/application/contacts/group_join_requests_handle.yml
+++ b/swagger/paths/application/contacts/group_join_requests_handle.yml
@@ -6,6 +6,17 @@ parameters:
     schema:
       type: number
     description: ID of the group contact
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 post:
   tags:

--- a/swagger/paths/application/contacts/group_join_requests_handle.yml
+++ b/swagger/paths/application/contacts/group_join_requests_handle.yml
@@ -15,8 +15,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 post:
   tags:

--- a/swagger/paths/application/contacts/group_members.yml
+++ b/swagger/paths/application/contacts/group_members.yml
@@ -6,6 +6,17 @@ parameters:
     schema:
       type: number
     description: ID of the contact
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 get:
   tags:

--- a/swagger/paths/application/contacts/group_members.yml
+++ b/swagger/paths/application/contacts/group_members.yml
@@ -15,8 +15,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 get:
   tags:

--- a/swagger/paths/application/contacts/group_members_member.yml
+++ b/swagger/paths/application/contacts/group_members_member.yml
@@ -21,8 +21,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 patch:
   tags:

--- a/swagger/paths/application/contacts/group_members_member.yml
+++ b/swagger/paths/application/contacts/group_members_member.yml
@@ -12,6 +12,17 @@ parameters:
     schema:
       type: number
     description: ID of the group member record
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 patch:
   tags:

--- a/swagger/paths/application/contacts/group_metadata.yml
+++ b/swagger/paths/application/contacts/group_metadata.yml
@@ -15,8 +15,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 patch:
   tags:

--- a/swagger/paths/application/contacts/group_metadata.yml
+++ b/swagger/paths/application/contacts/group_metadata.yml
@@ -6,6 +6,17 @@ parameters:
     schema:
       type: number
     description: ID of the group contact
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 patch:
   tags:

--- a/swagger/paths/application/contacts/sync_group.yml
+++ b/swagger/paths/application/contacts/sync_group.yml
@@ -6,6 +6,17 @@ parameters:
     schema:
       type: number
     description: ID of the contact
+  - name: inbox_id
+    in: query
+    required: false
+    schema:
+      type: number
+    description: >-
+      Which inbox the action is performed as. A group contact is account-scoped, so the
+      same WhatsApp group can belong to two inboxes of one account. Optional while a
+      group is in a single inbox; required once it is in more than one, since there is
+      otherwise no way to tell which number should act. An inbox the group is not in is
+      refused.
 
 post:
   tags:

--- a/swagger/paths/application/contacts/sync_group.yml
+++ b/swagger/paths/application/contacts/sync_group.yml
@@ -15,8 +15,9 @@ parameters:
       Which inbox the action is performed as. A group contact is account-scoped, so the
       same WhatsApp group can belong to two inboxes of one account. Optional while a
       group is in a single inbox; required once it is in more than one, since there is
-      otherwise no way to tell which number should act. An inbox the group is not in is
-      refused.
+      otherwise no way to tell which number should act. An inbox the group is not in, or
+      one the caller is not a member of, is refused. Accepted in the request body as well
+      as on the query string.
 
 post:
   tags:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3507,7 +3507,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "post": {
@@ -3684,7 +3684,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "get": {
@@ -3849,7 +3849,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "patch": {
@@ -3959,7 +3959,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "patch": {
@@ -4056,7 +4056,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "get": {
@@ -4129,7 +4129,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "post": {
@@ -4202,7 +4202,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "get": {
@@ -4274,7 +4274,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "post": {
@@ -4361,7 +4361,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "patch": {
@@ -4447,7 +4447,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "post": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3499,6 +3499,15 @@
             "type": "number"
           },
           "description": "ID of the contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "post": {
@@ -3667,6 +3676,15 @@
             "type": "number"
           },
           "description": "ID of the contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "get": {
@@ -3823,6 +3841,15 @@
             "type": "number"
           },
           "description": "ID of the group member record"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "patch": {
@@ -3924,6 +3951,15 @@
             "type": "number"
           },
           "description": "ID of the group contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "patch": {
@@ -4012,6 +4048,15 @@
             "type": "number"
           },
           "description": "ID of the group contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "get": {
@@ -4076,6 +4121,15 @@
             "type": "number"
           },
           "description": "ID of the group contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "post": {
@@ -4140,6 +4194,15 @@
             "type": "number"
           },
           "description": "ID of the group contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "get": {
@@ -4203,6 +4266,15 @@
             "type": "number"
           },
           "description": "ID of the group contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "post": {
@@ -4281,6 +4353,15 @@
             "type": "number"
           },
           "description": "ID of the group contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "patch": {
@@ -4358,6 +4439,15 @@
             "type": "number"
           },
           "description": "ID of the group contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "post": {

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -2044,7 +2044,7 @@
           "schema": {
             "type": "number"
           },
-          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in, or one the caller is not a member of, is refused. Accepted in the request body as well as on the query string."
         }
       ],
       "post": {

--- a/swagger/tag_groups/application_swagger.json
+++ b/swagger/tag_groups/application_swagger.json
@@ -2036,6 +2036,15 @@
             "type": "number"
           },
           "description": "ID of the contact"
+        },
+        {
+          "name": "inbox_id",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "number"
+          },
+          "description": "Which inbox the action is performed as. A group contact is account-scoped, so the same WhatsApp group can belong to two inboxes of one account. Optional while a group is in a single inbox; required once it is in more than one, since there is otherwise no way to tell which number should act. An inbox the group is not in is refused."
         }
       ],
       "post": {


### PR DESCRIPTION
Quando o mesmo grupo do WhatsApp está em duas caixas de entrada da mesma conta, as ações de grupo passavam por qualquer uma delas, não pela que o agente estava olhando. Sair do grupo tirava o número errado.

## Closes

- Closes #389

## How to reproduce

1. Duas caixas de entrada WhatsApp na mesma conta, as duas membros do mesmo grupo.
2. Abra a conversa do grupo pela **segunda** caixa de entrada.
3. Qualquer ação do painel (sair, promover, remover membro, trocar nome, revogar convite, sincronizar) era executada pela **primeira**.

O painel decide o que o agente pode fazer a partir da caixa de entrada aberta, então os dois podiam discordar: a permissão vinha das capacidades e do status de admin de uma, e o servidor agia como a outra.

## How to test

1. Abra a conversa do grupo por uma das caixas de entrada e confira, no devtools, que `group_members` leva `inbox_id` igual ao da conversa.
2. Abra a conversa do mesmo grupo pela outra e confira que o `inbox_id` acompanha.
3. Uma ação com `inbox_id` de uma caixa de entrada que não tem esse grupo responde 404.
4. Sem `inbox_id`, com o grupo em duas caixas de entrada, responde 400 pedindo que se diga qual.

## What changed

Um concern compartilhado (`GroupChannelResolver`) resolve o canal a partir do `inbox_id`, escopado ao contato, nos cinco controllers de grupo e no `sync_group`.

O parâmetro é opcional, porque esses endpoints são documentados e foram lançados sem ele. O que ele não pode ser é errado: uma caixa de entrada que não tem o grupo é recusada em vez de silenciosamente trocada por outra. Ausente, uma única caixa de entrada responde por si; ausente com o grupo em duas, não existe resposta a dar, então quem chamou é convidado a dizer qual, em vez de receber cara-ou-coroa.

O `sync_group` também passou a nomear o canal. O job já aceitava um, e sem ele a sincronização podia rodar por uma sessão que nem está conectada.

O painel lê a caixa de entrada da conversa em que está aberto, que é a mesma que suas próprias checagens de permissão já usam.

Swagger atualizado nos dez caminhos.

## O que fica de fora

`group_left` continua sendo uma flag no contato compartilhado, então duas caixas de entrada no mesmo grupo ainda compartilham. É o #374, e a correção dele mexe na camada Baileys congelada e muda onde a flag mora, então é mudança própria.

`getPendingRequests` saiu no caminho: não tinha chamador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/396)
<!-- Reviewable:end -->
