### PR TITLE
fix(whatsapp): deliver every file the new-conversation composer attached

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -91,12 +91,3 @@ app/jobs/webhooks/whatsapp_session_events_job.rb: Preserve order for dependent w
 # the layer does ship, because from then on a signature change to a queued job does have
 # to survive a rolling deploy.
 app/jobs/whatsapp/session/pairing_poll_job.rb: Preserve compatibility with queued pairing polls  # PR#380
-
-# Pre-existing and tracked as #385, not caused by this change. Collapsing the two
-# provider booleans into one session flag widened who sees the compose modal's attach
-# button, but the button was already there for Baileys and Z-API, and every WhatsApp
-# sender has always taken `attachments.first` because WhatsApp has no multi-media
-# message. The reply box splits into one message per attachment (the #277 fix); the
-# new-conversation composer never did. Fixing it means touching a helper shared with
-# email and the web widget, where one message carrying several files is correct.
-app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue: Split multiple session attachments before sending  # PR#383

--- a/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/ComposeConversation.vue
@@ -232,12 +232,38 @@ const createGroup = async ({ inboxId, subject, participants }) => {
   }
 };
 
-const createConversation = async ({ payload, isFromWhatsApp }) => {
+// The conversation carries the first attachment; anything else the agent picked follows
+// it as its own message. Only channels that cannot carry more than one per message get
+// here with a non-empty list — see splitAttachmentsForChannel.
+// Chained rather than fired together, so the attachments arrive in the order they were
+// picked: WhatsApp orders by arrival, and a Promise.all reorders them for the contact.
+const sendFollowUpFiles = (conversationId, followUpFiles) =>
+  followUpFiles.reduce(
+    (previous, file) =>
+      previous.then(() =>
+        store.dispatch('createPendingMessageAndSend', {
+          conversationId,
+          files: [
+            directUploadsEnabled.value ? file.blobSignedId : file.resource.file,
+          ],
+          message: '',
+          private: false,
+        })
+      ),
+    Promise.resolve()
+  );
+
+const createConversation = async ({
+  payload,
+  followUpFiles = [],
+  isFromWhatsApp,
+}) => {
   try {
     const data = await store.dispatch('contactConversations/create', {
       params: payload,
       isFromWhatsApp,
     });
+    if (followUpFiles.length) await sendFollowUpFiles(data.id, followUpFiles);
     const action = {
       type: 'link',
       to: `/app/accounts/${data.account_id}/conversations/${data.id}`,

--- a/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ComposeNewConversationForm.vue
@@ -12,6 +12,7 @@ import {
   buildContactableInboxesList,
   prepareNewMessagePayload,
   prepareWhatsAppMessagePayload,
+  splitAttachmentsForChannel,
 } from 'dashboard/components-next/NewConversation/helpers/composeConversationHelper.js';
 
 import { useCopilotReply } from 'dashboard/composables/useCopilotReply';
@@ -138,9 +139,17 @@ const validationStates = computed(() => ({
   isMessageInvalid: v$.value.message.$dirty && v$.value.message.$invalid,
 }));
 
+// On a channel that carries one attachment per message, only the first file travels
+// with the conversation; the rest follow it as their own messages, which is what the
+// reply box already does. Without the split every file shows in Chatwoot and one
+// reaches the contact.
 const newMessagePayload = () => {
   const { message, subject, ccEmails, bccEmails, attachedFiles } = state;
-  return prepareNewMessagePayload({
+  const { first, rest } = splitAttachmentsForChannel({
+    targetInbox: props.targetInbox,
+    attachedFiles,
+  });
+  const payload = prepareNewMessagePayload({
     targetInbox: props.targetInbox,
     selectedContact: props.selectedContact,
     message,
@@ -148,12 +157,13 @@ const newMessagePayload = () => {
     ccEmails,
     bccEmails,
     currentUser: props.currentUser,
-    attachedFiles,
+    attachedFiles: first,
     directUploadsEnabled: props.isDirectUploadsEnabled,
     sendWithSignature: props.sendWithSignature,
     messageSignature: props.messageSignature,
     signatureSettings: props.signatureSettings,
   });
+  return { payload, followUpFiles: rest };
 };
 
 const contactableInboxesList = computed(() => {
@@ -277,8 +287,10 @@ const handleSendMessage = async () => {
   if (!isValid) return;
 
   try {
+    const { payload, followUpFiles } = newMessagePayload();
     const success = await emit('createConversation', {
-      payload: newMessagePayload(),
+      payload,
+      followUpFiles,
       isFromWhatsApp: false,
     });
     if (success) {

--- a/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
+++ b/app/javascript/dashboard/components-next/NewConversation/helpers/composeConversationHelper.js
@@ -175,6 +175,44 @@ export const prepareNewMessagePayload = ({
   return payload;
 };
 
+/**
+ * Whether this inbox's channel carries one attachment per message.
+ *
+ * WhatsApp has no multi-media message, so every sender takes `attachments.first`
+ * (`WhatsappBaileysService#attachment_message_content` and
+ * `Whatsapp::Session::Outbound::MessageSender#attachment_content` alike). A payload with
+ * three files therefore shows three in Chatwoot and delivers one, with nothing telling
+ * the agent. The reply box already splits for this reason (#277).
+ *
+ * @param {{channelType?: string}|null|undefined} targetInbox
+ * @returns {boolean}
+ */
+export const carriesOneAttachmentPerMessage = targetInbox =>
+  targetInbox?.channelType === INBOX_TYPES.WHATSAPP;
+
+/**
+ * Splits the attached files into the one that travels with the new conversation and the
+ * ones that have to follow it as their own messages.
+ *
+ * Only for the channels that need it: on email and the web widget one message carrying
+ * several files is correct, and splitting there would turn one email into three.
+ *
+ * @param {{targetInbox: Object, attachedFiles: Array}} params
+ * @returns {{first: Array, rest: Array}}
+ */
+export const splitAttachmentsForChannel = ({
+  targetInbox,
+  attachedFiles = [],
+}) => {
+  if (
+    !carriesOneAttachmentPerMessage(targetInbox) ||
+    attachedFiles.length < 2
+  ) {
+    return { first: attachedFiles, rest: [] };
+  }
+  return { first: attachedFiles.slice(0, 1), rest: attachedFiles.slice(1) };
+};
+
 export const prepareWhatsAppMessagePayload = ({
   targetInbox,
   selectedContact,

--- a/app/javascript/dashboard/components-next/NewConversation/helpers/specs/composeConversationHelper.spec.js
+++ b/app/javascript/dashboard/components-next/NewConversation/helpers/specs/composeConversationHelper.spec.js
@@ -326,6 +326,56 @@ describe('composeConversationHelper', () => {
     });
   });
 
+  // WhatsApp has no multi-media message: every sender takes `attachments.first`, so a
+  // payload with three files showed three in Chatwoot and delivered one, with nothing
+  // telling the agent.
+  describe('splitAttachmentsForChannel', () => {
+    const files = [
+      { blobSignedId: 'a' },
+      { blobSignedId: 'b' },
+      { blobSignedId: 'c' },
+    ];
+
+    it('keeps one file with the conversation and sends the rest after it', () => {
+      const result = helpers.splitAttachmentsForChannel({
+        targetInbox: { channelType: 'Channel::Whatsapp' },
+        attachedFiles: files,
+      });
+
+      expect(result.first).toEqual([files[0]]);
+      expect(result.rest).toEqual([files[1], files[2]]);
+    });
+
+    it('leaves a single file alone', () => {
+      const result = helpers.splitAttachmentsForChannel({
+        targetInbox: { channelType: 'Channel::Whatsapp' },
+        attachedFiles: [files[0]],
+      });
+
+      expect(result).toEqual({ first: [files[0]], rest: [] });
+    });
+
+    // One email carrying three files is correct, and splitting there would turn it into
+    // three emails.
+    it('does not split for a channel that carries several', () => {
+      const result = helpers.splitAttachmentsForChannel({
+        targetInbox: { channelType: 'Channel::Email' },
+        attachedFiles: files,
+      });
+
+      expect(result).toEqual({ first: files, rest: [] });
+    });
+
+    it('handles an inbox that is not selected yet', () => {
+      expect(helpers.splitAttachmentsForChannel({ targetInbox: null })).toEqual(
+        {
+          first: [],
+          rest: [],
+        }
+      );
+    });
+  });
+
   describe('prepareWhatsAppMessagePayload', () => {
     it('prepares whatsapp message payload', () => {
       const params = {


### PR DESCRIPTION
Anexar mais de um arquivo ao iniciar uma conversa mostrava todos no Chatwoot e entregava só o primeiro para o contato. O agente não tinha como perceber: a thread mostrava o que ele tinha anexado.

## Closes

- Closes #385

## How to reproduce

1. Numa caixa de entrada de WhatsApp, abra o compositor de nova conversa.
2. Anexe dois ou mais arquivos e envie.
3. Antes: o Chatwoot mostrava uma mensagem com todos os arquivos e o celular do contato recebia só o primeiro. Agora: chegam todos, na ordem em que foram escolhidos.

## What changed

O WhatsApp não tem mensagem com várias mídias, então todo sender pega `attachments.first` (`WhatsappBaileysService#attachment_message_content` e `Whatsapp::Session::Outbound::MessageSender#attachment_content` igualmente). A caixa de resposta já resolvia isso montando uma mensagem por anexo (o #277); o compositor de nova conversa nunca ganhou o mesmo tratamento.

A divisão é condicional ao canal, porque `prepareNewMessagePayload` é compartilhado com e-mail e o widget, onde uma mensagem com vários arquivos é o certo e dividir viraria três e-mails:

- `splitAttachmentsForChannel` separa o arquivo que viaja com a conversa dos que precisam segui-la como mensagens próprias, e só faz isso para o canal que precisa.
- `ComposeConversation.vue` envia os restantes encadeados, não em paralelo: o WhatsApp ordena por chegada, e disparar juntos reordenaria os anexos para o contato.

Uma dispensa obsoleta sai do `.codex-review-waived`: a do #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/401)
<!-- Reviewable:end -->
