### PR TITLE
fix(webhooks): don't fail a message the channel already delivered

### DIFF
--- a/lib/webhooks/error_handler.rb
+++ b/lib/webhooks/error_handler.rb
@@ -35,7 +35,18 @@ class Webhooks::ErrorHandler
   end
 
   def handle_api_inbox_error
-    Messages::StatusUpdateService.new(message, 'failed', @error.message).perform
+    # ONLY A MESSAGE STILL IN ITS INITIAL `sent` STATE IS ONE THIS DELIVERY CAN STILL SPEAK FOR.
+    # The retries put minutes between the send and this handler, and the channel can report the
+    # message delivered or read inside that window. `Messages::StatusUpdateService` refuses only
+    # `read` -> `delivered`, so without this guard a failure decided minutes ago lands on top of a
+    # message the customer already has, and the agent is shown a resend they must not make.
+    # Locked because the channel's own update races this read, and the lock is what makes the
+    # channel's write wait rather than interleave.
+    message.with_lock do
+      break unless message.sent?
+
+      Messages::StatusUpdateService.new(message, 'failed', @error.message).perform
+    end
   end
 
   def activity_message_params(conversation)

--- a/spec/lib/webhooks/error_handler_spec.rb
+++ b/spec/lib/webhooks/error_handler_spec.rb
@@ -88,6 +88,31 @@ describe Webhooks::ErrorHandler do
 
       expect(service).to have_received(:perform)
     end
+
+    # The retries put minutes between the send and this handler, and the channel can report the
+    # message delivered or read inside that window. `Messages::StatusUpdateService` only refuses
+    # `read` -> `delivered`, so nothing below it stops a stale failure from landing on top of a
+    # message the customer already has, which is what puts a resend in front of an agent.
+    %i[delivered read].each do |later_status|
+      it "leaves a message already #{later_status} alone" do
+        message.update!(status: later_status)
+        payload = { event: 'message_created', id: message.id }
+
+        described_class.perform(payload, webhook_type, error)
+
+        expect(message.reload.status).to eq(later_status.to_s)
+        expect(message.external_error).to be_nil
+      end
+    end
+
+    it 'still fails a message that never moved past sent' do
+      payload = { event: 'message_created', id: message.id }
+
+      described_class.perform(payload, webhook_type, error)
+
+      expect(message.reload.status).to eq('failed')
+      expect(message.external_error).to eq(error.message)
+    end
   end
 
   context 'when event is not supported' do


### PR DESCRIPTION
## What broke

#413 moved agent-bot escalation to the exhausted-retries handler, and the `api_inbox` handler moved with it. That one carries a state the agent-bot path does not: a message status.

The window between the send and the handler went from about five seconds to about six minutes (the `polynomially_longer` ladder over five attempts), and the channel can report the message `delivered` or `read` anywhere inside it. `Messages::StatusUpdateService#valid_status_transition?` refuses only `read → delivered`, so nothing below this point stopped a failure decided minutes ago from landing on a message the customer already has. What an agent sees then is a failed send, and what they do about it is send it again.

Measured: with a webhook endpoint that stalls past `WEBHOOK_TIMEOUT`, the five attempts span roughly six minutes end to end (attempts landed at 3.9s, 12.0s, 44.2s, 146.9s and ~410s from the first).

## What changed

Only a message still in its initial `sent` state is one this delivery can still speak for. The check is taken under a row lock, because the channel's own status update races the read and the lock is what makes that write wait rather than interleave.

The guard is deliberately here and not in `Messages::StatusUpdateService`: other callers legitimately mark a `delivered` message `failed` when the provider reports a later failure, and widening the service would break them.

## Validation scope

**Proven by spec.** Three new examples in `spec/lib/webhooks/error_handler_spec.rb`: a `delivered` message and a `read` message are both left alone with `external_error` untouched, and a message still `sent` still fails with its error recorded. The first two are red before the change (`expected: "delivered", got: "failed"`). `spec/lib/webhooks/error_handler_spec.rb`, `spec/lib/webhooks/trigger_spec.rb` and `spec/jobs/webhook_job_spec.rb` together: 43 examples, 0 failures. Rubocop clean on both touched files.

**Not validated.** The row lock is not proven by a spec. Demonstrating it needs two threads racing the same row, and a concurrency spec that passes with and without the lock proves nothing, so none was written. What the specs prove is the guard; the lock is what narrows the read-then-write race the guard alone leaves open, and that race is orders of magnitude narrower than the six-minute one being closed. The `api_inbox` path is also not exercised end to end against a real channel reporting `delivered` mid-ladder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/414)
<!-- Reviewable:end -->
