### PR TITLE
fix(webhooks): escalate an agent bot failure only after the retries are gone

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -1,8 +1,13 @@
 class WebhookJob < ApplicationJob
   queue_as :medium
 
-  retry_on CustomExceptions::Webhook::RetriableError, wait: :polynomially_longer, attempts: 5
-  discard_on CustomExceptions::Webhook::RetriableError do |job, error|
+  # ONE handler, on purpose. `retry_on` and `discard_on` are both built on `rescue_from`, which
+  # appends handlers and then resolves them with `reverse_each`, so the LAST matching declaration
+  # wins. Declared as two statements for the same exception class, the `discard_on` shadowed the
+  # `retry_on` above it: the job was discarded on its first failure and the five attempts never ran.
+  # `retry_on`'s own block already runs exactly when the attempts are exhausted, which is what the
+  # separate `discard_on` was reaching for.
+  retry_on CustomExceptions::Webhook::RetriableError, wait: :polynomially_longer, attempts: 5 do |job, error|
     payload = job.arguments[1]
     webhook_type = job.arguments[2] || :account_webhook
 

--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -28,7 +28,16 @@ class Webhooks::Trigger
   rescue StandardError => e
     raise RetryableError.new(status: http_status(e), message: e.message) if retryable_agent_bot_error?(e)
 
-    handle_failure(e)
+    # NO ESCALATION HERE. A failed request is not a failed delivery: WebhookJob retries this, and
+    # escalating on attempt 1 makes those retries unreachable for an agent bot. The bot only acts on
+    # a `pending` conversation, so moving it to `open` here means every redelivery arrives at a
+    # conversation the bot will not answer, and the retry lands without changing anything.
+    # The same holds for an api_inbox message marked `failed` here: a later attempt can still
+    # deliver it, leaving an agent to resend what the customer already received.
+    # Escalation belongs to whoever learns the delivery is over, which is the retries-exhausted
+    # block in WebhookJob (`Webhooks::ErrorHandler` applies the same guards and the same activity
+    # note as `update_conversation_status`).
+    Rails.logger.warn "Exception: webhook request to #{@url} failed : #{e.message}"
     raise CustomExceptions::Webhook::RetriableError, "Webhook request failed: #{e.message}"
   end
 

--- a/spec/jobs/webhook_job_spec.rb
+++ b/spec/jobs/webhook_job_spec.rb
@@ -84,6 +84,53 @@ RSpec.describe WebhookJob do
         expect { perform_enqueued_jobs { job } }.not_to(change { message.reload.status })
       end
 
+      # These drive the REAL Webhooks::Trigger and stub only the HTTP call. Stubbing
+      # `Trigger.execute` (as the examples above do) skips `handle_failure` entirely, so it cannot
+      # tell escalation-on-attempt-1 from escalation-on-exhaustion, which is the whole point here.
+      context 'with the real trigger and a failing transport' do
+        let(:payload) { { event: 'message_created', id: message.id } }
+
+        def stub_fetch_failing(times:)
+          calls = 0
+          allow(SafeFetch).to receive(:fetch) do |*_args|
+            calls += 1
+            raise SafeFetch::HttpError, '404 Not Found' if calls <= times
+
+            nil
+          end
+          -> { calls }
+        end
+
+        it 'does not escalate while attempts remain, so a later attempt still reaches a pending conversation' do
+          calls = stub_fetch_failing(times: 4)
+
+          perform_enqueued_jobs { job }
+
+          expect(calls.call).to eq(5)
+          expect(conversation.reload.status).to eq('pending')
+          expect(conversation.messages.where(message_type: :activity)).to be_empty
+        end
+
+        it 'escalates exactly once when every attempt fails' do
+          stub_fetch_failing(times: 5)
+
+          perform_enqueued_jobs { job }
+
+          expect(conversation.reload.status).to eq('open')
+          expect(conversation.messages.where(message_type: :activity).count).to eq(1)
+        end
+
+        it 'honours keep_pending_on_bot_failure even after the attempts are exhausted' do
+          conversation.account.update!(keep_pending_on_bot_failure: true)
+          stub_fetch_failing(times: 5)
+
+          perform_enqueued_jobs { job }
+
+          expect(conversation.reload.status).to eq('pending')
+          expect(conversation.messages.where(message_type: :activity)).to be_empty
+        end
+      end
+
       context 'when conversation is not pending' do
         before { conversation.update!(status: :open) }
 

--- a/spec/lib/webhooks/trigger_spec.rb
+++ b/spec/lib/webhooks/trigger_spec.rb
@@ -63,14 +63,13 @@ describe Webhooks::Trigger do
       expect { trigger.execute(url, payload, webhook_type) }.to raise_error(CustomExceptions::Webhook::RetriableError)
     end
 
-    it 'treats blocked private webhook URLs as failures' do
+    it 'treats blocked private webhook URLs as failures without marking the message yet' do
       payload = { event: 'message_created', conversation: { id: conversation.id }, id: message.id }
 
       expect do
