### PR TITLE
fix(whatsapp): let a removed reaction reach the channel

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -25,14 +25,6 @@ app/services/whatsapp/session/inbound/dispatcher.rb: Deduplicate events before i
 # field the snapshot did not mention. Fixing it is a contract change, decided with the
 # payloads captured in the Uazapi slice. Removing this waiver does not close the issue.
 app/services/whatsapp/session/groups/syncer.rb: Remove avatars absent from rejoin snapshots  # PR#372
-# PR#377: real, tracked in fazer-ai/chatwoot#378, and not this stack's to fix. Removing a
-# reaction never reaches any provider, legacy included: the reactions controller marks the
-# reused row deleted and Base::SendOnChannelService refuses to send a deleted message. The
-# guard is ours, from #353, and it is shared by every channel, so the fix goes to main
-# rather than to a branch that merges in weeks. Removing this waiver does not close the issue.
-app/services/whatsapp/session/outbound/message_sender.rb: Allow deleted reaction rows to send removals  # PR#377
-# Same defect under the reviewer's other name for it.
-app/services/whatsapp/session/outbound/message_sender.rb: Allow removed reactions to reach the sender  # PR#377
 # PR#377: not a defect. A reaction stored with only `in_reply_to_external_id` gets its
 # `in_reply_to` filled in by Message's own `before_save :ensure_in_reply_to`, which runs
 # InReplyToMessageBuilder and resolves the target by source_id within the conversation. The

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -260,6 +260,16 @@ class Message < ApplicationRecord
     ActiveModel::Type::Boolean.new.cast(content_attributes['deleted']) == true
   end
 
+  # A removed reaction is a deleted row on purpose. WhatsApp allows one reaction per
+  # (message, sender), so Chatwoot reuses the row and marks it deleted rather than
+  # accumulating one per toggle, and the empty content it then carries is exactly the
+  # payload that clears the reaction on the contact's phone. Every guard that keeps a
+  # deleted message off the channel has to let this one through, or the emoji disappears
+  # in Chatwoot and stays on the contact's phone forever.
+  def removed_reaction?
+    deleted? && content_attributes['is_reaction'].present?
+  end
+
   # `content_attributes` is a single JSON column, so writing any of its store accessors from a stale
   # object rewrites the whole hash and drops flags another request set in the meantime — e.g. `deleted`,
   # written by the DELETE endpoint while an outgoing message was still in flight on the provider.

--- a/app/services/base/send_on_channel_service.rb
+++ b/app/services/base/send_on_channel_service.rb
@@ -48,8 +48,10 @@ class Base::SendOnChannelService
     # we should also avoid the case of message loops, when outgoing messages are created from channel
     # voice_call bubbles are call status indicators, not deliverable messages
     # a message deleted before the job got to run must not reach the contact — its content is already
-    # the "deleted" placeholder and its attachments are gone, so sending it would leak the placeholder
-    message.private? || outgoing_message_originated_from_channel? || message.content_type == 'voice_call' || message.deleted?
+    # the "deleted" placeholder and its attachments are gone, so sending it would leak the placeholder.
+    # A removed reaction is the exception: see Message#removed_reaction?
+    message.private? || outgoing_message_originated_from_channel? || message.content_type == 'voice_call' ||
+      (message.deleted? && !message.removed_reaction?)
   end
 
   def validate_target_channel

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -138,7 +138,8 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
   # Reads the flag straight from the database: a full `message.reload` would also drop the cached
   # conversation/inbox/channel chain this service leans on.
   def deleted_in_database?
-    Message.select(:id, :content_attributes).find_by(id: message.id)&.deleted?
+    stored = Message.select(:id, :content_attributes).find_by(id: message.id)
+    stored.present? && stored.deleted? && !stored.removed_reaction?
   end
 
   def recipient_id

--- a/app/services/whatsapp/session/outbound/source_id_reservation.rb
+++ b/app/services/whatsapp/session/outbound/source_id_reservation.rb
@@ -70,8 +70,13 @@ module Whatsapp::Session::Outbound::SourceIdReservation
 
     assigned_here = message.source_id.blank? && attributes[:source_id].present?
     message.update!(attributes.merge(assigned_here ? send_confirmation(message) : {}))
-    assigned_here && message.deleted? ? :revoke : :written
+    assigned_here && revoked?(message) ? :revoke : :written
   end
+
+  # A removed reaction is deleted from the start, and the empty emoji just sent is what
+  # clears it. Revoking on top of that would ask the provider to delete the reaction
+  # message itself, which is a different thing and one the contact never saw.
+  def revoked?(message) = message.deleted? && !message.removed_reaction?
 
   # Filling source_id is proof the message exists on WhatsApp, so it also retires a
   # failure recorded while it did not. StatusTransition.fail_send only ever writes one

