### PR TITLE
fix(avatar): stop a queued download from restoring a picture that was removed

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -6,12 +6,6 @@ app/javascript/dashboard/components/widgets/conversation/MoreActions.vue: Hide p
 app/javascript/dashboard/helper/actionCable.js: Refresh cached permissions before applying this gate  # PR#367
 app/javascript/dashboard/helper/actionCable.js: Align bot assignments with frontend list visibility  # PR#367
 app/javascript/dashboard/helper/actionCable.js: Upsert conversations when assignment grants access  # PR#367
-# PR#372: real, tracked in fazer-ai/chatwoot#375, and not specific to this layer. The
-# window belongs to `Avatar::AvatarFromUrlJob`, which is handed a URL with no notion of
-# how fresh it is; the Baileys avatar paths have the same one. Closing it means giving
-# that shared job a freshness check, which is its own change. Removing this waiver does
-# not close the issue.
-app/jobs/whatsapp/session/update_contact_avatar_job.rb: Prevent stale avatar jobs from restoring removed photos  # PR#372
 # PR#372: the redelivery half of fazer-ai/chatwoot#373, still deliberately not answered.
 # Slice 6 settled the ordering half and left this one open: nothing claims an event id
 # before a handler runs, so a webhook the provider redelivers (a timeout on our 200, a

--- a/app/jobs/avatar/avatar_from_url_job.rb
+++ b/app/jobs/avatar/avatar_from_url_job.rb
@@ -15,8 +15,12 @@ class Avatar::AvatarFromUrlJob < ApplicationJob
   MAX_DOWNLOAD_SIZE = 15.megabytes
   RATE_LIMIT_WINDOW = 1.minute
 
-  def perform(avatarable, avatar_url)
+  # `resolved_at` is when the caller obtained the URL. Without it the job cannot tell a
+  # picture that was removed while it waited in the queue from one that was never there,
+  # and it puts the deleted photo back until the next picture event.
+  def perform(avatarable, avatar_url, resolved_at: nil)
     return unless syncable_avatar?(avatarable, avatar_url)
+    return if superseded?(avatarable, resolved_at)
 
     fetch_and_attach_avatar(avatarable, avatar_url)
   rescue SafeFetch::HttpError => e
@@ -28,6 +32,18 @@ class Avatar::AvatarFromUrlJob < ApplicationJob
   end
 
   private
+
+  # A removal recorded after the URL was resolved makes that URL a picture the contact
+  # has already taken down. Only Contacts carry the marker, which is where this job
+  # keeps its other two; a caller that does not date its URL keeps the old behaviour.
+  def superseded?(avatarable, resolved_at)
+    return false if resolved_at.blank? || !avatarable.is_a?(Contact)
+
+    removed_at = (avatarable.additional_attributes || {})[Whatsapp::Session::AvatarSync::REMOVED_AT]
+    return false if removed_at.blank?
+
+    Time.zone.parse(removed_at) > Time.zone.parse(resolved_at)
+  end
 
   def syncable_avatar?(avatarable, avatar_url)
     avatarable.respond_to?(:avatar) &&

--- a/app/jobs/whatsapp/session/update_contact_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_contact_avatar_job.rb
@@ -25,13 +25,10 @@ class Whatsapp::Session::UpdateContactAvatarJob < ApplicationJob
     url = channel.session_backend.profile_picture_url(
       Whatsapp::Session::Model::Commands::ContactProfilePicture.new(party: address)
     )
-    # RACE, TRACKED (fazer-ai/chatwoot#375). A picture-removed event that purges the
-    # avatar after this is queued does not stop it: the download lands afterwards and
-    # puts the deleted picture back until the next picture event. The freshness check
-    # belongs in `Avatar::AvatarFromUrlJob`, which is shared well outside WhatsApp and
-    # has the same window on the Baileys paths. Do not delete this note without closing
-    # the issue.
-    ::Avatar::AvatarFromUrlJob.perform_later(contact, url) if url.present?
+    # Dated, so a picture-removed event landing between this lookup and the download
+    # wins: `Avatar::AvatarFromUrlJob` compares the two and drops a URL the contact has
+    # already taken down.
+    ::Avatar::AvatarFromUrlJob.perform_later(contact, url, resolved_at: Time.current.iso8601) if url.present?
   rescue Whatsapp::Session::Errors::ProviderUnavailable, Whatsapp::Session::Errors::RateLimited
     # Raised on so the `retry_on` above can see it: a rescue in this method catches the
     # error first, and the retry declaration never runs.

