### PR TITLE
feat(reports): read an agent overview for one inbox, and the other way around

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -78,3 +78,13 @@ app/jobs/webhooks/whatsapp_session_events_job.rb: Preserve order for dependent w
 # the layer does ship, because from then on a signature change to a queued job does have
 # to survive a rolling deploy.
 app/jobs/whatsapp/session/pairing_poll_job.rb: Preserve compatibility with queued pairing polls  # PR#380
+# PR#412: real, pre-existing, and bigger than this PR. `InboxPolicy::Scope` resolves to
+# `user.assigned_inboxes`, so an Enterprise custom role with `report_manage` already sees
+# only its own inboxes in the Inboxes overview itself, whose rows come from the same
+# `inboxes/getInboxes` this filter reads. Admins are unaffected (`assigned_inboxes` returns
+# every account inbox for them), and nothing is exposed either way: the summary endpoints
+# already return metrics for every account inbox to anyone who passes `ReportPolicy#view?`,
+# so only the names are scoped. Closing it means either widening `InboxPolicy::Scope`, which
+# changes every inbox picker in the app for those users, or a report-scoped inbox endpoint.
+# Neither belongs in a reports PR.
+app/javascript/dashboard/routes/dashboard/settings/reports/components/OverviewReportFilters.vue: Load all report-visible inboxes for the filter  # PR#412

--- a/app/builders/v2/reports/agent_summary_builder.rb
+++ b/app/builders/v2/reports/agent_summary_builder.rb
@@ -12,9 +12,9 @@ class V2::Reports::AgentSummaryBuilder < V2::Reports::BaseSummaryBuilder
               :avg_resolution_time, :avg_first_response_time, :avg_reply_time
 
   def prepare_report
-    account.account_users.map do |account_user|
-      build_agent_stats(account_user)
-    end
+    reject_untouched_rows(
+      account.account_users.map { |account_user| build_agent_stats(account_user) }
+    )
   end
 
   def build_agent_stats(account_user)

--- a/app/builders/v2/reports/base_summary_builder.rb
+++ b/app/builders/v2/reports/base_summary_builder.rb
@@ -36,8 +36,36 @@ class V2::Reports::BaseSummaryBuilder
       range: range,
       group_by: 'day',
       timezone_offset: params[:timezone_offset],
-      business_hours: params[:business_hours]
+      business_hours: params[:business_hours],
+      filters: summary_filters
     )
+  end
+
+  # A second dimension the summary is narrowed to, so a report grouped by agent
+  # can be read for a single inbox and the other way around.
+  def summary_filters
+    {
+      inbox_id: params[:inbox_id].presence,
+      user_id: params[:user_id].presence
+    }.compact
+  end
+
+  def filtered?
+    summary_filters.any?
+  end
+
+  # Rows an agent (or inbox) has no part in are noise once the report is narrowed
+  # to a single inbox (or agent), so they only survive while nothing is filtered.
+  def reject_untouched_rows(reports)
+    return reports unless filtered?
+
+    reports.reject { |report| untouched_row?(report) }
+  end
+
+  def untouched_row?(report)
+    report[:conversations_count].to_i.zero? &&
+      report[:resolved_conversations_count].to_i.zero? &&
+      [report[:avg_resolution_time], report[:avg_first_response_time], report[:avg_reply_time]].all?(&:nil?)
   end
 
   def summary_dimension_type

--- a/app/builders/v2/reports/inbox_summary_builder.rb
+++ b/app/builders/v2/reports/inbox_summary_builder.rb
@@ -12,9 +12,9 @@ class V2::Reports::InboxSummaryBuilder < V2::Reports::BaseSummaryBuilder
               :avg_resolution_time, :avg_first_response_time, :avg_reply_time
 
   def prepare_report
-    account.inboxes.map do |inbox|
-      build_inbox_stats(inbox)
-    end
+    reject_untouched_rows(
+      account.inboxes.map { |inbox| build_inbox_stats(inbox) }
+    )
   end
 
   def build_inbox_stats(inbox)

--- a/app/controllers/api/v2/accounts/summary_reports_controller.rb
+++ b/app/controllers/api/v2/accounts/summary_reports_controller.rb
@@ -3,7 +3,7 @@ class Api::V2::Accounts::SummaryReportsController < Api::V1::Accounts::BaseContr
   before_action :prepare_builder_params, only: [:agent, :team, :inbox, :label, :channel]
 
   def agent
-    render_report_with(V2::Reports::AgentSummaryBuilder, type: :agent)
+    render_report_with(V2::Reports::AgentSummaryBuilder, type: :agent, filters: { inbox_id: permitted_params[:inbox_id] })
   end
 
   def team
@@ -11,7 +11,7 @@ class Api::V2::Accounts::SummaryReportsController < Api::V1::Accounts::BaseContr
   end
 
   def inbox
-    render_report_with(V2::Reports::InboxSummaryBuilder, type: :inbox)
+    render_report_with(V2::Reports::InboxSummaryBuilder, type: :inbox, filters: { user_id: permitted_params[:user_id] })
   end
 
   def label
