### PR TITLE
fix(whatsapp): leave a group for the inbox that left it, not for the account

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -6,12 +6,6 @@ app/javascript/dashboard/components/widgets/conversation/MoreActions.vue: Hide p
 app/javascript/dashboard/helper/actionCable.js: Refresh cached permissions before applying this gate  # PR#367
 app/javascript/dashboard/helper/actionCable.js: Align bot assignments with frontend list visibility  # PR#367
 app/javascript/dashboard/helper/actionCable.js: Upsert conversations when assignment grants access  # PR#367
-# PR#372: real, tracked in fazer-ai/chatwoot#374, and inherited rather than introduced.
-# `group_left` is stored on the account-level group Contact, which is exactly where the
-# Baileys layer writes it and where three dashboard components read it. Scoping it per
-# inbox means changing that contract in the frozen legacy layer as well, so it is its
-# own change, not a slice of this one. Removing this waiver does not close the issue.
-app/services/whatsapp/session/inbound/handlers/group_updated.rb: Scope the group-left state to the originating inbox  # PR#372
 # PR#372: real, tracked in fazer-ai/chatwoot#375, and not specific to this layer. The
 # window belongs to `Avatar::AvatarFromUrlJob`, which is handed a URL with no notion of
 # how fresh it is; the Baileys avatar paths have the same one. Closing it means giving
@@ -114,13 +108,3 @@ app/jobs/whatsapp/session/pairing_poll_job.rb: Preserve compatibility with queue
 # new-conversation composer never did. Fixing it means touching a helper shared with
 # email and the web widget, where one message carrying several files is correct.
 app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue: Split multiple session attachments before sending  # PR#383
-
-# Tracked as #388, and a missing half rather than a defect: no button offers code
-# pairing, so nothing promises the user something that fails. Withdrawing the capability
-# instead would make backends refuse `request_pairing_code`, which both of them serve.
-app/services/whatsapp/session/registry.rb: Add a reachable pairing-code flow  # PR#387 → #388
-
-# Tracked as #389, and present on origin/main unchanged: `Contact#group_channel` is
-# `contact_inboxes.first`, every group controller has always resolved its channel that
-# way, and this branch neither introduces nor touches it. Same family as #374.
-app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue: Scope group commands to the selected inbox  # PR#387 → #389

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -354,11 +354,15 @@ export default {
         !this.isInboxAdminInCurrentGroup
       );
     },
+    // Read off the conversation, not off the contact: a group contact is
+    // account-scoped and the same group can be open in two inboxes of one account,
+    // where only one of them may have left. The server answers for this thread's own
+    // number.
     isGroupLeft() {
       return (
         this.isASessionWhatsAppChannel &&
         this.isGroupConversation &&
-        this.currentContact?.additional_attributes?.group_left === true
+        this.currentChat?.group_left === true
       );
     },
     isGroupsDisabled() {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -242,11 +242,15 @@ export default {
         !this.isInboxAdminInCurrentGroup
       );
     },