-        trigger.execute('http://127.0.0.1/webhook', payload, webhook_type)
-      rescue CustomExceptions::Webhook::RetriableError
-        nil
-      end.to change { message.reload.status }.from('sent').to('failed')
+        expect { trigger.execute('http://127.0.0.1/webhook', payload, webhook_type) }
+          .to raise_error(CustomExceptions::Webhook::RetriableError)
+      end.not_to(change { message.reload.status })
     end
 
     context 'when webhook type is agent bot' do
@@ -106,22 +105,18 @@ describe Webhooks::Trigger do
         expect(Conversations::ActivityMessageJob).not_to have_been_enqueued
       end
 
-      it 'reopens conversation and enqueues activity message if pending' do
+      it 'leaves a pending conversation alone so the retries can still land' do
         payload = { event: 'message_created', id: pending_message.id }
 
         expect(SafeFetch).to receive(:fetch).and_raise(SafeFetch::HttpError.new('404 Not Found'))
 
-        perform_enqueued_jobs do
-          trigger.execute(url, payload, webhook_type)
-        rescue CustomExceptions::Webhook::RetriableError
-          nil
-        end
+        expect { trigger.execute(url, payload, webhook_type) }.to raise_error(CustomExceptions::Webhook::RetriableError)
 
-        expect(pending_conversation.reload.status).to eq('open')
-
-        activity_message = pending_conversation.reload.messages.order(:created_at).last
-        expect(activity_message.message_type).to eq('activity')
-        expect(activity_message.content).to eq(agent_bot_error_content)
+        # The bot only answers a `pending` conversation. Escalating here would make every redelivery
+        # arrive at a conversation the bot will not answer, so the retries could never recover the
+        # turn. WebhookJob escalates once, after the attempts are exhausted (see spec/jobs).
+        expect(pending_conversation.reload.status).to eq('pending')
+        expect(Conversations::ActivityMessageJob).not_to have_been_enqueued
       end
 
       it 'does not change message status or enqueue activity when conversation is not pending' do
@@ -130,56 +125,24 @@ describe Webhooks::Trigger do
         expect(SafeFetch).to receive(:fetch).and_raise(SafeFetch::HttpError.new('404 Not Found'))
 
         expect do
-          trigger.execute(url, payload, webhook_type)
-        rescue CustomExceptions::Webhook::RetriableError
-          nil
+          expect { trigger.execute(url, payload, webhook_type) }
+            .to raise_error(CustomExceptions::Webhook::RetriableError)
         end.not_to(change { message.reload.status })
 
         expect(Conversations::ActivityMessageJob).not_to have_been_enqueued
         expect(conversation.reload.status).to eq('open')
       end
-
-      it 'keeps conversation pending when keep_pending_on_bot_failure setting is enabled' do
-        account.update!(keep_pending_on_bot_failure: true)
-        payload = { event: 'message_created', id: pending_message.id }
-
-        expect(SafeFetch).to receive(:fetch).and_raise(SafeFetch::HttpError.new('404 Not Found'))
-
-        expect { trigger.execute(url, payload, webhook_type) }.to raise_error(CustomExceptions::Webhook::RetriableError)
-
-        expect(Conversations::ActivityMessageJob).not_to have_been_enqueued
-        expect(pending_conversation.reload.status).to eq('pending')
-      end
-
-      it 'reopens conversation when keep_pending_on_bot_failure setting is disabled' do
-        account.update!(keep_pending_on_bot_failure: false)
-        payload = { event: 'message_created', id: pending_message.id }
-
-        expect(SafeFetch).to receive(:fetch).and_raise(SafeFetch::HttpError.new('404 Not Found'))
-
-        expect do
-          perform_enqueued_jobs do
-            trigger.execute(url, payload, webhook_type)
-          rescue CustomExceptions::Webhook::RetriableError
-            nil
-          end
-        end.not_to(change { pending_message.reload.status })
-
-        expect(pending_conversation.reload.status).to eq('open')
-
-        activity_message = pending_conversation.reload.messages.order(:created_at).last
-        expect(activity_message.message_type).to eq('activity')
-        expect(activity_message.content).to eq(agent_bot_error_content)
-      end
     end
 
-    it 'marks message as failed and raises RetriableError for non-agent webhooks on 500' do
+    it 'raises RetriableError for non-agent webhooks on 500 without marking the message failed' do
       payload = { event: 'message_created', conversation: { id: conversation.id }, id: message.id }
 
       expect(SafeFetch).to receive(:fetch).and_raise(SafeFetch::HttpError.new('500 Internal Server Error'))
 
       expect { trigger.execute(url, payload, webhook_type) }.to raise_error(CustomExceptions::Webhook::RetriableError)
-      expect(message.reload.status).to eq('failed')
+      # Still 'sent': four attempts remain, and one of them may deliver. Marking it failed here is
+      # what let an agent resend a message the retry had already delivered.
+      expect(message.reload.status).to eq('sent')
     end
   end
 


