### PR TITLE
fix(whatsapp): leave a group for the inbox that left it, not for the account

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -6,12 +6,6 @@ app/javascript/dashboard/components/widgets/conversation/MoreActions.vue: Hide p
 app/javascript/dashboard/helper/actionCable.js: Refresh cached permissions before applying this gate  # PR#367
 app/javascript/dashboard/helper/actionCable.js: Align bot assignments with frontend list visibility  # PR#367
 app/javascript/dashboard/helper/actionCable.js: Upsert conversations when assignment grants access  # PR#367
-# PR#372: real, tracked in fazer-ai/chatwoot#374, and inherited rather than introduced.
-# `group_left` is stored on the account-level group Contact, which is exactly where the
-# Baileys layer writes it and where three dashboard components read it. Scoping it per
-# inbox means changing that contract in the frozen legacy layer as well, so it is its
-# own change, not a slice of this one. Removing this waiver does not close the issue.
-app/services/whatsapp/session/inbound/handlers/group_updated.rb: Scope the group-left state to the originating inbox  # PR#372
 # PR#372: real, tracked in fazer-ai/chatwoot#375, and not specific to this layer. The
 # window belongs to `Avatar::AvatarFromUrlJob`, which is handed a URL with no notion of
 # how fresh it is; the Baileys avatar paths have the same one. Closing it means giving
@@ -114,13 +108,3 @@ app/jobs/whatsapp/session/pairing_poll_job.rb: Preserve compatibility with queue
 # new-conversation composer never did. Fixing it means touching a helper shared with
 # email and the web widget, where one message carrying several files is correct.
 app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue: Split multiple session attachments before sending  # PR#383
-
-# Tracked as #388, and a missing half rather than a defect: no button offers code
-# pairing, so nothing promises the user something that fails. Withdrawing the capability
-# instead would make backends refuse `request_pairing_code`, which both of them serve.
-app/services/whatsapp/session/registry.rb: Add a reachable pairing-code flow  # PR#387 → #388
-
-# Tracked as #389, and present on origin/main unchanged: `Contact#group_channel` is
-# `contact_inboxes.first`, every group controller has always resolved its channel that
-# way, and this branch neither introduces nor touches it. Same family as #374.
-app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue: Scope group commands to the selected inbox  # PR#387 → #389

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -22,7 +22,7 @@ import { mapGetters } from 'vuex';
 
 // mixins
 import inboxMixin, { INBOX_FEATURES } from 'shared/mixins/inboxMixin';
-import { CAPABILITIES } from 'dashboard/helper/whatsappSession';
+import { CAPABILITIES, hasLeftGroup } from 'dashboard/helper/whatsappSession';
 
 // utils
 import { emitter } from 'shared/helpers/mitt';