+    // Read off the conversation, not off the contact: a group contact is
+    // account-scoped and the same group can be open in two inboxes of one account,
+    // where only one of them may have left. The server answers for this thread's own
+    // number.
     isGroupLeft() {
       return (
         this.isASessionWhatsAppChannel &&
         this.isGroupConversation &&
-        this.currentContact?.additional_attributes?.group_left === true
+        this.currentChat?.group_left === true
       );
     },
     isGroupsDisabled() {

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
@@ -161,9 +161,10 @@ const {
   checkOverflow: checkDescOverflow,
 } = useExpandableContent({ maxLines: 3, useResizeObserverForCheck: true });
 
-const isGroupLeft = computed(
-  () => props.contact.additional_attributes?.group_left === true
-);
+// Read off the conversation, not off the contact: a group contact is account-scoped and
+// the same group can be open in two inboxes of one account, where only one of them may
+// have left. The server answers for this thread's own number.
+const isGroupLeft = computed(() => currentChat.value?.group_left === true);
 
 // The one predicate for "may this agent change the group". It carries the provider's
 // capability too, so the panel stays a readable shell rather than offering buttons that

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -158,6 +158,16 @@ class Contact < ApplicationRecord # rubocop:disable Metrics/ClassLength
     contact_inboxes.first&.inbox&.channel
   end
 
+  # Whether the number behind one inbox has left the WhatsApp group this contact is.
+  # The fact belongs to the contact inbox (see `ContactInbox#group_left?`); this is the
+  # reader for the callers that hold the group contact and an inbox id rather than the
+  # row itself.
+  def group_left_in?(inbox_id)
+    return false if inbox_id.blank?
+
+    contact_inboxes.find_by(inbox_id: inbox_id)&.group_left? || false
+  end
+
   def push_event_data
     data = {
       additional_attributes: additional_attributes,

--- a/app/models/contact_inbox.rb
+++ b/app/models/contact_inbox.rb
@@ -3,6 +3,8 @@
 # Table name: contact_inboxes
 #
 #  id            :bigint           not null, primary key
+#  group_left_at :datetime
+#  group_left_at :datetime
 #  hmac_verified :boolean          default(FALSE)
 #  pubsub_token  :string
 #  created_at    :datetime         not null
@@ -55,7 +57,55 @@ class ContactInbox < ApplicationRecord
     conversations.last
   end
 
+  # Whether this number has left the WhatsApp group this contact is.
+  #
+  # It lives here rather than on the contact because a group contact is
+  # account-scoped (its identifier is the group's own id) while this row is per inbox,
+  # so one WhatsApp group can belong to two inboxes of the same account. It used to be a
+  # boolean on the shared contact, and one number leaving marked the group as left for
+  # every other number in it: the dashboard hid the composer and the group actions on
+  # threads that could still send, `sync_group` returned early and stopped refreshing
+  # them, and nothing on the inboxes that stayed could clear it, because only a rejoin
+  # clears it and they never left.
+  def group_left? = group_left_at.present? || legacy_group_left?
+
+  def mark_group_left!
+    convert_legacy_group_left!
+    return if group_left_at.present?
+
+    update!(group_left_at: Time.current)
+  end
+
+  def mark_group_rejoined!
+    convert_legacy_group_left!
+    return if group_left_at.nil?
+
+    update!(group_left_at: nil)
+  end
+
   private
+
+  # The migration that introduced the column deleted `group_left` from every contact, so
+  # a truthy one can only have been written by a worker from the release before it: the
+  # rolling deploy window, where a group left through the old code would otherwise be
+  # read here as still joined.
+  def legacy_group_left? = contact.additional_attributes&.dig('group_left').present?
+
+  # Reading the old boolean is a stopgap; it says "left" without saying where, and it
+  # cannot survive the first write of the new shape, because a rejoin here would clear
+  # this row and then read the same stale `true` straight back. So the first write
+  # converts: every inbox this group is in gets stamped, which is what the boolean meant
+  # account wide, and the key goes. Same reading the data migration applies, and it runs
+  # at most once per contact.
+  def convert_legacy_group_left!
+    return unless legacy_group_left?
+
+    contact.with_lock do
+      contact.contact_inboxes.where(group_left_at: nil).update_all(group_left_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      contact.update!(additional_attributes: (contact.additional_attributes || {}).except('group_left'))
+    end
+    reload
+  end
 
   def validate_twilio_source_id
     # https://www.twilio.com/docs/glossary/what-e164#regex-matching-for-e164

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -64,8 +64,20 @@ class Conversations::EventDataPresenter < SimpleDelegator
       first_reply_created_at: first_reply_created_at,
       priority: priority,
       waiting_since: waiting_since.to_i,
-      **push_timestamps
+      **push_timestamps,
+      **group_left_data
     }
+  end
+
+  # Whether THIS thread's number has left the WhatsApp group. The group contact is
+  # account-scoped and can be in two inboxes of one account, so the answer belongs to the
+  # conversation rather than to the contact every thread shares. Absent, rather than
+  # false, on everything that is not a group: the question does not apply there, and the
+  # conversation partial leaves it out on the same terms.
+  def group_left_data
+    return {} unless group_type_group?
+
+    { group_left: contact_inbox&.group_left? }
   end
 
   # Like #push_data but with message text normalized for external integrations (webhooks).

--- a/app/services/whatsapp/baileys_handlers/concerns/group_stub_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/group_stub_message_handler.rb
@@ -52,8 +52,8 @@ module Whatsapp::BaileysHandlers::Concerns::GroupStubMessageHandler # rubocop:di
       ).perform
 
       group_contact = group_contact_inbox.contact
-      was_group_left = group_contact.additional_attributes&.dig('group_left').present?
-      reset_group_left_flag(group_contact)
+      was_group_left = group_contact_inbox.group_left?
+      group_contact_inbox.mark_group_rejoined!
       find_or_create_group_conversation(group_contact_inbox)
       handle_group_rejoin(group_contact) if was_group_left
       enqueue_group_sync(group_contact, force: was_group_left)
@@ -79,13 +79,6 @@ module Whatsapp::BaileysHandlers::Concerns::GroupStubMessageHandler # rubocop:di
     return if contact.blank?
 
     add_group_member(group_contact, contact)
-  end
-
-  def reset_group_left_flag(group_contact)
-    return unless group_contact.additional_attributes&.dig('group_left')
-
-    new_attrs = (group_contact.additional_attributes || {}).merge('group_left' => false)
-    group_contact.update!(additional_attributes: new_attrs)
   end
 
   def update_group_avatar(group_contact)

--- a/app/services/whatsapp/baileys_handlers/group_participants_update.rb
+++ b/app/services/whatsapp/baileys_handlers/group_participants_update.rb
@@ -97,16 +97,11 @@ module Whatsapp::BaileysHandlers::GroupParticipantsUpdate
     effective_action = resolve_effective_action(action, author_jid, contacts)
     return unless effective_action.in?(%w[leave remove])
 
-    mark_group_as_left(group_contact_inbox.contact)
+    group_contact_inbox.mark_group_left!
 
     group_contact_inbox.conversations.where(status: %i[open pending]).find_each do |conversation|
       conversation.update!(status: :resolved)
     end
-  end
-
-  def mark_group_as_left(group_contact)
-    new_attrs = (group_contact.additional_attributes || {}).merge('group_left' => true)
-    group_contact.update!(additional_attributes: new_attrs) if new_attrs != group_contact.additional_attributes
   end
 
   def inbox_phone_in_participants?(contacts)

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -355,10 +355,9 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
 
   def sync_group(conversation, soft: false)
     group_contact = conversation.contact
-
-    return true if group_contact.additional_attributes&.dig('group_left')
-
     inbox = conversation.inbox
+
+    return true if conversation.contact_inbox&.group_left?
 
     metadata = group_metadata(group_contact.identifier)
     raise ProviderUnavailableError, 'Could not fetch group metadata' if metadata.blank?
@@ -1011,11 +1010,12 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     group_contact.update!(additional_attributes: new_attrs) if new_attrs != group_contact.additional_attributes
   end
 
+  # `group_left` is not cleared here. It is per inbox now (see WhatsappGroupMembership),
+  # and a sync only ever reaches this point for an inbox that has not left, so there was
+  # nothing for it to clear; rejoining is what clears it, and only the rejoin path knows
+  # that happened.
   def persist_sync_status(group_contact)
-    new_attrs = (group_contact.additional_attributes || {}).merge(
-      'group_last_synced_at' => Time.current.to_i,
-      'group_left' => false
-    )
+    new_attrs = (group_contact.additional_attributes || {}).merge('group_last_synced_at' => Time.current.to_i)
     group_contact.update!(additional_attributes: new_attrs) if new_attrs != group_contact.additional_attributes
   end
 

--- a/app/services/whatsapp/session/groups/syncer.rb
+++ b/app/services/whatsapp/session/groups/syncer.rb
@@ -55,9 +55,16 @@ class Whatsapp::Session::Groups::Syncer
 
   def inbox = channel.inbox
 
+  def group_contact_inbox = group_contact.contact_inboxes.find_by(inbox_id: inbox.id)
+
   def apply(info)
     return if info.blank?
 
+    # Only rejoining clears the left flag, and only an event that carries the group
+    # (`group.joined`) knows that happened. A scheduled sync can still read cached
+    # metadata for a group this inbox left, and clearing it there would put the group
+    # actions back in the dashboard for a thread that can no longer send anything.
+    group_contact_inbox&.mark_group_rejoined! if @info.present?
     update_contact(info)
     sync_members(info)
     update_avatar(info) unless soft
@@ -105,12 +112,7 @@ class Whatsapp::Session::Groups::Syncer
       'owner' => info.owner&.identifier || info.owner&.phone,
       'owner_pn' => info.owner&.phone,
       'invite_code' => info.invite_code.presence,
-      'group_last_synced_at' => Time.current.to_i,
-      # Only rejoining clears this, and only `group.joined` knows that happened. A
-      # scheduled sync can still read cached metadata for a group the session left, and
-      # clearing the flag there would put the group actions back in the dashboard for a
-      # thread that can no longer send anything.
-      'group_left' => (false if @info.present?)
+      'group_last_synced_at' => Time.current.to_i
     }.compact
     attributes['description'] = info.description.presence unless info.description.nil?
     attributes.merge(setting_attributes(info))