@@ -38,14 +38,15 @@ class Api::V2::Accounts::SummaryReportsController < Api::V1::Accounts::BaseContr
     }
   end
 
-  def render_report_with(builder_class, type: nil)
-    builder_params = type.present? ? @builder_params.merge(type: type) : @builder_params
+  def render_report_with(builder_class, type: nil, filters: {})
+    builder_params = @builder_params.merge(filters.compact_blank)
+    builder_params = builder_params.merge(type: type) if type.present?
     builder = builder_class.new(account: Current.account, params: builder_params)
     render json: builder.build
   end
 
   def permitted_params
-    params.permit(:since, :until, :business_hours)
+    params.permit(:since, :until, :business_hours, :inbox_id, :user_id)
   end
 
   def date_range_too_long?

--- a/app/helpers/api/v2/accounts/reports_helper.rb
+++ b/app/helpers/api/v2/accounts/reports_helper.rb
@@ -2,11 +2,14 @@ module Api::V2::Accounts::ReportsHelper
   def generate_agents_report
     reports = V2::Reports::AgentSummaryBuilder.new(
       account: Current.account,
-      params: build_params(type: :agent)
+      params: build_params(type: :agent, inbox_id: params[:inbox_id].presence)
     ).build
 
-    Current.account.users.map do |agent|
+    Current.account.users.filter_map do |agent|
       report = reports.find { |r| r[:id] == agent.id }
+      # The builder drops agents with no part in the filtered inbox.
+      next if report.blank?
+
       [agent.name] + generate_readable_report_metrics(report)
     end
   end
@@ -14,11 +17,14 @@ module Api::V2::Accounts::ReportsHelper
   def generate_inboxes_report
     reports = V2::Reports::InboxSummaryBuilder.new(
       account: Current.account,
-      params: build_params(type: :inbox)
+      params: build_params(type: :inbox, user_id: params[:user_id].presence)
     ).build
 
-    Current.account.inboxes.map do |inbox|
+    Current.account.inboxes.filter_map do |inbox|
       report = reports.find { |r| r[:id] == inbox.id }
+      # The builder drops inboxes the filtered agent never touched.
+      next if report.blank?
+
       [inbox.name, inbox.channel&.name] + generate_readable_report_metrics(report)
     end
   end

--- a/app/javascript/dashboard/api/reports.js
+++ b/app/javascript/dashboard/api/reports.js
@@ -91,9 +91,14 @@ class ReportsAPI extends ApiClient {
     });
   }
 
-  getAgentReports({ from: since, to: until, businessHours }) {
+  getAgentReports({ from: since, to: until, businessHours, inboxId }) {
     return axios.get(`${this.url}/agents`, {
-      params: { since, until, business_hours: businessHours },
+      params: {
+        since,
+        until,
+        business_hours: businessHours,
+        inbox_id: inboxId,
+      },
     });
   }
 
@@ -115,9 +120,9 @@ class ReportsAPI extends ApiClient {
     });
   }
 
-  getInboxReports({ from: since, to: until, businessHours }) {
+  getInboxReports({ from: since, to: until, businessHours, userId }) {
     return axios.get(`${this.url}/inboxes`, {
-      params: { since, until, business_hours: businessHours },
+      params: { since, until, business_hours: businessHours, user_id: userId },
     });
   }
 

--- a/app/javascript/dashboard/api/summaryReports.js
+++ b/app/javascript/dashboard/api/summaryReports.js
@@ -16,22 +16,24 @@ class SummaryReportsAPI extends ApiClient {
     });
   }
 
