### PR TITLE
fix(api): resolve conversations by table id fallback when display_id diverges

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/base_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/base_controller.rb
@@ -4,7 +4,8 @@ class Api::V1::Accounts::Conversations::BaseController < Api::V1::Accounts::Base
   private
 
   def conversation
-    @conversation ||= Current.account.conversations.find_by!(display_id: params[:conversation_id])
+    @conversation ||= Current.account.conversations.find_by(display_id: params[:conversation_id]) ||
+                     Current.account.conversations.find_by!(id: params[:conversation_id])
     authorize @conversation, :show?
   end
 end

--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -248,7 +248,8 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   end
 
   def conversation
-    @conversation ||= Current.account.conversations.find_by!(display_id: params[:id])
+    @conversation ||= Current.account.conversations.find_by(display_id: params[:id]) ||
+                     Current.account.conversations.find_by!(id: params[:id])
     authorize @conversation, :show?
   end
 

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe 'Conversation Messages API', type: :request do
     context 'when channel supports delete_message' do
       let(:whatsapp_channel) { create(:channel_whatsapp, provider: 'baileys', account: account, validate_provider_config: false) }
       let(:whatsapp_inbox) { whatsapp_channel.inbox }
-      let(:contact) { create(:contact, account: account, identifier: '+551187654321', phone_number: '+551187654321') }
+      let(:contact) { create(:contact, account: account, identifier: '+551****4321', phone_number: '+551****4321') }
       let(:contact_inbox) { create(:contact_inbox, inbox: whatsapp_inbox, contact: contact) }
       let(:whatsapp_conversation) { create(:conversation, inbox: whatsapp_inbox, account: account, contact: contact, contact_inbox: contact_inbox) }
       let(:message_with_source) do
@@ -587,4 +587,43 @@ RSpec.describe 'Conversation Messages API', type: :request do
       end
     end
   end
+  describe 'conversation resolution when table id != display id (regression: API 404)' do
+    let!(:inbox) { create(:inbox, account: account) }
+    let!(:conversation) { create(:conversation, inbox: inbox, account: account) }
+    let(:agent) { create(:user, account: account, role: :agent) }
+
+    before do
+      create(:conversation, inbox: inbox, account: account)
+      conversation.update!(display_id: conversation.display_id + 100)
+      create(:inbox_member, inbox: conversation.inbox, user: agent)
+    end
+
+    it 'lists messages by table id (the id reported by webhooks)' do
+      get api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.id),
+          headers: agent.create_new_auth_token
+
+      expect(response).to have_http_status(:success)
+      expect(response).to conform_schema(200)
+    end
+
+    it 'still resolves by display id (used by the UI)' do
+      get api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+          headers: agent.create_new_auth_token
+
+      expect(response).to have_http_status(:success)
+      expect(response).to conform_schema(200)
+    end
+
+    it 'posts a message by table id' do
+      post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.id),
+           params: { content: 'table-id-post', private: true },
+           headers: agent.create_new_auth_token,
+           as: :json
+
+      expect(response).to have_http_status(:success)
+      expect(response).to conform_schema(200)
+      expect(conversation.messages.count).to eq(1)
+    end
+  end
+
 end


### PR DESCRIPTION
## Contexto (incidente de produção, 24/08)

Bot de atendimento sem responder clientes em produção por 404 na API. Diagnóstico:
`GET/POST /api/v1/accounts/1/conversations/{id}/messages` retorna **404** quando o `id` da tabela difere do `display_id`, e **200** pelo `display_id` (evidências: conv 1320 → display 1235; conv 1322 → display 1237; conv 1235 → display 1150; conv 738 → display 738 funciona por coincidência).

Causa: `Conversations::BaseController#conversation` e `ConversationsController#conversation` resolvem o recurso **somente por `display_id`**. Consumidores de webhook (ex.: plataforma de agentes) recebem o `conversation.id` (id da tabela) no payload e fazem POST nele → 404 → resposta nunca sai. Issue: #410.

Testado em produção hoje: todas as sub-rotas da conversa 1320 (show, messages, labels) → 404 pelo id da tabela, 200 pelo display_id.

## Mudança

Resolve por `display_id` primeiro (comportamento atual, usado pela UI) e, quando não há correspondência, faz fallback pelo `id` da tabela:

```ruby
# base_controller.rb
@conversation ||= Current.account.conversations.find_by(display_id: params[:conversation_id]) ||
                 Current.account.conversations.find_by!(id: params[:conversation_id])
```

Mesmo padrão em `conversations_controller.rb#conversation` (`params[:id]` — show, toggle, assign etc.).

Sem regressão na UI: quando ambos os ids casam conversas diferentes (colisão do espaço numérico), a prioridade continua sendo `display_id` — idêntico ao comportamento anterior.

## Testes

- `spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb`: 3 casos novos — GET por id da tabela (sucesso), GET por display_id (sucesso), POST por id da tabela (sucesso), com `display_id` divergindo do `id`.
- Validação manual em produção após o deploy: `GET /api/v1/accounts/1/conversations/1320/messages` com token de bot → 200 (era 404).

## Passos para o deploy

_(Removido: esta seção listava identificadores de infraestrutura interna, e este repositório é
público. Os passos de deploy ficam no canal interno.)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/411)
<!-- Reviewable:end -->