@@ -357,7 +357,7 @@ export default {
       return (
         this.isASessionWhatsAppChannel &&
         this.isGroupConversation &&
-        this.currentContact?.additional_attributes?.group_left === true
+        hasLeftGroup(this.currentContact, this.currentChat?.inbox_id)
       );
     },
     isGroupsDisabled() {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -35,7 +35,7 @@ import ContentTemplates from './ContentTemplates/ContentTemplatesModal.vue';
 import ScheduledMessageModal from 'dashboard/routes/dashboard/conversation/scheduledMessages/ScheduledMessageModal.vue';
 import { MESSAGE_MAX_LENGTH } from 'shared/helpers/MessageTypeHelper';
 import inboxMixin, { INBOX_FEATURES } from 'shared/mixins/inboxMixin';
-import { CAPABILITIES } from 'dashboard/helper/whatsappSession';
+import { CAPABILITIES, hasLeftGroup } from 'dashboard/helper/whatsappSession';
 import { trimContent, debounce, getRecipients } from '@chatwoot/utils';
 import wootConstants from 'dashboard/constants/globals';
 import {
@@ -246,7 +246,7 @@ export default {
       return (
         this.isASessionWhatsAppChannel &&
         this.isGroupConversation &&
-        this.currentContact?.additional_attributes?.group_left === true
+        hasLeftGroup(this.currentContact, this.currentChat?.inbox_id)
       );
     },
     isGroupsDisabled() {

--- a/app/javascript/dashboard/helper/whatsappSession.js
+++ b/app/javascript/dashboard/helper/whatsappSession.js
@@ -96,3 +96,25 @@ export const isHttpUrl = value => {
     return false;
   }
 };
+
+/**
+ * Whether *this* inbox has left the group. Mirrors `Contact#group_left_in?`.
+ *
+ * The group contact is account-scoped, so the same WhatsApp group can be in two inboxes
+ * of one account and only one of them may have left. `group_left_inbox_ids` names which,
+ * and the older boolean is kept alongside it meaning "every inbox left" — which is what
+ * it already said for the single-inbox case. A contact that predates the list carries
+ * the boolean alone, and it was account wide, so it answers for whichever inbox asks.
+ *
+ * @param {{additional_attributes?: Object}|null|undefined} contact
+ * @param {number|string|null|undefined} inboxId
+ * @returns {boolean}
+ */
+export const hasLeftGroup = (contact, inboxId) => {
+  const attributes = contact?.additional_attributes ?? {};
+  const leftInboxIds = attributes.group_left_inbox_ids;
+
+  if (!Array.isArray(leftInboxIds)) return attributes.group_left === true;
+
+  return leftInboxIds.some(id => Number(id) === Number(inboxId));
+};

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
@@ -20,7 +20,7 @@ import ContactsAPI from 'dashboard/api/contacts';
 import GroupMembersAPI from 'dashboard/api/groupMembers';
 import { phonesMatch } from 'dashboard/helper/phoneHelper';
 import { useInbox } from 'dashboard/composables/useInbox';
-import { CAPABILITIES } from 'dashboard/helper/whatsappSession';
+import { CAPABILITIES, hasLeftGroup } from 'dashboard/helper/whatsappSession';
 import Avatar from 'next/avatar/Avatar.vue';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 import DropdownMenu from 'dashboard/components-next/dropdown-menu/DropdownMenu.vue';
@@ -161,9 +161,7 @@ const {
   checkOverflow: checkDescOverflow,
 } = useExpandableContent({ maxLines: 3, useResizeObserverForCheck: true });
 
-const isGroupLeft = computed(
-  () => props.contact.additional_attributes?.group_left === true
-);
+const isGroupLeft = computed(() => hasLeftGroup(props.contact, inboxId.value));
 
 // The one predicate for "may this agent change the group". It carries the provider's
 // capability too, so the panel stays a readable shell rather than offering buttons that

--- a/app/models/concerns/whatsapp_group_membership.rb
+++ b/app/models/concerns/whatsapp_group_membership.rb
@@ -1,0 +1,63 @@
+# Which inboxes have left this WhatsApp group.
+#
+# A group contact is account-scoped (its identifier is the group's own id), while a
+# contact inbox is per inbox, so one WhatsApp group can belong to two inboxes of the same
+# account. `group_left` was a single boolean on the shared contact, so one number leaving
+# marked the group as left for every other number in it: the dashboard hid the composer
+# and the group actions on threads that could still send, `sync_group` returned early and
+# stopped refreshing them, and nothing on the inboxes that stayed could clear the flag,
+# because only a rejoin clears it and they never left.
+#
+# The list is the record now, and the boolean is derived from it: it stays true only when
+# every inbox this group is in has left, which is what it already meant for the single
+# inbox case that is nearly all of them. External consumers reading
+# `additional_attributes['group_left']` therefore keep the answer they had.
+module WhatsappGroupMembership
+  extend ActiveSupport::Concern
+
+  LEFT = 'group_left'.freeze
+  LEFT_INBOX_IDS = 'group_left_inbox_ids'.freeze
+
+  def group_left_in?(inbox_id)
+    inbox_id = inbox_id.to_i
+    return false if inbox_id.zero?
+
+    group_left_inbox_ids.include?(inbox_id)
+  end
+
+  def group_left_inbox_ids
+    stored = additional_attributes&.dig(LEFT_INBOX_IDS)
+    # A row written before the list existed says only "left", and it said it account
+    # wide, so every inbox this group is in is what it meant. Same reading the data
+    # migration writes down; this is what keeps a row it has not reached yet, or one
+    # restored from a backup that predates it, from reading as "still in the group".
+    return group_inbox_ids if stored.nil? && additional_attributes&.dig(LEFT).present?
+
+    Array(stored).map(&:to_i).reject(&:zero?)
+  end
+
+  def mark_group_left!(inbox_id) = write_group_left_inbox_ids(inbox_id) { |ids, id| ids | [id] }
+
+  def mark_group_rejoined!(inbox_id) = write_group_left_inbox_ids(inbox_id) { |ids, id| ids - [id] }
+
+  private
+
+  def group_inbox_ids = contact_inboxes.pluck(:inbox_id).compact.sort
+
+  # Read-modify-write on a jsonb every inbox in this group shares, so it takes the row
+  # lock: two of them leaving at the same moment would otherwise each build a list from
+  # the state before the other, and whichever wrote second would erase the first.
+  def write_group_left_inbox_ids(inbox_id)
+    inbox_id = inbox_id.to_i
+    return if inbox_id.zero?
+
+    with_lock do
+      ids = yield(group_left_inbox_ids, inbox_id).sort
+      attributes = (additional_attributes || {}).merge(
+        LEFT_INBOX_IDS => ids,
+        LEFT => ids.present? && (group_inbox_ids - ids).empty?
+      )
+      update!(additional_attributes: attributes) if attributes != additional_attributes
+    end
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -48,6 +48,7 @@ class Contact < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include AvailabilityStatusable
   include Labelable
   include LlmFormattable
+  include WhatsappGroupMembership
 
   validates :account_id, presence: true
   validates :email, allow_blank: true, uniqueness: { scope: [:account_id], case_sensitive: false },

--- a/app/services/whatsapp/baileys_handlers/concerns/group_stub_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/group_stub_message_handler.rb
@@ -52,8 +52,8 @@ module Whatsapp::BaileysHandlers::Concerns::GroupStubMessageHandler # rubocop:di
       ).perform
 
       group_contact = group_contact_inbox.contact
-      was_group_left = group_contact.additional_attributes&.dig('group_left').present?
-      reset_group_left_flag(group_contact)
+      was_group_left = group_contact.group_left_in?(group_contact_inbox.inbox_id)
+      group_contact.mark_group_rejoined!(group_contact_inbox.inbox_id)
       find_or_create_group_conversation(group_contact_inbox)
       handle_group_rejoin(group_contact) if was_group_left
       enqueue_group_sync(group_contact, force: was_group_left)
@@ -79,13 +79,6 @@ module Whatsapp::BaileysHandlers::Concerns::GroupStubMessageHandler # rubocop:di
     return if contact.blank?
 
     add_group_member(group_contact, contact)
-  end
-
-  def reset_group_left_flag(group_contact)
-    return unless group_contact.additional_attributes&.dig('group_left')
-
-    new_attrs = (group_contact.additional_attributes || {}).merge('group_left' => false)
-    group_contact.update!(additional_attributes: new_attrs)
   end
 
   def update_group_avatar(group_contact)

--- a/app/services/whatsapp/baileys_handlers/group_participants_update.rb
+++ b/app/services/whatsapp/baileys_handlers/group_participants_update.rb
@@ -97,16 +97,11 @@ module Whatsapp::BaileysHandlers::GroupParticipantsUpdate
     effective_action = resolve_effective_action(action, author_jid, contacts)
     return unless effective_action.in?(%w[leave remove])
 
-    mark_group_as_left(group_contact_inbox.contact)
+    group_contact_inbox.contact.mark_group_left!(group_contact_inbox.inbox_id)
 
     group_contact_inbox.conversations.where(status: %i[open pending]).find_each do |conversation|
       conversation.update!(status: :resolved)
     end
-  end
-
-  def mark_group_as_left(group_contact)
-    new_attrs = (group_contact.additional_attributes || {}).merge('group_left' => true)
-    group_contact.update!(additional_attributes: new_attrs) if new_attrs != group_contact.additional_attributes
   end
 
   def inbox_phone_in_participants?(contacts)

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -319,10 +319,9 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
 
   def sync_group(conversation, soft: false)
     group_contact = conversation.contact
-
-    return true if group_contact.additional_attributes&.dig('group_left')
-
     inbox = conversation.inbox
+
+    return true if group_contact.group_left_in?(inbox.id)
 
     metadata = group_metadata(group_contact.identifier)
     raise ProviderUnavailableError, 'Could not fetch group metadata' if metadata.blank?
@@ -848,11 +847,12 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     group_contact.update!(additional_attributes: new_attrs) if new_attrs != group_contact.additional_attributes
   end
 
+  # `group_left` is not cleared here. It is per inbox now (see WhatsappGroupMembership),
+  # and a sync only ever reaches this point for an inbox that has not left, so there was
+  # nothing for it to clear; rejoining is what clears it, and only the rejoin path knows
+  # that happened.
   def persist_sync_status(group_contact)
-    new_attrs = (group_contact.additional_attributes || {}).merge(
-      'group_last_synced_at' => Time.current.to_i,
-      'group_left' => false
-    )
+    new_attrs = (group_contact.additional_attributes || {}).merge('group_last_synced_at' => Time.current.to_i)
     group_contact.update!(additional_attributes: new_attrs) if new_attrs != group_contact.additional_attributes
   end
 

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -58,6 +58,11 @@ class Whatsapp::Session::Groups::Syncer
   def apply(info)
     return if info.blank?
 
+    # Only rejoining clears the left flag, and only an event that carries the group
+    # (`group.joined`) knows that happened. A scheduled sync can still read cached
+    # metadata for a group this inbox left, and clearing it there would put the group
+    # actions back in the dashboard for a thread that can no longer send anything.
+    group_contact.mark_group_rejoined!(inbox.id) if @info.present?
     update_contact(info)
     sync_members(info)
     update_avatar(info) unless soft
@@ -105,12 +110,7 @@ class Whatsapp::Session::Groups::Syncer
       'owner' => info.owner&.identifier || info.owner&.phone,
       'owner_pn' => info.owner&.phone,
       'invite_code' => info.invite_code.presence,
-      'group_last_synced_at' => Time.current.to_i,
-      # Only rejoining clears this, and only `group.joined` knows that happened. A
-      # scheduled sync can still read cached metadata for a group the session left, and
-      # clearing the flag there would put the group actions back in the dashboard for a
-      # thread that can no longer send anything.
-      'group_left' => (false if @info.present?)
+      'group_last_synced_at' => Time.current.to_i
     }.compact
     attributes['description'] = info.description.presence unless info.description.nil?
     attributes.merge(setting_attributes(info))

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -113,17 +113,10 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
     return unless action == 'leave'
     return unless contacts.any? { |contact| session_owner?(contact) }
 