### PR DESCRIPTION
## Contexto

Investigando um relato de produção de conversas sem resposta do bot (`fazer-ai/agents#225`),
a causa se mostrou uma cadeia em que **nada tinha falhado**: o consumidor demorou mais de 5 s
para *ackar* o webhook, e a escalação disparou por latência do recibo.

O agravante é que a escalação é auto-derrotante para um Agent Bot:

- o bot só responde conversa em `pending` (é o gate de atribuição dele);
- `Message#reopen_conversation` só reabre `snoozed` e `resolved`, então uma conversa `open`
  **nunca** volta para `pending` por mensagem nova;
- logo, escalar `pending → open` faz toda reentrega chegar num lugar onde o bot fica calado, e o
  auto-resolve não resgata porque as mensagens do próprio cliente empurram `last_activity_at`.

Na prática o bot ficava mudo naquela conversa enquanto o cliente insistisse.

## Os dois defeitos

### 1. Os cinco retries nunca rodavam

`WebhookJob` declarava `retry_on` e `discard_on` para a **mesma** classe de exceção:

```ruby
retry_on   CustomExceptions::Webhook::RetriableError, wait: :polynomially_longer, attempts: 5
discard_on CustomExceptions::Webhook::RetriableError do |job, error| ... end
```

Os dois são construídos sobre `rescue_from`, que faz `rescue_handlers += [[key, with]]` (append) e
resolve com `rescue_handlers.reverse_each.detect`. O **último registrado ganha**, então o
`discard_on` sombreava o `retry_on`: o job era descartado na primeira falha e as cinco tentativas
nunca aconteciam. E como `discard_on` não relança, o Sidekiq também não tentava de novo.

O `AgentBots::WebhookJob` já documenta exatamente essa regra no topo do arquivo e a aplica
corretamente; o arquivo pai é que escapou.

Conserto: dobrar o corpo do `discard_on` para dentro do bloco do próprio `retry_on`, que roda
justamente quando as tentativas se esgotam. Um handler só, sem ambiguidade de ordem.

### 2. A escalação acontecia na tentativa 1

`Trigger#execute` chamava `handle_failure(e)` antes de relançar. Com o retry realmente ligado,
isso torna as reentregas inúteis.

`Webhooks::ErrorHandler`, já ligado ao bloco de tentativas esgotadas, aplica **as mesmas guardas**
(`conversation&.pending?`, `keep_pending_on_bot_failure`) e a **mesma** nota de atividade que o
`Trigger#update_conversation_status`. A escalação não se perde: passa a acontecer uma vez, quando
a entrega de fato acabou.

`handle_failure` continua público e continua sendo chamado pelo bloco do `retry_on` de
`AgentBots::WebhookJob` (caminho 429/500), que já estava correto e não foi tocado.

## Alcance: api_inbox também

O `handle_error` despacha por tipo de webhook, então o mesmo statement tinha o mesmo defeito no
caminho `api_inbox_webhook`: a mensagem era marcada `failed` com quatro tentativas ainda pela
frente. Se uma delas entregasse, a mensagem chegava ao cliente exibida como falha, e o atendente
reenviava. `ErrorHandler#handle_api_inbox_error` já cobre esse caso no bloco de esgotamento
(`spec/jobs/webhook_job_spec.rb` já tinha o exemplo), então a correção é a mesma.

## Testes

O exemplo que distingue os dois comportamentos dirige o **`Trigger` real** e stuba só o transporte:

```ruby
it 'does not escalate while attempts remain, so a later attempt still reaches a pending conversation'
```

Isso é deliberado. Os exemplos existentes stubam `Webhooks::Trigger.execute`, o que pula o
`handle_failure` inteiro e **não consegue** diferenciar escalação-na-tentativa-1 de
escalação-no-esgotamento. Verificado: com os specs novos e o código antigo, 4 exemplos falham;
com o conserto, todos passam.

Também no spec do job: escalação acontece **exatamente uma vez** quando todas as tentativas
falham, e `keep_pending_on_bot_failure` continua respeitado mesmo depois do esgotamento.

Os exemplos do `trigger_spec` que afirmavam escalação no `execute` foram reescritos para o
contrato novo (o `execute` nunca escala); a cobertura da escalação vive no spec do job, que é o
único lugar onde dá para contar tentativas.

```
50 examples, 0 failures   # spec/lib/webhooks spec/jobs/webhook_job_spec.rb spec/jobs/agent_bots
rubocop: 4 files inspected, no offenses detected
```

## Nota

Existe um segundo defeito, do lado do consumidor, que faz o ack passar de 5 s (inversão de pool
entre duas conexões Postgres). Está sendo tratado em separado, no `fazer-ai/agents`. Os dois são
necessários: este faz o atraso virar reentrega recuperada, e o outro remove o atraso.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/413)
<!-- Reviewable:end -->