--- a/app/services/whatsapp/session/inbound/handlers/group_updated.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_updated.rb
@@ -113,17 +113,10 @@ class Whatsapp::Session::Inbound::Handlers::GroupUpdated < Whatsapp::Session::In
     return unless action == 'leave'
     return unless contacts.any? { |contact| session_owner?(contact) }
 
-    # ACCOUNT-WIDE, ON PURPOSE, FOR NOW (fazer-ai/chatwoot#374). The group contact is
-    # shared by every inbox of the account that is in this WhatsApp group, so this marks
-    # the group as left for all of them, and nothing on the inboxes that stayed will
-    # clear it. The flag lives here because that is where the Baileys layer writes it and
-    # where three dashboard components read it; scoping it per inbox means changing that
-    # contract in the frozen legacy layer too. Do not delete this note without closing
-    # the issue.
-    merge_attributes('group_left' => true)
-    # Only this inbox's threads, which the flag above cannot manage. Closing another
-    # number's conversations because *this* session left would end a thread it can
-    # still use.
+    @group_contact_inbox.mark_group_left!
+    # This inbox's threads only, for the same reason the flag above is this inbox's
+    # only. Closing another number's conversations because *this* session left would
+    # end a thread it can still use.
     # Snoozed as well: the snooze job reopens on its own schedule, and a thread reopened
     # for a group this inbox has left can no longer send anything.
     @group_contact_inbox.conversations.where(status: %i[open pending snoozed])

