### PR TITLE
feat(whatsapp): recover the messages a session missed while it was away

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -142,6 +142,31 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController #
     render json: { error: 'WhatsApp provider is currently unavailable. Please try again.' }, status: :service_unavailable
   end
 
+  # Asks the phone for the history behind the conversations this inbox already holds.
+  # Administrator only, like disconnecting: it is reached from the same settings screen,
+  # and one press can file a year of conversation into the account.
+  #
+  # Queued rather than performed here, and answered on the webhook rather than in this
+  # response: one press walks up to twenty five chats, and the provider is explicit that a
+  # sleeping phone may never answer at all. What the operator is told is that it was asked.
+  def sync_provider_history
+    channel = @inbox.channel
+
+    unless channel.try(:session_capabilities)&.include?('history_sync')
+      render json: { error: 'Channel does not support history sync' }, status: :unprocessable_entity and return
+    end
+
+    # The request reaches the phone through the session, so a closed one has nothing to
+    # carry it. Refused here rather than queued, or the operator is told the phone was
+    # asked and nothing ever arrives.
+    unless channel.provider_connection.to_h['connection'] == 'open'
+      render json: { error: 'Channel is not connected' }, status: :unprocessable_entity and return
+    end
+
+    Whatsapp::Session::HistoryBackfillJob.perform_later(channel)
+    head :ok
+  end
+
   def disconnect_channel_provider
     channel = @inbox.channel
 

--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -43,6 +43,10 @@ class MessageFinder
     end
   end
 
+  # Deliberately still by id, unlike `before_cursor`. This one answers "what has been
+  # written since I last looked", which is a question about the sequence and not about
+  # time: a client catching up has to be told about a backdated message imported a moment
+  # ago, and comparing timestamps is exactly what would hide it.
   def messages_after(after_id)
     messages.reorder('created_at asc').where('id > ?', after_id).limit(100)
   end
@@ -50,13 +54,43 @@ class MessageFinder
   def messages_before(before_id)
     return messages_latest if oversized_message_id?(before_id)
 
-    page_window(messages.where('id < ?', normalized_message_id(before_id)))
+    page_window(before_cursor(normalized_message_id(before_id)))
   end
 
   def messages_between(after_id, before_id)
     message_scope = messages.reorder('created_at asc').where('id >= ?', after_id)
-    message_scope = message_scope.where('id < ?', normalized_message_id(before_id)) unless oversized_message_id?(before_id)
+    message_scope = message_scope.merge(before_cursor(normalized_message_id(before_id))) unless oversized_message_id?(before_id)
     message_scope.limit(1000)
+  end
+
+  # Everything strictly earlier in the conversation than the cursor message.
+  #
+  # The cursor is an id, but "earlier" is a question about time, and the two only agree
+  # while ids are handed out in the order messages happened. Imported history breaks that
+  # by construction: the id comes from the sequence at INSERT and the timestamp is
+  # backdated to when the message was sent, so one delivered late carries a newer id and
+  # an older timestamp. An `id <` filter drops it from every page, permanently, including
+  # the ones reached by scrolling up. Measured on the first imported inbox: 167 of 951
+  # messages were unreachable that way, across 18 of 95 conversations.
+  #
+  # Comparing the pair puts this filter on the axis `page_window` has always ordered by,
+  # with the id as the tiebreak that keeps the cursor stable when two messages share a
+  # second (WhatsApp timestamps are second-resolution, and a burst lands inside one).
+  # Where ids do follow chronology the two predicates select exactly the same rows, so a
+  # conversation that never imported anything sees no change at all.
+  def before_cursor(before_id)
+    at = cursor_timestamp(before_id)
+    return messages.where('messages.id < ?', before_id) if at.nil?
+
+    messages.where('(messages.created_at, messages.id) < (?, ?)', at, before_id)
+  end
+
+  # Queried off the bare relation: `messages` carries the `includes` this finder needs for
+  # rendering, and Rails would try to eager-load the polymorphic sender for a one-column
+  # read. A cursor naming a message from another conversation has no timestamp to compare
+  # against, which is the one case that keeps the id-only filter.
+  def cursor_timestamp(message_id)
+    Message.where(conversation_id: @conversation.id, id: message_id).pick(:created_at)
   end
 
   def messages_latest

--- a/app/javascript/dashboard/api/inboxes.js
+++ b/app/javascript/dashboard/api/inboxes.js
@@ -122,6 +122,10 @@ class Inboxes extends CacheEnabledApiClient {
     return axios.post(`${this.url}/${inboxId}/disconnect_channel_provider`);
   }
 
+  syncProviderHistory(inboxId) {
+    return axios.post(`${this.url}/${inboxId}/sync_provider_history`);
+  }
+
   convertProvider(inboxId, { provider, providerConfig }) {
     return axios.post(`${this.url}/${inboxId}/convert_provider`, {
       provider,

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -9,9 +9,9 @@
           "ZAPI": "Z-API",
           "ZAPI_DESC": "Connect via non-official API Z-API",
           "NATIVE": "WhatsApp (native)",
-          "NATIVE_DESC": "Pair a phone through the connector that ships with this installation",
+          "NATIVE_DESC": "Connect through an unofficial API, using the connector that ships with this installation",
           "UAZAPI": "Uazapi",
-          "UAZAPI_DESC": "Pair a phone through your own Uazapi instance"
+          "UAZAPI_DESC": "Connect through the unofficial Uazapi API, on your own instance"
         },
         "PROVIDER_URL": {
           "LABEL": "Provider URL",
@@ -50,7 +50,10 @@
             "USE_PAIRING_CODE": "Link with a code instead",
             "USE_QRCODE": "Use the QR code instead",
             "LOADING_PAIRING_CODE": "Requesting a code...",
-            "PAIRING_CODE_HELP": "On the phone, open WhatsApp, go to Linked devices, tap \"Link with phone number instead\" and type this code. It expires in a few minutes.",
+            "PAIRING_CODE_STEP_1": "On the phone that will answer, open WhatsApp.",
+            "PAIRING_CODE_STEP_2": "Go to Linked devices and tap Link a device.",
+            "PAIRING_CODE_STEP_3": "Tap \"Link with phone number instead\" and type the code above.",
+            "PAIRING_CODE_EXPIRES": "The code is good for a few minutes. Ask for another one if it expires.",
             "RECONNECTING": "Connecting...",
             "LINK_DEVICE": "Link device",
             "DISCONNECT": "Disconnect",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -81,6 +81,10 @@
             },
             "PRESENCE_SUBSCRIBE": {
               "LABEL": "Show when the contact is online"
+            },
+            "HISTORY_SYNC": {
+              "LABEL": "Import older conversations when pairing",
+              "DESCRIPTION": "Brings in the history the phone offers at pairing, all of it as resolved conversations. Messages received while the connection was down are recovered either way."
             }
           }
         }
@@ -134,7 +138,14 @@
       "WHATSAPP_CLIENT_TOKEN_TITLE": "Security Token",
       "WHATSAPP_CLIENT_TOKEN_SUBHEADER": "Your Z-API Client Token (see Security tab on Z-API dashboard).",
       "WHATSAPP_CLIENT_TOKEN_UPDATE_TITLE": "Update Security Token",
-      "WHATSAPP_CLIENT_TOKEN_UPDATE_SUBHEADER": "Enter the new Security Token here"
+      "WHATSAPP_CLIENT_TOKEN_UPDATE_SUBHEADER": "Enter the new Security Token here",
+      "WHATSAPP_HISTORY_SYNC": {
+        "BUTTON": "Sync history now",
+        "HELP": "Asks the phone for the history of the most recent conversations. It has to be awake and unlocked to answer, and the messages arrive on their own over the next few minutes.",
+        "REQUESTED": "History requested. The messages will appear as the phone sends them.",
+        "ERROR": "Could not ask for the history. Try again in a moment.",
+        "OFFLINE_HELP": "Connect the device first: a history request travels to the phone through the session."
+      }
     },
     "ASSIGNMENT": {
       "PREVENT_TAKEOVER": "Prevent assignment takeover",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -77,10 +77,12 @@
               "ERROR": "The instance token is required"
             },
             "MARK_AS_READ": {
-              "LABEL": "Mark messages as read on WhatsApp"
+              "LABEL": "Mark messages as read on WhatsApp",
+              "DESCRIPTION": "Replying from Chatwoot also marks the conversation read on the phone."
             },
             "PRESENCE_SUBSCRIBE": {
-              "LABEL": "Show when the contact is online"
+              "LABEL": "Show when the contact is online",
+              "DESCRIPTION": "Shows “typing…” and “recording…” in the conversation while the contact is writing."
             },
             "HISTORY_SYNC": {
               "LABEL": "Import older conversations when pairing",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -77,10 +77,12 @@
               "ERROR": "El token de la instancia es obligatorio"
             },
             "MARK_AS_READ": {
-              "LABEL": "Marcar mensajes como leídos en WhatsApp"
+              "LABEL": "Marcar mensajes como leídos en WhatsApp",
+              "DESCRIPTION": "Al responder desde Chatwoot, la conversación también aparece como leída en el teléfono."
             },
             "PRESENCE_SUBSCRIBE": {
-              "LABEL": "Mostrar cuándo el contacto está en línea"
+              "LABEL": "Mostrar cuándo el contacto está en línea",
+              "DESCRIPTION": "Muestra “escribiendo…” y “grabando…” en la conversación mientras el contacto escribe."
             },
             "HISTORY_SYNC": {
               "LABEL": "Importar conversaciones antiguas al vincular",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -9,9 +9,9 @@
           "ZAPI": "Z-API",
           "ZAPI_DESC": "Conectar mediante la API no oficial Z-API",
           "NATIVE": "WhatsApp (nativo)",
-          "NATIVE_DESC": "Conecta un teléfono con el conector que ya viene en esta instalación",
+          "NATIVE_DESC": "Conectar mediante una API no oficial, con el conector que ya viene en esta instalación",
           "UAZAPI": "Uazapi",
-          "UAZAPI_DESC": "Conecta un teléfono con tu propia instancia de Uazapi"
+          "UAZAPI_DESC": "Conectar mediante la API no oficial de Uazapi, en tu propia instancia"
         },
         "PROVIDER_URL": {
           "LABEL": "URL del proveedor",
@@ -50,7 +50,10 @@
             "USE_PAIRING_CODE": "Vincular con un código",
             "USE_QRCODE": "Usar el código QR",
             "LOADING_PAIRING_CODE": "Solicitando un código...",
-            "PAIRING_CODE_HELP": "En el teléfono, abra WhatsApp, vaya a Dispositivos vinculados, toque \"Vincular con número de teléfono\" e ingrese este código. Caduca en unos minutos.",
+            "PAIRING_CODE_STEP_1": "En el teléfono que va a atender, abre WhatsApp.",
+            "PAIRING_CODE_STEP_2": "Ve a Dispositivos vinculados y toca Vincular un dispositivo.",
+            "PAIRING_CODE_STEP_3": "Toca \"Vincular con número de teléfono\" e ingresa el código de arriba.",
+            "PAIRING_CODE_EXPIRES": "El código dura unos minutos. Pide otro si caduca.",
             "RECONNECTING": "Conectando...",
             "LINK_DEVICE": "Vincular dispositivo",
             "DISCONNECT": "Desconectar",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -81,6 +81,10 @@
             },
             "PRESENCE_SUBSCRIBE": {
               "LABEL": "Mostrar cuándo el contacto está en línea"
+            },
+            "HISTORY_SYNC": {
+              "LABEL": "Importar conversaciones antiguas al vincular",
+              "DESCRIPTION": "Trae el historial que el teléfono ofrece al vincular, todo como conversaciones resueltas. Los mensajes recibidos mientras la conexión estuvo caída se recuperan igual."
             }
           }
         }
@@ -134,7 +138,14 @@
       "WHATSAPP_CLIENT_TOKEN_TITLE": "Token de seguridad",
       "WHATSAPP_CLIENT_TOKEN_SUBHEADER": "Su Client Token de Z-API (vea la pestaña Security en el panel de Z-API).",
       "WHATSAPP_CLIENT_TOKEN_UPDATE_TITLE": "Actualizar el token de seguridad",
-      "WHATSAPP_CLIENT_TOKEN_UPDATE_SUBHEADER": "Introduzca aquí el nuevo token de seguridad"
+      "WHATSAPP_CLIENT_TOKEN_UPDATE_SUBHEADER": "Introduzca aquí el nuevo token de seguridad",
+      "WHATSAPP_HISTORY_SYNC": {
+        "BUTTON": "Sincronizar historial ahora",
+        "HELP": "Pide al teléfono el historial de las conversaciones más recientes. Tiene que estar encendido y desbloqueado para responder, y los mensajes llegan solos en los próximos minutos.",
+        "REQUESTED": "Historial solicitado. Los mensajes irán apareciendo a medida que el teléfono los envía.",
+        "ERROR": "No se pudo pedir el historial. Inténtalo de nuevo en un momento.",
+        "OFFLINE_HELP": "Conecta primero el dispositivo: la solicitud de historial llega al teléfono por la sesión."
+      }
     },
     "ASSIGNMENT": {
       "PREVENT_TAKEOVER": "Impedir que otro agente tome la conversación",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -77,10 +77,12 @@
               "ERROR": "O token da instância é obrigatório"
             },
             "MARK_AS_READ": {
-              "LABEL": "Marcar mensagens como lidas no WhatsApp"
+              "LABEL": "Marcar mensagens como lidas no WhatsApp",
+              "DESCRIPTION": "Ao responder pelo Chatwoot, a conversa também aparece como lida no celular."
             },
             "PRESENCE_SUBSCRIBE": {
-              "LABEL": "Mostrar quando o contato está online"
+              "LABEL": "Mostrar quando o contato está online",
+              "DESCRIPTION": "Exibe “digitando…” e “gravando…” na conversa quando o contato está escrevendo."
             },
             "HISTORY_SYNC": {
               "LABEL": "Importar conversas antigas ao parear",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -81,6 +81,10 @@
             },
             "PRESENCE_SUBSCRIBE": {
               "LABEL": "Mostrar quando o contato está online"
+            },
+            "HISTORY_SYNC": {
+              "LABEL": "Importar conversas antigas ao parear",
+              "DESCRIPTION": "Traz o histórico que o celular oferece no pareamento, todo como conversas resolvidas. Mensagens recebidas enquanto a conexão esteve fora são recuperadas sempre, independente desta opção."
             }
           }
         }
@@ -134,7 +138,14 @@
       "WHATSAPP_CLIENT_TOKEN_TITLE": "Token de Segurança",
       "WHATSAPP_CLIENT_TOKEN_SUBHEADER": "Seu Token de Segurança Z-API (veja a aba Segurança no painel do Z-API).",
       "WHATSAPP_CLIENT_TOKEN_UPDATE_TITLE": "Atualizar Token de Segurança",
-      "WHATSAPP_CLIENT_TOKEN_UPDATE_SUBHEADER": "Digite o novo Token de Segurança aqui"
+      "WHATSAPP_CLIENT_TOKEN_UPDATE_SUBHEADER": "Digite o novo Token de Segurança aqui",
+      "WHATSAPP_HISTORY_SYNC": {
+        "BUTTON": "Sincronizar histórico agora",
+        "HELP": "Pede ao celular o histórico das conversas mais recentes. Ele precisa estar ligado e desbloqueado para responder, e as mensagens chegam sozinhas nos próximos minutos.",
+        "REQUESTED": "Histórico solicitado. As mensagens vão aparecendo conforme o celular envia.",
+        "ERROR": "Não foi possível pedir o histórico. Tente de novo em instantes.",
+        "OFFLINE_HELP": "Conecte o dispositivo primeiro: o pedido de histórico chega ao celular pela sessão."
+      }
     },
     "ASSIGNMENT": {
       "PREVENT_TAKEOVER": "Impedir tomada de conversa atribuída",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -9,9 +9,9 @@
           "ZAPI": "Z-API",
           "ZAPI_DESC": "Conectar via API não-oficial Z-API",
           "NATIVE": "WhatsApp (nativo)",
-          "NATIVE_DESC": "Conecte um telefone pelo conector que já vem nesta instalação",
+          "NATIVE_DESC": "Conectar via API não-oficial, pelo conector que já vem nesta instalação",
           "UAZAPI": "Uazapi",
-          "UAZAPI_DESC": "Conecte um telefone pela sua própria instância da Uazapi"
+          "UAZAPI_DESC": "Conectar via API não-oficial Uazapi, na sua própria instância"
         },
         "PROVIDER_URL": {
           "LABEL": "URL do provedor",
@@ -50,7 +50,10 @@
             "USE_PAIRING_CODE": "Conectar com um código",
             "USE_QRCODE": "Usar o QR code",
             "LOADING_PAIRING_CODE": "Pedindo um código...",
-            "PAIRING_CODE_HELP": "No telefone, abra o WhatsApp, vá em Dispositivos conectados, toque em \"Conectar com número de telefone\" e digite este código. Ele expira em alguns minutos.",
+            "PAIRING_CODE_STEP_1": "No telefone que vai atender, abra o WhatsApp.",
+            "PAIRING_CODE_STEP_2": "Vá em Dispositivos conectados e toque em Conectar dispositivo.",
+            "PAIRING_CODE_STEP_3": "Toque em \"Conectar com número de telefone\" e digite o código acima.",
+            "PAIRING_CODE_EXPIRES": "O código vale por poucos minutos. Se expirar, peça outro.",
             "RECONNECTING": "Conectando...",
             "LINK_DEVICE": "Conectar dispositivo",
             "DISCONNECT": "Desconectar",

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/channels/Whatsapp.vue
@@ -160,13 +160,13 @@ const PROVIDER_CATALOG = computed(() => [
     key: PROVIDER_TYPES.NATIVE,
     title: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.NATIVE'),
     description: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.NATIVE_DESC'),
-    icon: 'i-woot-whatsapp',
+    icon: 'i-woot-whatsapp-native',
   },
   {
     key: PROVIDER_TYPES.UAZAPI,
     title: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.UAZAPI'),
     description: t('INBOX_MGMT.ADD.WHATSAPP.PROVIDERS.UAZAPI_DESC'),
-    icon: 'i-woot-whatsapp',
+    icon: 'i-woot-uazapi',
   },
   {
     key: PROVIDER_TYPES.THREE_SIXTY_DIALOG,

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/WhatsappLinkDeviceModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, computed, onUnmounted, ref, watchEffect } from 'vue';
+import { onMounted, computed, ref, watchEffect } from 'vue';
 import { useStore } from 'vuex';
 import { useAlert } from 'dashboard/composables';
 import InboxName from 'dashboard/components/widgets/InboxName.vue';
@@ -32,6 +32,16 @@ const error = computed(() => providerConnection.value?.error);
 const pairingMode = ref('qr');
 const supportsCodePairing = computed(() =>
   hasCapability(props.inbox, CAPABILITIES.CODE_PAIRING)
+);
+
+// What the screen shows, which is not the same question as what the operator asked for.
+// A provider can answer a code pairing with a QR alongside the code (uazapi keeps
+// rotating one), and this component's own request is client-side state that a blip in
+// the connection resets. Both together used to hide a perfectly valid code behind the
+// QR branch. A code on the record is only ever there because a code was asked for, so
+// it decides on its own; the request still decides while nothing has arrived yet.
+const displayedPairing = computed(() =>
+  pairingMode.value === 'code' || pairingCode.value ? 'code' : 'qr'
 );
 
 // A send stall is the one failure that leaves `connection` reading 'open' while the
@@ -82,6 +92,11 @@ const pairWithCode = () => {
     })
     .catch(handleError);
 };