-    # ACCOUNT-WIDE, ON PURPOSE, FOR NOW (fazer-ai/chatwoot#374). The group contact is
-    # shared by every inbox of the account that is in this WhatsApp group, so this marks
-    # the group as left for all of them, and nothing on the inboxes that stayed will
-    # clear it. The flag lives here because that is where the Baileys layer writes it and
-    # where three dashboard components read it; scoping it per inbox means changing that
-    # contract in the frozen legacy layer too. Do not delete this note without closing
-    # the issue.
-    merge_attributes('group_left' => true)
-    # Only this inbox's threads, which the flag above cannot manage. Closing another
-    # number's conversations because *this* session left would end a thread it can
-    # still use.
+    @group_contact.mark_group_left!(@group_contact_inbox.inbox_id)
+    # This inbox's threads only, for the same reason the flag above is this inbox's
+    # only. Closing another number's conversations because *this* session left would
+    # end a thread it can still use.
     # Snoozed as well: the snooze job reopens on its own schedule, and a thread reopened
     # for a group this inbox has left can no longer send anything.
     @group_contact_inbox.conversations.where(status: %i[open pending snoozed])

--- a/db/migrate/20260822120000_scope_whatsapp_group_left_per_inbox.rb
+++ b/db/migrate/20260822120000_scope_whatsapp_group_left_per_inbox.rb
@@ -1,0 +1,46 @@
+# `group_left` was one boolean on a contact every inbox in the group shares, so it could
+# only say "left", never "left where". The list it becomes has to be seeded with an
+# answer, and the only honest one for a row written under the old rule is "all of them":
+# that is what the boolean meant to every reader at the time, so seeding it this way
+# leaves every existing group rendering exactly as it does today. The single-inbox case,
+# which is nearly all of them, is exact rather than merely unchanged.
+class ScopeWhatsappGroupLeftPerInbox < ActiveRecord::Migration[7.1]
+  GROUP_CONTACT = 1
+
+  def up
+    contact_class.where(group_type: GROUP_CONTACT)
+                 .where("additional_attributes ->> 'group_left' = 'true'")
+                 .where("additional_attributes -> 'group_left_inbox_ids' IS NULL")
+                 .find_each do |contact|
+      inbox_ids = contact_inbox_class.where(contact_id: contact.id).distinct.pluck(:inbox_id).compact.sort
+      attributes = contact.additional_attributes.merge('group_left_inbox_ids' => inbox_ids)
+      contact.update_column(:additional_attributes, attributes) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def down
+    contact_class.where(group_type: GROUP_CONTACT)
+                 .where("additional_attributes -> 'group_left_inbox_ids' IS NOT NULL")
+                 .find_each do |contact|
+      left_somewhere = contact.additional_attributes['group_left_inbox_ids'].present?
+      attributes = contact.additional_attributes.except('group_left_inbox_ids').merge('group_left' => left_somewhere)
+      contact.update_column(:additional_attributes, attributes) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  private
+
+  def contact_class
+    @contact_class ||= Class.new(ActiveRecord::Base) do
+      self.table_name = 'contacts'
+      self.inheritance_column = :_type_disabled
+    end
+  end
+
+  def contact_inbox_class
+    @contact_inbox_class ||= Class.new(ActiveRecord::Base) do
+      self.table_name = 'contact_inboxes'
+      self.inheritance_column = :_type_disabled
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_17_210000) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_22_120000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"