--- a/app/jobs/whatsapp/session/update_group_avatar_job.rb
+++ b/app/jobs/whatsapp/session/update_group_avatar_job.rb
@@ -23,7 +23,7 @@ class Whatsapp::Session::UpdateGroupAvatarJob < ApplicationJob
 
     return Whatsapp::Session::AvatarSync.refetch(group_contact, info.picture_url) if force
 
-    ::Avatar::AvatarFromUrlJob.perform_later(group_contact, info.picture_url)
+    ::Avatar::AvatarFromUrlJob.perform_later(group_contact, info.picture_url, resolved_at: Time.current.iso8601)
   end
 
   private

--- a/app/services/whatsapp/session/avatar_sync.rb
+++ b/app/services/whatsapp/session/avatar_sync.rb
@@ -8,6 +8,7 @@
 # refresh, and the group rejoin snapshot.
 module Whatsapp::Session::AvatarSync
   MARKERS = %w[last_avatar_sync_at avatar_url_hash].freeze
+  REMOVED_AT = 'avatar_removed_at'.freeze
 
   module_function
 
@@ -31,6 +32,24 @@ module Whatsapp::Session::AvatarSync
     return if contact.blank? || url.blank?
 
     reset(contact)
-    ::Avatar::AvatarFromUrlJob.perform_later(contact, url)
+    ::Avatar::AvatarFromUrlJob.perform_later(contact, url, resolved_at: Time.current.iso8601)
+  end
+
+  # Drops the picture and records when, so a download already queued for the picture
+  # that was just removed does not put it back.
+  #
+  # `Avatar::AvatarFromUrlJob` is handed a URL with no notion of how fresh it is, and a
+  # removal that lands between the URL being resolved and the job running cannot be seen
+  # from inside it: an avatarable with nothing attached is both "just purged" and "never
+  # had one", which is the case the job exists to fill. The timestamp is what separates
+  # them, and the job compares it against the moment its URL was resolved.
+  def remove(contact)
+    return if contact.blank?
+
+    contact.avatar.purge if contact.avatar.attached?
+    contact.with_lock do
+      attributes = (contact.additional_attributes || {}).except(*MARKERS).merge(REMOVED_AT => Time.current.iso8601)
+      contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
+    end
   end
 end

--- a/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/contact_picture_changed.rb
@@ -14,7 +14,7 @@ class Whatsapp::Session::Inbound::Handlers::ContactPictureChanged < Whatsapp::Se
   private
 
   def remove_avatar(contact)
-    contact.avatar.purge if contact.avatar.attached?
+    Whatsapp::Session::AvatarSync.remove(contact)
   end
 
   # The stored avatar stays until its replacement is attached, and the two sync markers

--- a/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
@@ -23,6 +23,6 @@ class Whatsapp::Session::Inbound::Handlers::GroupPictureChanged < Whatsapp::Sess
   def refresh_avatar(group_contact)
     return Whatsapp::Session::UpdateGroupAvatarJob.perform_later(group_contact, force: true, channel: channel) unless payload.removed
 
-    group_contact.avatar.purge if group_contact.avatar.attached?
+    Whatsapp::Session::AvatarSync.remove(group_contact)
   end
 end

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -14,6 +14,48 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       .to have_enqueued_job(described_class).on_queue('purgable')
   end
 