--- a/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
+++ b/app/views/api/v1/conversations/partials/_conversation.json.jbuilder
@@ -75,6 +75,12 @@ else
 end
 json.last_activity_at conversation.last_activity_at.to_i
 json.group_type conversation.group_type
+# Whether THIS thread's number has left the WhatsApp group. The group contact is
+# account-scoped and can be in two inboxes of one account, so the answer belongs to the
+# conversation rather than to the contact every thread shares. Only groups carry it:
+# `contact_inbox` is preloaded for the list, but the question is meaningless anywhere
+# else and an always-false field on every conversation is noise.
+json.group_left conversation.contact_inbox&.group_left? if conversation.group_type_group?
 json.priority conversation.priority
 json.waiting_since conversation.waiting_since.to_i.to_i
 sla_applicable = conversation.account.feature_enabled?('sla') && (!conversation.respond_to?(:sla_applicable?) || conversation.sla_applicable?)

--- a/db/migrate/20260822130000_add_group_left_at_to_contact_inboxes.rb
+++ b/db/migrate/20260822130000_add_group_left_at_to_contact_inboxes.rb
@@ -1,0 +1,5 @@
+class AddGroupLeftAtToContactInboxes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :contact_inboxes, :group_left_at, :datetime
+  end
+end

--- a/db/migrate/20260822130100_scope_whatsapp_group_left_per_inbox.rb
+++ b/db/migrate/20260822130100_scope_whatsapp_group_left_per_inbox.rb
@@ -1,0 +1,51 @@
+# `group_left` was one boolean on a contact every inbox in the group shares, so it could
+# only say "left", never "left where". It moves to the contact inbox, which is the row
+# the fact is actually about.
+#
+# The seed has to give an answer for a row written under the old rule, and the only
+# honest one is "all of them": that is what the boolean meant to every reader at the
+# time, so every existing group keeps rendering exactly as it does today. The single
+# inbox case, which is nearly all of them, is exact rather than merely unchanged.
+#
+# The old key is then removed, and the removal is what makes the transition safe to read:
+# after this runs, a truthy `group_left` on a contact can only have been written by a
+# worker from the previous release, which is the window `ContactInbox#group_left?` reads
+# it in.
+class ScopeWhatsappGroupLeftPerInbox < ActiveRecord::Migration[7.1]
+  GROUP_CONTACT = 1
+
+  def up
+    left = contact_class.where(group_type: GROUP_CONTACT).where("additional_attributes ->> 'group_left' = 'true'")
+    left.find_each do |contact|
+      contact_inbox_class.where(contact_id: contact.id).update_all(group_left_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      contact.update_column(:additional_attributes, contact.additional_attributes.except('group_left')) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  # Puts back what the boolean said, from the rows that now say it. "Left somewhere"
+  # collapses to "left", which is the only thing the old shape could express.
+  def down
+    contact_inbox_class.where.not(group_left_at: nil).distinct.pluck(:contact_id).each do |contact_id|
+      contact = contact_class.find_by(id: contact_id)
+      next if contact.nil?
+
+      contact.update_column(:additional_attributes, contact.additional_attributes.merge('group_left' => true)) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  private
+
+  def contact_class
+    @contact_class ||= Class.new(ActiveRecord::Base) do
+      self.table_name = 'contacts'
+      self.inheritance_column = :_type_disabled
+    end
+  end
+
+  def contact_inbox_class
+    @contact_inbox_class ||= Class.new(ActiveRecord::Base) do
+      self.table_name = 'contact_inboxes'
+      self.inheritance_column = :_type_disabled
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_17_210000) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_22_130100) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -783,6 +783,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_17_210000) do
     t.datetime "updated_at", null: false
     t.boolean "hmac_verified", default: false
     t.string "pubsub_token"