-  getAgentReports({ since, until, businessHours } = {}) {
+  getAgentReports({ since, until, businessHours, inboxId } = {}) {
     return axios.get(`${this.url}/agent`, {
       params: {
         since,
         until,
         business_hours: businessHours,
+        inbox_id: inboxId,
       },
     });
   }
 
-  getInboxReports({ since, until, businessHours } = {}) {
+  getInboxReports({ since, until, businessHours, userId } = {}) {
     return axios.get(`${this.url}/inbox`, {
       params: {
         since,
         until,
         business_hours: businessHours,
+        user_id: userId,
       },
     });
   }

--- a/app/javascript/dashboard/helper/downloadHelper.js
+++ b/app/javascript/dashboard/helper/downloadHelper.js
@@ -13,8 +13,27 @@ export const downloadCsvFile = (fileName, content) => {
   return link;
 };
 
-export const generateFileName = ({ type, to, businessHours = false }) => {
+// Keeps the same report downloaded for two different filters in two files.
+const slugifyFilterName = name =>
+  name
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+export const generateFileName = ({
+  type,
+  to,
+  businessHours = false,
+  filteredBy = '',
+}) => {
   let name = `${type}-report-${format(fromUnixTime(to), 'dd-MM-yyyy')}`;
+  const filterSlug = filteredBy ? slugifyFilterName(filteredBy) : '';
+  if (filterSlug) {
+    name = `${name}-${filterSlug}`;
+  }
   if (businessHours) {
     name = `${name}-business-hours`;
   }

--- a/app/javascript/dashboard/helper/downloadHelper.js
+++ b/app/javascript/dashboard/helper/downloadHelper.js
@@ -13,7 +13,8 @@ export const downloadCsvFile = (fileName, content) => {
   return link;
 };
 
-// Keeps the same report downloaded for two different filters in two files.
+// Readable half of the filter suffix. Drops to an empty string for a name
+// written outside the Latin alphabet, which is why the id carries the identity.
 const slugifyFilterName = name =>
   name
     .toString()
@@ -23,16 +24,27 @@ const slugifyFilterName = name =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)/g, '');
 
+// Keeps the same report downloaded for two different filters in two files. Two
+// agents can share a display name, so the id is what makes the pair distinct
+// and the name is only there to make the file recognizable.
+const buildFilterSuffix = (filteredBy, filterId) => {
+  const id =
+    filterId === null || filterId === undefined ? '' : String(filterId);
+  const slug = filteredBy ? slugifyFilterName(filteredBy) : '';
+  return [slug, id].filter(part => part !== '').join('-');
+};
+
 export const generateFileName = ({
   type,
   to,
   businessHours = false,
   filteredBy = '',
+  filterId = '',
 }) => {
   let name = `${type}-report-${format(fromUnixTime(to), 'dd-MM-yyyy')}`;
-  const filterSlug = filteredBy ? slugifyFilterName(filteredBy) : '';
-  if (filterSlug) {
-    name = `${name}-${filterSlug}`;
+  const filterSuffix = buildFilterSuffix(filteredBy, filterId);
+  if (filterSuffix) {
+    name = `${name}-${filterSuffix}`;
   }
   if (businessHours) {
     name = `${name}-business-hours`;

--- a/app/javascript/dashboard/helper/specs/downloadHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/downloadHelper.spec.js
@@ -10,4 +10,23 @@ describe('#generateFileName', () => {
       generateFileName({ type: 'csat', to: 1652812199, businessHours: true })
     ).toEqual('csat-report-17-05-2022-business-hours.csv');
   });
+
+  it('should append the filter it was narrowed to', () => {
+    expect(
+      generateFileName({
+        type: 'agent',
+        to: 1652812199,
+        filteredBy: 'SAC - WhatsApp Cobrança',
+      })
+    ).toEqual('agent-report-17-05-2022-sac-whatsapp-cobranca.csv');
+
+    expect(
+      generateFileName({
+        type: 'agent',
+        to: 1652812199,
+        businessHours: true,
+        filteredBy: 'SAC Email',
+      })
+    ).toEqual('agent-report-17-05-2022-sac-email-business-hours.csv');
+  });
 });

--- a/app/javascript/dashboard/helper/specs/downloadHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/downloadHelper.spec.js
@@ -17,8 +17,9 @@ describe('#generateFileName', () => {
         type: 'agent',
         to: 1652812199,
         filteredBy: 'SAC - WhatsApp Cobrança',
+        filterId: 7,
       })
-    ).toEqual('agent-report-17-05-2022-sac-whatsapp-cobranca.csv');
+    ).toEqual('agent-report-17-05-2022-sac-whatsapp-cobranca-7.csv');
 
     expect(
       generateFileName({
@@ -26,7 +27,43 @@ describe('#generateFileName', () => {
         to: 1652812199,
         businessHours: true,
         filteredBy: 'SAC Email',
+        filterId: 8,
       })
-    ).toEqual('agent-report-17-05-2022-sac-email-business-hours.csv');
+    ).toEqual('agent-report-17-05-2022-sac-email-8-business-hours.csv');
+  });
+
+  it('should tell two filters with the same name apart', () => {
+    const first = generateFileName({
+      type: 'agent',
+      to: 1652812199,
+      filteredBy: 'Ana',
+      filterId: 3,
+    });
+    const second = generateFileName({
+      type: 'agent',
+      to: 1652812199,
+      filteredBy: 'Ana',
+      filterId: 4,
+    });
+
+    expect(first).toEqual('agent-report-17-05-2022-ana-3.csv');
+    expect(second).toEqual('agent-report-17-05-2022-ana-4.csv');
+  });
+
+  it('should fall back to the id when the name leaves no slug', () => {
+    expect(
+      generateFileName({
+        type: 'inbox',
+        to: 1652812199,
+        filteredBy: 'サポート',
+        filterId: 12,
+      })
+    ).toEqual('inbox-report-17-05-2022-12.csv');
+  });
+
+  it('should stay unfiltered when no filter is given', () => {
+    expect(generateFileName({ type: 'agent', to: 1652812199 })).toEqual(
+      'agent-report-17-05-2022.csv'
+    );
   });
 });

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/report.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/report.json
@@ -1,0 +1,9 @@
+{
+  "REPORT": {
+    "CROSS_FILTER": {
+      "ALL_INBOXES": "All inboxes",
+      "ALL_AGENTS": "All agents",
+      "NO_RESULTS": "No activity for this filter in the selected period."
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/report.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/report.json
@@ -1,0 +1,9 @@
+{
+  "REPORT": {
+    "CROSS_FILTER": {
+      "ALL_INBOXES": "Todas las bandejas de entrada",
+      "ALL_AGENTS": "Todos los agentes",
+      "NO_RESULTS": "Sin actividad para este filtro en el período seleccionado."
+    }
+  }
+}

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/report.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/report.json
@@ -1,0 +1,9 @@
+{
+  "REPORT": {
+    "CROSS_FILTER": {
+      "ALL_INBOXES": "Todas as caixas de entrada",
+      "ALL_AGENTS": "Todos os agentes",
+      "NO_RESULTS": "Nenhuma atividade para este filtro no período selecionado."
+    }
+  }
+}

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/AgentReportsIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/AgentReportsIndex.vue
@@ -31,5 +31,6 @@ const onDownloadClick = () => {
     fetch-items-key="agents/get"
     summary-key="summaryReports/getAgentSummaryReports"
     type="agent"
+    cross-filter-type="inboxes"
   />
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/InboxReportsIndex.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/InboxReportsIndex.vue
@@ -31,5 +31,6 @@ const onDownloadClick = () => {
     fetch-items-key="inboxes/get"
     summary-key="summaryReports/getInboxSummaryReports"
     type="inbox"
+    cross-filter-type="agents"
   />
 </template>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/OverviewReportFilters.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/OverviewReportFilters.vue
@@ -1,20 +1,32 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { useStore } from 'dashboard/composables/store';
 import { getUnixStartOfDay, getUnixEndOfDay } from 'helpers/DateHelper';
 import subDays from 'date-fns/subDays';
 import WootDatePicker from 'dashboard/components/ui/DatePicker/DatePicker.vue';
 import ToggleSwitch from 'dashboard/components-next/switch/Switch.vue';
+import ActiveFilterChip from './Filters/v3/ActiveFilterChip.vue';
 import {
   generateReportURLParams,
   parseReportURLParams,
+  generateFilterURLParams,
+  parseFilterURLParams,
 } from '../helpers/reportFilterHelper';
 import { DATE_RANGE_TYPES } from 'dashboard/components/ui/DatePicker/helpers/DatePickerHelper';
 
-defineProps({
+const props = defineProps({
   disabled: {
     type: Boolean,
     default: false,
+  },
+  // Second dimension the report can be narrowed to: an agents overview reads for
+  // a single inbox, an inboxes overview reads for a single agent.
+  crossFilterType: {
+    type: String,
+    default: '',
+    validator: value => ['', 'inboxes', 'agents'].includes(value),
   },
 });
 
@@ -22,10 +34,63 @@ const emit = defineEmits(['filterChange']);
 
 const route = useRoute();
 const router = useRouter();
+const store = useStore();
+const { t } = useI18n();
 
 const customDateRange = ref([subDays(new Date(), 6), new Date()]);
 const selectedDateRange = ref(DATE_RANGE_TYPES.LAST_7_DAYS);
 const businessHoursSelected = ref(false);
+const crossFilterId = ref(null);
+const showCrossFilterMenu = ref(false);
+
+const CROSS_FILTER_CONFIG = {
+  inboxes: {
+    urlKey: 'inbox_id',
+    payloadKey: 'inboxId',
+    getterKey: 'inboxes/getInboxes',
+    fetchKey: 'inboxes/get',
+    allLabelKey: 'REPORT.CROSS_FILTER.ALL_INBOXES',
+    placeholderKey: 'INBOX_REPORTS.FILTERS.INPUT_PLACEHOLDER.INBOXES',
+  },
+  agents: {
+    urlKey: 'agent_id',
+    payloadKey: 'userId',
+    getterKey: 'agents/getAgents',
+    fetchKey: 'agents/get',
+    allLabelKey: 'REPORT.CROSS_FILTER.ALL_AGENTS',
+    placeholderKey: 'AGENT_REPORTS.FILTERS.INPUT_PLACEHOLDER.AGENTS',
+  },
+};
+
+const crossFilterConfig = computed(
+  () => CROSS_FILTER_CONFIG[props.crossFilterType] ?? null
+);
+
+const crossFilterOptions = computed(() => {
+  if (!crossFilterConfig.value) return [];
+
+  const items = store.getters[crossFilterConfig.value.getterKey] ?? [];
+  return items.map(item => ({
+    id: item.id,
+    name: item.name,
+    type: props.crossFilterType,
+  }));
+});
+
+const crossFilterName = computed(() => {
+  if (!crossFilterConfig.value) return '';
+
+  const selected = crossFilterOptions.value.find(
+    item => item.id === crossFilterId.value
+  );
+  return selected?.name ?? t(crossFilterConfig.value.allLabelKey);
+});
+
+const crossFilterPayload = computed(() => {
+  if (!crossFilterConfig.value) return {};
+
+  return { [crossFilterConfig.value.payloadKey]: crossFilterId.value };
+});
 
 const updateURLParams = () => {
   const params = generateReportURLParams({
@@ -35,7 +100,13 @@ const updateURLParams = () => {
     range: selectedDateRange.value,
   });
 
-  router.replace({ query: { ...params } });
+  const filterParams = crossFilterConfig.value
+    ? generateFilterURLParams({
+        [crossFilterConfig.value.urlKey]: crossFilterId.value,
+      })
+    : {};
+
+  router.replace({ query: { ...params, ...filterParams } });
 };
 
 const emitChange = () => {
@@ -44,6 +115,7 @@ const emitChange = () => {
     from: getUnixStartOfDay(customDateRange.value[0]),
     to: getUnixEndOfDay(customDateRange.value[1]),
     businessHours: businessHoursSelected.value,
+    ...crossFilterPayload.value,
   });
 };
 
@@ -55,6 +127,26 @@ const onDateRangeChange = value => {
 };
 
 const onBusinessHoursToggle = () => {
+  emitChange();
+};
+
+const toggleCrossFilterDropdown = () => {
+  showCrossFilterMenu.value = !showCrossFilterMenu.value;
+};
+
+const closeCrossFilterDropdown = () => {
+  showCrossFilterMenu.value = false;
+};
+
+const onCrossFilterSelect = item => {
+  crossFilterId.value = item.id;
+  closeCrossFilterDropdown();
+  emitChange();
+};
+
+const onCrossFilterRemove = () => {
+  crossFilterId.value = null;
+  closeCrossFilterDropdown();
   emitChange();
 };
 
@@ -77,9 +169,18 @@ const initializeFromURL = () => {
   if (urlParams.businessHours) {
     businessHoursSelected.value = urlParams.businessHours;
   }
+
+  if (crossFilterConfig.value) {
+    crossFilterId.value = parseFilterURLParams(route.query)[
+      crossFilterConfig.value.urlKey
+    ];
+  }
 };
 
 onMounted(() => {
+  if (crossFilterConfig.value) {
+    store.dispatch(crossFilterConfig.value.fetchKey);
+  }
   initializeFromURL();
   emitChange();
 });
@@ -95,6 +196,21 @@ onMounted(() => {
         v-model:date-range="customDateRange"
         v-model:range-type="selectedDateRange"
         @date-range-changed="onDateRangeChange"
+      />
+      <ActiveFilterChip
+        v-if="crossFilterConfig"
+        :id="crossFilterId"
+        :name="crossFilterName"
+        :type="crossFilterType"
+        :options="crossFilterOptions"
+        :active-filter-type="showCrossFilterMenu ? crossFilterType : ''"
+        :show-menu="showCrossFilterMenu"
+        :placeholder="$t(crossFilterConfig.placeholderKey)"
+        enable-search
+        @toggle-dropdown="toggleCrossFilterDropdown"
+        @close-dropdown="closeCrossFilterDropdown"
+        @add-filter="onCrossFilterSelect"
+        @remove-filter="onCrossFilterRemove"
       />
     </div>
     <div class="flex items-center">

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/OverviewReportFilters.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/OverviewReportFilters.vue
@@ -79,11 +79,16 @@ const crossFilterOptions = computed(() => {
 
 const crossFilterName = computed(() => {
   if (!crossFilterConfig.value) return '';
+  if (!crossFilterId.value) return t(crossFilterConfig.value.allLabelKey);
 
   const selected = crossFilterOptions.value.find(
     item => item.id === crossFilterId.value
   );
-  return selected?.name ?? t(crossFilterConfig.value.allLabelKey);
+  // The "All" label belongs to a cleared filter and to nothing else. A bookmarked
+  // URL applies the id before its list arrives, and the id can name something this
+  // user cannot list at all, so falling back to it here would leave the chip
+  // claiming the opposite of the request that was actually sent.
+  return selected?.name ?? `#${crossFilterId.value}`;
 });
 
 const crossFilterPayload = computed(() => {

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
@@ -228,6 +228,7 @@ const downloadReports = () => {
       to: to.value,
       businessHours: businessHours.value,
       filteredBy: crossFilterName.value,
+      filterId: crossFilterId.value ?? '',
     });
     const params = {
       from: from.value,

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
@@ -34,6 +34,12 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  // Second dimension the summary can be narrowed to: 'inboxes' on an agents
+  // overview, 'agents' on an inboxes overview.
+  crossFilterType: {
+    type: String,
+    default: '',
+  },
 });
 
 const store = useStore();
@@ -41,6 +47,7 @@ const store = useStore();
 const from = ref(0);
 const to = ref(0);
 const businessHours = ref(false);
+const crossFilterId = ref(null);
 import { useI18n } from 'vue-i18n';
 import SummaryReportLink from './SummaryReportLink.vue';
 
@@ -108,8 +115,17 @@ const renderAvgTime = value => (value ? formatTime(value) : '--');
 
 const renderCount = value => (value ? value.toLocaleString() : '--');
 
+// Once the report is narrowed to a single inbox (or agent), the backend only
+// returns the rows that took part in it, so the roster is trimmed to match.
+const visibleRowItems = computed(() => {
+  if (!crossFilterId.value) return rowItems.value;
+
+  const reportedIds = new Set(reportMetrics.value.map(metrics => metrics.id));
+  return rowItems.value.filter(row => reportedIds.has(Number(row.id)));
+});
+
 const tableData = computed(() =>
-  rowItems.value.map(row => {
+  visibleRowItems.value.map(row => {
     const rowMetrics = getMetrics(row.id);
     const {
       conversationsCount,
@@ -132,11 +148,33 @@ const tableData = computed(() =>
   })
 );
 
+// Names the downloaded file, so the same report filtered two ways lands in two
+// files instead of overwriting itself.
+const crossFilterName = computed(() => {
+  if (!crossFilterId.value) return '';
+
+  const getterKey =
+    props.crossFilterType === 'inboxes'
+      ? 'inboxes/getInboxes'
+      : 'agents/getAgents';
+  const items = store.getters[getterKey] ?? [];
+  return items.find(item => item.id === crossFilterId.value)?.name ?? '';
+});
+
+const crossFilterParams = computed(() => {
+  if (!props.crossFilterType || !crossFilterId.value) return {};
+
+  return props.crossFilterType === 'inboxes'
+    ? { inboxId: crossFilterId.value }
+    : { userId: crossFilterId.value };
+});
+
 const fetchReportsWithRetry = async () => {
   const params = {
     since: from.value,
     until: to.value,
     businessHours: businessHours.value,
+    ...crossFilterParams.value,
   };
   try {
     await store.dispatch(props.actionKey, params);
@@ -160,6 +198,7 @@ const onFilterChange = updatedFilter => {
   from.value = updatedFilter.from;
   to.value = updatedFilter.to;
   businessHours.value = updatedFilter.businessHours;
+  crossFilterId.value = updatedFilter.inboxId ?? updatedFilter.userId ?? null;
   fetchAllData();
 };
 
@@ -188,12 +227,14 @@ const downloadReports = () => {
       type: props.type,
       to: to.value,
       businessHours: businessHours.value,
+      filteredBy: crossFilterName.value,
     });
     const params = {
       from: from.value,
       to: to.value,
       fileName,
       businessHours: businessHours.value,
+      ...crossFilterParams.value,
     };
     store.dispatch(dispatchMethods[props.type], params);
   }
@@ -205,12 +246,19 @@ defineExpose({ downloadReports });
 <template>
   <OverviewReportFilters
     :disabled="isLoading"
+    :cross-filter-type="crossFilterType"
     @filter-change="onFilterChange"
   />
   <div
     class="relative flex-1 overflow-auto px-2 py-2 mt-5 shadow outline-1 outline outline-n-container rounded-xl bg-n-solid-2"
   >
     <Table :table="table" />
+    <p
+      v-if="!isLoading && crossFilterId && !tableData.length"
+      class="py-8 mb-0 text-sm text-center text-n-slate-11"
+    >
+      {{ $t('REPORT.CROSS_FILTER.NO_RESULTS') }}
+    </p>
     <Transition
       enter-active-class="transition-opacity duration-300 ease-out"
       leave-active-class="transition-opacity duration-200 ease-in"

--- a/app/services/reports/data_source.rb
+++ b/app/services/reports/data_source.rb
@@ -3,7 +3,7 @@ class Reports::DataSource
 
   attr_reader :account, :metric, :dimension_type, :dimension_id,
               :scope, :range, :group_by, :timezone_offset,
-              :business_hours
+              :business_hours, :filters
 
   class << self
     def for(**context)
@@ -22,6 +22,7 @@ class Reports::DataSource
     @group_by = context[:group_by].to_s.presence || 'day'
     @timezone_offset = context[:timezone_offset]
     @business_hours = context[:business_hours]
+    @filters = (context[:filters] || {}).compact
   end
 
   private

--- a/app/services/reports/raw_data_source.rb
+++ b/app/services/reports/raw_data_source.rb
@@ -99,16 +99,29 @@ class Reports::RawDataSource < Reports::DataSource
 
   def summary_scope
     scope = account.reporting_events.where(created_at: range)
-    return scope.joins(:conversation) if dimension_type == 'team'
+    scope = scope.joins(:conversation) if dimension_type == 'team'
 
-    scope
+    apply_event_filters(scope)
   end
 
   def summary_conversation_counts
-    account.conversations
-           .where(created_at: range)
-           .group(summary_conversation_group_by_key)
-           .count
+    apply_conversation_filters(account.conversations.where(created_at: range))
+      .group(summary_conversation_group_by_key)
+      .count
+  end
+
+  # Narrows a summary to a second dimension, so a report grouped by agent can be
+  # read for a single inbox and the other way around.
+  def apply_event_filters(events)
+    events = events.where(inbox_id: filters[:inbox_id]) if filters[:inbox_id].present?
+    events = events.where(user_id: filters[:user_id]) if filters[:user_id].present?
+    events
+  end
+
+  def apply_conversation_filters(conversations)
+    conversations = conversations.where(inbox_id: filters[:inbox_id]) if filters[:inbox_id].present?
+    conversations = conversations.where(assignee_id: filters[:user_id]) if filters[:user_id].present?
+    conversations
   end
 
   def merge_summary_results(metric_results, conversation_counts)

--- a/spec/builders/v2/reports/agent_summary_builder_spec.rb
+++ b/spec/builders/v2/reports/agent_summary_builder_spec.rb
@@ -120,6 +120,64 @@ RSpec.describe V2::Reports::AgentSummaryBuilder do
       end
     end
 
+    context 'when the report is narrowed to an inbox' do
+      let(:business_hours) { false }
+      let(:inbox) { create(:inbox, account: account) }
+      let(:other_inbox) { create(:inbox, account: account) }
+
+      let(:params) do
+        {
+          business_hours: business_hours,
+          since: 1.week.ago.beginning_of_day,
+          until: Time.current.end_of_day,
+          inbox_id: inbox.id
+        }
+      end
+
+      before do
+        filtered = create(:conversation, account: account, inbox: inbox, assignee: user1, created_at: Time.current)
+        elsewhere = create(:conversation, account: account, inbox: other_inbox, assignee: user1, created_at: Time.current)
+        create(:conversation, account: account, inbox: other_inbox, assignee: user2, created_at: Time.current)
+        create(
+          :reporting_event,
+          account: account,
+          conversation: filtered,
+          inbox: inbox,
+          user: user1,
+          name: 'conversation_resolved',
+          value: 10,
+          value_in_business_hours: 5,
+          created_at: Time.current
+        )
+        create(
+          :reporting_event,
+          account: account,
+          conversation: elsewhere,
+          inbox: other_inbox,
+          user: user1,
+          name: 'conversation_resolved',
+          value: 90,
+          value_in_business_hours: 45,
+          created_at: Time.current
+        )
+      end
+
+      it 'counts only what happened in that inbox' do
+        expect(builder.build).to contain_exactly(
+          id: user1.id,
+          conversations_count: 1,
+          resolved_conversations_count: 1,
+          avg_resolution_time: 10.0,
+          avg_first_response_time: nil,
+          avg_reply_time: nil
+        )
+      end
+
+      it 'drops the agents with no part in that inbox' do
+        expect(builder.build.pluck(:id)).not_to include(user2.id)
+      end
+    end
+
     context 'when there is no team data' do
       let!(:new_user) { create(:user, account: account, role: :agent) }
       let(:business_hours) { false }

--- a/spec/builders/v2/reports/inbox_summary_builder_spec.rb
+++ b/spec/builders/v2/reports/inbox_summary_builder_spec.rb
@@ -74,6 +74,36 @@ RSpec.describe V2::Reports::InboxSummaryBuilder do
       end
     end
 
+    context 'when the report is narrowed to an agent' do
+      let(:business_hours) { false }
+      let(:agent) { create(:user, account: account, role: :agent) }
+      let(:params) do
+        {
+          business_hours: business_hours,
+          since: 1.week.ago.beginning_of_day,
+          until: Time.current.end_of_day,
+          user_id: agent.id
+        }
+      end
+
+      before do
+        conversation = create(:conversation, account: account, inbox: i1, assignee: agent, created_at: 1.day.ago)
+        create(:reporting_event, account: account, conversation: conversation, inbox: i1, user: agent,
+                                 name: 'conversation_resolved', value: 20, value_in_business_hours: 10, created_at: 1.day.ago)
+      end
+
+      it 'keeps only the inboxes that agent took part in' do
+        expect(report).to contain_exactly(
+          id: i1.id,
+          conversations_count: 1,
+          resolved_conversations_count: 1,
+          avg_resolution_time: 20.0,
+          avg_first_response_time: nil,
+          avg_reply_time: nil
+        )
+      end
+    end
+
     context 'when there is no data for an inbox' do
       let!(:empty_inbox) { create(:inbox, account: account) }
       let(:business_hours) { false }

--- a/spec/controllers/api/v2/accounts/report_controller_spec.rb
+++ b/spec/controllers/api/v2/accounts/report_controller_spec.rb
@@ -366,6 +366,20 @@ RSpec.describe 'Reports API', type: :request do
 
         expect(response).to have_http_status(:success)
       end
+
+      it 'narrows the report to the given inbox' do
+        other_inbox = create(:inbox, account: account)
+        other_agent = create(:user, account: account, role: :agent)
+        create(:conversation, account: account, inbox: other_inbox, assignee: other_agent, created_at: Time.current)
+
+        get "/api/v2/accounts/#{account.id}/reports/agents.csv",
+            params: params.merge(inbox_id: inbox.id),
+            headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(user.name)
+        expect(response.body).not_to include(other_agent.name)
+      end
     end
 
     context 'when an agent has access to multiple accounts' do

--- a/spec/controllers/api/v2/accounts/summary_reports_controller_spec.rb
+++ b/spec/controllers/api/v2/accounts/summary_reports_controller_spec.rb
@@ -59,6 +59,23 @@ RSpec.describe 'Summary Reports API', type: :request do
         expect(json_response.first['conversations_count']).to eq(110)
         expect(json_response.first['avg_reply_time']).to be_nil
       end
+
+      it 'narrows the agent report to an inbox when one is given' do
+        inbox = create(:inbox, account: account)
+        agent_summary_builder = double
+        allow(V2::Reports::AgentSummaryBuilder).to receive(:new).and_return(agent_summary_builder)
+        allow(agent_summary_builder).to receive(:build).and_return([])
+
+        get "/api/v2/accounts/#{account.id}/summary_reports/agent",
+            params: params.merge(inbox_id: inbox.id),
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(V2::Reports::AgentSummaryBuilder).to have_received(:new).with(
+          account: account,
+          params: params.merge(type: :agent, inbox_id: inbox.id)
+        )
+      end
     end
   end
 
@@ -112,6 +129,22 @@ RSpec.describe 'Summary Reports API', type: :request do
         expect(json_response.first['id']).to eq(1)
         expect(json_response.first['conversations_count']).to eq(110)
         expect(json_response.first['avg_reply_time']).to be_nil
+      end
+
+      it 'narrows the inbox report to an agent when one is given' do
+        inbox_summary_builder = double
+        allow(V2::Reports::InboxSummaryBuilder).to receive(:new).and_return(inbox_summary_builder)
+        allow(inbox_summary_builder).to receive(:build).and_return([])
+
+        get "/api/v2/accounts/#{account.id}/summary_reports/inbox",
+            params: params.merge(user_id: agent.id),
+            headers: admin.create_new_auth_token,
+            as: :json
+
+        expect(V2::Reports::InboxSummaryBuilder).to have_received(:new).with(
+          account: account,
+          params: params.merge(type: :inbox, user_id: agent.id)
+        )
       end
     end
   end


### PR DESCRIPTION
## Por quê

Os relatórios do Chatwoot são de uma dimensão só: o controller aceita `type` (`account`/`agent`/`inbox`/`team`/`label`) mais um `id`, e o builder escolhe um único `group_by` (`user_id` **ou** `inbox_id`). Quem opera duas caixas de entrada consegue ver o desempenho por agente somando tudo, ou o desempenho de uma caixa sem separar por agente, mas nunca os dois juntos.

Foi o que um cliente pediu: o relatório de tickets fechados por responsável, restrito a uma caixa. Confirmei que não existe nativo nem no CE nem no `enterprise/`.

## O que mudou

- `Reports::DataSource` aceita `filters`, e o `RawDataSource` aplica em `reporting_events` (`inbox_id`/`user_id`) e em `conversations` (`inbox_id`/`assignee_id`). Como `reporting_events` já grava `inbox_id` e `user_id` na mesma linha, não tem migration nem reprocessamento.
- Relatórios > Agentes ganhou um chip de caixa de entrada; Relatórios > Caixa de Entrada ganhou o chip de agente. O filtro entra na URL (`?inbox_id=1`, `?agent_id=1`), então o link do relatório diário é salvável.
- Com filtro ativo, linhas sem nenhuma atividade saem da tabela: filtrar por uma caixa e ver todo o quadro de agentes com `--` não responde a pergunta que o filtro fez. Sem filtro, a lista completa continua.
- O CSV segue o mesmo filtro e leva o nome dele no arquivo (`agent-report-24-08-2026-acme-support.csv`), pra o mesmo relatório puxado pra duas caixas não se sobrescrever.

## Atribuição

Vale saber ao comparar com outras ferramentas: `conversations_count` conta pelo assignee atual, e `resolutions_count` pelo assignee no momento da resolução (`reporting_events.user_id`, gravado em `conversation_resolved`). Conversa reatribuída depois de fechada aparece em agentes diferentes nas duas colunas.

## Testes

- 4 casos novos no backend (builders de agente e caixa, controller de summary, CSV de agentes) e 1 no `downloadHelper`.
- `spec/builders/v2/reports`, `spec/controllers/api/v2/accounts` e `spec/services/reports` verdes, com uma exceção: `label_summary_builder_spec.rb:360` falha igual na `main` limpa, é anterior e não tem relação.
- Conferido na app: filtrando Acme Support em 90 dias, Alice 6 conversas / 1 resolvida, Bob 1 conversa, John 0 conversas / 3 resolvidas, batendo com o banco. Sem filtro, John mostra 7 resoluções (3 + 4 na outra caixa).

## Fora de escopo

O filtro está nas telas de visão geral. A tela de detalhe de um agente, com os gráficos, continua somando todas as caixas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoX4kF19t6maEdiAQBN3S9

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/412)
<!-- Reviewable:end -->
