### PR TITLE
chore(conversations): read the human assignee from one place

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -4,7 +4,6 @@ app/javascript/dashboard/helper/actionCable.js: Fetch missing conversations when
 app/models/conversation.rb: Defer fan-out when resolving a heavily pinned conversation  # PR#366
 app/javascript/dashboard/components/widgets/conversation/MoreActions.vue: Hide pin controls for conversations outside the list  # PR#366
 app/javascript/dashboard/helper/actionCable.js: Refresh cached permissions before applying this gate  # PR#367
-app/javascript/dashboard/helper/actionCable.js: Align bot assignments with frontend list visibility  # PR#367
 app/javascript/dashboard/helper/actionCable.js: Upsert conversations when assignment grants access  # PR#367
 # PR#372: the redelivery half of fazer-ai/chatwoot#373, still deliberately not answered.
 # Slice 6 settled the ordering half and left this one open: nothing claims an event id

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -12,6 +12,7 @@ import {
   handleWhatsappRemoteEnd,
   isLocalWhatsappCall,
 } from 'dashboard/composables/useWhatsappCallSession';
+import { humanAssignee } from 'dashboard/store/modules/conversations/helpers';
 import { VOICE_CALL_PROVIDERS } from 'dashboard/helper/inbox';
 import { markCallDismissed, isLocalCall } from 'dashboard/helper/voice';
 import { VOICE_CALL_DIRECTION } from 'dashboard/components-next/message/constants';
@@ -175,14 +176,12 @@ class ActionCableConnector extends BaseActionCableConnector {
     // A conversation handed to a bot is unassigned as far as visibility goes: the assignment service
     // clears `assignee_id` and tracks the bot beside it, so the filter that scopes a role to the
     // unassigned ones takes it in even though the payload still names the bot.
-    const { assignee, assignee_type: assigneeType } = payload.meta || {};
-    const humanAssignee = assigneeType === 'User' ? assignee : null;
-    if (humanAssignee && humanAssignee.id === user?.id) return true;
+    const assignee = humanAssignee(payload);
+    if (assignee && assignee.id === user?.id) return true;
 
     // Losing the assignee hands the conversation back to a role that sees the unassigned ones.
     return (
-      !humanAssignee &&
-      permissions.includes(CONVERSATION_UNASSIGNED_PERMISSIONS)
+      !assignee && permissions.includes(CONVERSATION_UNASSIGNED_PERMISSIONS)
     );
   };
 


### PR DESCRIPTION
Sem mudança de comportamento. Depois do #369, a regra "responsável quer dizer responsável humano" existia duas vezes: no `humanAssignee` do store e escrita à mão dentro do `assignmentMayHaveGrantedAccess` do `actionCable.js`. As duas concordam hoje; as duas juntas é como elas param de concordar.

O `actionCable.js` passa a usar o helper compartilhado.

Uma dispensa obsoleta sai do `.codex-review-waived`: "Align bot assignments with frontend list visibility" (PR#367) apontava justamente para a divergência que a #403 fechou.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/405)
<!-- Reviewable:end -->