+    t.datetime "group_left_at"
     t.index ["contact_id"], name: "index_contact_inboxes_on_contact_id"
     t.index ["inbox_id", "source_id"], name: "index_contact_inboxes_on_inbox_id_and_source_id", unique: true
     t.index ["inbox_id"], name: "index_contact_inboxes_on_inbox_id"

--- a/spec/models/contact_inbox_group_left_spec.rb
+++ b/spec/models/contact_inbox_group_left_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+# A group contact is account-scoped, so one WhatsApp group can belong to two inboxes of
+# the same account. `group_left` used to be a boolean on that shared contact, and one
+# number leaving marked the group as left for every other number in it.
+# Not a class: what it describes is one column and the three methods around it, which
+# read very differently from the rest of ContactInbox.
+RSpec.describe 'the inbox a WhatsApp group was left from' do # rubocop:disable RSpec/DescribeClass
+  let(:account) { create(:account) }
+  let(:group) { create(:contact, account: account, group_type: :group, identifier: '120363041234567890@g.us') }
+  let!(:first) { create(:contact_inbox, contact: group, inbox: create(:inbox, account: account), source_id: '120363041234567890') }
+  let!(:second) { create(:contact_inbox, contact: group, inbox: create(:inbox, account: account), source_id: '120363041234567891') }
+
+  it 'leaves the inboxes that stayed in the group' do
+    first.mark_group_left!
+
+    expect(first.group_left?).to be(true)
+    expect(second.reload.group_left?).to be(false)
+  end
+
+  it 'clears it for the inbox that rejoined, and leaves the other one alone' do
+    first.mark_group_left!
+    second.mark_group_left!
+
+    first.mark_group_rejoined!
+
+    expect(first.group_left?).to be(false)
+    expect(second.reload.group_left?).to be(true)
+  end
+
+  it 'does not restamp an inbox that already left' do
+    first.mark_group_left!
+
+    expect { first.mark_group_left! }.not_to(change { first.reload.group_left_at })
+  end
+
+  # The migration that added the column deleted `group_left` from every contact, so a
+  # truthy one can only come from a worker of the release before it: the rolling deploy
+  # window, where a group left through the old code would otherwise read as still joined.
+  context 'with a contact a previous release wrote to' do
+    before { group.update!(additional_attributes: { 'group_left' => true }) }
+
+    it 'reads the old boolean while the column says nothing' do
+      expect(first.group_left?).to be(true)
+      expect(second.group_left?).to be(true)
+    end
+
+    it 'stops reading it once the inbox rejoins' do
+      first.mark_group_left!
+      first.mark_group_rejoined!
+
+      expect(first.group_left?).to be(false)
+      expect(second.reload.group_left?).to be(true)
+    end
+  end
+
+  describe 'Contact#group_left_in?' do
+    it 'answers for the inbox it is asked about' do
+      first.mark_group_left!
+
+      expect(group.group_left_in?(first.inbox_id)).to be(true)
+      expect(group.group_left_in?(second.inbox_id)).to be(false)
+      expect(group.group_left_in?(nil)).to be(false)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/groups/syncer_spec.rb
+++ b/spec/services/whatsapp/session/groups/syncer_spec.rb
@@ -79,15 +79,38 @@ RSpec.describe Whatsapp::Session::Groups::Syncer do
   context 'when the group was already left and the sync fetched its metadata' do
     subject(:fetched_sync) { described_class.new(channel: channel, group_contact: group_contact).perform }
 