--- a/spec/services/whatsapp/reaction_removal_spec.rb
+++ b/spec/services/whatsapp/reaction_removal_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+# Regression: removing a reaction never reached WhatsApp. Chatwoot models "one reaction
+# per (message, sender)" by reusing the row and marking it deleted, and the guard that
+# keeps a deleted message off the channel (#353) could not tell the two apart: the emoji
+# disappeared from the dashboard and stayed on the contact's phone forever.
+RSpec.describe 'WhatsApp reaction removal', type: :request do
+  let(:account) { create(:account) }
+  let(:agent) { create(:user, account: account, role: :administrator) }
+  let(:channel) { create(:channel_whatsapp, provider: 'baileys', account: account, validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:contact) { create(:contact, account: account, phone_number: '+551187654321', identifier: nil) }
+  let(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '551187654321') }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  let(:send_url) { "#{channel.provider_config['provider_url']}/connections/#{channel.phone_number}/send-message" }
+  let!(:send_stub) do
+    stub_request(:post, send_url).to_return(
+      status: 200,
+      body: { data: { key: { id: 'wa_reaction_1' }, messageTimestamp: 1_700_000_000 } }.to_json,
+      headers: { 'content-type' => 'application/json' }
+    )
+  end
+
+  let!(:target) do
+    create(:message, message_type: :incoming, content: 'oi', conversation: conversation,
+                     account: account, inbox: inbox, source_id: 'wa_target_1')
+  end
+
+  before { create(:inbox_member, inbox: inbox, user: agent) }
+
+  def toggle_reaction(emoji)
+    post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/messages/#{target.id}/reactions",
+         params: { emoji: emoji }, headers: agent.create_new_auth_token, as: :json
+    expect(response).to have_http_status(:success)
+    # Only the send: the surrounding jobs include avatar fetches, which would go to the
+    # network for something this spec is not about.
+    perform_enqueued_jobs(only: SendReplyJob)
+  end
+
+  def reaction_sent_with(emoji)
+    a_request(:post, send_url).with { |request| JSON.parse(request.body).dig('messageContent', 'react', 'text') == emoji }
+  end
+
+  it 'sends the empty emoji that clears the reaction on the phone' do
+    toggle_reaction('👍')
+    toggle_reaction('👍')
+
+    expect(send_stub).to have_been_requested.twice
+    expect(reaction_sent_with('👍')).to have_been_made
+    expect(reaction_sent_with('')).to have_been_made
+  end
+
+  it 'leaves the reaction row deleted, which is how the dashboard hides it' do
+    toggle_reaction('👍')
+    toggle_reaction('👍')
+
+    reaction = conversation.reload.messages.detect { |message| message.content_attributes['is_reaction'] }
+    expect(reaction).to be_deleted
+    expect(reaction).to be_removed_reaction
+  end
+
+  # The row was deleted from the start, and the empty emoji is what clears the reaction.
+  # Revoking on top of it would ask the provider to delete the reaction message itself.
+  it 'does not also revoke the reaction message' do
+    toggle_reaction('👍')
+    toggle_reaction('👍')
+
+    expect(Messages::DeleteOnChannelJob).not_to have_been_enqueued
+  end
+
+  # A message the agent deleted still must not reach the contact: the guard this change
+  # narrows is the one that stops the "deleted" placeholder from being delivered.
+  it 'still keeps a deleted message off the channel' do
+    message = create(:message, message_type: :outgoing, content: 'segredo', conversation: conversation,
+                               account: account, inbox: inbox, source_id: nil)
+    message.update!(content_attributes: message.content_attributes.merge('deleted' => true))
+
+    SendReplyJob.perform_now(message.id)
+
+    expect(send_stub).not_to have_been_requested
+  end
+end


### PR DESCRIPTION
Remover uma reação não fazia nada no WhatsApp. O emoji sumia da bolha no Chatwoot, o agente via como removido, e ele continuava no celular do contato para sempre. Adicionar e trocar funcionavam; só a remoção se perdia.

Vale para todo provedor de WhatsApp (baileys em produção hoje, cloud, zapi e os provedores de sessão novos), porque a falha estava em código compartilhado, não no serviço de um provedor.

## Closes

- Closes #378

## How to reproduce

1. Reaja a qualquer mensagem de WhatsApp pelo dashboard.
2. Confirme que o emoji chegou no celular do contato.
3. Remova a reação (clique no mesmo emoji de novo).
4. Antes: sumia no Chatwoot e continuava no celular. Agora: some nos dois.

## What changed

O Chatwoot modela "uma reação por (mensagem, remetente)" reaproveitando a mesma linha de `messages`: trocar o emoji atualiza a linha, remover grava `content: ''` e `deleted: true`, e reagir de novo ressuscita a mesma linha. Isso mantém o histórico limpo em vez de acumular uma mensagem por toque.

O problema é que três guardas que impedem uma mensagem apagada de chegar no canal não conseguiam distinguir as duas coisas. A guarda veio do #353 e está certa para mensagens: uma que o agente apagou já tem o texto de placeholder no lugar do conteúdo, e mandar isso vazaria o placeholder pro contato. Só que para a linha de uma reação removida, o conteúdo vazio **é** o payload que limpa a reação no celular.

`Message#removed_reaction?` distingue as duas, e as três guardas passam a usá-la:

- `Base::SendOnChannelService#invalid_message?`, que é onde o envio morria para todos os canais.
- `SendOnWhatsappService#deleted_in_database?`, a re-checagem depois da fila do lock do canal no baileys.
- `Session::Outbound::SourceIdReservation`, que devolvia `:revoke` para a linha e enfileirava um `DeleteOnChannelJob` — ou seja, pediria pro provedor apagar a mensagem de reação em si, que é outra coisa e que o contato nunca viu.

Duas dispensas obsoletas saem do `.codex-review-waived`: as do #378, que apontavam para esta correção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/400)
<!-- Reviewable:end -->