--- a/spec/models/concerns/whatsapp_group_membership_spec.rb
+++ b/spec/models/concerns/whatsapp_group_membership_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe WhatsappGroupMembership do
+  let(:account) { create(:account) }
+  let(:group) { create(:contact, account: account, group_type: :group, identifier: '120363041234567890@g.us') }
+  let(:first_inbox) { create(:inbox, account: account) }
+  let(:second_inbox) { create(:inbox, account: account) }
+
+  before do
+    create(:contact_inbox, contact: group, inbox: first_inbox, source_id: '120363041234567890')
+    create(:contact_inbox, contact: group, inbox: second_inbox, source_id: '120363041234567891')
+  end
+
+  it 'leaves the inboxes that stayed in the group' do
+    group.mark_group_left!(first_inbox.id)
+
+    expect(group.group_left_in?(first_inbox.id)).to be(true)
+    expect(group.group_left_in?(second_inbox.id)).to be(false)
+  end
+
+  # The boolean is what every external consumer of the contact payload already reads, so
+  # it has to keep meaning something. "Every inbox left" is what it said for the single
+  # inbox case, which is nearly all of them.
+  it 'only says the group was left once every inbox has left it' do
+    group.mark_group_left!(first_inbox.id)
+
+    expect(group.reload.additional_attributes['group_left']).to be(false)
+
+    group.mark_group_left!(second_inbox.id)
+
+    expect(group.reload.additional_attributes['group_left']).to be(true)
+  end
+
+  it 'clears the flag for the inbox that rejoined, and leaves the other one alone' do
+    group.mark_group_left!(first_inbox.id)
+    group.mark_group_left!(second_inbox.id)
+
+    group.mark_group_rejoined!(first_inbox.id)
+
+    expect(group.group_left_in?(first_inbox.id)).to be(false)
+    expect(group.group_left_in?(second_inbox.id)).to be(true)
+    expect(group.reload.additional_attributes['group_left']).to be(false)
+  end
+
+  it 'does not write the same list twice' do
+    group.mark_group_left!(first_inbox.id)
+
+    expect { group.mark_group_left!(first_inbox.id) }.not_to(change { group.reload.updated_at })
+  end
+
+  # A contact written before the list existed carries the boolean alone, and it was
+  # account wide, so it answers for whichever inbox asks until the migration converts it.
+  context 'with a contact that predates the list' do
+    before { group.update!(additional_attributes: { 'group_left' => true }) }
+
+    it 'reads the old boolean for every inbox' do
+      expect(group.group_left_in?(first_inbox.id)).to be(true)
+      expect(group.group_left_in?(second_inbox.id)).to be(true)
+    end
+
+    it 'converts it the moment one inbox rejoins, without losing the other one' do
+      group.mark_group_rejoined!(first_inbox.id)
+
+      expect(group.group_left_in?(first_inbox.id)).to be(false)
+      expect(group.group_left_in?(second_inbox.id)).to be(true)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/groups/syncer_spec.rb
+++ b/spec/services/whatsapp/session/groups/syncer_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
   context 'when the group was already left and the sync fetched its metadata' do
     subject(:fetched_sync) { described_class.new(channel: channel, group_contact: group_contact).perform }
 