-    let(:stored) { super().merge('group_left' => true) }
     let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
 
-    before { allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend) }
+    before do
+      group_contact.contact_inboxes.find_by(inbox: inbox).mark_group_left!
+      allow(Whatsapp::Session::Registry).to receive(:backend_for).and_return(backend)
+    end
 
     it 'keeps the group marked as left' do
       fetched_sync
 
-      expect(group_contact.reload.additional_attributes['group_left']).to be(true)
+      expect(group_contact.reload.group_left_in?(inbox.id)).to be(true)
+    end
+  end
+
+  # The snapshot comes from `group.joined`, which is the one event that knows the session
+  # is back in the group, and it clears the flag for that inbox alone.
+  context 'when the group was left and an event brought its metadata back' do
+    let(:other_inbox) do
+      create(:channel_whatsapp, account: channel.account, provider: 'native', phone_number: '+5541977776666',
+                                validate_provider_config: false, sync_templates: false).inbox
+    end
+
+    before do
+      create(:contact_inbox, inbox: other_inbox, contact: group_contact, source_id: '120363041234567890')
+      group_contact.contact_inboxes.each(&:mark_group_left!)
+    end
+
+    it 'rejoins this inbox and leaves the other one out of the group' do
+      sync
+
+      expect(group_contact.reload.group_left_in?(inbox.id)).to be(false)
+      expect(group_contact.group_left_in?(other_inbox.id)).to be(true)
     end
   end
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_updated_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
       expect(dispatch).to eq(:handled)
 
       group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
-      expect(group_contact.additional_attributes['group_left']).to be(true)
+      expect(group_contact.group_left_in?(inbox.id)).to be(true)
     end
   end
 
@@ -179,13 +179,13 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
       expect(dispatch).to eq(:handled)
 
       group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
-      expect(group_contact.additional_attributes['group_left']).to be(true)
+      expect(group_contact.group_left_in?(inbox.id)).to be(true)
     end
   end
 
   # The group contact is shared by every inbox of the account that is in the same
-  # WhatsApp group, so closing all of its threads would end a conversation another
-  # number can still use.
+  # WhatsApp group, so closing all of its threads, or marking the group left on the
+  # contact itself, would end a conversation another number can still use.
   context 'when another inbox of the account is in the same group' do
     let(:changes) { model::Events::GroupUpdated::Changes.new(leave: [model::Party.new(phone: '5541988887777')]) }
     let(:other_inbox) do
