### PR TITLE
fix(conversations): count a bot-held conversation the way the server does

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/getters.js
+++ b/app/javascript/dashboard/store/modules/conversations/getters.js
@@ -1,5 +1,10 @@
 import { MESSAGE_TYPE } from 'shared/constants/messages';
-import { applyPageFilters, applyRoleFilter, sortComparator } from './helpers';
+import {
+  applyPageFilters,
+  applyRoleFilter,
+  humanAssignee,
+  sortComparator,
+} from './helpers';
 import filterQueryGenerator from 'dashboard/helper/filterQueryGenerator';
 import { matchesFilters } from './helpers/filterHelpers';
 import {
@@ -100,7 +105,10 @@ const getters = {
     const currentUserID = rootGetters.getCurrentUser?.id;
 
     const chats = _state.allConversations.filter(conversation => {
-      const { assignee } = conversation.meta;
+      // The human, not whoever holds it: an agent bot's id comes from its own table and
+      // can be the same integer as an agent's, which would put a bot's conversation in
+      // that agent's "Mine".
+      const assignee = humanAssignee(conversation);
       const isAssignedToMe = assignee && assignee.id === currentUserID;
       const shouldFilter = applyPageFilters(conversation, activeFilters);
       const isChatMine = isAssignedToMe && shouldFilter;
@@ -123,7 +131,11 @@ const getters = {
   },
   getUnAssignedChats: (_state, _, __, rootGetters) => activeFilters => {
     const chats = _state.allConversations.filter(conversation => {
-      const isUnAssigned = !conversation.meta.assignee;
+      // A human assignee, not any assignee: handing a conversation to a bot clears
+      // `assignee_id`, so the server counts it as unassigned and the tab's badge says
+      // so. Reading `meta.assignee` alone (which names the bot) kept it out of the list
+      // the badge was counting.
+      const isUnAssigned = !humanAssignee(conversation);
       const shouldFilter = applyPageFilters(conversation, activeFilters);
       return isUnAssigned && shouldFilter;
     });

--- a/app/javascript/dashboard/store/modules/conversations/helpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers.js
@@ -71,6 +71,27 @@ export const applyPageFilters = (conversation, filters) => {
  * @param {number|string} currentUserId - The ID of the current user
  * @returns {boolean} - Whether the user has permissions to access this conversation
  */
+/**
+ * The human this conversation is assigned to, or undefined.
+ *
+ * `meta.assignee` is whoever the conversation was handed to, bot included, and
+ * `meta.assignee_type` is what says which. Everything that asks "is this unassigned"
+ * means "does a human own it", because that is the question the server answers:
+ * assigning to a bot clears `assignee_id` and stores the bot in its own column, so the
+ * `unassigned` scope, the tab's badge and `conversation_unassigned_manage` all count it
+ * as unassigned.
+ *
+ * Bots are excluded rather than humans required: the payload sets the type in the same
+ * branch that names the bot, so a payload without one only ever named a human.
+ *
+ * @param {{meta?: {assignee?: Object, assignee_type?: string}}} conversation
+ * @returns {Object|undefined}
+ */
+export const humanAssignee = conversation => {
+  const { assignee, assignee_type: assigneeType } = conversation?.meta ?? {};
+  return assigneeType === 'AgentBot' ? undefined : assignee;
+};
+
 export const applyRoleFilter = (
   conversation,
   role,
@@ -90,7 +111,14 @@ export const applyRoleFilter = (
     return true;
   }
 
-  const conversationAssignee = conversation.meta.assignee;
+  // Assigned means assigned to a HUMAN, which is what the database says: handing a
+  // conversation to a bot clears `assignee_id` and stores the bot in its own column, so
+  // the server's `unassigned` scope, the tab's badge and
+  // `conversation_unassigned_manage` all count it as unassigned. The payload still names
+  // the bot under `meta.assignee` (`Conversation#assigned_entity` prefers it), so reading
+  // that alone made the client disagree with the server that fed it: an agent with only
+  // `conversation_unassigned_manage` lost the conversations the server had granted them.
+  const conversationAssignee = humanAssignee(conversation);
   const isUnassigned = !conversationAssignee;
   const isAssignedToUser = conversationAssignee?.id === currentUserId;
 

--- a/app/javascript/dashboard/store/modules/conversations/specs/helpers.spec.js
+++ b/app/javascript/dashboard/store/modules/conversations/specs/helpers.spec.js
@@ -266,6 +266,24 @@ describe('Conversation Helpers', () => {
       ).toBe(false);
     });
 
+    // A conversation handed to a bot has `assignee_id` cleared, so
+    // `conversation_unassigned_manage` grants it on the server. The client read
+    // `meta.assignee`, which still names the bot, and removed it from a list the server
+    // had already decided the agent could see.
+    it('treats a bot-held conversation as unassigned', () => {
+      const conversation = {
+        meta: { assignee: { id: 99, name: 'Bot' }, assignee_type: 'AgentBot' },
+      };
+      expect(
+        applyRoleFilter(
+          conversation,
+          'custom_role',
+          ['conversation_unassigned_manage'],
+          1
+        )
+      ).toBe(true);
+    });
+
     // Test edge cases for meta.assignee
     describe('handles edge cases with meta.assignee', () => {
       const role = 'custom_role';

--- a/app/javascript/dashboard/store/modules/specs/conversations/getters.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/getters.spec.js
@@ -128,6 +128,46 @@ describe('#getters', () => {
       ]);
     });
   });
+  // Handing a conversation to a bot clears `assignee_id`, so the server's `unassigned`
+  // scope and the tab's badge both count it. The list read `meta.assignee`, which still
+  // names the bot, and left it out: badge and list disagreed on the same conversation.
+  describe('#getUnAssignedChats with a bot', () => {
+    const botConversation = {
+      id: 1,
+      inbox_id: 2,
+      status: 1,
+      meta: { assignee: { id: 7, name: 'Bot' }, assignee_type: 'AgentBot' },
+      labels: [],
+    };
+    const humanConversation = {
+      id: 2,
+      inbox_id: 2,
+      status: 1,
+      meta: { assignee: { id: 7, name: 'Agent' }, assignee_type: 'User' },
+      labels: [],
+    };
+
+    it('counts a bot conversation as unassigned, like the badge does', () => {
+      const chats = getters.getUnAssignedChats({
+        allConversations: [botConversation, humanConversation],
+      })({ status: 1 });
+
+      expect(chats.map(chat => chat.id)).toEqual([1]);
+    });
+
+    // The bot's id comes from its own table and can be the same integer as an agent's.
+    it('keeps a bot conversation out of the agent who shares its id', () => {
+      const chats = getters.getMineChats(
+        { allConversations: [botConversation, humanConversation] },
+        {},
+        {},
+        { getCurrentUser: { id: 7 } }
+      )({ status: 1 });
+
+      expect(chats.map(chat => chat.id)).toEqual([2]);
+    });
+  });
+
   describe('#getUnAssignedChats', () => {
     it('order returns only chats assigned to user', () => {
       const conversationList = [


### PR DESCRIPTION
Uma conversa entregue a um bot contava como "não atribuída" no badge da aba, mas não aparecia na lista dessa aba. Contagem e lista discordavam sobre a mesma conversa, e a mesma divergência escondia conversas de agentes com papel customizado que o servidor já tinha liberado pra eles.

## Closes

- Closes #369

## How to reproduce

1. Numa caixa de entrada com bot, atribua uma conversa aberta ao bot.
2. Olhe a aba **Não atribuídas**: antes, o badge incluía a conversa e a lista não. Agora as duas concordam.
3. Com um agente de papel customizado que tenha só `conversation_unassigned_manage`: antes o servidor devolvia a conversa e o cliente a removia. Agora ele a vê.

## What changed

Atribuir a um bot **limpa** o responsável no banco: `Conversations::AssignmentService#assign_agent_bot` faz `conversation.assignee = nil` e guarda o bot em `assignee_agent_bot`. Por isso o `scope :unassigned`, a contagem do badge (`COUNT(*) FILTER (WHERE assignee_id IS NULL)`) e o `conversation_unassigned_manage` todos contam a conversa como não atribuída.

O cliente decidia pelo payload, que ainda nomeia o bot em `meta.assignee` porque `Conversation#assigned_entity` devolve `assignee_agent_bot || assignee`. Um helper único, `humanAssignee`, alinha o cliente com a semântica do banco, e os três leitores passam por ele:

- `getUnAssignedChats`, que é onde badge e lista discordavam.
- `applyRoleFilter`, que é a perda de acesso silenciosa.
- `getMineChats`, que comparava ids sem olhar o tipo: o id de um bot vem da tabela dele e pode ser o mesmo inteiro do de um agente, o que colocaria a conversa de um bot na aba "Minhas" desse agente.

O helper exclui bots em vez de exigir humanos, porque o payload grava o tipo no mesmo ramo em que nomeia o bot: um payload sem tipo só pode ter nomeado um humano, e mantém o comportamento que tinha.

Nada muda no backend: `assignee_type` já vem no payload, tanto no jbuilder quanto no `push_meta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/403)
<!-- Reviewable:end -->
