### PR TITLE
fix(conversations): treat a bot-held conversation as assigned, like the server does

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -64,6 +64,7 @@ import {
   getVisibleAssigneeTabPermissions,
 } from 'dashboard/helper/permissionsHelper.js';
 import { matchesFilters } from '../store/modules/conversations/helpers/filterHelpers';
+import { humanAssignee } from '../store/modules/conversations/helpers';
 import { CONVERSATION_EVENTS } from '../helper/AnalyticsHelper/events';
 
 const props = defineProps({
@@ -336,11 +337,14 @@ const pageTitle = computed(() => {
 
 function filterByAssigneeTab(conversations) {
   if (activeAssigneeTab.value === wootConstants.ASSIGNEE_TYPE.ME) {
+    // The human, since the id being compared is an agent's: a bot's comes from its own table and
+    // can be the same integer.
     return conversations.filter(
-      c => c.meta?.assignee?.id === currentUser.value?.id
+      c => humanAssignee(c)?.id === currentUser.value?.id
     );
   }
   if (activeAssigneeTab.value === wootConstants.ASSIGNEE_TYPE.UNASSIGNED) {
+    // Whoever holds it, bot included, which is what the server's `unassigned` scope says.
     return conversations.filter(c => !c.meta?.assignee);
   }
   return [...conversations];

--- a/app/javascript/dashboard/helper/actionCable.js
+++ b/app/javascript/dashboard/helper/actionCable.js
@@ -173,15 +173,16 @@ class ActionCableConnector extends BaseActionCableConnector {
     if (!permissions.some(held => ASSIGNMENT_SCOPED_PERMISSIONS.includes(held)))
       return false;
 
-    // A conversation handed to a bot is unassigned as far as visibility goes: the assignment service
-    // clears `assignee_id` and tracks the bot beside it, so the filter that scopes a role to the
-    // unassigned ones takes it in even though the payload still names the bot.
-    const assignee = humanAssignee(payload);
-    if (assignee && assignee.id === user?.id) return true;
+    // The human, because the id being compared is an agent's: a bot's id comes from its own table
+    // and can be the same integer.
+    if (humanAssignee(payload)?.id === user?.id) return true;
 
-    // Losing the assignee hands the conversation back to a role that sees the unassigned ones.
+    // Whoever holds it, bot included: an unassigned-only role is scoped on the server by
+    // `conversations.unassigned`, which a bot-held conversation is not part of. Being handed to a
+    // bot takes access away rather than granting it, the same as being handed to another agent.
     return (
-      !assignee && permissions.includes(CONVERSATION_UNASSIGNED_PERMISSIONS)
+      !payload.meta?.assignee &&
+      permissions.includes(CONVERSATION_UNASSIGNED_PERMISSIONS)
     );
   };
 

--- a/app/javascript/dashboard/helper/specs/actionCable.spec.js
+++ b/app/javascript/dashboard/helper/specs/actionCable.spec.js
@@ -576,16 +576,16 @@ describe('ActionCableConnector - Copilot Tests', () => {
       expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
     });
 
-    // The assignment service clears `assignee_id` when a bot takes over, so the backend sees no assignee
-    // even though the payload names the bot.
-    it('refetches when a bot takes over and the role sees unassigned ones', () => {
+    // `conversations.unassigned` excludes a conversation a bot holds, so a bot taking over takes it
+    // away from an unassigned-only role instead of handing it over.
+    it('does not refetch when a bot takes over, which grants no access', () => {
       store.$store.getters.getCurrentUser = userWith([
         'conversation_unassigned_manage',
       ]);
 
       actionCable.onReceived(assigneeChanged({ id: 99 }, 'AgentBot'));
 
-      expect(mockDispatch).toHaveBeenCalledWith('conversationPins/fetch');
+      expect(mockDispatch).not.toHaveBeenCalledWith('conversationPins/fetch');
     });
 
     it('refetches when the conversation is unassigned and the role sees unassigned ones', () => {

--- a/app/javascript/dashboard/store/modules/conversations/getters.js
+++ b/app/javascript/dashboard/store/modules/conversations/getters.js
@@ -131,11 +131,11 @@ const getters = {
   },
   getUnAssignedChats: (_state, _, __, rootGetters) => activeFilters => {
     const chats = _state.allConversations.filter(conversation => {
-      // A human assignee, not any assignee: handing a conversation to a bot clears
-      // `assignee_id`, so the server counts it as unassigned and the tab's badge says
-      // so. Reading `meta.assignee` alone (which names the bot) kept it out of the list
-      // the badge was counting.
-      const isUnAssigned = !humanAssignee(conversation);
+      // Any assignee, bot included, which is the server's own answer: `scope :unassigned`
+      // requires `assignee_agent_bot_id` to be null too, and the tab's badge counts the same
+      // way. Asking for a human here put bot-held conversations in a list whose badge did not
+      // count them, and only after a visit to "All" had loaded them into the store.
+      const isUnAssigned = !conversation.meta.assignee;
       const shouldFilter = applyPageFilters(conversation, activeFilters);
       return isUnAssigned && shouldFilter;
     });

--- a/app/javascript/dashboard/store/modules/conversations/helpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers.js
@@ -110,12 +110,13 @@ export const applyRoleFilter = (
     return true;
   }
 
-  // Whoever holds it, bot included: `conversation_unassigned_manage` is scoped on the server by
-  // `conversations.unassigned`, which excludes a conversation a bot holds. Reading the human
-  // assignee here instead would show the agent conversations the server never granted them.
-  const conversationAssignee = conversation.meta.assignee;
-  const isUnassigned = !conversationAssignee;
-  const isAssignedToUser = conversationAssignee?.id === currentUserId;
+  // Two different questions, and the server answers them from two different columns:
+  // `conversations.unassigned` (which excludes a conversation a bot holds, so whoever holds it is
+  // what settles it) OR `assigned_to(user)`, which reads `assignee_id` and can only ever name a
+  // human. Comparing the raw assignee's id against the agent's would match a bot that happens to
+  // share the integer, since bot ids come from their own table.
+  const isUnassigned = !conversation.meta.assignee;
+  const isAssignedToUser = humanAssignee(conversation)?.id === currentUserId;
 
   // Check unassigned management permission
   if (permissions.includes('conversation_unassigned_manage')) {

--- a/app/javascript/dashboard/store/modules/conversations/helpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers.js
@@ -74,15 +74,14 @@ export const applyPageFilters = (conversation, filters) => {
 /**
  * The human this conversation is assigned to, or undefined.
  *
- * `meta.assignee` is whoever the conversation was handed to, bot included, and
- * `meta.assignee_type` is what says which. Everything that asks "is this unassigned"
- * means "does a human own it", because that is the question the server answers:
- * assigning to a bot clears `assignee_id` and stores the bot in its own column, so the
- * `unassigned` scope, the tab's badge and `conversation_unassigned_manage` all count it
- * as unassigned.
+ * `meta.assignee` is whoever holds the conversation, bot included, and `meta.assignee_type`
+ * is what says which. A bot holding a conversation counts as ASSIGNED everywhere the server
+ * decides: `scope :unassigned` requires `assignee_agent_bot_id` to be null too, the tab's
+ * badge counts the same way, and `conversation_unassigned_manage` grants access through that
+ * same scope. So this helper is not the answer to "is this unassigned" — `meta.assignee` is.
  *
- * Bots are excluded rather than humans required: the payload sets the type in the same
- * branch that names the bot, so a payload without one only ever named a human.
+ * Use it only where the question really is "which human", such as matching an agent's own id:
+ * a bot's id comes from its own table and can be the same integer as an agent's.
  *
  * @param {{meta?: {assignee?: Object, assignee_type?: string}}} conversation
  * @returns {Object|undefined}
@@ -111,14 +110,10 @@ export const applyRoleFilter = (
     return true;
   }
 
-  // Assigned means assigned to a HUMAN, which is what the database says: handing a
-  // conversation to a bot clears `assignee_id` and stores the bot in its own column, so
-  // the server's `unassigned` scope, the tab's badge and
-  // `conversation_unassigned_manage` all count it as unassigned. The payload still names
-  // the bot under `meta.assignee` (`Conversation#assigned_entity` prefers it), so reading
-  // that alone made the client disagree with the server that fed it: an agent with only
-  // `conversation_unassigned_manage` lost the conversations the server had granted them.
-  const conversationAssignee = humanAssignee(conversation);
+  // Whoever holds it, bot included: `conversation_unassigned_manage` is scoped on the server by
+  // `conversations.unassigned`, which excludes a conversation a bot holds. Reading the human
+  // assignee here instead would show the agent conversations the server never granted them.
+  const conversationAssignee = conversation.meta.assignee;
   const isUnassigned = !conversationAssignee;
   const isAssignedToUser = conversationAssignee?.id === currentUserId;
 

--- a/app/javascript/dashboard/store/modules/conversations/specs/assigneeContract.spec.js
+++ b/app/javascript/dashboard/store/modules/conversations/specs/assigneeContract.spec.js
@@ -1,0 +1,41 @@
+import getters from '../getters';
+import contract from './contracts/assigneeContract.json';
+
+// The other half of `spec/contracts/conversation_assignee_contract_spec.rb`. That spec asks the real
+// endpoint what each tab holds and writes it to the fixture below; this one replays the same payload
+// through the store getters that build the list on screen. When the two definitions of "unassigned"
+// drift apart, this is what fails.
+//
+// It reproduces the shape of the bug it exists for (#416): the store holds every conversation the
+// "All" tab loaded, and the "Unassigned" tab filters that locally. A tab that disagrees with the
+// count the server sent is a tab whose badge disagrees with its own list.
+describe('assignee contract', () => {
+  const { conversations, server, current_user_id: currentUserId } = contract;
+  const state = { allConversations: conversations, chatSortFilter: '' };
+  const filters = { status: 'open' };
+
+  it('lists in Unassigned exactly what the server calls unassigned', () => {
+    const chats = getters.getUnAssignedChats(state, {}, {}, {})(filters);
+
+    expect(chats.map(chat => chat.id)).toEqual(server.unassigned_ids);
+    expect(chats).toHaveLength(server.counts.unassigned_count);
+  });
+
+  it('lists in Mine exactly what the server calls mine', () => {
+    const chats = getters.getMineChats(
+      state,
+      {},
+      {},
+      {
+        getCurrentUser: { id: currentUserId },
+      }
+    )(filters);
+
+    expect(chats.map(chat => chat.id)).toEqual(server.mine_ids);
+    expect(chats).toHaveLength(server.counts.mine_count);
+  });
+
+  it('loads the whole All tab into the store, which is where the tabs filter from', () => {
+    expect(conversations).toHaveLength(server.counts.all_count);
+  });
+});

--- a/app/javascript/dashboard/store/modules/conversations/specs/contracts/assigneeContract.json
+++ b/app/javascript/dashboard/store/modules/conversations/specs/contracts/assigneeContract.json
@@ -1,0 +1,55 @@
+{
+  "_generated_by": "spec/contracts/conversation_assignee_contract_spec.rb",
+  "_regenerate_with": "UPDATE_CONTRACTS=1 bundle exec rspec spec/contracts/conversation_assignee_contract_spec.rb",
+  "current_user_id": 100,
+  "conversations": [
+    {
+      "id": 1,
+      "status": "open",
+      "inbox_id": 1,
+      "labels": [],
+      "meta": {
+        "assignee": null,
+        "assignee_type": null
+      }
+    },
+    {
+      "id": 2,
+      "status": "open",
+      "inbox_id": 1,
+      "labels": [],
+      "meta": {
+        "assignee": {
+          "id": 100
+        },
+        "assignee_type": "User"
+      }
+    },
+    {
+      "id": 3,
+      "status": "open",
+      "inbox_id": 1,
+      "labels": [],
+      "meta": {
+        "assignee": {
+          "id": 100
+        },
+        "assignee_type": "AgentBot"
+      }
+    }
+  ],
+  "server": {
+    "unassigned_ids": [
+      1
+    ],
+    "mine_ids": [
+      2
+    ],
+    "counts": {
+      "mine_count": 1,
+      "assigned_count": 2,
+      "unassigned_count": 1,
+      "all_count": 3
+    }
+  }
+}

--- a/app/javascript/dashboard/store/modules/conversations/specs/helpers.spec.js
+++ b/app/javascript/dashboard/store/modules/conversations/specs/helpers.spec.js
@@ -266,11 +266,10 @@ describe('Conversation Helpers', () => {
       ).toBe(false);
     });
 
-    // A conversation handed to a bot has `assignee_id` cleared, so
-    // `conversation_unassigned_manage` grants it on the server. The client read
-    // `meta.assignee`, which still names the bot, and removed it from a list the server
-    // had already decided the agent could see.
-    it('treats a bot-held conversation as unassigned', () => {
+    // `conversation_unassigned_manage` is scoped on the server by `conversations.unassigned`,
+    // which requires `assignee_agent_bot_id` to be null: a bot-held conversation is never granted
+    // through it.
+    it('treats a bot-held conversation as assigned', () => {
       const conversation = {
         meta: { assignee: { id: 99, name: 'Bot' }, assignee_type: 'AgentBot' },
       };
@@ -281,7 +280,7 @@ describe('Conversation Helpers', () => {
           ['conversation_unassigned_manage'],
           1
         )
-      ).toBe(true);
+      ).toBe(false);
     });
 
     // Test edge cases for meta.assignee

--- a/app/javascript/dashboard/store/modules/conversations/specs/helpers.spec.js
+++ b/app/javascript/dashboard/store/modules/conversations/specs/helpers.spec.js
@@ -283,6 +283,21 @@ describe('Conversation Helpers', () => {
       ).toBe(false);
     });
 
+    // The other half of the same payload: the server grants "mine" through `assigned_to(user)`,
+    // which reads `assignee_id` and can only name a human, so a bot sharing the agent's integer
+    // grants nothing. Both scoped roles ask the question, so both are checked.
+    it.each([
+      'conversation_unassigned_manage',
+      'conversation_participating_manage',
+    ])('keeps a bot sharing the agent id out of %s', permission => {
+      const conversation = {
+        meta: { assignee: { id: 1, name: 'Bot' }, assignee_type: 'AgentBot' },
+      };
+      expect(
+        applyRoleFilter(conversation, 'custom_role', [permission], 1)
+      ).toBe(false);
+    });
+
     // Test edge cases for meta.assignee
     describe('handles edge cases with meta.assignee', () => {
       const role = 'custom_role';

--- a/app/javascript/dashboard/store/modules/specs/conversations/getters.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/getters.spec.js
@@ -128,9 +128,10 @@ describe('#getters', () => {
       ]);
     });
   });
-  // Handing a conversation to a bot clears `assignee_id`, so the server's `unassigned`
-  // scope and the tab's badge both count it. The list read `meta.assignee`, which still
-  // names the bot, and left it out: badge and list disagreed on the same conversation.
+  // A bot holding a conversation counts as assigned on the server: `scope :unassigned` requires
+  // `assignee_agent_bot_id` to be null too, and the tab's badge counts the same way. Counting it
+  // as unassigned here put it in a list whose badge did not count it, and only once a visit to
+  // "All" had loaded it into the store.
   describe('#getUnAssignedChats with a bot', () => {
     const botConversation = {
       id: 1,
@@ -147,12 +148,24 @@ describe('#getters', () => {
       labels: [],
     };
 
-    it('counts a bot conversation as unassigned, like the badge does', () => {
+    const unassignedConversation = {
+      id: 3,
+      inbox_id: 2,
+      status: 1,
+      meta: {},
+      labels: [],
+    };
+
+    it('leaves a bot conversation out, like the badge does', () => {
       const chats = getters.getUnAssignedChats({
-        allConversations: [botConversation, humanConversation],
+        allConversations: [
+          botConversation,
+          humanConversation,
+          unassignedConversation,
+        ],
       })({ status: 1 });
 
-      expect(chats.map(chat => chat.id)).toEqual([1]);
+      expect(chats.map(chat => chat.id)).toEqual([3]);
     });
 
     // The bot's id comes from its own table and can be the same integer as an agent's.

--- a/spec/contracts/conversation_assignee_contract_spec.rb
+++ b/spec/contracts/conversation_assignee_contract_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+# The client decides which conversations belong in the "Unassigned" and "Mine" tabs by filtering the
+# store locally, while the badge next to each tab is a count the server sent. Nothing used to tie the
+# two definitions together, so they could drift apart with every test on both sides still green: the
+# server counted a bot-held conversation as assigned and the client listed it as unassigned, and the
+# tab only disagreed with its own badge once a visit to "All" had loaded those conversations into the
+# store (#416).
+#
+# This spec is the tie. It asks the real endpoint what each tab holds and writes the answer next to
+# the client's own specs, which replay it through the store getters. A change to the server's
+# semantics rewrites the fixture here and breaks the client spec that reads it.
+RSpec.describe 'Conversation assignee contract', type: :request do
+  let(:account) { create(:account) }
+  let(:agent) { create(:user, account: account, role: :agent) }
+  let(:inbox) { create(:inbox, account: account) }
+  # Same integer as the agent, which is a real payload: bot ids come from their own table.
+  let(:agent_bot) { create(:agent_bot, account: account, id: agent.id) }
+
+  let(:contract_path) do
+    Rails.root.join('app/javascript/dashboard/store/modules/conversations/specs/contracts/assigneeContract.json')
+  end
+
+  let!(:unassigned_conversation) { create(:conversation, account: account, inbox: inbox, status: :open) }
+  let!(:human_conversation) { create(:conversation, account: account, inbox: inbox, status: :open, assignee: agent) }
+  let!(:bot_conversation) do
+    create(:conversation, account: account, inbox: inbox, status: :open, assignee_agent_bot: agent_bot)
+  end
+
+  # Ids the fixture can be diffed on: the conversations by the role they play here, and both
+  # assignees onto the single integer they share. The payload identifies a conversation by its
+  # `display_id`, which is what the client stores as `id`.
+  let(:conversation_ids) do
+    {
+      unassigned_conversation.display_id => 1,
+      human_conversation.display_id => 2,
+      bot_conversation.display_id => 3
+    }
+  end
+  let(:normalized_assignee_id) { 100 }
+
+  before { create(:inbox_member, user: agent, inbox: inbox) }
+
+  def list(assignee_type)
+    get "/api/v1/accounts/#{account.id}/conversations",
+        params: { status: 'open', assignee_type: assignee_type },
+        headers: agent.create_new_auth_token,
+        as: :json
+
+    expect(response).to have_http_status(:success)
+    JSON.parse(response.body, symbolize_names: true)[:data]
+  end
+
+  def normalize(conversation)
+    assignee = conversation[:meta][:assignee]
+
+    {
+      id: conversation_ids.fetch(conversation[:id]),
+      status: conversation[:status],
+      inbox_id: 1,
+      labels: conversation[:labels],
+      meta: {
+        assignee: assignee && { id: normalized_assignee_id },
+        assignee_type: conversation[:meta][:assignee_type]
+      }
+    }
+  end
+
+  it 'matches the assignee semantics the client replays' do
+    all = list('all')
+    unassigned = list('unassigned')
+    mine = list('me')
+
+    contract = {
+      _generated_by: 'spec/contracts/conversation_assignee_contract_spec.rb',
+      _regenerate_with: 'UPDATE_CONTRACTS=1 bundle exec rspec spec/contracts/conversation_assignee_contract_spec.rb',
+      current_user_id: normalized_assignee_id,
+      # What a visit to the "All" tab loads into the store, which is every conversation the tabs
+      # filter locally from.
+      conversations: all[:payload].map { |conversation| normalize(conversation) }.sort_by { |c| c[:id] },
+      server: {
+        unassigned_ids: unassigned[:payload].map { |c| conversation_ids.fetch(c[:id]) }.sort,
+        mine_ids: mine[:payload].map { |c| conversation_ids.fetch(c[:id]) }.sort,
+        counts: all[:meta].slice(:mine_count, :assigned_count, :unassigned_count, :all_count)
+      }
+    }
+
+    json = "#{JSON.pretty_generate(contract)}\n"
+
+    if ENV.fetch('UPDATE_CONTRACTS', nil)
+      contract_path.write(json)
+    else
+      expect(contract_path.read).to eq(json), <<~MESSAGE
+        The conversation assignee contract changed. If the new behaviour is intended, regenerate the
+        fixture with `#{contract[:_regenerate_with]}` and run the client spec that reads it
+        (assigneeContract.spec.js), which is what keeps the tabs agreeing with their badges.
+      MESSAGE
+    end
+  end
+end


### PR DESCRIPTION
A aba **Não atribuídas** mostrava conversas que o badge ao lado dela não contava, e só depois de o agente passar pela aba **Todos**. Em **Pendentes**, que é justamente onde o bot está com a conversa, o badge dizia 0 e a lista aparecia cheia. Agora as duas concordam: conversa que um bot segura é atribuída, do mesmo jeito no cliente e no servidor.

## Closes

- Closes #416

## How to reproduce

1. Numa caixa de entrada com bot, deixe conversas abertas seguradas pelo bot.
2. Abra **Abertas → Não atribuídas**, clique em **Todos** e volte: antes a lista crescia sem o badge mudar, agora ela fica igual.
3. Troque o filtro para **Pendentes** e repita: antes a lista aparecia cheia com badge 0, agora as duas dizem o mesmo.

## What changed

Conversa que um bot segura conta como atribuída em todo ponto que o servidor decide: `scope :unassigned` exige `assignee_agent_bot_id` nulo, o badge conta do mesmo jeito, e `conversation_unassigned_manage` é escopado por esse mesmo scope. A #403 fez o cliente contá-la como não atribuída, apoiada na #369, que descrevia o backend como ele era antes de a #382 trazer o upstream v4.17.0 (chatwoot#15343 inverteu exatamente esses arquivos, dois dias antes).

- `getUnAssignedChats` e `applyRoleFilter` voltam a ler `meta.assignee`.
- `getMineChats` continua com `humanAssignee`: ali a pergunta é mesmo "qual humano", porque o id de um bot vem da tabela dele e pode ser o mesmo inteiro do de um agente. O upstream trata a colisão do mesmo jeito no backend.
- `assignmentMayHaveGrantedAccess` passa a olhar quem segura a conversa para decidir se um papel que só vê as não atribuídas ganhou acesso: um bot assumindo tira acesso, não concede.

A lista de cada aba é filtrada localmente sobre o store, e o badge é uma contagem que o servidor mandou. Nada amarrava as duas definições, então elas podiam divergir com os testes dos dois lados verdes. Um teste de contrato passa a amarrá-las: `spec/contracts/conversation_assignee_contract_spec.rb` pergunta ao endpoint real o que cada aba contém e grava a resposta numa fixture ao lado dos specs do cliente; `assigneeContract.spec.js` reproduz essa fixture pelos getters, na mesma situação do bug (o store carregado pela aba **Todos**). Se a semântica do servidor mudar de novo, a fixture muda e o spec do cliente quebra. Regenerar com `UPDATE_CONTRACTS=1 bundle exec rspec spec/contracts/conversation_assignee_contract_spec.rb`.

Fica valendo o comportamento do upstream desde a 4.16: conversa em **Pendentes** que o bot segura não aparece em **Não atribuídas**, e sim em **Todos**, até um humano assumir.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/417)
<!-- Reviewable:end -->