@@ -206,6 +206,19 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
       end
 
       expect(other_thread.reload.status).to eq('open')
+    end
+
+    it 'leaves the group only for the inbox that left it' do
+      dispatch
+      group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
+      create(:contact_inbox, inbox: other_inbox, contact: group_contact, source_id: '120363041234567890')
+
+      with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)
+      end
+
+      expect(group_contact.reload.group_left_in?(inbox.id)).to be(true)
+      expect(group_contact.group_left_in?(other_inbox.id)).to be(false)
     end
   end
 
@@ -251,7 +264,7 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupUpdated do
       expect(dispatch).to eq(:handled)
 
       group_contact = inbox.contacts.find_by(identifier: '120363041234567890@g.us')
-      expect(group_contact.additional_attributes['group_left']).to be(true)
+      expect(group_contact.group_left_in?(inbox.id)).to be(true)
       expect(group_contact.conversations.where(status: %i[open pending])).to be_empty
     end
   end


### PR DESCRIPTION
Quando a mesma conversa de grupo do WhatsApp existe em duas caixas de entrada da conta, uma delas sair do grupo marcava o grupo como abandonado para a outra também: o campo de resposta e as ações de grupo sumiam de uma conversa que ainda podia enviar, o sync parava de atualizar o grupo, e nada na caixa que ficou conseguia limpar a marca, porque só uma reentrada limpa e essa caixa nunca saiu.

Agora a marca é por caixa de entrada. Sair de um número não muda nada para o outro, e reentrar limpa só para quem reentrou.

## Closes

- Closes #374

## How to test

1. Com duas caixas WhatsApp na mesma conta, ambas no mesmo grupo, abra as duas conversas do grupo.
2. Saia do grupo pela caixa A.
3. A conversa de A perde o campo de resposta e as ações de grupo, como antes. A conversa de B continua inteira: envia mensagem, edita o grupo, sincroniza.
4. Reentre pela caixa A: as ações voltam para A, e B nunca foi afetada.

## What changed

O contato do grupo é da conta inteira (o identificador é o id do próprio grupo), e o `contact_inbox` é por caixa. `group_left` era um booleano no contato compartilhado; vira a coluna `group_left_at` no `contact_inbox`, que é a linha sobre a qual o fato realmente é.

Guardar a lista de caixas dentro do `additional_attributes` do contato foi a primeira tentativa e não se sustenta, por duas razões:

- Aquele documento tem outros sete escritores que fazem merge e salvam ele inteiro (o `Syncer`, as três persistências de settings/convite/sync-status do Baileys, os handlers de pedido de entrada). Uma saída gravada entre a leitura e a escrita de qualquer um deles é apagada, e nada percebe.
- O booleano derivado ("todas as caixas saíram") fica obsoleto assim que um `contact_inbox` é criado ou removido, e não há gancho que o recalcule.

Uma coluna não tem nenhum dos dois problemas.

- `ContactInbox#group_left?` / `mark_group_left!` / `mark_group_rejoined!`, e `Contact#group_left_in?(inbox_id)` para quem só tem o contato e um id de caixa.
- Escritores atualizados: `whatsapp_baileys_service.rb` (early return do `sync_group`, e `persist_sync_status` deixa de limpar a marca), `group_stub_message_handler.rb`, `group_participants_update.rb`, `Session::Groups::Syncer`, `Session::Inbound::Handlers::GroupUpdated`.
- O dashboard lê `group_left` da **conversa**, não do contato: a resposta é do número daquela thread. O campo entra no partial da conversa e no `push_data`, só para grupos.
- Migração de dados: cada grupo já marcado carimba `group_left_at` em todos os `contact_inboxes` dele, que é o que o booleano dizia para todo leitor na época, e a chave antiga sai do contato. Um `group_left` verdadeiro que sobre só pode ter vindo de um worker da release anterior, então `ContactInbox#group_left?` ainda o lê durante a janela do deploy, e a primeira escrita nova converte a linha e descarta a chave.

Mexe na camada Baileys congelada em três arquivos, que é o que o próprio #374 diz ser necessário e o motivo de ter ficado fora do #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/398)
<!-- Reviewable:end -->