-    let(:stored) { super().merge('group_left' => true) }
+    let(:stored) { super().merge('group_left_inbox_ids' => [channel.inbox.id]) }
     let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
 
     before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
@@ -87,7 +87,27 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
     it 'keeps the group marked as left' do
       fetched_sync
 
-      expect(group_contact.reload.additional_attributes['group_left']).to be(true)
+      expect(group_contact.reload.group_left_in?(channel.inbox.id)).to be(true)
+    end
+  end
+
+  # The snapshot comes from `group.joined`, which is the one event that knows the session
+  # is back in the group, and it clears the flag for that inbox alone.
+  context 'when the group was left and an event brought its metadata back' do
+    let(:other_inbox) do
+      create(:channel_whatsapp, account: channel.account, provider: 'native', phone_number: '+5541977776666',
+                                validate_provider_config: false, sync_templates: false).inbox
+    end
+    let(:stored) { super().merge('group_left_inbox_ids' => [inbox.id, other_inbox.id], 'group_left' => true) }
+
+    before { create(:contact_inbox, inbox: other_inbox, contact: group_contact, source_id: '120363041234567890') }
+
+    it 'rejoins this inbox and leaves the other one out of the group' do
+      sync
+
+      expect(group_contact.reload.group_left_in?(inbox.id)).to be(false)
+      expect(group_contact.group_left_in?(other_inbox.id)).to be(true)
+      expect(group_contact.additional_attributes['group_left']).to be(false)
     end
   end
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -184,8 +184,8 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
   end
 
   # The group contact is shared by every inbox of the account that is in the same