+// Only ever the operator asking for it. Closing this screen used to end the pairing on
+// the way out, which made a look-and-close cost a fresh code, and on a provider that
+// issues one only from a disconnected instance that is a round trip the operator has to
+// discover. An attempt nobody completes expires on its own: the provider stops offering
+// it, and the poll writes the timeout.
 const disconnect = () => {
   loading.value = true;
   store
@@ -89,17 +104,14 @@ const disconnect = () => {
     .catch(handleError);
 };
 
+// Deliberately reads the record as it stands rather than refreshing it. Reloading the
+// inboxes from here replaces them in the store, which re-renders the settings page this
+// modal is mounted inside and takes the modal down with it: the operator clicks the
+// button and nothing opens. The connection record is kept current by the cable, and the
+// poll behind a live pairing is what refreshes what is on screen.
 onMounted(() => {
   if (!connection.value || connection.value === 'close') {
     setup();
-  }
-});
-onUnmounted(() => {
-  if (
-    connection.value === 'connecting' ||
-    connection.value === 'reconnecting'
-  ) {
-    disconnect();
   }
 });
 watchEffect(() => {
@@ -154,10 +166,28 @@ watchEffect(() => {
                 )
               }}
             </Button>
+
+            <!-- The other way in, offered before the pairing starts rather than only
+                 during it. A provider can refuse to issue a code once a pairing is
+                 already in flight (uazapi answers the state it is in and no code at
+                 all), which left the operator having to start the QR they cannot use
+                 to reach the option they can. -->
+            <Button
+              v-if="supportsCodePairing"
+              link
+              blue
+              :is-loading="loading"
+              :label="
+                $t(
+                  'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.USE_PAIRING_CODE'
+                )
+              "
+              @click="pairWithCode"
+            />
           </template>
 
           <template v-else-if="connection === 'connecting'">
-            <template v-if="pairingMode === 'code'">
+            <template v-if="displayedPairing === 'code'">
               <div v-if="!pairingCode" class="flex flex-col gap-4 items-center">
                 <p>
                   {{
@@ -174,10 +204,38 @@ watchEffect(() => {
                 >
                   {{ pairingCode }}
                 </p>
-                <p class="max-w-xs text-sm text-center text-n-slate-11">
+                <!-- Numbered, because this is read by someone holding the phone with
+                     one hand: a paragraph makes them find where they are again after
+                     every step. -->
+                <ol
+                  class="max-w-xs pl-5 text-sm list-decimal text-n-slate-11 marker:text-n-slate-10"
+                >
+                  <li>
+                    {{
+                      $t(
+                        'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.PAIRING_CODE_STEP_1'
+                      )
+                    }}
+                  </li>
+                  <li>
+                    {{
+                      $t(
+                        'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.PAIRING_CODE_STEP_2'
+                      )
+                    }}
+                  </li>
+                  <li>
+                    {{
+                      $t(
+                        'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.PAIRING_CODE_STEP_3'
+                      )
+                    }}
+                  </li>
+                </ol>
+                <p class="max-w-xs text-xs text-center text-n-slate-10">
                   {{
                     $t(
-                      'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.PAIRING_CODE_HELP'
+                      'INBOX_MGMT.ADD.WHATSAPP.EXTERNAL_PROVIDER.LINK_DEVICE_MODAL.PAIRING_CODE_EXPIRES'
                     )
                   }}
                 </p>
@@ -208,7 +266,7 @@ watchEffect(() => {
                  also how a code that expired is replaced. -->
             <template v-if="supportsCodePairing">
               <Button
-                v-if="pairingMode === 'code'"
+                v-if="displayedPairing === 'code'"
                 link
                 blue
                 :is-loading="loading"

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/WhatsappLinkDeviceModal.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/WhatsappLinkDeviceModal.spec.js
@@ -96,6 +96,83 @@ describe('WhatsappLinkDeviceModal', () => {
       expect(wrapper.html()).not.toContain('data:image/png;base64,x');
     });
 
+    // The provider can answer a code pairing with a QR alongside the code (uazapi keeps
+    // rotating one), and this component's request is client-side state that a blip in
+    // the connection resets to the QR. Both together hid a perfectly good code behind
+    // the QR branch, which is what an operator reported as "the code never shows up".
+    it('shows the code even when the mode was reset and a QR is on the record', () => {
+      const wrapper = mountModal(['qr_pairing', 'code_pairing'], {
+        connection: 'connecting',
+        qr_data_url: 'data:image/png;base64,x',
+        pairing_code: 'K7QP-2M4X',
+      });
+
+      expect(wrapper.html()).toContain('K7QP-2M4X');
+      expect(wrapper.html()).not.toContain('data:image/png;base64,x');
+    });
+
+    // The option used to live only inside the `connecting` branch, so reaching it meant
+    // starting the QR first. That is the one state a provider can refuse to issue a code
+    // from, which left the way in through the thing the operator already said they could
+    // not use.
+    it('is offered before the pairing starts, not only during it', async () => {
+      const wrapper = mountModal(['qr_pairing', 'code_pairing'], {
+        connection: 'close',
+      });
+
+      expect(wrapper.html()).toContain(USE_PAIRING_CODE_KEY);
+
+      await wrapper.findAll('button')[1].trigger('click');
+      await flushPromises();
+
+      expect(dispatch).toHaveBeenCalledWith('inboxes/requestPairingCode', 1);
+    });
+
+    it('spells the phone steps out one by one under the code', () => {
+      const wrapper = mountModal(['qr_pairing', 'code_pairing'], {
+        connection: 'connecting',
+        pairing_code: 'K7QP-2M4X',
+      });
+
+      expect(wrapper.html()).toContain(`${KEY}.PAIRING_CODE_STEP_1`);
+      expect(wrapper.html()).toContain(`${KEY}.PAIRING_CODE_STEP_3`);
+      expect(wrapper.html()).toContain(`${KEY}.PAIRING_CODE_EXPIRES`);
+    });
+
+    // Refreshing the inboxes from here replaces them in the store, which re-renders the
+    // settings page this is mounted inside and takes the modal down with it: the operator
+    // clicks the button and nothing opens. What is on screen is kept current by the cable
+    // and by the poll behind the pairing.
+    it('opens on the record it was given, without reloading the inboxes', async () => {
+      const wrapper = mountModal(['qr_pairing', 'code_pairing'], {
+        connection: 'connecting',
+        pairing_code: 'K7QP-2M4X',
+      });
+      await flushPromises();
+
+      expect(dispatch).not.toHaveBeenCalledWith('inboxes/get');
+      expect(wrapper.html()).toContain('K7QP-2M4X');
+    });
+
+    // Closing the screen is not abandoning the account: it used to disconnect on the way
+    // out, and on a provider that issues a code only from a disconnected instance that
+    // turned a look-and-close into a new round of pairing.
+    it('leaves the pairing alone when the screen is closed', async () => {
+      const wrapper = mountModal(['qr_pairing', 'code_pairing'], {
+        connection: 'connecting',
+        pairing_code: 'K7QP-2M4X',
+      });
+      await flushPromises();
+      dispatch.mockClear();
+
+      wrapper.unmount();
+
+      expect(dispatch).not.toHaveBeenCalledWith(
+        'inboxes/disconnectChannelProvider',
+        1
+      );
+    });
+
     it('shows the code the provider issued, and the way back to the QR', async () => {
       const wrapper = mountModal(['qr_pairing', 'code_pairing'], {
         ...connecting,

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
@@ -3,7 +3,12 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from 'vue-i18n';
 import { useAlert } from 'dashboard/composables';
-import { isHttpUrl } from 'dashboard/helper/whatsappSession';
+import {
+  isHttpUrl,
+  hasCapability,
+  CAPABILITIES,
+} from 'dashboard/helper/whatsappSession';
+import InboxesAPI from 'dashboard/api/inboxes';
 import { useWhatsappSessionProviders } from 'dashboard/composables/useWhatsappSessionProviders';
 
 import SettingsSection from 'dashboard/components/SettingsSection.vue';
@@ -57,6 +62,36 @@ watch(
 );
 
 const showLinkDeviceModal = ref(false);
+
+// Deliberately independent of the setting below, which is standing consent to the dump
+// that follows a pairing. This is a single act, and tying it to the setting would mean
+// turning on a permanent behaviour to recover one weekend.
+//
+// The phone answers whenever it feels like it, and sometimes never: the provider only
+// promises to pass the ask along. So the button reports that it asked, and the messages
+// appear later on their own.
+const supportsHistorySync = computed(() =>
+  hasCapability(props.inbox, CAPABILITIES.HISTORY_SYNC)
+);
+// A request travels to the phone through the session. With the session down there is
+// nothing to carry it, so the button would report that it asked and nothing would ever
+// arrive, which is worse than not offering it.
+const isConnected = computed(
+  () => props.inbox.provider_connection?.connection === 'open'
+);
+const syncingHistory = ref(false);
+
+const syncHistory = async () => {
+  syncingHistory.value = true;
+  try {
+    await InboxesAPI.syncProviderHistory(props.inbox.id);
+    useAlert(t('INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_HISTORY_SYNC.REQUESTED'));
+  } catch (error) {
+    useAlert(t('INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_HISTORY_SYNC.ERROR'));
+  } finally {
+    syncingHistory.value = false;
+  }
+};
 
 const fieldKey = field =>
   `INBOX_MGMT.ADD.WHATSAPP.SESSION.FIELDS.${field.name.toUpperCase()}`;
@@ -145,6 +180,27 @@ const save = async field => {
               )
             }}
           </NextButton>
+          <div v-if="supportsHistorySync" class="flex flex-col gap-1">
+            <NextButton
+              class="w-fit"
+              faded
+              slate
+              :is-loading="syncingHistory"
+              :disabled="!isConnected || syncingHistory"
+              @click="syncHistory"
+            >
+              {{ $t('INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_HISTORY_SYNC.BUTTON') }}
+            </NextButton>
+            <span class="text-sm text-n-slate-11">
+              {{
+                isConnected
+                  ? $t('INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_HISTORY_SYNC.HELP')
+                  : $t(
+                      'INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_HISTORY_SYNC.OFFLINE_HELP'
+                    )
+              }}
+            </span>
+          </div>
         </div>
       </SettingsSection>
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/SessionProviderConfiguration.vue
@@ -229,7 +229,7 @@ const save = async field => {
         v-for="field in preferenceFields"
         :key="field.name"
         :title="$t(`${fieldKey(field)}.LABEL`)"
-        :sub-title="$t(`${fieldKey(field)}.LABEL`)"
+        :sub-title="$t(`${fieldKey(field)}.DESCRIPTION`)"
       >
         <div class="flex items-center gap-2">
           <Switch

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/specs/SessionProviderConfiguration.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/settingsPage/specs/SessionProviderConfiguration.spec.js
@@ -3,9 +3,14 @@ import { defineComponent, nextTick } from 'vue';
 import { flushPromises, mount } from '@vue/test-utils';
 import SessionProviderConfiguration from '../SessionProviderConfiguration.vue';
 import WhatsappChannel from 'dashboard/api/channel/whatsappChannel';
+import InboxesAPI from 'dashboard/api/inboxes';
 
 vi.mock('dashboard/api/channel/whatsappChannel', () => ({
   default: { getSessionProviders: vi.fn() },
+}));
+
+vi.mock('dashboard/api/inboxes', () => ({
+  default: { syncProviderHistory: vi.fn() },
 }));
 
 const mockDispatch = vi.fn();
@@ -60,13 +65,18 @@ const INBOX = {
   provider_config: { base_url: 'https://uaz.example', mark_as_read: true },
 };
 
-const mountPage = async ({ beta = true } = {}) => {
+// Scoped to the connection section, where the connect button is first and the history
+// one sits under it. The credential sections further down carry buttons of their own.
+const historyButton = wrapper =>
+  wrapper.findAll('.SettingsSection-stub')[0].findAll('.NextButton-stub')[1];
+
+const mountPage = async ({ beta = true, inbox = INBOX } = {}) => {
   WhatsappChannel.getSessionProviders.mockResolvedValue({
     data: { payload: catalog({ beta }) },
   });
 
   const wrapper = mount(SessionProviderConfiguration, {
-    props: { inbox: INBOX },
+    props: { inbox },
     global: {
       stubs: {
         WhatsappLinkDeviceModal: stub('WhatsappLinkDeviceModal'),
@@ -140,6 +150,76 @@ describe('SessionProviderConfiguration', () => {
     await wrapper.vm.save(url);
 
     expect(wrapper.vm.values[url.name]).toBe('https://moved.example');
+  });
+
+  describe('the history sync button', () => {
+    const withHistory = (config = {}, connection = 'open') => ({
+      ...INBOX,
+      capabilities: ['history_sync'],
+      provider_config: { ...INBOX.provider_config, ...config },
+      provider_connection: { connection },
+    });
+
+    it('is absent on a provider that cannot fetch history', async () => {
+      const wrapper = await mountPage();
+
+      expect(historyButton(wrapper)).toBeUndefined();
+    });
+
+    // Recovering one weekend must not require turning on the dump that repeats at every
+    // future pairing: the two are different decisions and the button owns neither.
+    it('does not wait for the connect-time setting', async () => {
+      InboxesAPI.syncProviderHistory.mockResolvedValue({});
+      const wrapper = await mountPage({
+        inbox: withHistory({ history_sync: false }),
+      });
+
+      expect(historyButton(wrapper).attributes('disabled')).toBe('false');
+
+      await historyButton(wrapper).trigger('click');
+      await flushPromises();
+
+      expect(InboxesAPI.syncProviderHistory).toHaveBeenCalledWith(INBOX.id);
+    });
+
+    it('reports back once the phone has been asked', async () => {
+      InboxesAPI.syncProviderHistory.mockResolvedValue({});
+      const wrapper = await mountPage({
+        inbox: withHistory({ history_sync: true }),
+      });
+
+      await historyButton(wrapper).trigger('click');
+      await flushPromises();
+
+      expect(InboxesAPI.syncProviderHistory).toHaveBeenCalledWith(INBOX.id);
+      expect(mockAlert).toHaveBeenCalledWith(
+        'INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_HISTORY_SYNC.REQUESTED'
+      );
+    });
+
+    // The request travels to the phone through the session, so with the session down the
+    // button would report that it asked and nothing would ever arrive.
+    it('is not offered while the session is down', async () => {
+      const wrapper = await mountPage({
+        inbox: withHistory({ history_sync: true }, 'close'),
+      });
+
+      expect(historyButton(wrapper).attributes('disabled')).toBe('true');
+    });
+
+    it('reports a request the provider refused', async () => {
+      InboxesAPI.syncProviderHistory.mockRejectedValue(new Error('nope'));
+      const wrapper = await mountPage({
+        inbox: withHistory({ history_sync: true }),
+      });
+
+      await historyButton(wrapper).trigger('click');
+      await flushPromises();
+
+      expect(mockAlert).toHaveBeenCalledWith(
+        'INBOX_MGMT.SETTINGS_POPUP.WHATSAPP_HISTORY_SYNC.ERROR'
+      );
+    });
   });
 
   it('sends a secret the operator actually typed', async () => {

--- a/app/jobs/whatsapp/session/history_backfill_job.rb
+++ b/app/jobs/whatsapp/session/history_backfill_job.rb
@@ -1,0 +1,48 @@
+# The on-demand half of history sync: the operator asks, on the inbox's settings screen,
+# for the phone to hand over what came before.
+#
+# The connect-time half needs no job. Subscribing to the event is the whole trigger there:
+# the phone dumps what it has of its own accord once the session is up. This one is for
+# afterwards, and for the conversations the inbox already holds.
+#
+# Nothing here waits for messages. Each request is acknowledged and answered later on the
+# webhook, or not answered at all: the provider is explicit that a sleeping phone may
+# never respond, so what the operator is told is that the request went out.
+class Whatsapp::Session::HistoryBackfillJob < ApplicationJob
+  queue_as :low
+
+  # How many chats one press asks about. A cap rather than a page: the phone ignores the
+  # count on a request (one instance answered a request for fifty messages with nine
+  # hundred and forty seven), so the only thing bounding an import is how many chats were
+  # asked, and every one of them can come back with a year of conversation.
+  CHATS = 25
+
+  def perform(channel)
+    return unless channel.try(:session_capabilities)&.include?('history_sync')
+
+    facade = channel.provider_service
+
+    # Before the first request, because it is what puts `history` on the instance's
+    # webhook subscription and what tells the import that these frames were asked for.
+    Whatsapp::Session::HistoryBackfill.open!(channel)
+    contacts(channel).each { |contact| request(facade, contact, channel) }
+  end
+
+  private
+
+  # Most recently active first, which is where an operator asking for history is looking.
+  # Read off conversations rather than contacts: a contact's own activity stamp moves for
+  # reasons that have nothing to do with this inbox.
+  def contacts(channel)
+    channel.inbox.conversations.order(last_activity_at: :desc).limit(CHATS).includes(:contact).filter_map(&:contact).uniq
+  end
+
+  # One failure does not end the walk. A number that is no longer on WhatsApp, or a chat
+  # the provider refuses, says nothing about the next one, and the operator pressed a
+  # button that means "as much as you can get".
+  def request(facade, contact, channel)
+    facade.request_history(contact)
+  rescue Whatsapp::Session::Errors::Error => e
+    Rails.logger.warn("[WHATSAPP SESSION] history request failed for contact ##{contact.id} on inbox ##{channel.inbox&.id}: #{e.message}")
+  end
+end

--- a/app/policies/inbox_policy.rb
+++ b/app/policies/inbox_policy.rb
@@ -86,6 +86,10 @@ class InboxPolicy < ApplicationPolicy
     @account_user.administrator?
   end
 
+  def sync_provider_history?
+    @account_user.administrator?
+  end
+
   def on_whatsapp?
     true
   end

--- a/app/services/whatsapp/session/backend.rb
+++ b/app/services/whatsapp/session/backend.rb
@@ -111,6 +111,11 @@ class Whatsapp::Session::Backend
   # bytes again once the ref it first handed out has lapsed.
   def download_media(_command) = not_supported!(:download_media)
 
+  # --- history ---------------------------------------------------------------------
+  # Asks for what came before. What comes back is not the answer to this call: the
+  # provider acknowledges it and the messages arrive as `history.sync` events.
+  def request_history(_command) = not_supported!(:request_history)
+
   # --- presence --------------------------------------------------------------------
   def send_chat_presence(_command) = not_supported!(:send_chat_presence)
   def update_presence(_command) = not_supported!(:update_presence)

--- a/app/services/whatsapp/session/backends/uazapi/backend.rb
+++ b/app/services/whatsapp/session/backends/uazapi/backend.rb
@@ -34,10 +34,16 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
   DISCONNECT_SETTLE_TRIES = 4
   DISCONNECT_SETTLE_WAIT = 0.5
 
-  # The events this inbox asks for. `chats`, `contacts`, `labels` and `history` are the
-  # instance's own CRM chatter and are not subscribed: everything Chatwoot needs is in
-  # these five.
+  # The events this inbox asks for. `chats`, `contacts` and `labels` are the instance's own
+  # CRM chatter and are never subscribed: everything Chatwoot needs is in these five.
   WEBHOOK_EVENTS = %w[connection messages messages_update presence groups].freeze
+
+  # `history` is the sixth, and it is asked for only by an inbox that turned the sync on.
+  # It is not a stream of its own: the same event carries the initial dump the phone sends
+  # after pairing and the answer to every on-demand request, and it arrives in batches of
+  # up to 200 messages. An inbox that does not want the history should not be paying to
+  # receive it and then throw it away.
+  HISTORY_EVENT = 'history'.freeze
 
   # Our own sends come back as an echo, and nothing is excluded from the subscription:
   # the echo is the only way to learn that a send whose answer never arrived actually
@@ -188,6 +194,18 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
     { 'reachout_time_lock' => reachout_time_lock(limits), 'new_chat_cap' => new_chat_cap(limits) }.compact
   end
 
+  # Asks the phone for what came before. The answer is not this call's: the provider
+  # acknowledges the request and the messages arrive later on the `history` webhook, in
+  # batches, and only if the phone is awake to answer at all. `count` is passed on as the
+  # hint it is.
+  def request_history(command)
+    client.post('/message/history-sync', {
+      number: command.chat.to_jid, mode: 'history',
+      count: command.count, messageid: command.before_id
+    }.compact)
+    nil
+  end
+
   # --- presence and contacts -------------------------------------------------------
 
   # `delay` is how long the provider holds the indicator up. Chatwoot sends a fresh one on
@@ -281,9 +299,19 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
 
   def webhook_body(enabled:)
     {
-      url: webhook_url, enabled: enabled, events: WEBHOOK_EVENTS, excludeMessages: WEBHOOK_EXCLUDES,
+      url: webhook_url, enabled: enabled, events: subscribed_events, excludeMessages: WEBHOOK_EXCLUDES,
       addUrlEvents: false, addUrlTypesMessages: false
     }
+  end
+
+  def subscribed_events
+    return WEBHOOK_EVENTS unless history_sync?
+
+    WEBHOOK_EVENTS + [HISTORY_EVENT]
+  end
+
+  def history_sync?
+    ActiveModel::Type::Boolean.new.cast(provider_config['history_sync']).present?
   end
 
   # The address this instance can reach us at. Always the public one: the instance runs on

--- a/app/services/whatsapp/session/backends/uazapi/backend.rb
+++ b/app/services/whatsapp/session/backends/uazapi/backend.rb
@@ -199,9 +199,15 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
   # batches, and only if the phone is awake to answer at all. `count` is passed on as the
   # hint it is.
   def request_history(command)
+    # The answer to this comes back on the webhook, and the webhook only carries history
+    # for an instance subscribed to that event. Subscription is set at connect time, so an
+    # inbox that turned the setting on afterwards would send the request and never see the
+    # reply. Registering is idempotent and this runs once per backend, so a backfill
+    # walking fifty chats still registers once.
+    ensure_history_subscription
     client.post('/message/history-sync', {
       number: command.chat.to_jid, mode: 'history',
-      count: command.count, messageid: command.before_id
+      count: command.count, messageid: command.before&.id
     }.compact)
     nil
   end
@@ -251,6 +257,13 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
 
   def register_webhook
     client.post('/webhook', webhook_body(enabled: true))
+  end
+
+  def ensure_history_subscription
+    return if @history_subscribed
+
+    register_webhook
+    @history_subscribed = true
   end
 
   # Best effort by design: the inbox is being torn down either way, and a provider that
@@ -304,9 +317,16 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
     }
   end
 
+  # Always subscribed, because not listening is a decision that cannot be revisited later.
+  # The phone's account of what arrived while the session was down is pushed once, right
+  # after a pairing, and there is no request that fetches it afterwards: `/message/history-sync`
+  # only walks backwards from a message the instance already has (`mode` accepts nothing
+  # else, checked against the API). An inbox that was not subscribed at that moment has
+  # lost the weekend for good.
+  #
+  # Subscribing is not consent to import: the handler keeps only the gap out of a pile
+  # nobody asked for, and a first pairing has no coverage, so all of it is dropped.
   def subscribed_events
-    return WEBHOOK_EVENTS unless history_sync?
-
     WEBHOOK_EVENTS + [HISTORY_EVENT]
   end
 

--- a/app/services/whatsapp/session/backends/uazapi/backend.rb
+++ b/app/services/whatsapp/session/backends/uazapi/backend.rb
@@ -15,6 +15,7 @@
 # NOT to exist on that build: `/instance/logout` and `/group/invitelink` both answer 405,
 # which is why logging out is a disconnect and why `group_invites` is not declared.
 class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
+  include Whatsapp::Session::Backends::Uazapi::Backend::State
   include Whatsapp::Session::Backends::Uazapi::Backend::Messages
   include Whatsapp::Session::Backends::Uazapi::Backend::Groups
 
@@ -27,6 +28,11 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
   # administrator is waiting on, so an instance that has stopped answering costs seconds
   # rather than the full ceiling.
   RELEASE_TIMEOUT = 5
+
+  # How long a code pairing waits for a disconnect to take effect before connecting
+  # anyway. See `restart_for_code_pairing`.
+  DISCONNECT_SETTLE_TRIES = 4
+  DISCONNECT_SETTLE_WAIT = 0.5
 
   # The events this inbox asks for. `chats`, `contacts`, `labels` and `history` are the
   # instance's own CRM chatter and are not subscribed: everything Chatwoot needs is in
@@ -43,17 +49,6 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
   # A second row is not the risk it looks like either: the same matcher recognizes the
   # echo of a message already stored.
   WEBHOOK_EXCLUDES = [].freeze
-
-  # `instance.status` -> canonical connection. `hibernated` is a paused instance on the
-  # provider's side, which for an inbox is the same as being closed.
-  CONNECTIONS = {
-    'disconnected' => 'close', 'disconnecting' => 'close', 'hibernated' => 'close',
-    'connecting' => 'connecting', 'connected' => 'open'
-  }.freeze
-
-  # The disconnect reason that means the pairing itself is gone, not just the socket.
-  # Anything else the provider reports is a connection that can come back.
-  LOGGED_OUT = /401|logged out/i
 
   class << self
     def provider_key
@@ -146,6 +141,7 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
   # where the session opens and its first messages have nowhere to be delivered.
   def connect(command)
     register_webhook
+    restart_for_code_pairing if command.pairing == 'code'
     body = { phone: (command.phone if command.pairing == 'code') }
     connection_state(client.post('/instance/connect', body))
   end
@@ -233,27 +229,6 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
 
   # Both `/instance/status` and `/instance/connect` answer with the instance under the
   # same key, so one reader serves them.
-  def connection_state(response)
-    instance = (response.to_h['instance'] || response.to_h).to_h
-    connection = CONNECTIONS.fetch(instance['status'].to_s, 'close')
-    model::ConnectionState.new(
-      connection: connection,
-      qr_data_url: (instance['qrcode'].presence if connection == 'connecting'),
-      pairing_code: (instance['paircode'].presence if connection == 'connecting'),
-      phone_number: (instance['owner'].presence if connection == 'open'),
-      error: connection_error(instance, connection)
-    )
-  end
-
-  # `owner` keeps the previous number for as long as the instance sits disconnected, so a
-  # closed state never reports one: taking it at face value would tell the inbox it is
-  # paired with a number that is no longer there.
-  def connection_error(instance, connection)
-    return if connection != 'close'
-
-    'logged_out' if instance['lastDisconnectReason'].to_s.match?(LOGGED_OUT)
-  end
-
   # --- webhook -----------------------------------------------------------------------
 
   def register_webhook
@@ -267,6 +242,41 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
     client.post('/webhook', webhook_body(enabled: false), timeout: RELEASE_TIMEOUT)
   rescue Whatsapp::Session::Errors::Error => e
     Rails.logger.warn("[WHATSAPP SESSION] could not withdraw the uazapi webhook of inbox ##{channel.inbox&.id}: #{e.message}")
+  end
+
+  # This provider issues a pairing code only when the connect starts from a disconnected
+  # instance. Asked for one while a pairing is already in flight, it answers the state it
+  # is already in: no code, and the QR it was rotating before. The operator is then left
+  # on a screen waiting for a code that is never coming, which is exactly the state the
+  # dashboard offers the code from. Observed against a live instance on 22/08/2026.
+  #
+  # Ending that attempt first is safe, because pairing by code replaces whatever pairing
+  # was on screen anyway. An open session is deliberately left alone: disconnecting one
+  # here would cost the pairing itself, since this provider has no logout, its disconnect
+  # drops the credentials, and connecting again asks for a new QR.
+  # The disconnect itself settles asynchronously, and a connect fired before it does is
+  # answered with the state from before: a closed session, no code, and a pairing screen
+  # that never starts, which is how this looked the first time it was run against a live
+  # instance. So the connect waits for the instance to actually be down. The ceiling is
+  # what an operator waits on a button they pressed, and reaching it is not fatal: the
+  # connect goes out anyway and the poll picks up whatever the provider settles on.
+  def restart_for_code_pairing
+    return unless fetch_connection_state.connecting?
+
+    disconnect
+    DISCONNECT_SETTLE_TRIES.times do
+      sleep(DISCONNECT_SETTLE_WAIT)
+      break if instance_down?
+    end
+  end
+
+  # The provider's raw verdict, not the one `pairing_connection` softens: what this waits
+  # for is the socket being down, and a stale QR left on the instance is exactly what it
+  # is waiting to stop mattering.
+  def instance_down?
+    status = client.get('/instance/status').to_h['instance'].to_h['status'].to_s
+
+    CONNECTIONS.fetch(status, 'close') == 'close'
   end
 
   def webhook_body(enabled:)
@@ -287,29 +297,6 @@ class Whatsapp::Session::Backends::Uazapi::Backend < Whatsapp::Session::Backend
   def webhook_url
     host = ENV.fetch('FRONTEND_URL', nil)
     "#{host.to_s.chomp('/')}/webhooks/whatsapp/session/uazapi/#{channel.id}/#{provider_config['webhook_verify_token']}"
-  end
-
-  # --- limits ------------------------------------------------------------------------
-
-  # Answered in the shape the dashboard banner already reads, which the Baileys layer
-  # established. A provider that reports nothing leaves the key out entirely, because the
-  # check job treats a missing value as "unknown" and keeps the last one rather than
-  # clearing a banner that is legitimately up.
-  def reachout_time_lock(limits)
-    lock = limits['reachout_timelock']
-    return if lock.blank?
-
-    { 'is_active' => lock['active'].present?, 'time_enforcement_ends' => lock['until'].presence }.compact
-  end
-
-  def new_chat_cap(limits)
-    cap = limits['new_chat_message_capping']
-    return if cap.blank?
-
-    {
-      'capping_status' => cap['status'].presence, 'total_quota' => cap['total_quota'],
-      'used_quota' => cap['used_quota'], 'cycle_end_timestamp' => cap['cycle_end'].presence
-    }.compact
   end
 
   # --- media -------------------------------------------------------------------------

--- a/app/services/whatsapp/session/backends/uazapi/backend/state.rb
+++ b/app/services/whatsapp/session/backends/uazapi/backend/state.rb
@@ -1,0 +1,81 @@
+# How this provider's answers are read: the connection state behind a pairing screen, and
+# the account limits behind the banner.
+#
+# Split out of the backend for the same reason its messaging and group halves are: the
+# class was over the length the project allows, and reading a provider's state is its own
+# subject.
+module Whatsapp::Session::Backends::Uazapi::Backend::State
+  # `instance.status` -> canonical connection. `hibernated` is a paused instance on the
+  # provider's side, which for an inbox is the same as being closed.
+  CONNECTIONS = {
+    'disconnected' => 'close', 'disconnecting' => 'close', 'hibernated' => 'close',
+    'connecting' => 'connecting', 'connected' => 'open'
+  }.freeze
+
+  # The disconnect reason that means the pairing itself is gone, not just the socket.
+  # Anything else the provider reports is a connection that can come back.
+  LOGGED_OUT = /401|logged out/i
+
+  private
+
+  def connection_state(response)
+    instance = (response.to_h['instance'] || response.to_h).to_h
+    connection = pairing_connection(instance)
+    model::ConnectionState.new(
+      connection: connection,
+      qr_data_url: (instance['qrcode'].presence if connection == 'connecting'),
+      pairing_code: (instance['paircode'].presence if connection == 'connecting'),
+      phone_number: (instance['owner'].presence if connection == 'open'),
+      error: connection_error(instance, connection)
+    )
+  end
+
+  # The provider's own `status`, except that a state still handing out a QR or a pairing
+  # code is not a closed one. Its `/instance/connect` answers `connecting`, and a second
+  # later `/instance/status` can report `disconnected` while serving the very same QR,
+  # unchanged, for as long as anyone keeps asking (measured 22/08/2026). Taken at face
+  # value that empties the pairing screen one second after the operator asked for it,
+  # while the code they were about to scan is still on offer.
+  #
+  # A pairing that has really ended stops carrying either artifact, and the poll's own
+  # ceiling closes the screen with a timeout rather than leaving it up forever.
+  def pairing_connection(instance)
+    connection = CONNECTIONS.fetch(instance['status'].to_s, 'close')
+    return connection unless connection == 'close'
+    return connection if instance['qrcode'].blank? && instance['paircode'].blank?
+
+    'connecting'
+  end
+
+  # `owner` keeps the previous number for as long as the instance sits disconnected, so a
+  # closed state never reports one: taking it at face value would tell the inbox it is
+  # paired with a number that is no longer there.
+  def connection_error(instance, connection)
+    return if connection != 'close'
+
+    'logged_out' if instance['lastDisconnectReason'].to_s.match?(LOGGED_OUT)
+  end
+
+  # --- limits ------------------------------------------------------------------------
+
+  # Answered in the shape the dashboard banner already reads, which the Baileys layer
+  # established. A provider that reports nothing leaves the key out entirely, because the
+  # check job treats a missing value as "unknown" and keeps the last one rather than
+  # clearing a banner that is legitimately up.
+  def reachout_time_lock(limits)
+    lock = limits['reachout_timelock']
+    return if lock.blank?
+
+    { 'is_active' => lock['active'].present?, 'time_enforcement_ends' => lock['until'].presence }.compact
+  end
+
+  def new_chat_cap(limits)
+    cap = limits['new_chat_message_capping']
+    return if cap.blank?
+
+    {
+      'capping_status' => cap['status'].presence, 'total_quota' => cap['total_quota'],
+      'used_quota' => cap['used_quota'], 'cycle_end_timestamp' => cap['cycle_end'].presence
+    }.compact
+  end
+end

--- a/app/services/whatsapp/session/backends/uazapi/webhook_translator.rb
+++ b/app/services/whatsapp/session/backends/uazapi/webhook_translator.rb
@@ -10,6 +10,7 @@
 # provider add an event type, or an operator subscribe to more than Chatwoot asked for,
 # without the inbox failing on every delivery.
 class Whatsapp::Session::Backends::Uazapi::WebhookTranslator
+  include Whatsapp::Session::Backends::Uazapi::WebhookTranslator::History
   # `state` at the top of the body, not `event.Type`: the casing of the latter is not
   # stable (a peer reading answers `Read`, our own `/message/markread` answers `read`),
   # while `state` was consistent across every capture.
@@ -37,17 +38,23 @@ class Whatsapp::Session::Backends::Uazapi::WebhookTranslator
   def perform
     return [] unless this_instance?
 
-    case body[:EventType]
-    when 'connection' then [connection].compact
-    when 'messages' then [message].compact
-    when 'messages_update' then message_update
-    when 'presence' then [chat_presence].compact
-    when 'groups' then [group].compact
-    else []
-    end
+    return message_update if body[:EventType] == 'messages_update'
+
+    [single_event].compact
   end
 
   private
+
+  # Every envelope but `messages_update`, which is the one that can carry several.
+  def single_event
+    case body[:EventType]
+    when 'connection' then connection
+    when 'messages' then message
+    when 'presence' then chat_presence
+    when 'groups' then group
+    when 'history' then history
+    end
+  end
 
   # The instance the body says it came from, against the one the inbox is pointed at now.
   # A body is authenticated when it arrives and dispatched later, and an inbox re-pointed

--- a/app/services/whatsapp/session/backends/uazapi/webhook_translator/history.rb
+++ b/app/services/whatsapp/session/backends/uazapi/webhook_translator/history.rb
@@ -1,0 +1,36 @@
+# The history half of the translator: the initial dump the phone sends after pairing and
+# the answer to every on-demand request, which arrive as the same event under a
+# discriminator of their own.
+#
+# Split out because the translator is at the length the project allows, and because these
+# frames are the live ones minus three fields rather than a shape of their own.
+module Whatsapp::Session::Backends::Uazapi::WebhookTranslator::History
+  private
+
+  # Only the messages are translated: `chats` is the provider's own CRM object for a
+  # conversation and `labels` is the account's WhatsApp labels, neither of which this
+  # layer imports.
+  #
+  # A batch carries up to 200 messages and one request can produce several, so the whole
+  # batch becomes a single event: putting each message through the live path instead would
+  # notify, automate and broadcast a year of history as if it had just arrived.
+  def history
+    return unless body[:event] == 'messages'
+
+    messages = Array(body[:messages]).filter_map { |raw| historical(raw) }
+    return if messages.empty?
+
+    event(events::HistorySync.new(kind: 'messages', data: { 'messages' => messages.map(&:to_h) }))
+  end
+
+  # The history shape is the live one minus `type`, `mediaType` and `groupName`, so the
+  # same builder reads it. What it cannot read is the media kind behind an audio, which is
+  # what `mediaType` carries: a voice note imported from history arrives as an audio file
+  # and the bubble says so, rather than guessing which of the two it was.
+  def historical(raw)
+    payload = raw.to_h.with_indifferent_access
+    return if payload[:messageid].blank?
+
+    inbound_message(payload, timestamp_ms(payload[:messageTimestamp]))
+  end
+end

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -158,12 +158,24 @@ class Whatsapp::Session::ConnectionStateWriter
 
   # The token identifying the pairing attempt in progress. Only the connect answer and the
   # poll carry one, and every other event about the same attempt (a rotated QR, a pairing
-  # code, a connecting state) arrives without it: dropping it there retires the polling
-  # chain that is driving the very screen those events are updating, and the code on it
-  # stops rotating. Kept while the attempt is still connecting, gone once it resolved.
+  # code, a connecting state, the close of the pairing before it) arrives without one.
+  # Dropping the token on any of those retires the polling chain that is driving the very
+  # screen they are updating, and whatever is on it stops rotating.
+  #
+  # Which is why a `close` that names no attempt no longer ends one. The provider does not
+  # know this token exists, so a closed state without it says nothing about which pairing
+  # it belongs to, and it is as likely to be the tail of the session before. The case that
+  # proved it is pairing by code on Uazapi, which only issues a code from a disconnected
+  # instance: the disconnect that clears the way is answered by a webhook landing after
+  # the connect that follows it, and that `close` used to retire the attempt the connect
+  # had just claimed, three milliseconds into the chain.
+  #
+  # `open` still ends it, from any writer. That one is not ambiguous: the session is
+  # paired, so whatever pairing was in flight is over, and leaving the token behind would
+  # keep a finished chain looking current to the fence.
   def carry_attempt(payload, persisted)
     return if payload['pairing_attempt'].present?
-    return unless payload['connection'].in?(%w[connecting reconnecting])
+    return if payload['connection'] == 'open'
 
     payload['pairing_attempt'] = persisted['pairing_attempt'] if persisted['pairing_attempt'].present?
   end

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -79,11 +79,29 @@ class Whatsapp::Session::ConnectionStateWriter
     # job transport leaves the state in place, so every repeat of it is reported as
     # unchanged and the logout is never asked for again. The job re-reads the quarantine
     # and stands down when it is gone, so asking twice costs nothing.
-    ensure_logout(written) if %i[written unchanged].include?(result)
+    if %i[written unchanged].include?(result)
+      ensure_logout(written)
+      end_backfill
+    end
     result
   end
 
   private
+
+  # A history request reaches the phone through the session, so a session that is no longer
+  # up cannot be answered: whatever arrives after the next pairing is the phone's own dump,
+  # not the answer to anything anybody asked for. Closing the window here is what keeps that
+  # dump out of an inbox whose operator only ever asked once, hours earlier.
+  #
+  # Read off the record rather than off the state that was applied, so what decides is what
+  # was actually persisted: a state can be replaced on the way in (an account that turns out
+  # to be the wrong one is rewritten as a quarantined close), and the record is the one place
+  # that has already been through all of it.
+  def end_backfill
+    return if channel.provider_connection.to_h['connection'] == 'open'
+
+    Whatsapp::Session::HistoryBackfill.close!(channel)
+  end
 
   def ensure_logout(written)
     return unless written.error == WRONG_PHONE_ERROR

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -9,12 +9,8 @@
 # `session_backend` and speaks the canonical API directly.
 class Whatsapp::Session::Facade
   include Whatsapp::Session::Facade::Groups
-
-  TYPING_STATES = {
-    Events::Types::CONVERSATION_TYPING_ON => 'composing',
-    Events::Types::CONVERSATION_RECORDING => 'recording',
-    Events::Types::CONVERSATION_TYPING_OFF => 'paused'
-  }.freeze
+  include Whatsapp::Session::Facade::History
+  include Whatsapp::Session::Facade::Presence
 
   attr_reader :channel, :backend, :provider, :instance
 
@@ -151,46 +147,7 @@ class Whatsapp::Session::Facade
     true
   end
 
-  # --- presence and contacts -----------------------------------------------------
-  #
-  # These four are background synchronization the dashboard triggers as a side effect of
-  # something else: a listener firing on a typing event, a conversation being marked
-  # unread. `Channel::Whatsapp` used to skip them by asking `respond_to?`, which was true
-  # of the legacy service and false of anything it did not implement; a facade that
-  # answers every message makes that test useless, so the capability is what decides now.
-  # Nothing here is an action the agent waits on, so an unsupported one is skipped rather
-  # than raised: a listener that raises takes the whole event down with it.
-
-  def toggle_typing_status(typing_status, recipient_id:, **)
-    state = TYPING_STATES[typing_status]
-    return if state.blank? || !capability?('typing')
-
-    backend.send_chat_presence(model::Commands::ChatPresence.new(chat: address(recipient_id), state: state))
-  end
-
-  # `online`, `offline` and `busy` are Chatwoot availability; the contract knows only
-  # `available` and `unavailable`. The same mapping the Baileys service has.
-  PRESENCE_STATES = { 'online' => 'available', 'offline' => 'unavailable', 'busy' => 'unavailable' }.freeze
-
-  def update_presence(status)
-    return unless capability?('presence')
-
-    state = PRESENCE_STATES[status.to_s]
-    return if state.blank?
-
-    backend.update_presence(model::Commands::PresenceSet.new(state: state))
-  end
-
-  # The command's `party` field carries an Address, not a Party: `PresenceSubscribe`
-  # coerces it as one, and `.new` does not run that coercion, so building a Party here
-  # put `{phone, lid}` on the wire where the connector expects `{kind, id}`.
-  def presence_subscribe(jids)
-    return unless capability?('presence_subscribe')
-
-    Array(jids).filter_map { |jid| model::Address.parse(jid) }.each do |address|
-      backend.subscribe_presence(model::Commands::PresenceSubscribe.new(party: address))
-    end
-  end
+  # --- contacts --------------------------------------------------------------------
 
   # Answered in the shape the contact builder and the inbox controller already read:
   # `exists` plus the phone JID WhatsApp actually knows the number by, which is what the
@@ -268,7 +225,7 @@ class Whatsapp::Session::Facade
     backend.connect(
       model::Commands::SessionConnect.new(
         pairing: mode, phone: channel.phone_number.to_s.delete('+'),
-        groups: capability?('groups'), calls: call_policy
+        groups: capability?('groups'), calls: call_policy, history_sync: history_sync?
       )
     )
   rescue Whatsapp::Session::Errors::Error

--- a/app/services/whatsapp/session/facade/history.rb
+++ b/app/services/whatsapp/session/facade/history.rb
@@ -8,21 +8,29 @@ module Whatsapp::Session::Facade::History
   # acknowledges the request and the messages arrive as `history.sync` events, if the
   # phone is awake to answer at all, which is why the caller is told the request went out
   # rather than what it produced.
-  def request_history(contact, count: nil, before_id: nil)
+  # `before` is the stored message to page backwards from, or nil to start from the oldest
+  # the provider knows. A message rather than an id: the anchor needs its timestamp and its
+  # direction too, and the row is the one place that has all three together.
+  def request_history(contact, count: nil, before: nil)
     raise Whatsapp::Session::Errors::NotSupported, I18n.t('errors.inboxes.channel.history_sync_unsupported') unless capability?('history_sync')
 
     backend.request_history(
-      model::Commands::HistoryRequest.new(chat: model::Address.for_contact(contact), count: count, before_id: before_id)
+      model::Commands::HistoryRequest.new(
+        chat: model::Address.for_contact(contact), count: count,
+        before: model::Commands::HistoryAnchor.for_message(before)
+      )
     )
     true
   end
-
-  private
 
   # Whether this inbox asked for the history the phone already has. Off unless the
   # operator turned it on: the phone answers with everything it has, and an inbox that
   # never asked should not have a year of somebody else's conversations imported into it
   # on the first connect.
+  #
+  # Public because it also gates the on-demand backfill. The answer to a request arrives
+  # on the webhook, and the webhook only carries history for an inbox that subscribed to
+  # it, so with this off the request would go out and the reply would be dropped.
   def history_sync?
     capability?('history_sync') && ActiveModel::Type::Boolean.new.cast(channel.provider_config&.dig('history_sync')).present?
   end

--- a/app/services/whatsapp/session/facade/history.rb
+++ b/app/services/whatsapp/session/facade/history.rb
@@ -1,0 +1,29 @@
+# The history half of the facade: asking a chat for what came before, and whether this
+# inbox asked for it at all.
+#
+# Split out for the same reason the group half is: the facade is at the length the project
+# allows, and this is its own subject.
+module Whatsapp::Session::Facade::History
+  # Asks a chat for the history behind it. Nothing here waits for it: the provider
+  # acknowledges the request and the messages arrive as `history.sync` events, if the
+  # phone is awake to answer at all, which is why the caller is told the request went out
+  # rather than what it produced.
+  def request_history(contact, count: nil, before_id: nil)
+    raise Whatsapp::Session::Errors::NotSupported, I18n.t('errors.inboxes.channel.history_sync_unsupported') unless capability?('history_sync')
+
+    backend.request_history(
+      model::Commands::HistoryRequest.new(chat: model::Address.for_contact(contact), count: count, before_id: before_id)
+    )
+    true
+  end
+
+  private
+
+  # Whether this inbox asked for the history the phone already has. Off unless the
+  # operator turned it on: the phone answers with everything it has, and an inbox that
+  # never asked should not have a year of somebody else's conversations imported into it
+  # on the first connect.
+  def history_sync?
+    capability?('history_sync') && ActiveModel::Type::Boolean.new.cast(channel.provider_config&.dig('history_sync')).present?
+  end
+end

--- a/app/services/whatsapp/session/facade/presence.rb
+++ b/app/services/whatsapp/session/facade/presence.rb
@@ -1,0 +1,54 @@
+# The presence half of the facade: typing indicators, the agent's own availability, and
+# subscribing to a contact's.
+#
+# Split out for the same reason the group and history halves are: the facade is at the
+# length the project allows.
+module Whatsapp::Session::Facade::Presence
+  # Chatwoot's typing events, in the terms the contract uses.
+  TYPING_STATES = {
+    Events::Types::CONVERSATION_TYPING_ON => 'composing',
+    Events::Types::CONVERSATION_RECORDING => 'recording',
+    Events::Types::CONVERSATION_TYPING_OFF => 'paused'
+  }.freeze
+
+  # --- presence and contacts -----------------------------------------------------
+  #
+  # These four are background synchronization the dashboard triggers as a side effect of
+  # something else: a listener firing on a typing event, a conversation being marked
+  # unread. `Channel::Whatsapp` used to skip them by asking `respond_to?`, which was true
+  # of the legacy service and false of anything it did not implement; a facade that
+  # answers every message makes that test useless, so the capability is what decides now.
+  # Nothing here is an action the agent waits on, so an unsupported one is skipped rather
+  # than raised: a listener that raises takes the whole event down with it.
+
+  def toggle_typing_status(typing_status, recipient_id:, **)
+    state = TYPING_STATES[typing_status]
+    return if state.blank? || !capability?('typing')
+
+    backend.send_chat_presence(model::Commands::ChatPresence.new(chat: address(recipient_id), state: state))
+  end
+
+  # `online`, `offline` and `busy` are Chatwoot availability; the contract knows only
+  # `available` and `unavailable`. The same mapping the Baileys service has.
+  PRESENCE_STATES = { 'online' => 'available', 'offline' => 'unavailable', 'busy' => 'unavailable' }.freeze
+
+  def update_presence(status)
+    return unless capability?('presence')
+
+    state = PRESENCE_STATES[status.to_s]
+    return if state.blank?
+
+    backend.update_presence(model::Commands::PresenceSet.new(state: state))
+  end
+
+  # The command's `party` field carries an Address, not a Party: `PresenceSubscribe`
+  # coerces it as one, and `.new` does not run that coercion, so building a Party here
+  # put `{phone, lid}` on the wire where the connector expects `{kind, id}`.
+  def presence_subscribe(jids)
+    return unless capability?('presence_subscribe')
+
+    Array(jids).filter_map { |jid| model::Address.parse(jid) }.each do |address|
+      backend.subscribe_presence(model::Commands::PresenceSubscribe.new(party: address))
+    end
+  end
+end

--- a/app/services/whatsapp/session/history_backfill.rb
+++ b/app/services/whatsapp/session/history_backfill.rb
@@ -1,0 +1,52 @@
+# The operator asked for history, just now.
+#
+# Two different things ask the phone for its history, and they are not the same decision.
+# The inbox setting is standing consent: on every connect, take what the phone offers. The
+# button is a single act: take it now, because a connection was down over the weekend or
+# because somebody wants the context of a conversation that predates this inbox.
+#
+# Nothing on the wire tells the two apart. A history frame is a history frame whether the
+# phone sent it on its own after pairing or in answer to a request, so the difference has
+# to be held here: a mark with an expiry that says a person asked, recently.
+#
+# Without it the button would have to borrow the setting, and pressing it once would mean
+# turning on a dump that then repeats at every future pairing. That is a bad trade for a
+# one-off recovery, and it is what this exists to avoid.
+module Whatsapp::Session::HistoryBackfill
+  # A backstop, not the guard. What the window had to be short enough to avoid was a
+  # reconnect landing inside it, because the dump that follows a pairing would then be
+  # filed as if it had been asked for. `close!` removes that case by construction: the
+  # session cannot come back up without having gone down first, and going down closes the
+  # window. Tuning a number to make an accident unlikely is a worse answer than removing
+  # the accident.
+  #
+  # With that gone, the only thing left for the clock to do is stop a mark from outliving
+  # the request forever on a session that never drops, and the only cost of it being long
+  # is nil. So it is sized for the case that remains: a phone that answers hours later,
+  # once somebody unlocks it, which is exactly what the provider warns about.
+  WINDOW = 6.hours
+
+  module_function
+
+  # Opens the window, and re-opens it while an answer is still arriving. A dump comes in
+  # several frames over some stretch of time, and a window that closed between two of them
+  # would drop the tail of the very import it authorised.
+  def open!(channel)
+    Redis::Alfred.set(key(channel), '1', ex: WINDOW)
+  end
+
+  # Called whenever the session is written as anything but open. A request travels to the
+  # phone through the session, so one that ends takes any outstanding request with it, and
+  # what arrives after the next pairing is the phone's own dump rather than an answer.
+  def close!(channel)
+    Redis::Alfred.delete(key(channel))
+  end
+
+  def pending?(channel)
+    Redis::Alfred.get(key(channel)).present?
+  end
+
+  def key(channel)
+    "WHATSAPP::HISTORY_BACKFILL::#{channel.id}"
+  end
+end

--- a/app/services/whatsapp/session/inbound/chat_identity.rb
+++ b/app/services/whatsapp/session/inbound/chat_identity.rb
@@ -1,0 +1,33 @@
+# Who a chat belongs to, and every key that names it.
+#
+# Shared by the live path and the history import so the two cannot drift: a message that
+# resolves to one contact when it arrives and to another when it is imported would file
+# the same person twice, and a lock key computed differently in the two places would let
+# an import and a live message open a conversation each for the same chat.
+module Whatsapp::Session::Inbound::ChatIdentity
+  module_function
+
+  # In a 1:1 chat the other side is the chat itself; `sender` is the author, which is the
+  # session owner on an echo and therefore not who the conversation belongs to. An
+  # incoming message carries the richer Party (phone and LID together), so it wins.
+  def peer_party(message)
+    return message.sender if message.incoming? && message.sender.present?
+
+    Whatsapp::Session::Model::Party.from_address(message.chat)
+  end
+
+  # Every id this chat can be addressed by. WhatsApp names the same 1:1 peer by phone in
+  # one event and by LID in the next, and both resolve to one contact: locking only the id
+  # this event carries lets a worker holding the other alias run alongside, and each opens
+  # a conversation of its own.
+  #
+  # Every ninth-digit form as well: WhatsApp reports a Brazilian or Argentinian line with
+  # or without the extra digit, `ContactResolver` files both under one contact, and two
+  # keys differing by that digit would not serialize against each other.
+  def lock_ids(message)
+    return [message.chat.id] if message.group?
+
+    party = peer_party(message)
+    [message.chat.id, party&.lid, *Whatsapp::Session::PhoneMatch.variants(party&.phone)]
+  end
+end

--- a/app/services/whatsapp/session/inbound/conversation_finder.rb
+++ b/app/services/whatsapp/session/inbound/conversation_finder.rb
@@ -5,17 +5,27 @@
 # rules are the upstream ones: a reaction lands in the thread holding its target, and
 # everything else follows the inbox reopen policy.
 class Whatsapp::Session::Inbound::ConversationFinder
-  attr_reader :inbox, :contact, :contact_inbox, :attribution, :reaction_target_id
+  attr_reader :inbox, :contact, :contact_inbox, :attribution, :reaction_target_id, :archived, :occurred_at
 
   # `attribution` is the first-touch payload ({ 'referral' =>, 'entry_point' => }) the
   # message carried, already compacted by the handler.
-  def initialize(inbox:, contact:, contact_inbox:, attribution: {}, reaction_target_id: nil)
+  #
+  # `archived` is the history import saying this message predates the inbox's coverage
+  # (see Inbound::Coverage): it never had a chance to be answered here, so it must not
+  # open work. `occurred_at` is when it actually happened, used to date a thread that has
+  # to be created for it.
+  # rubocop:disable Metrics/ParameterLists -- every one of these is an independent fact
+  # about the message being filed; an options object would only move the list elsewhere.
+  def initialize(inbox:, contact:, contact_inbox:, attribution: {}, reaction_target_id: nil, archived: false, occurred_at: nil)
     @inbox = inbox
     @contact = contact
     @contact_inbox = contact_inbox
     @attribution = attribution.presence || {}
     @reaction_target_id = reaction_target_id
+    @archived = archived
+    @occurred_at = occurred_at
   end
+  # rubocop:enable Metrics/ParameterLists
 
   def perform
     conversation = conversation_for_reaction || conversation_by_inbox_config
@@ -39,7 +49,13 @@ class Whatsapp::Session::Inbound::ConversationFinder
     # Scoped to the contact across all its contact_inboxes: one person can hold several
     # source_ids in the same inbox (phone and LID), and reopen must see all of them.
     conversations = contact.conversations.where(inbox_id: inbox.id)
-    return conversations.last if inbox.lock_to_single_conversation
+    # An archived import takes whatever thread the contact last had, open or resolved. The
+    # reopen policy is the wrong question for it twice over: skipping a resolved thread
+    # would open a new one for a message from last year, and doing that per message would
+    # end an import of nine hundred messages with nine hundred conversations. Landing in
+    # the thread that is already on screen is also what the on-demand button means, since
+    # it is pressed to see further back in a conversation that exists.
+    return conversations.last if archived || inbox.lock_to_single_conversation
 
     conversations.where.not(status: :resolved).last
   end
@@ -51,6 +67,16 @@ class Whatsapp::Session::Inbound::ConversationFinder
     }
     params[:additional_attributes] = attribution if attribution.present?
     params[:group_type] = :group if group?
+    # Dated to the message, so a thread reads as the past it is: an inbox sorted by
+    # creation does not show a decade of history as having started this afternoon, and a
+    # conversation never claims to be younger than the messages inside it.
+    params[:created_at] = occurred_at if occurred_at.present?
+    # Resolved from the start, never resolved afterwards. The difference is the whole
+    # reason the archive is free: `notify_status_change` and `create_activity` are
+    # after_update callbacks, so a thread born in this state fires no resolution reporting
+    # event and writes no "resolved by" line into itself. Transitioning to the same state
+    # would do both, and every imported thread would land in today's figures.
+    params[:status] = :resolved if archived
     params
   end
 

--- a/app/services/whatsapp/session/inbound/coverage.rb
+++ b/app/services/whatsapp/session/inbound/coverage.rb
@@ -1,0 +1,44 @@
+# When this inbox was last known to be receiving.
+#
+# History arrives as one undifferentiated pile, and the two halves of it want opposite
+# treatment. Messages that piled up while the connection was down were never seen by
+# anybody, because the system that would have shown them was off: those belong in the
+# queue on Monday morning. Everything older was lived somewhere else and is being filed
+# here for reference, so it belongs in the archive.
+#
+# The boundary is not age. A conversation from two hours ago that an agent already
+# answered is history; a message from Saturday that nobody saw is work. What separates
+# them is whether the inbox was covering the channel when it arrived, and the inbox knows
+# that: the newest message it holds is the last moment it can prove it was listening.
+#
+# WhatsApp draws the same line itself, incidentally. Its history sync is typed, and
+# `RECENT` means exactly "what arrived while this device was offline" as opposed to the
+# bootstrap dump. Uazapi does not pass the type through (the frames carry `messages`,
+# `chats` or `labels` and nothing else), so the line is redrawn here from what we hold.
+module Whatsapp::Session::Inbound::Coverage
+  module_function
+
+  # Nil when the inbox has never stored a provider message, which is a first connection:
+  # nothing predates coverage that has not also predated the inbox, so the whole import is
+  # archive. That is also what keeps a freshly paired inbox from opening a year of threads.
+  #
+  # Only messages that came from the provider count. An agent's private note or a status
+  # activity says the *dashboard* was in use, not that the channel was up, and a note
+  # typed on Monday would otherwise date the coverage past the weekend that was missed.
+  #
+  # `created_at` rather than the provider timestamp in `content_attributes`: an imported
+  # message is written with its original date, so the column stays the same clock for both
+  # kinds of row, and it is a column rather than a jsonb key. Live traffic puts the two
+  # within seconds of each other, which is the precision this boundary needs.
+  def watermark(inbox)
+    inbox.messages.where.not(source_id: nil).maximum(:created_at)
+  end
+
+  # True when the message arrived after the inbox stopped covering the channel: nobody
+  # has had the chance to read it, so it is late mail rather than history.
+  def gap?(message, watermark)
+    return false if watermark.blank?
+
+    message.sent_at > watermark
+  end
+end

--- a/app/services/whatsapp/session/inbound/dispatcher.rb
+++ b/app/services/whatsapp/session/inbound/dispatcher.rb
@@ -33,6 +33,7 @@ class Whatsapp::Session::Inbound::Dispatcher
     'group.updated' => 'GroupUpdated',
     'group.picture_changed' => 'GroupPictureChanged',
     'group.activity' => 'GroupActivity',
+    'history.sync' => 'HistorySync',
     'account.reachout_timelock' => 'AccountLimits',
     'account.new_chat_cap' => 'AccountLimits',
     'raw' => 'Raw'
@@ -42,7 +43,7 @@ class Whatsapp::Session::Inbound::Dispatcher
   # missing from both tables shows up as a gap instead of as silence.
   IGNORED = %w[
     pairing.passkey_request pairing.passkey_confirmation contact.identity_changed
-    call.offer call.terminate history.sync
+    call.offer call.terminate
   ].freeze
 
   attr_reader :channel, :event, :instance

--- a/app/services/whatsapp/session/inbound/group_resolver.rb
+++ b/app/services/whatsapp/session/inbound/group_resolver.rb
@@ -34,9 +34,10 @@ class Whatsapp::Session::Inbound::GroupResolver
   # would get a second conversation and split the group in two. It lives in the concern
   # the frozen Baileys layer also uses, so the policy is applied here instead of changed
   # there.
-  def conversation_for(group_contact_inbox)
+  def conversation_for(group_contact_inbox, archived: false, occurred_at: nil)
     Whatsapp::Session::Inbound::ConversationFinder.new(
-      inbox: inbox, contact: group_contact_inbox.contact, contact_inbox: group_contact_inbox
+      inbox: inbox, contact: group_contact_inbox.contact, contact_inbox: group_contact_inbox,
+      archived: archived, occurred_at: occurred_at
     ).perform
   end
 

--- a/app/services/whatsapp/session/inbound/handlers/history_sync.rb
+++ b/app/services/whatsapp/session/inbound/handlers/history_sync.rb
@@ -1,0 +1,42 @@
+# A batch of history: what the phone sends after pairing, and what it answers a request
+# with. Both arrive under the same event, discriminated by `kind`.
+class Whatsapp::Session::Inbound::Handlers::HistorySync < Whatsapp::Session::Inbound::Handlers::Base
+  def perform
+    return :ignored unless capability?(:history_sync)
+    # `chats` and `labels` are the provider's own CRM objects and the account's WhatsApp
+    # labels. Only messages are imported, and a kind this layer does not know is dropped
+    # rather than guessed at.
+    return :ignored unless payload.kind == 'messages'
+    return :ignored if messages.empty?
+
+    inbound::HistoryImporter.new(channel: channel, messages: messages, requested: asked_for?).perform
+  end
+
+  private
+
+  # Whether anybody asked, which decides how much of the pile is kept rather than whether
+  # any of it is. The setting is standing consent given on the inbox; the window is one
+  # person having pressed the button. Neither means the phone is offering its history
+  # unprompted, and then the importer files only what arrived while the session was down.
+  #
+  # That last case is the whole reason this no longer refuses outright. WhatsApp has no way
+  # to ask for messages *after* a point: the on-demand request only walks backwards, and
+  # the phone's own account of what was missed arrives on its own after a pairing. Refusing
+  # it threw away the only copy of the weekend.
+  def asked_for?
+    return true if channel.provider_service.try(:history_sync?)
+    return false unless Whatsapp::Session::HistoryBackfill.pending?(channel)
+
+    # Held open for as long as the answer keeps coming: a dump arrives in several frames,
+    # and a window closing between two of them would drop the tail of the import it
+    # authorised in the first place.
+    Whatsapp::Session::HistoryBackfill.open!(channel)
+    true
+  end
+
+  # The batch is carried as plain hashes, the shape the contract puts on the wire, so each
+  # is rehydrated here into the same InboundMessage the live path reads.
+  def messages
+    @messages ||= Array(payload.data.to_h['messages']).map { |raw| model::InboundMessage.from_h(raw) }
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -84,27 +84,11 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
     inbound::EchoMatcher.new(inbox: inbox, message_id: message.id, client_ref: message.client_ref).perform.present?
   end
 
-  # Every id this chat can be addressed by. WhatsApp names the same 1:1 peer by phone in
-  # one event and by LID in the next, and both resolve to one contact: locking only the
-  # id this event carries lets a worker holding the other alias run alongside, and each
-  # opens a conversation of its own.
-  def chat_lock_ids
-    return [message.chat.id] if message.group?
-
-    # Every ninth-digit form as well: WhatsApp reports a Brazilian or Argentinian line
-    # with or without the extra digit, `ContactResolver` files both under one contact,
-    # and two keys differing by that digit would not serialize against each other.
-    [message.chat.id, peer_party&.lid, *Whatsapp::Session::PhoneMatch.variants(peer_party&.phone)]
-  end
-
-  # In a 1:1 chat the other side is the chat itself; `sender` is the author, which is
-  # the session owner on an echo and therefore not who the conversation belongs to.
-  # An incoming message carries the richer Party (phone and LID together), so it wins.
-  def peer_party
-    return message.sender if message.incoming? && message.sender.present?
-
-    model::Party.from_address(message.chat)
-  end
+  # Both delegate to Inbound::ChatIdentity, which the history import reads as well: the
+  # live path and the import must agree on who a chat belongs to and on the keys that
+  # serialize it, or the two file the same person twice.
+  def chat_lock_ids = inbound::ChatIdentity.lock_ids(message)
+  def peer_party = inbound::ChatIdentity.peer_party(message)
 
   # The same rule the Cloud path applies (`IncomingMessageBaseService#contact_processable?`):
   # a blocked contact stops generating messages and notifications, but the echo of a

--- a/app/services/whatsapp/session/inbound/history_importer.rb
+++ b/app/services/whatsapp/session/inbound/history_importer.rb
@@ -1,0 +1,249 @@
+# Files a batch of history into the inbox.
+#
+# What arrives is one undifferentiated pile: the phone answers a request with everything
+# it has for a chat, and answers the first connection with everything it has, full stop.
+# One live instance answered a request for fifty messages with nine hundred and forty
+# seven. So the policy on volume, on status and on what may be set off is applied here, on
+# the way in, and never assumed of the provider.
+#
+# Two decisions run through it, and they are not the same decision:
+#
+#   what it is       Inbound::Coverage splits the pile against the last moment the inbox
+#                    was known to be receiving. Newer means nobody has had the chance to
+#                    read it: that is late mail and it belongs in the queue. Older is
+#                    history and it belongs in the archive, filed resolved.
+#   what it may do   almost nothing. Whatsapp::Session::SilentWrite holds for the whole
+#                    run, so no imported message notifies, automates, posts a webhook,
+#                    wakes a bot or answers with a template, whichever half it lands in.
+#                    The one exception follows the same split: the gap half is written
+#                    announcing, so the queue an operator is watching updates itself,
+#                    while the archive stays silent because a reader has nothing to gain
+#                    from eight hundred backdated rows arriving one cable frame at a time.
+class Whatsapp::Session::Inbound::HistoryImporter
+  # A chat's whole batch is written under one lock, and a batch can be two hundred
+  # messages with an avatar lookup and a contact resolution behind the first of them. The
+  # ordinary thirty seconds is a lease that would expire mid-import, and a lease that
+  # expires is not a lock: a live message for the same chat would take the key and open a
+  # second conversation alongside the one being filled.
+  CHAT_LOCK_TTL = 5.minutes
+
+  attr_reader :channel, :messages
+
+  # Threads this run created, which is what tells an artifact from a fact. A new
+  # conversation is stamped by its own callbacks as waiting since now and active now, and
+  # for a message from Saturday both readings are wrong; on a thread that already existed
+  # the same two columns hold something real that the import may only refine.
+  attr_reader :opened
+
+  # Whether anybody asked for this pile. False is the phone volunteering what it has,
+  # which happens at every pairing, and then only the gap is filed: see `import_chat`.
+  attr_reader :requested
+
+  def initialize(channel:, messages:, requested: true)
+    @channel = channel
+    @messages = messages
+    @requested = requested
+    @opened = Set.new
+  end
+
+  def perform
+    batches = importable.group_by { |message| message.chat.to_jid }
+    return :ignored if batches.empty?
+
+    # Read once, before anything is written. Every message in the run is classified
+    # against the same boundary, or the first imported message would move the line the
+    # rest of its own batch is measured against.
+    watermark = inbound::Coverage.watermark(inbox)
+    Whatsapp::Session::SilentWrite.wrap do
+      batches.each_value { |batch| import_chat(batch, watermark) }
+    end
+    :handled
+  end
+
+  private
+
+  def inbox = channel.inbox
+  def inbound = Whatsapp::Session::Inbound
+
+  def importable
+    messages.select { |message| importable?(message) }
+  end
+
+  # The same gate the live path applies, for the same reasons: a chat Chatwoot has no
+  # representation for is not filed, and a group is only filed when the inbox handles
+  # groups. A history dump is where an inbox without the capability would otherwise
+  # discover several years of group traffic at once.
+  def importable?(message)
+    return false if message.id.blank? || message.chat.blank? || message.chat.ignorable?
+    return channel.session_capabilities.include?('groups') if message.group?
+
+    true
+  end
+
+  # Oldest first, which is what makes the thread read in the order it happened and what
+  # lets `settle` take the last row as the state the conversation ended in. Archive before
+  # gap for the same reason: the two land in different threads, and the older one has to
+  # exist first or the reopen policy picks it up as the current conversation.
+  def import_chat(batch, watermark)
+    ordered = batch.sort_by { |message| message.timestamp.to_i }
+
+    inbound::Locks.with_chat_lock(inbox, inbound::ChatIdentity.lock_ids(ordered.first), ttl: CHAT_LOCK_TTL) do
+      pending = unstored(ordered)
+      next if pending.empty?
+
+      runs = pending.group_by { |message| inbound::Coverage.gap?(message, watermark) }
+      # An unrequested pile keeps only its gap. The phone offers its whole history at every
+      # pairing, and an inbox nobody asked would otherwise fill with a year of somebody's
+      # conversations; what arrived while the session was down is a different thing, and it
+      # is the only part of that offer this inbox is missing. A first pairing has no
+      # coverage at all, so `gap?` calls the whole pile archive and this drops all of it,
+      # which is what the old outright refusal was protecting.
+      archived = requested ? import_run(runs[false], archived: true) : []
+      gap = announcing { import_run(runs[true], archived: false) }
+      settle(archived, gap)
+    end
+  end
+
+  # Inside the lock, so a redelivery cannot pass this check alongside the run that is
+  # writing the rows it is checking for. One query for the chat rather than one per
+  # message: a batch is up to two hundred of them.
+  #
+  # `uniq` before the query, because the phone repeats itself: forty six of the nine
+  # hundred and forty seven messages one instance sent were second copies of an id already
+  # in the same dump. They happened to fall in different batches there, where the stored
+  # row catches them, but nothing promises that.
+  def unstored(ordered)
+    ordered = ordered.uniq(&:id)
+    stored = inbox.messages.where(source_id: ordered.map(&:id)).pluck(:source_id).to_set
+    ordered.reject { |message| stored.include?(message.id) }
+  end
+
+  # A run is one chat's messages that all belong on the same side of the boundary, so the
+  # contact and the conversation behind them are resolved once rather than once per
+  # message. On nine hundred messages that is the difference between an import that takes
+  # seconds and one that takes minutes.
+  def import_run(run, archived:)
+    return [] if run.blank?
+    return run.filter_map { |message| import_group(message, archived) } if run.first.group?
+
+    contact_inbox = resolve_contact(identifying(run))
+    return [] if contact_inbox.nil?
+
+    conversation = track(conversation_for(contact_inbox, run.first, archived))
+    run.filter_map { |message| write(conversation, contact_inbox.contact, message) }
+  end
+
+  # The message in the run that says the most about who the chat belongs to: an incoming
+  # one carries phone and LID together, while an echo only carries whatever the chat is
+  # addressed by, which can be a LID with no number behind it.
+  def identifying(run)
+    run.find(&:incoming?) || run.first
+  end
+
+  def conversation_for(contact_inbox, message, archived)
+    inbound::ConversationFinder.new(
+      inbox: inbox, contact: contact_inbox.contact, contact_inbox: contact_inbox,
+      archived: archived, occurred_at: message.sent_at
+    ).perform
+  end
+
+  # A group is the one chat whose author changes from message to message, so its sender
+  # is resolved per message. Its own contact and thread are looked up each time too, which
+  # is a query a group batch pays and a 1:1 batch does not.
+  def import_group(message, archived)
+    resolver = inbound::GroupResolver.new(inbox: inbox, group: message.chat, sender: message.sender)
+    group = resolver.perform
+    conversation = track(resolver.conversation_for(group.group_contact_inbox, archived: archived, occurred_at: message.sent_at))
+
+    write(conversation, group.sender_contact, message)
+  end
+
+  # `overwrite: false` because the push name on a message from last June is what the
+  # contact was called last June, and the live path has been keeping it current since.
+  # Avatars are skipped for the same kind of reason and one more: an inbox connecting for
+  # the first time would otherwise ask the provider for five hundred profile pictures in
+  # one go, which is how an instance gets itself rate limited on the day it is set up. A
+  # live message fills the avatar in.
+  def resolve_contact(message)
+    inbound::ContactResolver.new(
+      inbox: inbox, party: inbound::ChatIdentity.peer_party(message), overwrite: false, skip_avatar: true
+    ).perform
+  end
+
+  def track(conversation)
+    opened << conversation.id if conversation.previously_new_record?
+    conversation
+  end
+
+  def write(conversation, sender, message)
+    inbound::MessageWriter.new(conversation: conversation, inbound: message, sender: sender, imported: true).perform
+  end
+
+  # What the suppressed callbacks would have kept up to date, applied once per
+  # conversation instead of once per message, and only in the direction that is true.
+  # Raises the flag for the stretch it wraps. Only the gap ever asks for it, and only the
+  # dashboard push gets through: see Whatsapp::Session::SilentWrite.
+  def announcing(&) = Whatsapp::Session::SilentWrite.wrap(announce: true, &)
+
+  # Both halves are settled together rather than one after the other, because a chat can
+  # hand rows to each and the stamps have to see all of them at once: split in two, the
+  # archive pass would read a conversation's rows without the newer gap rows beside them.
+  # Which conversations may announce is therefore carried separately from the rows.
+  def settle(archived, gap)
+    announced = gap.compact.filter_map(&:conversation).uniq
+    (archived + gap).compact.group_by(&:conversation).each do |conversation, rows|
+      stamp_activity(conversation, rows)
+      stamp_waiting(conversation, rows)
+      if announced.include?(conversation)
+        announcing { inbound::ChatList.refresh(conversation) }
+      else
+        inbound::ChatList.refresh(conversation)
+      end
+    end
+  end
+
+  # Where the inbox sorts, and where a thread appears in the list. `set_conversation_activity`
+  # assigns whatever row it has just written, unconditionally: left to run over history it
+  # would drag a thread answered this morning back to 2025. A thread this run opened takes
+  # the batch outright, because it was born stamped with the time of the import; one that
+  # already existed only ever moves forward.
+  def stamp_activity(conversation, rows)
+    newest = rows.filter_map(&:created_at).max
+    return if newest.blank?
+    return if opened.exclude?(conversation.id) && conversation.last_activity_at.present? &&
+              conversation.last_activity_at >= newest
+
+    conversation.update_columns(last_activity_at: newest) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  # The clock the queue and the unattended reports read. Live traffic keeps it by hand: a
+  # message from the contact starts it, an answer of ours clears it. An archive thread is
+  # resolved and runs no clock at all; an open one gets the same reading live traffic
+  # would have left, taken over the whole batch.
+  def stamp_waiting(conversation, rows)
+    return if conversation.resolved?
+
+    waiting_since = first_unanswered(rows)
+    return unless restamp_waiting?(conversation, waiting_since)
+
+    conversation.update_columns(waiting_since: waiting_since) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  # A thread this run opened carries what `ensure_waiting_since` stamps on every new
+  # conversation, which reads "waiting since now" about a message from Saturday: an
+  # artifact, replaced by whatever the batch says, nil included. On a thread that already
+  # existed the stored clock is real, and only an older unanswered message may pull it back.
+  def restamp_waiting?(conversation, waiting_since)
+    return true if opened.include?(conversation.id)
+    return false if waiting_since.blank?
+
+    conversation.waiting_since.blank? || conversation.waiting_since > waiting_since
+  end
+
+  # The oldest message the contact sent that nothing of ours came after.
+  def first_unanswered(rows)
+    answered_at = rows.select(&:outgoing?).filter_map(&:created_at).max
+    pending = rows.select { |row| row.incoming? && (answered_at.blank? || row.created_at > answered_at) }
+    pending.first&.created_at
+  end
+end

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -6,12 +6,16 @@
 # afterwards. Downloading inline would stall the consumer thread that keeps a session's
 # events in order, and the attachment lands within seconds either way.
 class Whatsapp::Session::Inbound::MessageWriter
-  attr_reader :conversation, :inbound, :sender
+  attr_reader :conversation, :inbound, :sender, :imported
 
-  def initialize(conversation:, inbound:, sender: nil)
+  # `imported` marks a row the history import is writing rather than one that just
+  # arrived. It changes two things and deliberately nothing else: the row is dated to when
+  # it was sent, and WhatsApp is not told it was received.
+  def initialize(conversation:, inbound:, sender: nil, imported: false)
     @conversation = conversation
     @inbound = inbound
     @sender = sender
+    @imported = imported
   end
 
   # The media an inbound message carries, whichever shape holds it, or nil.
@@ -59,7 +63,7 @@ class Whatsapp::Session::Inbound::MessageWriter
   def content_type = content&.wire_type
 
   def message_attributes
-    {
+    attributes = {
       account_id: inbox.account_id,
       inbox_id: inbox.id,
       source_id: inbound.id,
@@ -71,6 +75,12 @@ class Whatsapp::Session::Inbound::MessageWriter
       status: incoming? ? :sent : :delivered,
       content_attributes: content_attributes
     }
+    # Dated to when it was sent, not to when it was filed. The thread renders in
+    # `created_at` order, so an import written at today's timestamp would stack a year of
+    # conversation on top of this morning's, in whatever order it was imported. It is also
+    # the clock Inbound::Coverage reads to decide what a later import already had eyes on.
+    attributes[:created_at] = inbound.sent_at if imported
+    attributes
   end
 
   def message_content
@@ -94,6 +104,10 @@ class Whatsapp::Session::Inbound::MessageWriter
       in_reply_to_external_id: inbound.quoted_id.presence,
       referral: inbound.referral.presence,
       is_unsupported: (true if unsupported?),
+      # Not the same statement as `external_created_at`, which every session message
+      # carries: this one says the row was filed after the fact, which is what a report
+      # excluding backfilled traffic, or a bubble explaining an old date, has to read.
+      imported: (true if imported),
       rich: (content.to_content_attribute if content_type == 'rich')
     }.compact
   end
@@ -155,6 +169,11 @@ class Whatsapp::Session::Inbound::MessageWriter
   # and Z-API writers both do this for every incoming row; without it every message this
   # layer stores stays unread on the contact's phone forever.
   def acknowledge(messages)
+    # Never for an import. These are messages the contact sent long ago, or while nobody
+    # was watching, and reading them is an agent's act: acknowledging on their behalf puts
+    # the second tick on the contact's screen for a message no human has opened, and with
+    # `mark_as_read` on it empties the unread badge of the whole chat on the phone.
+    return messages if imported
     return messages unless incoming? && messages.present?
 
     inbox.channel.received_messages(messages, conversation)

--- a/app/services/whatsapp/session/model/commands.rb
+++ b/app/services/whatsapp/session/model/commands.rb
@@ -123,6 +123,16 @@ module Whatsapp::Session::Model::Commands
     coerce chat: Address, ref: MediaRef
   end
 
+  # The history a chat already has on the phone. `count` is a hint rather than a cap: a
+  # live instance answered a request for 50 with 947 messages, so what bounds the import
+  # is the policy on the way in, not this. `before_id` is the anchor to page backwards
+  # from, which is what makes a second request continue the first instead of repeating it.
+  class HistoryRequest < Data.define(:chat, :count, :before_id)
+    include Serializable
+    wire_type 'history.request'
+    coerce chat: Address
+  end
+
   class PresenceSet < Data.define(:state)
     include Serializable
     wire_type 'presence.set'
@@ -250,7 +260,7 @@ module Whatsapp::Session::Model::Commands
 
   CLASSES = [
     SessionConnect, SessionDisconnect, SessionLogout, SessionDelete, SessionStatus, SessionUpdate, SessionWake,
-    AdminPing, PairingRequestCode, PairingPasskeyResponse, PairingPasskeyConfirm, MessageSend, MessageEdit,
+    AdminPing, PairingRequestCode, PairingPasskeyResponse, PairingPasskeyConfirm, HistoryRequest, MessageSend, MessageEdit,
     MessageRevoke, MessageReact, MessageMarkRead, MessageMarkUnread, MessageDownloadMedia, PresenceSet,
     PresenceSubscribe, ChatPresence, ContactCheck, ContactProfilePicture, ContactInfo, ContactResolve, GroupCreate,
     GroupInfo, GroupList, GroupLeave, GroupParticipantsUpdate, GroupNameSet, GroupDescriptionSet, GroupPhotoSet,

--- a/app/services/whatsapp/session/model/commands.rb
+++ b/app/services/whatsapp/session/model/commands.rb
@@ -123,14 +123,30 @@ module Whatsapp::Session::Model::Commands
     coerce chat: Address, ref: MediaRef
   end
 
+  # Where a backwards page starts. An id on its own cannot address one: whatsmeow takes a
+  # whole `types.MessageInfo` to build the request, so the anchor carries the timestamp and
+  # the direction alongside it. Chatwoot holds all three on the message row, so nothing has
+  # to be reconstructed at the far end.
+  class HistoryAnchor < Data.define(:id, :timestamp, :from_me)
+    include Serializable
+    defaults from_me: false
+
+    # The anchor a stored message stands for.
+    def self.for_message(message)
+      return if message.blank?
+
+      new(id: message.source_id, timestamp: (message.created_at.to_f * 1000).to_i, from_me: message.outgoing?)
+    end
+  end
+
   # The history a chat already has on the phone. `count` is a hint rather than a cap: a
   # live instance answered a request for 50 with 947 messages, so what bounds the import
-  # is the policy on the way in, not this. `before_id` is the anchor to page backwards
-  # from, which is what makes a second request continue the first instead of repeating it.
-  class HistoryRequest < Data.define(:chat, :count, :before_id)
+  # is the policy on the way in, not this. `before` is the anchor to page backwards from,
+  # which is what makes a second request continue the first instead of repeating it.
+  class HistoryRequest < Data.define(:chat, :count, :before)
     include Serializable
     wire_type 'history.request'
-    coerce chat: Address
+    coerce chat: Address, before: HistoryAnchor
   end
 
   class PresenceSet < Data.define(:state)
@@ -275,6 +291,7 @@ module Whatsapp::Session::Model::Commands
   RPC_TYPES = %w[
     session.connect session.status session.update admin.ping
     message.send message.edit message.revoke message.react message.download_media
+    history.request
     contact.check contact.profile_picture contact.info contact.resolve
     group.create group.info group.list group.leave group.participants.update group.name.set
     group.description.set group.photo.set group.settings.set group.invite.get

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -12,6 +12,10 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
 
   MARK_AS_READ = Field.new(name: 'mark_as_read', type: 'boolean', default: true).freeze
   PRESENCE_SUBSCRIBE = Field.new(name: 'presence_subscribe', type: 'boolean', default: false).freeze
+  # Off by default, and behind the advanced toggle: the phone answers a history request
+  # with everything it has (947 messages for one chat, measured), so an inbox opts into
+  # that rather than discovering it on the first connect.
+  HISTORY_SYNC = Field.new(name: 'history_sync', type: 'boolean', default: false).freeze
 
   DESCRIPTORS = [
     Descriptor.new(
@@ -41,13 +45,14 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
       # face, so it is not declared.
       capabilities: %w[
         qr_pairing code_pairing edit revoke reactions typing presence read_receipts check_number
-        profile_picture groups group_admin account_limits media_download
+        profile_picture groups group_admin account_limits media_download history_sync
       ],
       fields: [
         Field.new(name: 'base_url', type: 'url', required: true),
         Field.new(name: 'token', type: 'password', required: true, secret: true),
         MARK_AS_READ,
-        PRESENCE_SUBSCRIBE
+        PRESENCE_SUBSCRIBE,
+        HISTORY_SYNC
       ]
     ),
     # Legacy: described so the UI can label and gate an existing inbox, never served here.

--- a/app/services/whatsapp/session/silent_write.rb
+++ b/app/services/whatsapp/session/silent_write.rb
@@ -1,0 +1,65 @@
+# Marks a stretch of work as "writing history", which is not the same as receiving it.
+#
+# An imported message goes through the same writers a live one does, and that is the
+# point: what is stored must not depend on when it was imported. What must not run is
+# everything a live message *sets off*. A year of history replayed through the ordinary
+# path would notify every agent, fire every automation, post every outgoing webhook, wake
+# the bots, reopen conversations somebody resolved months ago and send out-of-office
+# replies for messages that were answered long ago.
+#
+# One thing does have to run, though, and it is why this has two levels rather than a
+# boolean. Somebody pressed a button and is watching a screen. A gap thread that lands in
+# the queue while the list shows the queue from before the import is a thread nobody works
+# until they happen to reload, which defeats the point of importing it. So the gap half of
+# a run is written in `:announce`, where the dashboard push survives and everything else
+# is still suppressed, and the archive half stays `:silent`: eight hundred backdated rows
+# have nothing to tell an operator now, and pushing one cable frame per row would be a
+# flood aimed at every agent in the account.
+#
+# Three guards read this flag, all declared in config/initializers/whatsapp_session_import.rb:
+#
+#   AsyncDispatcher#dispatch                 the listeners that act on the world:
+#                                            automations, campaigns, CSAT, webhooks,
+#                                            notifications, reporting, the outgoing
+#                                            channel. Never reached, at either level
+#   SyncDispatcher#dispatch                  ActionCableListener (the dashboard push) and
+#                                            AgentBotListener. Under `:announce` the cable
+#                                            listener runs and the bot does not
+#   Message#execute_after_create_commit_callbacks
+#                                            the side effects that are not events: reopen,
+#                                            message templates, the reply send, and the
+#                                            activity stamps the importer sets itself.
+#                                            Under `:announce` it re-emits `message.created`
+#                                            on its own, so the thread an operator has open
+#                                            fills in rather than only the list card
+#
+# Scoped to the thread rather than to a request: the importer runs inside a Sidekiq job,
+# and the flag must not leak into whatever that worker picks up next.
+module Whatsapp::Session::SilentWrite
+  KEY = :whatsapp_session_silent_write
+
+  module_function
+
+  # Nested calls are safe: the previous value is restored rather than cleared, so an
+  # importer running inside another silenced block does not un-silence it on the way out.
+  # That restore is what lets the gap run raise the level for its own stretch and hand the
+  # archive level back afterwards, inside one enclosing `wrap`.
+  def wrap(announce: false)
+    previous = ActiveSupport::IsolatedExecutionState[KEY]
+    ActiveSupport::IsolatedExecutionState[KEY] = announce ? :announce : :silent
+    yield
+  ensure
+    ActiveSupport::IsolatedExecutionState[KEY] = previous
+  end
+
+  def on?
+    ActiveSupport::IsolatedExecutionState[KEY].present?
+  end
+
+  # Whether this stretch may reach the dashboard. Only ever true inside `on?`, so a guard
+  # that checks it still has to check `on?` first to tell "importing, announcing" from
+  # "not importing at all", which is the ordinary case and must go through untouched.
+  def announce?
+    ActiveSupport::IsolatedExecutionState[KEY] == :announce
+  end
+end

--- a/config/initializers/whatsapp_session_import.rb
+++ b/config/initializers/whatsapp_session_import.rb
@@ -1,0 +1,77 @@
+# The three guards that make Whatsapp::Session::SilentWrite mean something.
+#
+# Declared here, and not as autoloaded classes, on purpose: a reloadable module handed to
+# `prepend` is a new object after every reload, so the ancestor chain would grow one copy
+# per edit in development. These are defined once at boot and re-prepended to whatever
+# generation of the class `to_prepare` hands over, which Ruby ignores when the module is
+# already in the chain.
+#
+# Prepended rather than edited into the classes themselves: all three are files the
+# upstream sync rewrites, and a guard clause inside them is a conflict on every merge.
+module WhatsappSessionImportGuards
+  # Everything that acts on the world outside this request. An imported message may never
+  # reach any of it, at either level of the flag: history that fires an automation, posts
+  # an outgoing webhook or notifies an agent is history pretending to be an arrival.
+  #
+  # Stopped at enqueue rather than inside EventDispatcherJob, because the flag is scoped
+  # to the importing thread and the job runs on another one, where it would read as unset.
+  module SilentAsyncDispatch
+    def dispatch(event_name, timestamp, data)
+      return if Whatsapp::Session::SilentWrite.on?
+
+      super
+    end
+  end
+
+  # The two listeners that run in this thread. ActionCableListener is the push that moves
+  # the operator's screen; AgentBotListener is a bot about to answer a message from June.
+  # Under `:announce` the first is exactly what the import is for and the second is exactly
+  # what it must not do, so the split is drawn by hand here instead of by the dispatcher.
+  #
+  # Wisper subscribes its listeners once, at boot, so there is no per-call listener set to
+  # narrow: the announcing branch bypasses the publisher and calls the one listener it
+  # allows, the same way the publisher would have. `respond_to?` because a listener only
+  # implements the events it cares about, which is the check Wisper itself makes.
+  module SilentSyncDispatch
+    def dispatch(event_name, timestamp, data)
+      return super unless Whatsapp::Session::SilentWrite.on?
+      return unless Whatsapp::Session::SilentWrite.announce?
+
+      event = Events::Base.new(event_name, timestamp, data)
+      listener = ActionCableListener.instance
+      listener.public_send(event.method_name, event) if listener.respond_to?(event.method_name)
+    end
+  end
+
+  # What the dispatcher does not cover: reopening a resolved conversation, the message
+  # template hooks (an out-of-office reply to a message from June), the outgoing send, the
+  # contact activity stamp and the conversation activity stamp. The importer sets the
+  # activity stamps itself, because the callback moves them to whatever it just wrote and
+  # history is written oldest first.
+  #
+  # One of the seven is a message to the screen rather than an action, and under `:announce`
+  # the gap needs it: without `message.created` the conversation card in the list updates
+  # and the thread the operator has open stays empty, which is a worse place to stop than
+  # not updating at all.
+  #
+  # Only the event is re-emitted, not `dispatch_create_events`, which wraps it in bookkeeping
+  # this importer has taken over: the first-reply branch writes `first_reply_created_at` and
+  # clears `waiting_since`, and the other branch recomputes `waiting_since` from a message
+  # being written oldest first. Both would fight `settle` for the same columns.
+  module SilentMessageCallbacks
+    def execute_after_create_commit_callbacks
+      return super unless Whatsapp::Session::SilentWrite.on?
+      return unless Whatsapp::Session::SilentWrite.announce?
+
+      Rails.configuration.dispatcher.dispatch(
+        Events::Types::MESSAGE_CREATED, Time.zone.now, message: self, performed_by: Current.executed_by
+      )
+    end
+  end
+end
+
+Rails.application.config.to_prepare do
+  SyncDispatcher.prepend(WhatsappSessionImportGuards::SilentSyncDispatch)
+  AsyncDispatcher.prepend(WhatsappSessionImportGuards::SilentAsyncDispatch)
+  Message.prepend(WhatsappSessionImportGuards::SilentMessageCallbacks)
+end

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -34,6 +34,7 @@ en:
         provider_withdrawn: This WhatsApp provider is no longer offered for new inboxes. Existing inboxes on it keep working.
         cannot_unpair: This provider cannot unlink the WhatsApp account paired with it, so connecting again would resume the same account. Reset the instance on the provider, point this inbox at another one, or correct the number configured here.
         code_pairing_unsupported: This WhatsApp provider cannot pair with a code. Scan the QR code instead.
+        history_sync_unsupported: This WhatsApp provider cannot fetch the history behind a chat.
         outgoing:
           provider_error: WhatsApp could not send this message right now.
           provider_unreachable: Could not reach the WhatsApp provider.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -34,6 +34,7 @@ es:
         provider_withdrawn: Este proveedor de WhatsApp ya no se ofrece para bandejas de entrada nuevas. Las que ya lo usan siguen funcionando.
         cannot_unpair: Este proveedor no puede desvincular la cuenta de WhatsApp emparejada con él, así que conectar de nuevo retomaría la misma cuenta. Reinicia la instancia en el proveedor, apunta esta bandeja de entrada a otra, o corrige el número configurado aquí.
         code_pairing_unsupported: Este proveedor de WhatsApp no puede emparejarse con un código. Escanea el código QR en su lugar.
+        history_sync_unsupported: Este proveedor de WhatsApp no puede traer el historial de un chat.
         outgoing:
           provider_error: WhatsApp no pudo enviar este mensaje en este momento.
           provider_unreachable: No se pudo contactar al proveedor de WhatsApp.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -34,6 +34,7 @@ pt_BR:
         provider_withdrawn: Este provedor de WhatsApp não é mais oferecido para novas caixas de entrada. As caixas que já usam ele continuam funcionando.
         cannot_unpair: Este provedor não consegue desvincular a conta do WhatsApp pareada com ele, então conectar de novo retomaria a mesma conta. Reinicie a instância no provedor, aponte esta caixa de entrada para outra, ou corrija o número configurado aqui.
         code_pairing_unsupported: Este provedor do WhatsApp não consegue parear com código. Escaneie o QR Code no lugar.
+        history_sync_unsupported: Este provedor do WhatsApp não consegue buscar o histórico de uma conversa.
         outgoing:
           provider_error: O WhatsApp não conseguiu enviar esta mensagem no momento.
           provider_unreachable: Não foi possível alcançar o provedor do WhatsApp.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -361,6 +361,7 @@ Rails.application.routes.draw do
             post :request_pairing_code, on: :member
             post :import_whatsapp_session, on: :member
             post :disconnect_channel_provider, on: :member
+            post :sync_provider_history, on: :member
             post :convert_provider, on: :member
             delete :avatar, on: :member
             post :sync_templates, on: :member

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1889,6 +1889,78 @@ RSpec.describe 'Inboxes API', type: :request do
     end
   end
 
+  describe 'POST /api/v1/accounts/:account_id/inboxes/:id/sync_provider_history' do
+    let(:channel) do
+      create(:channel_whatsapp, account: account, provider: 'uazapi', validate_provider_config: false, sync_templates: false,
+                                provider_config: { 'base_url' => 'https://uazapi.test', 'token' => 'x', 'history_sync' => true },
+                                provider_connection: { 'connection' => 'open' })
+    end
+    let(:inbox) { channel.inbox }
+
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/sync_provider_history"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'queues the backfill and reports that the phone was asked' do
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/sync_provider_history",
+             headers: admin.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(Whatsapp::Session::HistoryBackfillJob).to have_been_enqueued.with(channel)
+      end
+
+      # The connect-time setting is standing consent to the dump that follows a pairing.
+      # Pressing this is a single act, and requiring the setting would mean turning on a
+      # permanent behaviour to recover one weekend.
+      it 'does not require the connect-time setting' do
+        channel.update!(provider_config: channel.provider_config.merge('history_sync' => false))
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/sync_provider_history",
+             headers: admin.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(Whatsapp::Session::HistoryBackfillJob).to have_been_enqueued.with(channel)
+      end
+
+      # The request reaches the phone through the session. Queueing it with the session
+      # down would tell the operator the phone was asked and leave them waiting.
+      it 'refuses while the session is down' do
+        channel.update!(provider_connection: { 'connection' => 'close' })
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{inbox.id}/sync_provider_history",
+             headers: admin.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(Whatsapp::Session::HistoryBackfillJob).not_to have_been_enqueued
+      end
+
+      it 'refuses on a provider that cannot fetch history at all' do
+        legacy = create(:channel_whatsapp, account: account, provider: 'zapi', validate_provider_config: false,
+                                           sync_templates: false)
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{legacy.inbox.id}/sync_provider_history",
+             headers: admin.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(Whatsapp::Session::HistoryBackfillJob).not_to have_been_enqueued
+      end
+
+      it 'refuses on a channel that has no session provider at all' do
+        other = create(:inbox, account: account)
+
+        post "/api/v1/accounts/#{account.id}/inboxes/#{other.id}/sync_provider_history",
+             headers: admin.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
   describe 'POST /api/v1/accounts/:account_id/inboxes/:id/disconnect_channel_provider' do
     let(:channel) { create(:channel_whatsapp, account: account, provider: 'baileys', validate_provider_config: false) }
     let(:inbox) { channel.inbox }

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -113,6 +113,51 @@ describe MessageFinder do
     end
   end
 
+  # Imported history is written in the order the provider hands it over, which is not the
+  # order it happened: a message delivered late gets the next id and an older timestamp.
+  # An id-only cursor would drop it from every page, including the ones reached by
+  # scrolling up.
+  describe 'a message written out of chronological order' do
+    let(:params) { {} }
+    let!(:newest) do
+      create(:message, account: account, inbox: inbox, conversation: conversation,
+                       content: 'sent last', created_at: 2.minutes.ago)
+    end
+    # Higher id, earlier timestamp: this is the shape a late history frame takes.
+    let!(:late_arrival) do
+      create(:message, account: account, inbox: inbox, conversation: conversation,
+                       content: 'sent first, stored last', created_at: 3.minutes.ago)
+    end
+
+    it 'is reachable from a cursor anchored on the newer message' do
+      result = described_class.new(conversation, { before: newest.id }).perform
+
+      expect(late_arrival.id).to be > newest.id
+      expect(result).to include(late_arrival)
+      expect(result).not_to include(newest)
+    end
+
+    # The cursor now means a point in time, so a message with a *lower* id that happened
+    # after it is excluded. Under the id filter it would have come back as "before".
+    it 'excludes the cursor and everything that happened after it' do
+      result = described_class.new(conversation, { before: late_arrival.id }).perform
+
+      expect(newest.id).to be < late_arrival.id
+      expect(result).not_to include(late_arrival, newest)
+    end
+
+    # The cursor names a message this conversation does not have, so there is no timestamp
+    # to compare against and the id filter is all that is left.
+    it 'falls back to the id filter for a cursor from another conversation' do
+      elsewhere = create(:conversation, account: account, inbox: inbox, contact: contact)
+      foreign = create(:message, account: account, inbox: inbox, conversation: elsewhere)
+
+      result = described_class.new(conversation, { before: foreign.id }).perform
+
+      expect(result).to include(newest, late_arrival)
+    end
+  end
+
   describe 'page_window with reactions' do
     # Isolated setup: skip the shared `before` block's fixtures so count assertions stay stable.
     subject(:message_finder) { described_class.new(fresh_conversation, {}) }

--- a/spec/fixtures/whatsapp/session/contract/CONTRACT_REF
+++ b/spec/fixtures/whatsapp/session/contract/CONTRACT_REF
@@ -1,3 +1,3 @@
 repo=fazer-ai/whatsapp-connector
-ref=f88c3e1
-checksum=68d189b95c26216e11b08991cfb7a4ba081265936e770bc4bd148ed71b23c4ea
+ref=2c8da96
+checksum=b38049377a2f9295a7ca3c6f2bfb8e9e89fbb5124ff5bc0dbade36b7badaf56d

--- a/spec/fixtures/whatsapp/session/contract/CONTRACT_REF
+++ b/spec/fixtures/whatsapp/session/contract/CONTRACT_REF
@@ -1,3 +1,3 @@
 repo=fazer-ai/whatsapp-connector
-ref=dc977602b2b57c05d470dd6534f106b217ffae6a
-checksum=9b4a05c04654e977808b0588d9880ad0e3d178dc2e45dc242ded4fc14b7c7dcf
+ref=f88c3e1
+checksum=68d189b95c26216e11b08991cfb7a4ba081265936e770bc4bd148ed71b23c4ea

--- a/spec/fixtures/whatsapp/session/contract/fixtures/commands/history_request.json
+++ b/spec/fixtures/whatsapp/session/contract/fixtures/commands/history_request.json
@@ -10,7 +10,11 @@
       "id": "5541999990000"
     },
     "count": 50,
-    "before_id": "3EB0A1B2C3D4E5F60720"
+    "before": {
+      "id": "3EB0A1B2C3D4E5F60720",
+      "timestamp": 1755439000123,
+      "from_me": false
+    }
   },
   "reply_to": "wa:reply:cmd_000031",
   "deadline": 1755440015123

--- a/spec/fixtures/whatsapp/session/contract/fixtures/commands/history_request.json
+++ b/spec/fixtures/whatsapp/session/contract/fixtures/commands/history_request.json
@@ -1,0 +1,17 @@
+{
+  "v": 1,
+  "id": "cmd_000031",
+  "type": "history.request",
+  "sid": "9f1c0f4e-6a2b-4c8e-9d1a-2b3c4d5e6f70",
+  "ts": 1755440000123,
+  "payload": {
+    "chat": {
+      "kind": "phone",
+      "id": "5541999990000"
+    },
+    "count": 50,
+    "before_id": "3EB0A1B2C3D4E5F60720"
+  },
+  "reply_to": "wa:reply:cmd_000031",
+  "deadline": 1755440015123
+}

--- a/spec/fixtures/whatsapp/session/contract/schema/protocol.schema.json
+++ b/spec/fixtures/whatsapp/session/contract/schema/protocol.schema.json
@@ -865,12 +865,22 @@
       "required": ["chat"],
       "additionalProperties": true
     },
+    "history_anchor": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/definitions/message_id" },
+        "timestamp": { "$ref": "#/definitions/timestamp_ms" },
+        "from_me": { "type": "boolean" }
+      },
+      "required": ["id", "timestamp", "from_me"],
+      "additionalProperties": true
+    },
     "command_history_request": {
       "type": "object",
       "properties": {
         "chat": { "$ref": "#/definitions/address" },
         "count": { "type": ["integer", "null"], "minimum": 1 },
-        "before_id": { "type": ["string", "null"] }
+        "before": { "anyOf": [{ "$ref": "#/definitions/history_anchor" }, { "type": "null" }] }
       },
       "required": ["chat"],
       "additionalProperties": true

--- a/spec/fixtures/whatsapp/session/contract/schema/protocol.schema.json
+++ b/spec/fixtures/whatsapp/session/contract/schema/protocol.schema.json
@@ -711,6 +711,7 @@
             { "properties": { "type": { "const": "message.mark_read" }, "payload": { "$ref": "#/definitions/command_message_mark_read" } }, "required": ["type"] },
             { "properties": { "type": { "const": "message.mark_unread" }, "payload": { "$ref": "#/definitions/command_message_mark_unread" } }, "required": ["type"] },
             { "properties": { "type": { "const": "message.download_media" }, "payload": { "$ref": "#/definitions/command_message_download_media" } }, "required": ["type"] },
+            { "properties": { "type": { "const": "history.request" }, "payload": { "$ref": "#/definitions/command_history_request" } }, "required": ["type"] },
             { "properties": { "type": { "const": "presence.set" }, "payload": { "$ref": "#/definitions/command_presence_set" } }, "required": ["type"] },
             { "properties": { "type": { "const": "presence.subscribe" }, "payload": { "$ref": "#/definitions/command_presence_subscribe" } }, "required": ["type"] },
             { "properties": { "type": { "const": "chat.presence" }, "payload": { "$ref": "#/definitions/command_chat_presence" } }, "required": ["type"] },
@@ -860,6 +861,16 @@
         "chat": { "$ref": "#/definitions/address" },
         "last_message_id": { "type": ["string", "null"] },
         "from_me": { "type": "boolean" }
+      },
+      "required": ["chat"],
+      "additionalProperties": true
+    },
+    "command_history_request": {
+      "type": "object",
+      "properties": {
+        "chat": { "$ref": "#/definitions/address" },
+        "count": { "type": ["integer", "null"], "minimum": 1 },
+        "before_id": { "type": ["string", "null"] }
       },
       "required": ["chat"],
       "additionalProperties": true

--- a/spec/jobs/whatsapp/session/history_backfill_job_spec.rb
+++ b/spec/jobs/whatsapp/session/history_backfill_job_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::HistoryBackfillJob do
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'uazapi', validate_provider_config: false, sync_templates: false,
+                              provider_config: { 'base_url' => 'https://uazapi.test', 'token' => 'x', 'history_sync' => true })
+  end
+  let(:inbox) { channel.inbox }
+  let(:facade) { instance_double(Whatsapp::Session::Facade, request_history: true) }
+
+  before { allow(channel).to receive(:provider_service).and_return(facade) }
+
+  def conversation_with_contact(last_activity_at:)
+    contact = create(:contact, account: inbox.account)
+    contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox)
+    create(:conversation, inbox: inbox, account: inbox.account, contact: contact, contact_inbox: contact_inbox,
+                          last_activity_at: last_activity_at)
+  end
+
+  it 'asks the phone about the conversations the inbox already holds' do
+    conversation = conversation_with_contact(last_activity_at: 1.hour.ago)
+
+    described_class.perform_now(channel)
+
+    expect(facade).to have_received(:request_history).with(conversation.contact)
+  end
+
+  # What arrives is indistinguishable from the dump that follows a pairing, so the window
+  # is the only thing that will tell the import these frames were asked for. Opened before
+  # the first request, since it also puts `history` on the webhook subscription.
+  it 'opens the window before it asks' do
+    conversation_with_contact(last_activity_at: 1.hour.ago)
+
+    described_class.perform_now(channel)
+
+    expect(Whatsapp::Session::HistoryBackfill.pending?(channel)).to be(true)
+  end
+
+  # Recovering one outage must not require turning on the dump that then repeats at every
+  # future pairing: the setting is standing consent, this is a single act.
+  it 'does not need the connect-time setting' do
+    channel.update!(provider_config: channel.provider_config.merge('history_sync' => false))
+    conversation = conversation_with_contact(last_activity_at: 1.hour.ago)
+
+    described_class.perform_now(channel)
+
+    expect(facade).to have_received(:request_history).with(conversation.contact)
+  end
+
+  it 'stops at the cap, most recently active first' do
+    stub_const("#{described_class}::CHATS", 2)
+    recent = Array.new(3) { |i| conversation_with_contact(last_activity_at: (i + 1).hours.ago) }
+
+    described_class.perform_now(channel)
+
+    expect(facade).to have_received(:request_history).with(recent.first.contact)
+    expect(facade).not_to have_received(:request_history).with(recent.last.contact)
+  end
+
+  # A number that has left WhatsApp says nothing about the next chat, and the operator
+  # pressed a button that means "as much as you can get".
+  it 'keeps going when one chat is refused' do
+    first = conversation_with_contact(last_activity_at: 1.hour.ago)
+    second = conversation_with_contact(last_activity_at: 2.hours.ago)
+    allow(facade).to receive(:request_history).with(first.contact).and_raise(Whatsapp::Session::Errors::ProviderUnavailable)
+
+    described_class.perform_now(channel)
+
+    expect(facade).to have_received(:request_history).with(second.contact)
+  end
+end

--- a/spec/services/whatsapp/session/backends/uazapi/backend_spec.rb
+++ b/spec/services/whatsapp/session/backends/uazapi/backend_spec.rb
@@ -118,9 +118,72 @@ RSpec.describe Whatsapp::Session::Backends::Uazapi::Backend do
       expect(WebMock).to have_requested(:post, "#{base}/instance/connect")
         .with(body: hash_including('phone' => '5541999991111'))
     end
+
+    # The provider issues a code only when the connect starts from a disconnected
+    # instance: asked for one mid-pairing it answers the state it is already in, with no
+    # code at all, and the operator waits on a screen that never fills in.
+    it 'ends a pairing already in flight before asking for a code' do
+      stub_uazapi(:get, '/instance/status', fixture('instance_status_connecting'))
+
+      backend.connect(commands::SessionConnect.new(pairing: 'code', phone: '5541999991111'))
+
+      expect(WebMock).to have_requested(:post, "#{base}/instance/disconnect")
+    end
+
+    # The disconnect settles asynchronously there, and a connect that goes out before it
+    # does is answered with the state from before: closed, no code, and a screen that
+    # never starts. Observed against a live instance on 22/08/2026.
+    it 'waits for the disconnect to take effect before connecting' do
+      stub_const("#{described_class}::DISCONNECT_SETTLE_WAIT", 0)
+      json = { 'Content-Type' => 'application/json' }
+      stub_request(:get, "#{base}/instance/status").to_return(
+        { status: 200, body: fixture('instance_status_connecting').to_json, headers: json },
+        { status: 200, body: fixture('instance_status_connecting').to_json, headers: json },
+        { status: 200, body: fixture('instance_status_disconnected').to_json, headers: json }
+      )
+
+      backend.connect(commands::SessionConnect.new(pairing: 'code', phone: '5541999991111'))
+
+      # The one that opened the pairing, then one per wait until the instance is really down.
+      expect(WebMock).to have_requested(:get, "#{base}/instance/status").times(3)
+    end
+
+    # Disconnecting costs the pairing on this provider, so it is only worth spending on
+    # an attempt that is in the way.
+    it 'leaves a session that is not pairing alone' do
+      stub_uazapi(:get, '/instance/status', fixture('instance_status_disconnected'))
+
+      backend.connect(commands::SessionConnect.new(pairing: 'code', phone: '5541999991111'))
+
+      expect(WebMock).not_to have_requested(:post, "#{base}/instance/disconnect")
+    end
   end
 
   describe 'the connection state' do
+    # The provider answers `connecting` to the connect and can report `disconnected` a
+    # second later while still serving the same QR, unchanged, for as long as anyone asks.
+    # Read literally that empties the pairing screen one second after the operator asked
+    # for it, with the code they were about to scan still on offer.
+    it 'reads a state still handing out a QR as a pairing, not a closed session' do
+      stub_uazapi(:get, '/instance/status',
+                  { 'instance' => { 'status' => 'disconnected', 'qrcode' => 'data:image/png;base64,AAA' } })
+
+      expect(backend.fetch_connection_state).to have_attributes(connection: 'connecting',
+                                                                qr_data_url: 'data:image/png;base64,AAA')
+    end
+
+    it 'reads the same for a code the provider is still offering' do
+      stub_uazapi(:get, '/instance/status', { 'instance' => { 'status' => 'disconnected', 'paircode' => 'K7QP-2M4X' } })
+
+      expect(backend.fetch_connection_state).to have_attributes(connection: 'connecting', pairing_code: 'K7QP-2M4X')
+    end
+
+    it 'reads a closed session carrying neither as closed' do
+      stub_uazapi(:get, '/instance/status', fixture('instance_status_disconnected'))
+
+      expect(backend.fetch_connection_state).to have_attributes(connection: 'close')
+    end
+
     it 'reports the paired number when the session is open' do
       expect(backend.fetch_connection_state).to have_attributes(connection: 'open', phone_number: '5511999990001')
     end

--- a/spec/services/whatsapp/session/backends/uazapi/webhook_translator_history_spec.rb
+++ b/spec/services/whatsapp/session/backends/uazapi/webhook_translator_history_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Backends::Uazapi::WebhookTranslator do
+  let(:channel) { create(:channel_whatsapp, provider: 'uazapi', validate_provider_config: false, sync_templates: false) }
+
+  let(:message) do
+    {
+      'messageid' => '3EB0AAA', 'chatid' => '5541999990000@s.whatsapp.net', 'sender_pn' => '5541999990000@s.whatsapp.net',
+      'fromMe' => false, 'messageType' => 'Conversation', 'text' => 'oi', 'messageTimestamp' => 1_781_824_019_000
+    }
+  end
+
+  def translate(body)
+    described_class.new(channel, body).perform
+  end
+
+  it 'turns a history batch into one event carrying every message' do
+    events = translate({ 'EventType' => 'history', 'event' => 'messages', 'messages' => [message, message.merge('messageid' => '3EB0BBB')] })
+
+    expect(events.size).to eq(1)
+    expect(events.first.payload).to be_a(Whatsapp::Session::Model::Events::HistorySync)
+    expect(events.first.payload.data['messages'].map { |m| m['id'] }).to eq(%w[3EB0AAA 3EB0BBB])
+  end
+
+  it 'ignores the chats and labels the same event carries' do
+    expect(translate({ 'EventType' => 'history', 'event' => 'chats', 'chats' => [{ 'wa_chatid' => 'x' }] })).to be_empty
+    expect(translate({ 'EventType' => 'history', 'event' => 'labels', 'labels' => [{ 'id' => 'x' }] })).to be_empty
+  end
+
+  it 'drops a history entry with no message id' do
+    expect(translate({ 'EventType' => 'history', 'event' => 'messages', 'messages' => [{ 'text' => 'sem id' }] })).to be_empty
+  end
+end

--- a/spec/services/whatsapp/session/connection_state_writer_spec.rb
+++ b/spec/services/whatsapp/session/connection_state_writer_spec.rb
@@ -58,6 +58,31 @@ RSpec.describe Whatsapp::Session::ConnectionStateWriter do
       expect(channel.reload.provider_connection).not_to have_key('qr_data_url')
     end
 
+    # A provider knows nothing about this token, so a state that arrives without one says
+    # nothing about which pairing it belongs to and must not end the one in flight. The
+    # case that proved it: pairing by code on Uazapi needs a disconnected instance, and the
+    # webhook answering that disconnect lands after the connect that follows it.
+    it 'keeps the attempt in flight when a late close arrives without one' do
+      channel.update_provider_connection!({ 'connection' => 'connecting', 'pairing_attempt' => 'attempt-1',
+                                            'pairing_code' => 'K7QP-2M4X' })
+
+      expect(writer.apply(state.new(connection: 'close'))).to eq(:written)
+
+      expect(channel.reload.provider_connection).to include('connection' => 'close', 'pairing_attempt' => 'attempt-1')
+    end
+
+    # Which is what makes the chain survive it: the poll that owns the screen reads the
+    # record again on its next run and is still the one driving it.
+    it 'lets the attempt that owns the screen write again after that close' do
+      channel.update_provider_connection!({ 'connection' => 'connecting', 'pairing_attempt' => 'attempt-1' })
+      writer.apply(state.new(connection: 'close'))
+
+      result = writer.apply(state.new(connection: 'connecting', pairing_code: 'K7QP-2M4X'), attempt: 'attempt-1')
+
+      expect(result).to eq(:written)
+      expect(channel.reload.provider_connection).to include('pairing_code' => 'K7QP-2M4X')
+    end
+
     # The token is only ever absent once the attempt it named is over, so a write still
     # carrying one is answering about a pairing that has already ended.
     it 'refuses a write for an attempt the record no longer names' do

--- a/spec/services/whatsapp/session/connection_state_writer_spec.rb
+++ b/spec/services/whatsapp/session/connection_state_writer_spec.rb
@@ -128,4 +128,26 @@ RSpec.describe Whatsapp::Session::ConnectionStateWriter do
 
     expect(Whatsapp::Session::LogoutJob).to have_been_enqueued.with(channel)
   end
+
+  # A history request travels to the phone through the session, so a session that ends
+  # takes any outstanding request with it. Without this the dump that follows the next
+  # pairing would be filed as if somebody had asked for it, and tuning the window's length
+  # to make that unlikely is a worse answer than removing the case.
+  describe 'an outstanding history backfill' do
+    let(:backfill) { Whatsapp::Session::HistoryBackfill }
+
+    before { backfill.open!(channel) }
+
+    it 'is closed when the session is no longer open' do
+      writer.apply(Whatsapp::Session::Model::ConnectionState.new(connection: 'close'))
+
+      expect(backfill.pending?(channel)).to be(false)
+    end
+
+    it 'survives a state that reports the session up' do
+      writer.apply(Whatsapp::Session::Model::ConnectionState.new(connection: 'open', phone_number: channel.phone_number))
+
+      expect(backfill.pending?(channel)).to be(true)
+    end
+  end
 end

--- a/spec/services/whatsapp/session/inbound/coverage_spec.rb
+++ b/spec/services/whatsapp/session/inbound/coverage_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Coverage do
+  let(:channel) { create(:channel_whatsapp, provider: 'uazapi', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:conversation) { create(:conversation, inbox: inbox, account: inbox.account) }
+
+  describe '.watermark' do
+    it 'is nil for an inbox that never stored a provider message' do
+      expect(described_class.watermark(inbox)).to be_nil
+    end
+
+    it 'is the newest message that came from the provider' do
+      create(:message, conversation: conversation, inbox: inbox, source_id: 'A', created_at: 3.days.ago)
+      newest = create(:message, conversation: conversation, inbox: inbox, source_id: 'B', created_at: 1.day.ago)
+
+      expect(described_class.watermark(inbox)).to be_within(1.second).of(newest.created_at)
+    end
+
+    # An agent typing a private note says the dashboard was in use, not that the channel
+    # was up. Counting it would date the coverage past the outage it is meant to measure,
+    # and every message from the weekend would then read as history nobody needs to see.
+    it 'ignores rows that did not come from the provider' do
+      create(:message, conversation: conversation, inbox: inbox, source_id: 'A', created_at: 3.days.ago)
+      create(:message, conversation: conversation, inbox: inbox, source_id: nil, private: true, created_at: 1.minute.ago)
+
+      expect(described_class.watermark(inbox)).to be_within(1.second).of(3.days.ago)
+    end
+  end
+
+  describe '.gap?' do
+    let(:message) do
+      Whatsapp::Session::Model::InboundMessage.new(
+        id: 'X', chat: Whatsapp::Session::Model::Address.phone('5541999990000'), from_me: false,
+        timestamp: 2.days.ago.to_i * 1000, content: Whatsapp::Session::Model::Content::Text.new(body: 'oi')
+      )
+    end
+
+    it 'is true for a message that arrived after the inbox stopped listening' do
+      expect(described_class.gap?(message, 3.days.ago)).to be(true)
+    end
+
+    it 'is false for a message the inbox was already covering' do
+      expect(described_class.gap?(message, 1.day.ago)).to be(false)
+    end
+
+    # A first connection: nothing predates coverage that has not also predated the inbox,
+    # so the whole dump is archive and a freshly paired inbox opens no threads at all.
+    it 'is false when the inbox has no coverage yet' do
+      expect(described_class.gap?(message, nil)).to be(false)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/history_sync_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/history_sync_spec.rb
@@ -1,0 +1,268 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::HistorySync do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) do
+    create(:channel_whatsapp, provider: 'uazapi', validate_provider_config: false, sync_templates: false,
+                              provider_config: { 'base_url' => 'https://uazapi.test', 'token' => 'x', 'history_sync' => true })
+  end
+  let(:inbox) { channel.inbox }
+  let(:model) { Whatsapp::Session::Model }
+  let(:chat) { model::Address.phone('5541999990000') }
+  let(:sender) { model::Party.new(phone: '5541999990000', lid: '182736451928374', push_name: 'Ana Souza') }
+
+  # Coverage: an unrelated chat this inbox received four days ago. It is what makes the
+  # boundary exist at all, and keeping it on another contact leaves the chat under test
+  # untouched by it.
+  let(:covered_until) { 4.days.ago }
+
+  let(:event) { model::Event.build(model::Events::HistorySync.new(kind: 'messages', data: { 'messages' => messages.map(&:to_h) })) }
+  let(:messages) { [historical(id: 'HIST01', at: 2.years.ago, body: 'orçamento de junho')] }
+
+  def historical(id:, at:, body:, from_me: false)
+    model::InboundMessage.new(
+      id: id, chat: chat, sender: (sender unless from_me), from_me: from_me,
+      timestamp: (at.to_f * 1000).to_i, content: model::Content::Text.new(body: body)
+    )
+  end
+
+  def cover!
+    conversation = create(:conversation, inbox: inbox, account: inbox.account)
+    create(:message, conversation: conversation, inbox: inbox, source_id: 'LIVE01', created_at: covered_until)
+  end
+
+  describe 'the archive half' do
+    before { cover! }
+
+    it 'files the message in a conversation that is resolved from the start' do
+      expect(dispatch).to eq(:handled)
+
+      conversation = inbox.messages.find_by(source_id: 'HIST01').conversation
+      expect(conversation.status).to eq('resolved')
+    end
+
+    # Resolved on create rather than resolved afterwards. `notify_status_change` and
+    # `create_activity` are after_update callbacks, so a thread born resolved writes no
+    # "resolved by" line and reports no resolution: an import of five hundred threads
+    # would otherwise land in today's figures as five hundred resolutions.
+    it 'writes no activity message into the imported thread' do
+      dispatch
+
+      conversation = inbox.messages.find_by(source_id: 'HIST01').conversation
+      expect(conversation.messages.where(message_type: :activity)).to be_empty
+    end
+
+    it 'dates the message and the thread to when it happened' do
+      dispatch
+
+      message = inbox.messages.find_by(source_id: 'HIST01')
+      expect(message.created_at).to be_within(1.second).of(2.years.ago)
+      expect(message.conversation.created_at).to be_within(1.second).of(2.years.ago)
+      expect(message.content_attributes['imported']).to be(true)
+    end
+
+    # A thread is born stamped as active now, and the inbox sorts on that column: without
+    # correcting it, importing an archive would put every thread from 2024 above this
+    # morning's conversations.
+    it 'does not put a two-year-old thread at the top of the inbox' do
+      dispatch
+
+      conversation = inbox.messages.find_by(source_id: 'HIST01').conversation
+      expect(conversation.last_activity_at).to be_within(1.second).of(2.years.ago)
+    end
+
+    it 'does not tell WhatsApp the message was received' do
+      expect_any_instance_of(Channel::Whatsapp).not_to receive(:received_messages) # rubocop:disable RSpec/AnyInstance
+
+      dispatch
+    end
+
+    # Nothing at all, the dashboard included. The archive is backfill: a reader has
+    # nothing to gain from eight hundred backdated threads arriving one cable frame at a
+    # time, and every agent in the account would get the flood.
+    it 'sets off no listener, the dashboard push included' do
+      expect(ActionCableListener.instance).not_to receive(:conversation_updated)
+      expect(ActionCableListener.instance).not_to receive(:message_created)
+      expect(AgentBotListener.instance).not_to receive(:conversation_updated)
+      expect(EventDispatcherJob).not_to receive(:perform_later)
+
+      dispatch
+    end
+
+    context 'when the contact already has a resolved thread' do
+      let!(:existing) do
+        contact = create(:contact, account: inbox.account, phone_number: '+5541999990000')
+        contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox, source_id: '5541999990000')
+        create(:conversation, inbox: inbox, account: inbox.account, contact: contact, contact_inbox: contact_inbox,
+                              status: :resolved)
+      end
+
+      it 'lands in it instead of opening work' do
+        dispatch
+
+        expect(inbox.messages.find_by(source_id: 'HIST01').conversation).to eq(existing)
+        expect(existing.reload.status).to eq('resolved')
+      end
+
+      # `set_conversation_activity` assigns whatever row it has just written. Left to run
+      # over history it would drag the thread's last activity back two years, and an inbox
+      # sorted by activity would show a conversation answered this morning as untouched.
+      it 'does not drag the thread activity backwards' do
+        existing.update!(last_activity_at: 1.hour.ago)
+
+        expect { dispatch }.not_to(change { existing.reload.last_activity_at.to_i })
+      end
+    end
+
+    context 'with a batch for one chat' do
+      let(:messages) do
+        [
+          historical(id: 'HIST01', at: 2.years.ago, body: 'primeira'),
+          historical(id: 'HIST02', at: 1.year.ago, body: 'segunda'),
+          historical(id: 'HIST03', at: 6.months.ago, body: 'terceira')
+        ]
+      end
+
+      it 'keeps the whole chat in one conversation' do
+        dispatch
+
+        expect(inbox.conversations.count).to eq(2) # the covering thread, and this one
+        expect(inbox.messages.where(source_id: %w[HIST01 HIST02 HIST03]).map(&:conversation_id).uniq.size).to eq(1)
+      end
+    end
+
+    it 'is idempotent' do
+      dispatch
+
+      expect { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }.not_to change(inbox.messages, :count)
+    end
+  end
+
+  describe 'the gap half' do
+    before { cover! }
+
+    let(:messages) { [historical(id: 'GAP01', at: 2.days.ago, body: 'bom dia, ainda preciso do orçamento')] }
+
+    it 'opens the conversation, because nobody has had the chance to read it' do
+      dispatch
+
+      conversation = inbox.messages.find_by(source_id: 'GAP01').conversation
+      expect(conversation.status).to eq('open')
+      expect(conversation.waiting_since).to be_within(1.second).of(2.days.ago)
+    end
+
+    # The half somebody is waiting for, so the queue has to move without a reload: a gap
+    # thread that lands behind a stale list is a thread nobody works. That is the whole of
+    # the exception, though. A bot must not answer it and nothing may act on the world,
+    # which is what the async side carries.
+    it 'refreshes the dashboard and still sets off nothing else' do
+      # Both halves of the screen: the card in the list, and the thread somebody has open.
+      # Without the second, a reader watching the conversation sees the list say there is a
+      # new message and the conversation stay empty underneath it.
+      expect(ActionCableListener.instance).to receive(:conversation_updated).at_least(:once)
+      expect(ActionCableListener.instance).to receive(:message_created).at_least(:once)
+      expect(AgentBotListener.instance).not_to receive(:message_created)
+      expect(AgentBotListener.instance).not_to receive(:conversation_updated)
+      expect(EventDispatcherJob).not_to receive(:perform_later)
+
+      dispatch
+    end
+
+    context 'when the contact answered on the phone during the outage' do
+      let(:messages) do
+        [
+          historical(id: 'GAP01', at: 2.days.ago, body: 'bom dia'),
+          historical(id: 'GAP02', at: 2.days.ago + 1.hour, body: 'já respondo', from_me: true)
+        ]
+      end
+
+      it 'leaves no waiting clock running' do
+        dispatch
+
+        expect(inbox.messages.find_by(source_id: 'GAP01').conversation.waiting_since).to be_nil
+      end
+    end
+  end
+
+  # No coverage at all means a first connection, and the whole dump is history: an inbox
+  # paired this morning must not open a year of threads on its way up.
+  describe 'a first connection' do
+    let(:messages) { [historical(id: 'HIST01', at: 10.minutes.ago, body: 'oi')] }
+
+    it 'archives even what happened minutes ago' do
+      dispatch
+
+      expect(inbox.messages.find_by(source_id: 'HIST01').conversation.status).to eq('resolved')
+    end
+  end
+
+  describe 'what it refuses' do
+    it 'ignores a kind it does not import' do
+      chats = model::Event.build(model::Events::HistorySync.new(kind: 'chats', data: { 'chats' => [] }))
+
+      expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, chats)).to eq(:ignored)
+    end
+
+    # A history frame says nothing about why it came, and the phone dumps what it has at
+    # every pairing. On an inbox with no coverage there is no gap by definition, so the
+    # whole pile is archive and none of it is filed: setting a number up on Monday must not
+    # fill it with a year of somebody's private conversations.
+    it 'files nothing from an unrequested dump on an inbox with no coverage' do
+      channel.update!(provider_config: channel.provider_config.merge('history_sync' => false))
+
+      dispatch
+
+      expect(inbox.messages).to be_empty
+    end
+
+    # The case the outright refusal used to destroy. Nobody asked, but the session was down
+    # and came back, and what the phone is offering includes the only copy of what arrived
+    # meanwhile. WhatsApp has no request that fetches it later, so this frame is the one
+    # chance to keep it.
+    context 'when an unrequested dump straddles the coverage boundary' do
+      before do
+        channel.update!(provider_config: channel.provider_config.merge('history_sync' => false))
+        cover!
+      end
+
+      let(:messages) do
+        [
+          historical(id: 'OLD01', at: 2.years.ago, body: 'orçamento de junho'),
+          historical(id: 'GAP99', at: 2.days.ago, body: 'chegou no fim de semana')
+        ]
+      end
+
+      it 'keeps what arrived while the session was down' do
+        dispatch
+
+        gap = inbox.messages.find_by(source_id: 'GAP99')
+        expect(gap).to be_present
+        expect(gap.conversation.status).to eq('open')
+      end
+
+      it 'drops the archive half, which nobody asked for' do
+        dispatch
+
+        expect(inbox.messages.find_by(source_id: 'OLD01')).to be_nil
+      end
+    end
+
+    # The other half of that: the button was pressed, so this was asked for, and it must
+    # not need the connect-time setting to be honoured.
+    it 'imports inside an open backfill window with the setting off' do
+      channel.update!(provider_config: channel.provider_config.merge('history_sync' => false))
+      Whatsapp::Session::HistoryBackfill.open!(channel)
+
+      expect(dispatch).to eq(:handled)
+      expect(inbox.messages.find_by(source_id: 'HIST01')).to be_present
+    end
+
+    it 'ignores history on a provider that does not declare the capability' do
+      native = create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false)
+
+      expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(native, event)).to eq(:ignored)
+      expect(native.inbox.messages).to be_empty
+    end
+  end
+end

--- a/theme/icons.js
+++ b/theme/icons.js
@@ -284,6 +284,27 @@ export const icons = {
     width: 48,
     height: 32,
   },
+  uazapi: {
+    body: `<g fill="none" stroke="currentColor" stroke-width="1.15" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="4.05" r="1.75"/>
+    <path d="M12 5.8v1.95"/>
+    <path d="M5.8 7.75h12.43a1.5 1.5 0 0 1 1.5 1.5v7.35a1.5 1.5 0 0 1-1.5 1.5H10.1l-3.5 3.52V18.1H5.8a1.5 1.5 0 0 1-1.5-1.5V9.25a1.5 1.5 0 0 1 1.5-1.5Z"/>
+    <path d="M4.3 11.4a1.6 1.6 0 0 0 0 3.2"/>
+    <path d="M19.7 11.4a1.6 1.6 0 0 1 0 3.2"/>
+    <circle cx="8.55" cy="13" r="1.7"/>
+    <circle cx="15.45" cy="13" r="1.7"/>
+    </g>`,
+    width: 24,
+    height: 24,
+  },
+  'whatsapp-native': {
+    body: `<g fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="6" y="6" width="12" height="12" rx="2.6"/>
+    <path d="M9.5 6V3.2M14.5 6V3.2M9.5 18v2.8M14.5 18v2.8M6 9.5H3.2M6 14.5H3.2M18 9.5h2.8M18 14.5h2.8"/>
+    </g>`,
+    width: 24,
+    height: 24,
+  },
   'voice-call': {
     body: `<mask id="cvc" maskUnits="userSpaceOnUse" x="0" y="0" width="16" height="16"><rect width="16" height="16" fill="#fff"/><circle cx="12" cy="4" r="4" fill="#000"/></mask><g mask="url(#cvc)"><path d="M7.916 10.784a.5.5 0 0 0 .607-.152L8.7 10.4a1 1 0 0 1 .8-.4H11a1 1 0 0 1 1 1v1.5a1 1 0 0 1-1 1 9 9 0 0 1-9-9 1 1 0 0 1 1-1h1.5a1 1 0 0 1 1 1V6a1 1 0 0 1-.4.8l-.234.176a.5.5 0 0 0-.146.616 7 7 0 0 0 3.196 3.192" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"/></g><circle cx="12" cy="4" r="4" fill="currentColor" fill-opacity="0.15"/><path d="M10.4 3.2v1.6M12 2.4v3.2m1.6-2.4v1.6" stroke="currentColor" stroke-width=".833" stroke-linecap="round" stroke-linejoin="round"/>`,
     width: 16,


### PR DESCRIPTION
A WhatsApp session that drops over the weekend used to cost every message that arrived meanwhile: nothing replayed them, and importing everything the phone offered would bury the queue under a year of settled conversations. This splits the two by *when they happened* rather than by how they got here.

Messages newer than the last moment the inbox is known to have been receiving are late mail: the conversation opens, lands in the queue and starts its waiting clock. Everything older is history, filed resolved and backdated, out of the way. An inbox with no coverage yet has no gap by definition, so a number set up on Monday does not open a year of somebody's private conversations.

Two ways in: an inbox setting that takes the archive along at pairing, and a button on the settings screen for one person asking now. A dump nobody asked for keeps only its gap, because WhatsApp has no way to request messages *after* a point and the phone's own account of what was missed is the only copy there will ever be.

Along the way this also fixes a conversation-pagination bug that imported history exposed, and gives `uazapi` and `native` their own icons in the channel picker.

## Closes

- Recuperação de mensagens perdidas em queda de sessão (uazapi e, adiante, o conector nativo)

## How to test

1. Create or open a `uazapi` inbox and connect it.
2. Turn **Importar conversas antigas ao parear** off, then press **Sincronizar histórico agora** under *Gerenciar conexão*. The button is disabled while the session is down, with its help text swapped for the offline version.
3. Old conversations land already **resolved**, backdated, and the queue stays clean. Nobody is notified, no automation runs, no template is answered and no resolved thread reopens.
4. Disconnect, send a few messages from another phone, and pair again. Those messages arrive **open**, at the top of the queue, and the list updates without a reload.
5. Open a conversation that received imported messages and scroll to the top: no gaps, and messages delivered out of order sit in their chronological place.

## What changed

- `Inbound::Coverage` draws the boundary; `Inbound::HistoryImporter` writes each chat under one lock, oldest first, archive before gap.
- `Whatsapp::Session::SilentWrite` has two levels rather than a boolean. Three guards read it — `AsyncDispatcher`, `SyncDispatcher` and `Message#execute_after_create_commit_callbacks` — so the gap reaches the dashboard and nothing else reaches the world.
- `HistoryBackfill` is the window that tells "somebody pressed the button" from "the phone dumped at pairing". A disconnect closes it, which removes the accident a shorter TTL was only making unlikely.
- `MessageFinder#messages_before` now compares `(created_at, id)`. It filtered by id while the window ordered by `created_at`, and imported rows broke that coincidence: 167 of 951 messages were unreachable on the first imported inbox. `messages_after` stays on id on purpose, and the change is inert wherever ids already follow chronology.
- The session settings toggles stop rendering their own name three times.

## Known limitation

On `uazapi`, only a **brand-new instance** asks the phone for its history. Reconnecting does not, and re-pairing the same instance does not either — verified with three re-pairings that each issued a QR and delivered nothing. So on that provider the gap is recoverable at pairing of a fresh instance, not after an ordinary drop. The native connector gets this from whatsmeow directly, via `OfflineSyncPreview` / `OfflineSyncCompleted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEA9tweznzdvp4R84ueALh

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/409)
<!-- Reviewable:end -->
