### PR TITLE
chore: drop the duplicated group_left_at annotation

### DIFF
--- a/app/models/contact_inbox.rb
+++ b/app/models/contact_inbox.rb
@@ -4,7 +4,6 @@
 #
 #  id            :bigint           not null, primary key
 #  group_left_at :datetime
-#  group_left_at :datetime
 #  hmac_verified :boolean          default(FALSE)
 #  pubsub_token  :string
 #  created_at    :datetime         not null


### PR DESCRIPTION
A comment-only fix: the `group_left_at` column line in `ContactInbox`'s schema annotation was written by hand and then again by `annotate`, and both landed in #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/399)
<!-- Reviewable:end -->