+  # A picture removed between the URL being resolved and this job running cannot be seen
+  # from inside it: an avatarable with nothing attached is both "just purged" and "never
+  # had one", and filling the second is the job's whole purpose. The date the caller
+  # stamps is what separates them.
+  context 'when the picture was removed while the job waited' do
+    let(:avatarable) { create(:contact) }
+
+    before do
+      stub_request(:get, valid_url).to_return(
+        status: 200,
+        body: File.read(Rails.root.join('spec/assets/avatar.png')),
+        headers: { 'Content-Type' => 'image/png' }
+      )
+    end
+
+    it 'does not put the removed picture back' do
+      resolved_at = 1.minute.ago.iso8601
+      Whatsapp::Session::AvatarSync.remove(avatarable)
+
+      described_class.perform_now(avatarable, valid_url, resolved_at: resolved_at)
+
+      expect(avatarable.reload.avatar).not_to be_attached
+    end
+
+    it 'attaches a picture resolved after the removal' do
+      Whatsapp::Session::AvatarSync.remove(avatarable)
+
+      described_class.perform_now(avatarable, valid_url, resolved_at: 1.minute.from_now.iso8601)
+
+      expect(avatarable.reload.avatar).to be_attached
+    end
+
+    # Every caller that does not date its URL keeps the behaviour it had.
+    it 'attaches when the caller did not date the url' do
+      Whatsapp::Session::AvatarSync.remove(avatarable)
+
+      described_class.perform_now(avatarable, valid_url)
+
+      expect(avatarable.reload.avatar).to be_attached
+    end
+  end
+
   context 'with rate-limited avatarable (Contact)' do
     let(:avatarable) { create(:contact) }
 

--- a/spec/jobs/whatsapp/session/update_contact_avatar_job_spec.rb
+++ b/spec/jobs/whatsapp/session/update_contact_avatar_job_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Whatsapp::Session::UpdateContactAvatarJob do
     command = backend.commands_of('contact.profile_picture').first
     expect(command.party).to be_a(model::Address)
     expect(command.party.id).to eq('182736451928374')
-    expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(contact, %r{/avatars/182736451928374\.jpg})
+    expect(Avatar::AvatarFromUrlJob).to have_been_enqueued
+      .with(contact, %r{/avatars/182736451928374\.jpg}, resolved_at: be_present)
   end
 
   # `retry_on` only sees what escapes `perform`, and a rescue in the method catches the

--- a/spec/jobs/whatsapp/session/update_group_avatar_job_spec.rb
+++ b/spec/jobs/whatsapp/session/update_group_avatar_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Whatsapp::Session::UpdateGroupAvatarJob do
   it 'asks for the picture of a group that has none' do
     described_class.perform_now(group_contact, channel: channel)
 
-    expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(group_contact, info.picture_url)
+    expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(group_contact, info.picture_url, resolved_at: be_present)
   end
 
   it 'leaves an attached avatar alone when the refresh is not forced' do

--- a/spec/services/whatsapp/session/inbound/handlers/group_joined_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_joined_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupJoined do
     it 'asks for the picture the snapshot reports' do
       dispatch
 
-      expect(Avatar::AvatarFromUrlJob).to have_been_enqueued.with(anything, 'https://connector.test/new.jpg')
+      expect(Avatar::AvatarFromUrlJob).to have_been_enqueued
+        .with(anything, 'https://connector.test/new.jpg', resolved_at: be_present)
     end
 
     it 'clears the markers that would suppress the download' do


### PR DESCRIPTION
Quando um contato (ou um grupo) tira a foto de perfil logo depois de trocá-la, a foto antiga podia voltar: o download já estava na fila com a URL antiga, e rodava depois da remoção. O contato ficava mostrando uma imagem que já tinha apagado até o próximo evento de foto.

## Closes

- Closes #375

## What changed

`Avatar::AvatarFromUrlJob` recebia uma URL sem nenhuma noção de quão fresca ela era, e de dentro dele a remoção é invisível: um avatarable sem nada anexado é ao mesmo tempo "acabou de ser apagado" e "nunca teve", e preencher o segundo caso é a razão de o job existir.

- O job aceita `resolved_at`, o momento em que quem enfileirou obteve a URL, e desiste quando uma remoção foi registrada depois disso. Quem não datar a URL mantém o comportamento que tinha.
- `Whatsapp::Session::AvatarSync.remove` faz a remoção e grava esse momento, junto da limpeza dos dois marcadores que o job já mantinha ali. Os dois handlers de foto removida (contato e grupo) passam por ele.
- Os dois jobs de avatar da camada de sessão datam a URL que acabaram de resolver.

A janela também existe nos caminhos do Baileys, que continuam sem datar a URL: para eles nada muda, que é o motivo de a checagem ser opcional em vez de obrigatória.

Uma dispensa obsoleta sai do `.codex-review-waived`: a do #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/402)
<!-- Reviewable:end -->