-  # WhatsApp group, so closing all of its threads would end a conversation another
-  # number can still use.
+  # WhatsApp group, so closing all of its threads, or marking the group left on the
+  # contact itself, would end a conversation another number can still use.
   context 'when another inbox of the account is in the same group' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(leave: [model::Party.new(phone: '5541988887777')]) }
     let(:other_inbox) do
@@ -206,6 +206,20 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
       end
 
       expect(other_thread.reload.status).to eq('open')
+    end
+
+    it 'leaves the group only for the inbox that left it' do
+      dispatch
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      create(:contact_inbox, inbox: other_inbox, contact: group_contact, source_id: '120363041234567890')
+
+      with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+      end
+
+      expect(group_contact.reload.group_left_in?(inbox.id)).to be(true)
+      expect(group_contact.group_left_in?(other_inbox.id)).to be(false)
+      expect(group_contact.additional_attributes['group_left']).to be(false)
     end
   end
 


### PR DESCRIPTION
Quando a mesma conversa de grupo do WhatsApp existe em duas caixas de entrada da conta, uma delas sair do grupo marcava o grupo como abandonado para a outra também: o campo de resposta e as ações de grupo sumiam de uma conversa que ainda podia enviar, o sync parava de atualizar o grupo, e nada na caixa que ficou conseguia limpar a marca, porque só uma reentrada limpa e essa caixa nunca saiu.

Agora a marca é por caixa de entrada. Sair de um número não muda nada para o outro, e reentrar limpa só para quem reentrou.

## Closes

- Closes #374

## How to test

1. Com duas caixas WhatsApp na mesma conta, ambas no mesmo grupo, abra as duas conversas do grupo.
2. Saia do grupo pela caixa A.
3. A conversa de A perde o campo de resposta e as ações de grupo, como antes. A conversa de B continua inteira: envia mensagem, edita o grupo, sincroniza.
4. Reentre pela caixa A: as ações voltam para A, e B nunca foi afetada.

## What changed

`group_left` era um booleano em `contact.additional_attributes`, e o contato do grupo é da conta inteira, não de uma caixa. O registro passa a ser `group_left_inbox_ids`, e o booleano continua existindo derivado dele: fica `true` só quando todas as caixas em que o grupo está saíram, que é exatamente o que ele já significava no caso de uma caixa só, quase todos. Quem lê `additional_attributes['group_left']` pela API continua com a mesma resposta.

- `WhatsappGroupMembership` (novo concern em `Contact`) tem a leitura (`group_left_in?`) e as duas escritas (`mark_group_left!` / `mark_group_rejoined!`), sob lock de linha porque o jsonb é compartilhado pelas caixas.
- Leitores atualizados: `whatsapp_baileys_service.rb` (early return do `sync_group` e `persist_sync_status`), `group_stub_message_handler.rb`, `group_participants_update.rb`, `Session::Groups::Syncer`, `Session::Inbound::Handlers::GroupUpdated`, e os três componentes Vue (`MessagesView`, `ReplyBox`, `GroupContactInfo`) por um helper único em `helper/whatsappSession.js`.
- Migração de dados converte os grupos já marcados: `group_left: true` vira a lista com todas as caixas do contato, que é o que o booleano dizia para todo leitor na época. Um registro que a migração ainda não alcançou continua sendo lido do mesmo jeito, então a correção não depende dela ter rodado.
- Três dispensas obsoletas saem do `.codex-review-waived`: a do #374 (esta PR), a do #388 (pareamento por código, PR #394) e a do #389 (PR #396).

Mexe na camada Baileys congelada em três arquivos, que é o que o próprio #374 diz ser necessário e o motivo de ter ficado fora do #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/397)
<!-- Reviewable:end -->
