### PR TITLE
feat(redirect): record which conversation a redirect link was minted on

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -88,3 +88,16 @@ app/jobs/whatsapp/session/pairing_poll_job.rb: Preserve compatibility with queue
 # changes every inbox picker in the app for those users, or a report-scoped inbox endpoint.
 # Neither belongs in a reports PR.
 app/javascript/dashboard/routes/dashboard/settings/reports/components/OverviewReportFilters.vue: Load all report-visible inboxes for the filter  # PR#412
+# PR#418: not a defect, and the remedy would make the payload worse. The mechanism is
+# real — `WebhookListener` runs at job time and rebuilds `webhook_data` from a row it just
+# reloaded through the GlobalID — but it is not this column's. Measured on a running
+# instance, in a rolled-back transaction: with the row at origin=77/priority=low/status=open
+# at enqueue and moved to 91/urgent/resolved before the perform, the payload carried
+# 91/"urgent"/"resolved". `priority` and `status` were in `list_of_keys` long before this
+# change and drift by exactly the same amount. Snapshotting only the pairing would make it
+# the one key in the account webhook whose value is event-time while everything beside it in
+# the same object is delivery-time, and a consumer reading two of them would be reading two
+# instants with no way to tell. The account webhook is a state snapshot at delivery; a
+# consumer that acts on it fences it as state, which is what fazer-ai/agents#355 does with a
+# version mark of its own.
+app/controllers/api/v1/widget/redirect_tokens_controller.rb: Snapshot the origin in async event payloads  # PR#418

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -101,3 +101,12 @@ app/javascript/dashboard/routes/dashboard/settings/reports/components/OverviewRe
 # consumer that acts on it fences it as state, which is what fazer-ai/agents#355 does with a
 # version mark of its own.
 app/controllers/api/v1/widget/redirect_tokens_controller.rb: Snapshot the origin in async event payloads  # PR#418
+# PR#418: real, upstream, and not this change's to make. AgentBotListener handles
+# conversation_resolved / opened / status_changed / updated / message_created / message_updated /
+# webwidget_triggered and no conversation_created, so a message-less token that CREATES the
+# conversation delivers an empty list of bot events. Measured, and pinned by "delivers no bot event
+# on creation, and names the origin on the first one that follows" in the controller spec. Nothing is
+# lost by it: the pairing is on the row from the insert, so the first event a bot does receive
+# carries it, and until a message exists there is no episode for a consumer to act on. Making
+# creation bot-visible changes the agent-bot contract for every inbox in the account.
+app/controllers/api/v1/widget/redirect_tokens_controller.rb: Notify the agent bot on the first message-less redirect  # PR#418

--- a/app/controllers/api/v1/accounts/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/accounts/redirect_tokens_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Accounts::RedirectTokensController < Api::V1::Accounts::BaseContr
     authorize inbox, :show?
     return render(json: { error: 'not_a_web_widget' }, status: :unprocessable_entity) unless inbox.web_widget?
 
-    payload = token_payload(inbox)
+    payload = token_payload(inbox, origin_conversation)
     ttl = (permitted_params[:ttl_seconds].presence&.to_i || ::Widget::RedirectToken::DEFAULT_TTL).clamp(1, ::Widget::RedirectToken::DEFAULT_TTL)
     token = ::Widget::RedirectToken.generate(payload, ttl: ttl)
 
@@ -17,13 +17,28 @@ class Api::V1::Accounts::RedirectTokensController < Api::V1::Accounts::BaseContr
   # It rides in the token because this is the only moment the two halves of a redirect episode are
   # known together: the resolve endpoint identifies the CONTACT, and a contact does not say which of
   # its conversations minted the link. Carried through to the widget conversation on resolve.
-  def token_payload(inbox)
+  def token_payload(inbox, origin)
     {
       inbox_id: inbox.id,
       identifier: permitted_params[:identifier],
       message: permitted_params[:message],
-      origin_display_id: permitted_params[:origin_display_id].presence&.to_i
+      origin_display_id: origin&.display_id
     }.compact
+  end
+
+  # The mint is the earliest shared entry point for the pairing, so the caller's right to name that
+  # conversation is settled here rather than downstream. A display_id is account-wide and guessable,
+  # and what the consumer does with the pairing is destructive — its follow-up ladder messages and
+  # RESOLVES the conversation it names. An origin the caller cannot see is refused outright instead
+  # of dropped: minting without it would silently hand back a link whose episode cannot be paired,
+  # which is the failure this whole field exists to remove.
+  def origin_conversation
+    display_id = permitted_params[:origin_display_id].presence
+    return if display_id.blank?
+
+    conversation = Current.account.conversations.find_by!(display_id: display_id)
+    authorize conversation, :show?
+    conversation
   end
 
   def permitted_params

--- a/app/controllers/api/v1/accounts/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/accounts/redirect_tokens_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Accounts::RedirectTokensController < Api::V1::Accounts::BaseContr
     authorize inbox, :show?
     return render(json: { error: 'not_a_web_widget' }, status: :unprocessable_entity) unless inbox.web_widget?
 
-    payload = { inbox_id: inbox.id, identifier: permitted_params[:identifier], message: permitted_params[:message] }.compact
+    payload = token_payload(inbox)
     ttl = (permitted_params[:ttl_seconds].presence&.to_i || ::Widget::RedirectToken::DEFAULT_TTL).clamp(1, ::Widget::RedirectToken::DEFAULT_TTL)
     token = ::Widget::RedirectToken.generate(payload, ttl: ttl)
 
@@ -13,7 +13,20 @@ class Api::V1::Accounts::RedirectTokensController < Api::V1::Accounts::BaseContr
 
   private
 
+  # `origin_display_id` is the conversation the link is being sent ON (the WhatsApp entry thread).
+  # It rides in the token because this is the only moment the two halves of a redirect episode are
+  # known together: the resolve endpoint identifies the CONTACT, and a contact does not say which of
+  # its conversations minted the link. Carried through to the widget conversation on resolve.
+  def token_payload(inbox)
+    {
+      inbox_id: inbox.id,
+      identifier: permitted_params[:identifier],
+      message: permitted_params[:message],
+      origin_display_id: permitted_params[:origin_display_id].presence&.to_i
+    }.compact
+  end
+
   def permitted_params
-    params.permit(:inbox_id, :identifier, :message, :ttl_seconds)
+    params.permit(:inbox_id, :identifier, :message, :ttl_seconds, :origin_display_id)
   end
 end

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -92,13 +92,30 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   # to nil on assignment (measured), so a malformed token writes nil either way — but `nil == ''` is
   # false, so without it the guard would miss and spend an UPDATE that changes nothing. That is why
   # deleting it leaves the specs green.
+  #
+  # But it has to compare against the ROW, not against an instance loaded before the token was even
+  # resolved, and `with_lock` is what makes those the same thing: it reloads under SELECT ... FOR
+  # UPDATE, so the comparison sees whatever a concurrent resume committed and this request's own
+  # token still gets the last word. Removing the lock does not merely re-open a window — a stale
+  # instance holding this request's own origin makes the guard skip, and skipping is silent on both
+  # counts: no write, and no conversation_updated for the message-less path. Dropping the guard
+  # instead does not help either, because ActiveRecord issues no UPDATE for a value the instance
+  # already believes it has. The staleness is the defect; the guard only reads it out.
   def record_redirect_origin(payload)
     return if @conversation.blank?
+    # Born in this request, from start_conversation, which already wrote the origin from the same
+    # payload — there is no earlier value to reconcile and nothing could have raced a row that did
+    # not exist. Skipped rather than locked, and it has to be: a just-created Conversation still
+    # holds an unpersisted `display_id` change (Chatwoot assigns it around the insert), and
+    # `with_lock` refuses to lock a record with unpersisted changes rather than silently discard them.
+    return if @conversation.previously_new_record?
 
     origin = payload['origin_display_id'].presence
-    return if @conversation.redirect_origin_display_id == origin
+    @conversation.with_lock do
+      next if @conversation.redirect_origin_display_id == origin
 
-    @conversation.update!(redirect_origin_display_id: origin)
+      @conversation.update!(redirect_origin_display_id: origin)
+    end
   end
 
   # A brand-new conversation carries the pairing from birth, so even the conversation_created event

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
 
     identify_from_token(payload)
     resume_or_start_conversation(payload)
+    record_redirect_origin(payload)
 
     render json: {
       widget_auth_token: @widget_auth_token,
@@ -39,6 +40,22 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
     else
       @conversation = conversations.last || start_conversation
     end
+  end
+
+  # The pairing, written at the one moment it is a fact rather than an inference. Everything this
+  # side knows afterwards is about the CONTACT, and a contact carries neither the conversation the
+  # link was minted on nor which of its threads the lead came from — five different predicates over
+  # the mirrored rows were tried downstream and each is wrong in its own way (fazer-ai/agents#222).
+  #
+  # Last write wins: a token is burned by exactly one click, so the value is always the origin of the
+  # redirect that just happened, which is the episode the follow-up ladder acts on. A re-entry with
+  # no origin in the token leaves the previous one standing rather than clearing it.
+  def record_redirect_origin(payload)
+    origin = payload['origin_display_id']
+    return if origin.blank? || @conversation.blank?
+    return if @conversation.redirect_origin_display_id == origin
+
+    @conversation.update!(redirect_origin_display_id: origin)
   end
 
   def start_conversation

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -71,13 +71,18 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   # about which WhatsApp thread this episode has. Held across both, the two requests serialize whole:
   # whichever commits last owns the row AND sent the last message, and they name the same origin.
   #
-  # A conversation born in this request is not locked. start_conversation already wrote the origin
-  # from the same payload, nothing could have raced a row that did not exist, and a just-created
-  # Conversation still carries an unpersisted `display_id` change that `with_lock` refuses to lock
-  # over ("Locking a record with unpersisted changes is not supported").
+  # A conversation born in this request is RELOADED first, then locked like any other. Skipping the
+  # lock there was reasoned from "nothing could have raced a row that did not exist", and that stops
+  # being true the moment the INSERT commits: a second resume can load the same conversation and move
+  # its origin, and this request would then build its message from a cached origin the row no longer
+  # holds. What the born-here case actually needs is only the reload — a just-created Conversation
+  # still carries an unpersisted `display_id` change (Chatwoot assigns it around the insert) and
+  # `with_lock` refuses to lock a record holding unpersisted changes rather than discard them
+  # silently. Reloading discards exactly that, and costs one SELECT on the path that creates a row.
   def with_episode_lock(&)
-    return yield if @conversation.blank? || @conversation.previously_new_record?
+    return yield if @conversation.blank?
 
+    @conversation.reload if @conversation.previously_new_record?
     @conversation.with_lock(&)
   end
 
@@ -132,9 +137,18 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
     @conversation.update!(redirect_origin_display_id: origin)
   end
 
-  # A brand-new conversation carries the pairing from birth, so even the conversation_created event
-  # names its origin — the same reason record_redirect_origin runs before the message on the resume
-  # path.
+  # A brand-new conversation carries the pairing from birth, so the row is right from its first
+  # instant and every event that follows names the origin — the same reason record_redirect_origin
+  # runs before the message on the resume path.
+  #
+  # No agent bot hears about the creation itself, and that is upstream behaviour rather than
+  # something this change can set: AgentBotListener handles conversation_resolved, opened,
+  # status_changed, updated, message_created, message_updated and webwidget_triggered, and no
+  # conversation_created. Measured — a message-less token that creates the conversation delivers an
+  # empty list of bot events. Nothing is lost by it: the pairing is on the row, so the FIRST event a
+  # bot does receive for this conversation carries it, and until a message exists there is no episode
+  # for a consumer to act on. Making creation bot-visible would change the agent-bot contract for
+  # every inbox in the account, which is not this change's to make (fazer-ai/agents#222).
   def start_conversation(payload)
     ::Conversation.create!(
       account_id: @web_widget.inbox.account_id,

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -52,12 +52,33 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   def resume_or_start_conversation(payload)
     if payload['message'].present?
       @conversation = conversations.where.not(status: :resolved).last || start_conversation(payload)
-      record_redirect_origin(payload)
-      inject_cloned_message(payload['message'])
+      with_episode_lock do
+        record_redirect_origin(payload)
+        inject_cloned_message(payload['message'])
+      end
     else
       @conversation = conversations.last || start_conversation(payload)
-      record_redirect_origin(payload)
+      with_episode_lock { record_redirect_origin(payload) }
     end
+  end
+
+  # The pairing and the message it belongs to, under ONE lock, because the invariant above is about
+  # the two TOGETHER: the message's payload is built from the conversation as it stands when
+  # Message.create! runs, so the pairing has to still be this request's when it does. Two
+  # message-bearing redirects resuming the same conversation at once break that if the lock ends with
+  # the origin write — A writes 77 and releases, B writes 91 and finishes, then A's message goes out
+  # naming 77 while the row says 91, and a consumer mirroring that message disagrees with Chatwoot
+  # about which WhatsApp thread this episode has. Held across both, the two requests serialize whole:
+  # whichever commits last owns the row AND sent the last message, and they name the same origin.
+  #
+  # A conversation born in this request is not locked. start_conversation already wrote the origin
+  # from the same payload, nothing could have raced a row that did not exist, and a just-created
+  # Conversation still carries an unpersisted `display_id` change that `with_lock` refuses to lock
+  # over ("Locking a record with unpersisted changes is not supported").
+  def with_episode_lock(&)
+    return yield if @conversation.blank? || @conversation.previously_new_record?
+
+    @conversation.with_lock(&)
   end
 
   # The pairing, written at the one moment it is a fact rather than an inference. Everything this
@@ -94,28 +115,21 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   # deleting it leaves the specs green.
   #
   # But it has to compare against the ROW, not against an instance loaded before the token was even
-  # resolved, and `with_lock` is what makes those the same thing: it reloads under SELECT ... FOR
-  # UPDATE, so the comparison sees whatever a concurrent resume committed and this request's own
-  # token still gets the last word. Removing the lock does not merely re-open a window — a stale
-  # instance holding this request's own origin makes the guard skip, and skipping is silent on both
-  # counts: no write, and no conversation_updated for the message-less path. Dropping the guard
-  # instead does not help either, because ActiveRecord issues no UPDATE for a value the instance
-  # already believes it has. The staleness is the defect; the guard only reads it out.
+  # resolved, and the lock its caller holds is what makes those the same thing: `with_lock` reloads
+  # under SELECT ... FOR UPDATE, so the comparison sees whatever a concurrent resume committed and
+  # this request's own token still gets the last word. Take that lock away and the window does not
+  # merely re-open — a stale instance holding this request's own origin makes the guard skip, and
+  # skipping is silent on both counts: no write, and no conversation_updated for the message-less
+  # path. Dropping the guard instead does not help either, because ActiveRecord issues no UPDATE for
+  # a value the instance already believes it has. The staleness is the defect; the guard only reads
+  # it out.
   def record_redirect_origin(payload)
     return if @conversation.blank?
-    # Born in this request, from start_conversation, which already wrote the origin from the same
-    # payload — there is no earlier value to reconcile and nothing could have raced a row that did
-    # not exist. Skipped rather than locked, and it has to be: a just-created Conversation still
-    # holds an unpersisted `display_id` change (Chatwoot assigns it around the insert), and
-    # `with_lock` refuses to lock a record with unpersisted changes rather than silently discard them.
-    return if @conversation.previously_new_record?
 
     origin = payload['origin_display_id'].presence
-    @conversation.with_lock do
-      next if @conversation.redirect_origin_display_id == origin
+    return if @conversation.redirect_origin_display_id == origin
 
-      @conversation.update!(redirect_origin_display_id: origin)
-    end
+    @conversation.update!(redirect_origin_display_id: origin)
   end
 
   # A brand-new conversation carries the pairing from birth, so even the conversation_created event

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -66,8 +66,18 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   # the mirrored rows were tried downstream and each is wrong in its own way (fazer-ai/agents#222).
   #
   # Last write wins: a token is burned by exactly one click, so the value is always the origin of the
-  # redirect that just happened, which is the episode the follow-up ladder acts on. A re-entry with
-  # no origin in the token leaves the previous one standing rather than clearing it.
+  # redirect that just happened, which is the episode the follow-up ladder acts on.
+  #
+  # A token that names NO origin clears it, rather than leaving the previous one standing. Consuming a
+  # token is the one event that sets this column, so a re-entry that cannot say where it came from
+  # leaves the stored answer with nothing behind it — the lead came back through a link this instance
+  # cannot attribute. Keeping it would hand a consumer that MESSAGES and RESOLVES the named
+  # conversation full confidence in a previous episode's answer; clearing it sends that consumer to
+  # whatever it does with no answer at all, which is a decision it makes knowingly.
+  #
+  # Note the asymmetry with the consumer's own /reset, which deliberately KEEPS the pairing
+  # (fazer-ai/agents#355): a reset is not a redirect and does not un-click the link, so the stored
+  # answer is still the last true one. Here a redirect did happen and did not name an origin.
   #
   # On the message-less path this update is the ONLY thing that happens, so it has to be observable on
   # its own — nothing is created and no message is sent. That is why the column is in
@@ -78,9 +88,14 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   # before dispatching anything. Removing this line leaves every event this endpoint emits identical
   # and only adds an UPDATE per repeated click — measured, because a repeated link from ONE WhatsApp
   # conversation is a supported flow and it would be easy to read the silence as this guard's doing.
+  # `.presence` normalizes for the equality check below and nothing else: an integer column casts ''
+  # to nil on assignment (measured), so a malformed token writes nil either way — but `nil == ''` is
+  # false, so without it the guard would miss and spend an UPDATE that changes nothing. That is why
+  # deleting it leaves the specs green.
   def record_redirect_origin(payload)
-    origin = payload['origin_display_id']
-    return if origin.blank? || @conversation.blank?
+    return if @conversation.blank?
+
+    origin = payload['origin_display_id'].presence
     return if @conversation.redirect_origin_display_id == origin
 
     @conversation.update!(redirect_origin_display_id: origin)

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -34,9 +34,9 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
 
   # The order here is load-bearing. AgentBotListener is on the SYNC dispatcher, so the payload a
   # consumer receives for the cloned message is built INSIDE Message.create!, from the conversation as
-  # it stands at that moment. The pairing therefore has to be on the row before the message exists,
-  # and a later update would not correct it: `redirect_origin_display_id` is not in
-  # Conversation#list_of_keys, so it emits no conversation_updated of its own.
+  # it stands at that moment. The pairing therefore has to be on the row before the message exists:
+  # the conversation_updated that follows would be a second, weaker witness, and a consumer that acts
+  # on the first event it sees would have already acted on the previous episode's origin.
   def resume_or_start_conversation(payload)
     if payload['message'].present?
       @conversation = conversations.where.not(status: :resolved).last || start_conversation(payload)
@@ -56,6 +56,11 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   # Last write wins: a token is burned by exactly one click, so the value is always the origin of the
   # redirect that just happened, which is the episode the follow-up ladder acts on. A re-entry with
   # no origin in the token leaves the previous one standing rather than clearing it.
+  #
+  # On the message-less path this update is the ONLY thing that happens, so it has to be observable on
+  # its own — nothing is created and no message is sent. That is why the column is in
+  # Conversation#list_of_keys: the update then emits its own conversation_updated, carrying the new
+  # pairing and a fresh `updated_at` for consumers to order it by.
   def record_redirect_origin(payload)
     origin = payload['origin_display_id']
     return if origin.blank? || @conversation.blank?

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -8,7 +8,6 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
 
     identify_from_token(payload)
     resume_or_start_conversation(payload)
-    record_redirect_origin(payload)
 
     render json: {
       widget_auth_token: @widget_auth_token,
@@ -33,12 +32,19 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
     ).perform
   end
 
+  # The order here is load-bearing. AgentBotListener is on the SYNC dispatcher, so the payload a
+  # consumer receives for the cloned message is built INSIDE Message.create!, from the conversation as
+  # it stands at that moment. The pairing therefore has to be on the row before the message exists,
+  # and a later update would not correct it: `redirect_origin_display_id` is not in
+  # Conversation#list_of_keys, so it emits no conversation_updated of its own.
   def resume_or_start_conversation(payload)
     if payload['message'].present?
-      @conversation = conversations.where.not(status: :resolved).last || start_conversation
+      @conversation = conversations.where.not(status: :resolved).last || start_conversation(payload)
+      record_redirect_origin(payload)
       inject_cloned_message(payload['message'])
     else
-      @conversation = conversations.last || start_conversation
+      @conversation = conversations.last || start_conversation(payload)
+      record_redirect_origin(payload)
     end
   end
 
@@ -58,12 +64,16 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
     @conversation.update!(redirect_origin_display_id: origin)
   end
 
-  def start_conversation
+  # A brand-new conversation carries the pairing from birth, so even the conversation_created event
+  # names its origin — the same reason record_redirect_origin runs before the message on the resume
+  # path.
+  def start_conversation(payload)
     ::Conversation.create!(
       account_id: @web_widget.inbox.account_id,
       inbox_id: @web_widget.inbox.id,
       contact_id: @contact.id,
-      contact_inbox_id: @contact_inbox.id
+      contact_inbox_id: @contact_inbox.id,
+      redirect_origin_display_id: payload['origin_display_id'].presence
     )
   end
 

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -34,9 +34,21 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
 
   # The order here is load-bearing. AgentBotListener is on the SYNC dispatcher, so the payload a
   # consumer receives for the cloned message is built INSIDE Message.create!, from the conversation as
-  # it stands at that moment. The pairing therefore has to be on the row before the message exists:
-  # the conversation_updated that follows would be a second, weaker witness, and a consumer that acts
-  # on the first event it sees would have already acted on the previous episode's origin.
+  # it stands at that moment. The pairing therefore has to be on the row before the message exists, or
+  # the message — the event a consumer actually acts on — carries the PREVIOUS episode's origin.
+  #
+  # Measured on a running instance, mint + resolve over HTTP with an agent bot on the widget inbox:
+  #
+  #   origin changes, cloned message   ->  1. conversation_updated (new origin)
+  #                                        2. message_created      (new origin)
+  #   origin changes, no message       ->  1. conversation_updated (new origin)
+  #   origin unchanged, cloned message ->  1. message_created      (new origin)
+  #   origin unchanged, no message     ->  nothing
+  #
+  # So the update PRECEDES the message rather than following it, and that is the point: every event a
+  # consumer can see already names the right origin. The standalone update is not a second trigger —
+  # it states a value, and a consumer that acts on episodes acts on the customer message, which is the
+  # only thing either path produces that is one.
   def resume_or_start_conversation(payload)
     if payload['message'].present?
       @conversation = conversations.where.not(status: :resolved).last || start_conversation(payload)
@@ -61,6 +73,11 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   # its own — nothing is created and no message is sent. That is why the column is in
   # Conversation#list_of_keys: the update then emits its own conversation_updated, carrying the new
   # pairing and a fresh `updated_at` for consumers to order it by.
+  # The equality check is write avoidance and nothing more: ActiveRecord records no change for a write
+  # of the same value, so `previous_changes` comes back empty and notify_conversation_updation returns
+  # before dispatching anything. Removing this line leaves every event this endpoint emits identical
+  # and only adds an UPDATE per repeated click — measured, because a repeated link from ONE WhatsApp
+  # conversation is a supported flow and it would be easy to read the silence as this guard's doing.
   def record_redirect_origin(payload)
     origin = payload['origin_display_id']
     return if origin.blank? || @conversation.blank?

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -2,64 +2,60 @@
 #
 # Table name: conversations
 #
-#  id                     :integer          not null, primary key
-#  additional_attributes  :jsonb
-#  agent_last_seen_at     :datetime
-#  assignee_last_seen_at  :datetime
-#  cached_label_list      :text
-#  contact_last_seen_at   :datetime
-#  custom_attributes      :jsonb
-#  first_reply_created_at :datetime
-#  group_type             :integer          default("individual"), not null
-#  identifier             :string
-#  last_activity_at       :datetime         not null
-#  priority               :integer
-#  snoozed_until          :datetime
-#  status                 :integer          default("open"), not null
-#  status_changed_at      :datetime
-#  uuid                   :uuid             not null
-#  waiting_since          :datetime
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  account_id             :integer          not null
-#  assignee_agent_bot_id  :bigint
-#  assignee_id            :integer
-#  campaign_id            :bigint
-#  contact_id             :bigint           not null
-#  contact_inbox_id       :bigint
-#  display_id             :integer          not null
-#  inbox_id               :integer          not null
-#  kanban_task_id         :bigint
-#  sla_policy_id          :bigint
-#  team_id                :bigint
+#  id                         :integer          not null, primary key
+#  additional_attributes      :jsonb
+#  agent_last_seen_at         :datetime
+#  assignee_last_seen_at      :datetime
+#  cached_label_list          :text
+#  contact_last_seen_at       :datetime
+#  custom_attributes          :jsonb
+#  first_reply_created_at     :datetime
+#  group_type                 :integer          default("individual"), not null
+#  identifier                 :string
+#  last_activity_at           :datetime         not null
+#  priority                   :integer
+#  snoozed_until              :datetime
+#  status                     :integer          default("open"), not null
+#  status_changed_at          :datetime
+#  uuid                       :uuid             not null
+#  waiting_since              :datetime
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  account_id                 :integer          not null
+#  assignee_agent_bot_id      :bigint
+#  assignee_id                :integer
+#  campaign_id                :bigint
+#  contact_id                 :bigint           not null
+#  contact_inbox_id           :bigint
+#  display_id                 :integer          not null
+#  inbox_id                   :integer          not null
+#  redirect_origin_display_id :integer
+#  sla_policy_id              :bigint
+#  team_id                    :bigint
 #
 # Indexes
 #
-#  conv_acid_inbid_stat_asgnid_idx                    (account_id,inbox_id,status,assignee_id)
-#  index_conversations_on_account_id                  (account_id)
-#  index_conversations_on_account_id_and_display_id   (account_id,display_id) UNIQUE
-#  index_conversations_on_account_id_and_group_type   (account_id,group_type)
-#  index_conversations_on_assignee_id_and_account_id  (assignee_id,account_id)
-#  index_conversations_on_campaign_id                 (campaign_id)
-#  index_conversations_on_contact_id                  (contact_id)
-#  index_conversations_on_contact_inbox_id            (contact_inbox_id)
-#  index_conversations_on_created_at                  (created_at)
-#  index_conversations_on_first_reply_created_at      (first_reply_created_at)
-#  index_conversations_on_id_and_account_id           (account_id,id)
-#  index_conversations_on_identifier_and_account_id   (identifier,account_id)
-#  index_conversations_on_inbox_id                    (inbox_id)
-#  index_conversations_on_inbox_id_and_group_type     (inbox_id,group_type)
-#  index_conversations_on_kanban_task_id              (kanban_task_id)
-#  index_conversations_on_priority                    (priority)
-#  index_conversations_on_status_and_account_id       (status,account_id)
-#  index_conversations_on_status_and_priority         (status,priority)
-#  index_conversations_on_team_id                     (team_id)
-#  index_conversations_on_uuid                        (uuid) UNIQUE
-#  index_conversations_on_waiting_since               (waiting_since)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (kanban_task_id => kanban_tasks.id)
+#  conv_acid_inbid_stat_asgnid_idx                      (account_id,inbox_id,status,assignee_id)
+#  index_conversations_on_account_id                    (account_id)
+#  index_conversations_on_account_id_and_display_id     (account_id,display_id) UNIQUE
+#  index_conversations_on_account_id_and_group_type     (account_id,group_type)
+#  index_conversations_on_account_id_status_created_at  (account_id,status,created_at)
+#  index_conversations_on_assignee_id_and_account_id    (assignee_id,account_id)
+#  index_conversations_on_campaign_id                   (campaign_id)
+#  index_conversations_on_contact_id                    (contact_id)
+#  index_conversations_on_contact_inbox_id              (contact_inbox_id)
+#  index_conversations_on_created_at                    (created_at)
+#  index_conversations_on_first_reply_created_at        (first_reply_created_at)
+#  index_conversations_on_id_and_account_id             (account_id,id)
+#  index_conversations_on_identifier_and_account_id     (identifier,account_id)
+#  index_conversations_on_inbox_id                      (inbox_id)
+#  index_conversations_on_inbox_id_and_group_type       (inbox_id,group_type)
+#  index_conversations_on_priority                      (priority)
+#  index_conversations_on_status_and_account_id         (status,account_id)
+#  index_conversations_on_status_and_priority           (status,priority)
+#  index_conversations_on_team_id                       (team_id)
+#  index_conversations_on_uuid                          (uuid) UNIQUE
+#  index_conversations_on_waiting_since                 (waiting_since)
 #
 
 class Conversation < ApplicationRecord

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -29,33 +29,38 @@
 #  contact_inbox_id           :bigint
 #  display_id                 :integer          not null
 #  inbox_id                   :integer          not null
+#  kanban_task_id             :bigint
 #  redirect_origin_display_id :integer
 #  sla_policy_id              :bigint
 #  team_id                    :bigint
 #
 # Indexes
 #
-#  conv_acid_inbid_stat_asgnid_idx                      (account_id,inbox_id,status,assignee_id)
-#  index_conversations_on_account_id                    (account_id)
-#  index_conversations_on_account_id_and_display_id     (account_id,display_id) UNIQUE
-#  index_conversations_on_account_id_and_group_type     (account_id,group_type)
-#  index_conversations_on_account_id_status_created_at  (account_id,status,created_at)
-#  index_conversations_on_assignee_id_and_account_id    (assignee_id,account_id)
-#  index_conversations_on_campaign_id                   (campaign_id)
-#  index_conversations_on_contact_id                    (contact_id)
-#  index_conversations_on_contact_inbox_id              (contact_inbox_id)
-#  index_conversations_on_created_at                    (created_at)
-#  index_conversations_on_first_reply_created_at        (first_reply_created_at)
-#  index_conversations_on_id_and_account_id             (account_id,id)
-#  index_conversations_on_identifier_and_account_id     (identifier,account_id)
-#  index_conversations_on_inbox_id                      (inbox_id)
-#  index_conversations_on_inbox_id_and_group_type       (inbox_id,group_type)
-#  index_conversations_on_priority                      (priority)
-#  index_conversations_on_status_and_account_id         (status,account_id)
-#  index_conversations_on_status_and_priority           (status,priority)
-#  index_conversations_on_team_id                       (team_id)
-#  index_conversations_on_uuid                          (uuid) UNIQUE
-#  index_conversations_on_waiting_since                 (waiting_since)
+#  conv_acid_inbid_stat_asgnid_idx                    (account_id,inbox_id,status,assignee_id)
+#  index_conversations_on_account_id                  (account_id)
+#  index_conversations_on_account_id_and_display_id   (account_id,display_id) UNIQUE
+#  index_conversations_on_account_id_and_group_type   (account_id,group_type)
+#  index_conversations_on_assignee_id_and_account_id  (assignee_id,account_id)
+#  index_conversations_on_campaign_id                 (campaign_id)
+#  index_conversations_on_contact_id                  (contact_id)
+#  index_conversations_on_contact_inbox_id            (contact_inbox_id)
+#  index_conversations_on_created_at                  (created_at)
+#  index_conversations_on_first_reply_created_at      (first_reply_created_at)
+#  index_conversations_on_id_and_account_id           (account_id,id)
+#  index_conversations_on_identifier_and_account_id   (identifier,account_id)
+#  index_conversations_on_inbox_id                    (inbox_id)
+#  index_conversations_on_inbox_id_and_group_type     (inbox_id,group_type)
+#  index_conversations_on_kanban_task_id              (kanban_task_id)
+#  index_conversations_on_priority                    (priority)
+#  index_conversations_on_status_and_account_id       (status,account_id)
+#  index_conversations_on_status_and_priority         (status,priority)
+#  index_conversations_on_team_id                     (team_id)
+#  index_conversations_on_uuid                        (uuid) UNIQUE
+#  index_conversations_on_waiting_since               (waiting_since)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (kanban_task_id => kanban_tasks.id)
 #
 
 class Conversation < ApplicationRecord
@@ -406,9 +411,14 @@ class Conversation < ApplicationRecord
     dispatch_conversation_updated_event(previous_changes)
   end
 
+  # Every key here answers the same question: does a consumer of this conversation need to be TOLD
+  # when it changes? `redirect_origin_display_id` does, and only this list can say so. The pairing is
+  # written on an existing conversation whenever a message-less redirect token resumes one, and that
+  # write carries no message and creates nothing, so without an event of its own the change is
+  # invisible and the consumer keeps acting on the previous episode's origin (fazer-ai/agents#222).
   def list_of_keys
     %w[team_id assignee_id assignee_agent_bot_id status snoozed_until custom_attributes label_list waiting_since
-       first_reply_created_at priority]
+       first_reply_created_at priority redirect_origin_display_id]
   end
 
   def allowed_keys?

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -65,7 +65,8 @@ class Conversations::EventDataPresenter < SimpleDelegator
       priority: priority,
       waiting_since: waiting_since.to_i,
       **push_timestamps,
-      **group_left_data
+      **group_left_data,
+      **redirect_origin_data
     }
   end
 
@@ -78,6 +79,18 @@ class Conversations::EventDataPresenter < SimpleDelegator
     return {} unless group_type_group?
 
     { group_left: contact_inbox&.group_left? }
+  end
+
+  # The WhatsApp entry conversation this widget thread was redirected from, as its display_id (the
+  # per-account number, the same one `id` above carries) — never the primary key, which is a
+  # different number for the same conversation and is what a consumer would silently mis-join on.
+  #
+  # Absent, rather than nil, on every conversation that is not the widget half of a redirect episode,
+  # on the same terms as group_left above: the question does not arise there.
+  def redirect_origin_data
+    return {} if redirect_origin_display_id.blank?
+
+    { redirect_origin_display_id: redirect_origin_display_id }
   end
 
   # Like #push_data but with message text normalized for external integrations (webhooks).

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -85,11 +85,16 @@ class Conversations::EventDataPresenter < SimpleDelegator
   # per-account number, the same one `id` above carries) — never the primary key, which is a
   # different number for the same conversation and is what a consumer would silently mis-join on.
   #
-  # Absent, rather than nil, on every conversation that is not the widget half of a redirect episode,
-  # on the same terms as group_left above: the question does not arise there.
+  # ALWAYS present, nil included, and that is the opposite of group_left right above. The two look
+  # alike and are not: a conversation does not stop being a group, but a pairing IS cleared — by a
+  # re-entry whose token names no origin (see the widget controller). Omitting nil would make that
+  # clear indistinguishable from "this conversation was never part of an episode", and a consumer
+  # holding the previous pairing has no way to tell it to drop one. It kept acting on it.
+  #
+  # A Chatwoot without this change omits the key entirely, so absent still means "said nothing" — the
+  # distinction a consumer needs is between an instance that speaks about pairings and one that does
+  # not, and the key's presence is exactly that.
   def redirect_origin_data
-    return {} if redirect_origin_display_id.blank?
-
     { redirect_origin_display_id: redirect_origin_display_id }
   end
 

--- a/db/migrate/20260826130000_add_redirect_origin_display_id_to_conversations.rb
+++ b/db/migrate/20260826130000_add_redirect_origin_display_id_to_conversations.rb
@@ -1,0 +1,5 @@
+class AddRedirectOriginDisplayIdToConversations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :conversations, :redirect_origin_display_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_22_130100) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_26_130000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -908,6 +908,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_22_130100) do
     t.bigint "assignee_agent_bot_id"
     t.datetime "status_changed_at"
     t.integer "group_type", default: 0, null: false
+    t.integer "redirect_origin_display_id"
     t.index ["account_id", "display_id"], name: "index_conversations_on_account_id_and_display_id", unique: true
     t.index ["account_id", "group_type"], name: "index_conversations_on_account_id_and_group_type"
     t.index ["account_id", "id"], name: "index_conversations_on_id_and_account_id"

--- a/spec/controllers/api/v1/accounts/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/redirect_tokens_controller_spec.rb
@@ -84,14 +84,40 @@ RSpec.describe 'Api::V1::Accounts::RedirectTokensController', type: :request do
 
       # fazer-ai/agents#222: the origin conversation only exists as a fact at mint time.
       it 'carries the origin conversation into the token payload' do
+        origin = create(:conversation, account: account)
+
         post "/api/v1/accounts/#{account.id}/redirect_tokens",
              headers: admin.create_new_auth_token,
-             params: { inbox_id: web_widget.inbox.id, identifier: 'user-1', origin_display_id: 77 },
+             params: { inbox_id: web_widget.inbox.id, identifier: 'user-1', origin_display_id: origin.display_id },
              as: :json
 
         expect(response).to have_http_status(:success)
         payload = Widget::RedirectToken.consume(response.parsed_body['token'])
-        expect(payload['origin_display_id']).to eq(77)
+        expect(payload['origin_display_id']).to eq(origin.display_id)
+      end
+
+      # A display_id is account-wide and guessable, and the consumer RESOLVES the conversation the
+      # pairing names, so the right to name it is settled at the mint.
+      it 'refuses an origin the caller cannot see' do
+        other_inbox = create(:inbox, account: account)
+        origin = create(:conversation, account: account, inbox: other_inbox)
+        create(:inbox_member, user: agent, inbox: web_widget.inbox)
+
+        post "/api/v1/accounts/#{account.id}/redirect_tokens",
+             headers: agent.create_new_auth_token,
+             params: { inbox_id: web_widget.inbox.id, identifier: 'user-1', origin_display_id: origin.display_id },
+             as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'refuses an origin that does not exist' do
+        post "/api/v1/accounts/#{account.id}/redirect_tokens",
+             headers: admin.create_new_auth_token,
+             params: { inbox_id: web_widget.inbox.id, identifier: 'user-1', origin_display_id: 999_999 },
+             as: :json
+
+        expect(response).to have_http_status(:not_found)
       end
 
       it 'omits the origin when the caller sends none' do

--- a/spec/controllers/api/v1/accounts/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/redirect_tokens_controller_spec.rb
@@ -82,6 +82,28 @@ RSpec.describe 'Api::V1::Accounts::RedirectTokensController', type: :request do
         expect(response.parsed_body['error']).to eq('not_a_web_widget')
       end
 
+      # fazer-ai/agents#222: the origin conversation only exists as a fact at mint time.
+      it 'carries the origin conversation into the token payload' do
+        post "/api/v1/accounts/#{account.id}/redirect_tokens",
+             headers: admin.create_new_auth_token,
+             params: { inbox_id: web_widget.inbox.id, identifier: 'user-1', origin_display_id: 77 },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        payload = Widget::RedirectToken.consume(response.parsed_body['token'])
+        expect(payload['origin_display_id']).to eq(77)
+      end
+
+      it 'omits the origin when the caller sends none' do
+        post "/api/v1/accounts/#{account.id}/redirect_tokens",
+             headers: admin.create_new_auth_token,
+             params: { inbox_id: web_widget.inbox.id, identifier: 'user-1' },
+             as: :json
+
+        payload = Widget::RedirectToken.consume(response.parsed_body['token'])
+        expect(payload).not_to have_key('origin_display_id')
+      end
+
       it 'returns not found for an inbox from another account' do
         other_widget = create(:channel_widget)
 

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
           # templates ride along on the first inbound and say nothing about the episode, so the
           # sequence below is the customer-visible one.
           expect(seen.map { |pl| pl[:redirect_origin_display_id] || pl.dig(:conversation, :redirect_origin_display_id) }.uniq)
-            .to eq(seen.empty? ? [] : [payload['origin_display_id']])
+            .to eq(seen.empty? ? [] : [payload['origin_display_id']].compact.presence || [nil])
           seen.reject { |pl| pl[:message_type] == 'template' }.map do |pl|
             [pl[:event], pl[:redirect_origin_display_id] || pl.dig(:conversation, :redirect_origin_display_id)]
           end
@@ -188,6 +188,13 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         # Origin unchanged, no message: no row changed and no message exists, so there is nothing for
         # an event to say. A repeated link from one WhatsApp conversation lands here.
         expect(redirect.call('origin_display_id' => 77)).to eq([])
+
+        # No origin at all: the pairing is CLEARED, and the clear is announced like any other change.
+        # The key is then absent from the payload, the same shape a conversation outside an episode has.
+        expect(redirect.call({})).to eq([['conversation_updated', nil]])
+
+        # ...and once it is gone, a second origin-less token has nothing left to clear.
+        expect(redirect.call({})).to eq([])
       end
 
       # The message-less resume path (cloneWaMessage off, or a media-only WhatsApp message) writes the
@@ -220,7 +227,7 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(updated[:redirect_origin_display_id]).to eq(91)
       end
 
-      it 'takes the newest origin on re-entry, and a token without one leaves the old standing' do
+      it 'takes the newest origin on re-entry, and a token without one clears it' do
         first = Widget::RedirectToken.generate(
           { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 77 }
         )
@@ -236,11 +243,43 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
              headers: { 'X-Auth-Token' => token }, as: :json
         expect(contact.reload.conversations.last.redirect_origin_display_id).to eq(91)
 
+        # Consuming a token is the ONE event that sets the pairing, so a token that names no origin
+        # leaves the previous one with nothing behind it: the lead came back through a link this
+        # instance cannot attribute. Keeping it would hand a consumer that MESSAGES and RESOLVES the
+        # named conversation full confidence in a previous episode's answer; clearing it sends that
+        # consumer to whatever it does when it has no answer, which is a decision it makes knowingly.
         third = Widget::RedirectToken.generate({ 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42' })
         post '/api/v1/widget/redirect_token',
              params: { website_token: web_widget.website_token, token: third },
              headers: { 'X-Auth-Token' => token }, as: :json
-        expect(contact.reload.conversations.last.redirect_origin_display_id).to eq(91)
+        expect(contact.reload.conversations.last.redirect_origin_display_id).to be_nil
+      end
+
+      # And the clear is announced, on the same terms as a change: it moves the column, so it emits
+      # its own conversation_updated. A consumer that only ever hears about origins it can act on
+      # would keep acting on the one this token just invalidated.
+      it 'announces the clear, and stops shipping the key' do
+        agent_bot = create(:agent_bot, account: account, outgoing_url: 'https://bot.test/hook')
+        create(:agent_bot_inbox, inbox: web_widget.inbox, agent_bot: agent_bot, account: account)
+        first = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 77 }
+        )
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: first },
+             headers: { 'X-Auth-Token' => token }, as: :json
+
+        payloads = []
+        allow(AgentBots::WebhookJob).to receive(:perform_later) { |_url, pl, *| payloads << pl }
+
+        second = Widget::RedirectToken.generate({ 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42' })
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: second },
+             headers: { 'X-Auth-Token' => token }, as: :json
+
+        updated = payloads.find { |pl| pl[:event] == 'conversation_updated' }
+        expect(updated).to be_present
+        # Absent rather than nil, the same shape a conversation outside an episode has.
+        expect(updated).not_to have_key(:redirect_origin_display_id)
       end
     end
 

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -144,6 +144,52 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(message_created[:conversation][:redirect_origin_display_id]).to eq(77)
       end
 
+      # The four event shapes this endpoint can produce, pinned together so no reordering can change
+      # one without showing up here. What every row has in common is the point: the origin a consumer
+      # reads is the NEW one, on every event either path emits.
+      it 'names the new origin on every event it emits, whichever path ran' do
+        agent_bot = create(:agent_bot, account: account, outgoing_url: 'https://bot.test/hook')
+        create(:agent_bot_inbox, inbox: web_widget.inbox, agent_bot: agent_bot, account: account)
+
+        redirect = lambda do |payload|
+          seen = []
+          allow(AgentBots::WebhookJob).to receive(:perform_later) { |_url, pl, *| seen << pl }
+          post '/api/v1/widget/redirect_token',
+               params: { website_token: web_widget.website_token,
+                         token: Widget::RedirectToken.generate({ 'inbox_id' => web_widget.inbox.id,
+                                                                 'identifier' => 'user-42' }.merge(payload)) },
+               headers: { 'X-Auth-Token' => token }, as: :json
+          # Every payload names the pairing, template messages included; the widget's email-collect
+          # templates ride along on the first inbound and say nothing about the episode, so the
+          # sequence below is the customer-visible one.
+          expect(seen.map { |pl| pl[:redirect_origin_display_id] || pl.dig(:conversation, :redirect_origin_display_id) }.uniq)
+            .to eq(seen.empty? ? [] : [payload['origin_display_id']])
+          seen.reject { |pl| pl[:message_type] == 'template' }.map do |pl|
+            [pl[:event], pl[:redirect_origin_display_id] || pl.dig(:conversation, :redirect_origin_display_id)]
+          end
+        end
+
+        # A first redirect creates the conversation, so its pairing rides on the creation itself.
+        redirect.call('origin_display_id' => 77)
+
+        # Origin changes, cloned message: the update states it, and the message a consumer acts on
+        # already carries it.
+        expect(redirect.call('origin_display_id' => 91, 'message' => 'oi'))
+          .to eq([%w[conversation_updated] << 91, %w[message_created] << 91].map(&:flatten))
+
+        # Origin changes, no message: the update is the only witness there is, which is why the column
+        # is in list_of_keys at all.
+        expect(redirect.call('origin_display_id' => 77)).to eq([['conversation_updated', 77]])
+
+        # Origin unchanged, cloned message: nothing to state, and the message still names it.
+        expect(redirect.call('origin_display_id' => 77, 'message' => 'de novo'))
+          .to eq([['message_created', 77]])
+
+        # Origin unchanged, no message: no row changed and no message exists, so there is nothing for
+        # an event to say. A repeated link from one WhatsApp conversation lands here.
+        expect(redirect.call('origin_display_id' => 77)).to eq([])
+      end
+
       # The message-less resume path (cloneWaMessage off, or a media-only WhatsApp message) writes the
       # pairing onto a conversation that ALREADY exists, so neither a creation event nor a cloned
       # message carries it. Unless that write is observable on its own, a consumer keeps the previous

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -302,6 +302,70 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(conversation.reload.redirect_origin_display_id).to eq(77)
       end
 
+      # The create path's event shape, pinned because a comment in this controller used to imply more
+      # than it should. The row carries the pairing from birth, but AgentBotListener has no
+      # conversation_created handler, so nothing reaches a bot at creation. Nothing is lost by it —
+      # the pairing is on the row, so the first event a bot DOES receive carries it — and widening
+      # that is a change to the agent-bot contract for every inbox, not this endpoint's to make.
+      it 'delivers no bot event on creation, and names the origin on the first one that follows' do
+        agent_bot = create(:agent_bot, account: account, outgoing_url: 'https://bot.test/hook')
+        create(:agent_bot_inbox, inbox: web_widget.inbox, agent_bot: agent_bot, account: account)
+        payloads = []
+        allow(AgentBots::WebhookJob).to receive(:perform_later) { |_url, pl, *| payloads << pl }
+
+        creating = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 77 }
+        )
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: creating },
+             headers: { 'X-Auth-Token' => token }, as: :json
+
+        conversation = contact.reload.conversations.last
+        expect(conversation.redirect_origin_display_id).to eq(77)
+        expect(payloads).to be_empty
+
+        # The lead writes. That message is the first thing the bot hears about this conversation, and
+        # it names the pairing the creation recorded.
+        create(:message, account: account, inbox: web_widget.inbox, conversation: conversation,
+                         sender: contact, message_type: :incoming, content: 'oi')
+        first = payloads.find { |pl| pl[:event] == 'message_created' }
+        expect(first).to be_present
+        expect(first[:conversation][:redirect_origin_display_id]).to eq(77)
+      end
+
+      # Review round 9 of #418. The born-here skip was reasoned from "nothing could have raced a row
+      # that did not exist", and that is only true until the INSERT commits. After it, a second
+      # resume can load the same conversation and move its origin, and this request would then create
+      # its message from a cached origin the row no longer holds — the same incoherence the lock
+      # exists to prevent, on the one path that skipped the lock.
+      #
+      # The skip was never about the race anyway: it was about `with_lock` refusing to lock a record
+      # with an unpersisted `display_id`. A reload clears that, so the lock can be taken here too.
+      it 'locks a conversation it created itself' do
+        conversation = nil
+        # rubocop:disable RSpec/AnyInstance, Rails/SkipsModelValidations
+        allow_any_instance_of(Api::V1::Widget::RedirectTokensController)
+          .to receive(:with_episode_lock).and_wrap_original do |original, *args, &block|
+          conversation = contact.reload.conversations.last
+          Conversation.where(id: conversation.id).update_all(redirect_origin_display_id: 91)
+          original.call(*args, &block)
+        end
+        # rubocop:enable RSpec/AnyInstance, Rails/SkipsModelValidations
+
+        t = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 77, 'message' => 'oi' }
+        )
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: t },
+             headers: { 'X-Auth-Token' => token }, as: :json
+
+        expect(response).to have_http_status(:success)
+        # This request's token named 77 and it is the one that ran, so the row is 77 — and the message
+        # it created belongs to the same episode.
+        expect(conversation.reload.redirect_origin_display_id).to eq(77)
+        expect(conversation.messages.where(message_type: :incoming).last.content).to eq('oi')
+      end
+
       # And the clear is announced, on the same terms as a change: it moves the column, so it emits
       # its own conversation_updated. A consumer that only ever hears about origins it can act on
       # would keep acting on the one this token just invalidated.

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -86,6 +86,64 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
       end
     end
 
+    # fazer-ai/agents#222: the two conversations of one redirect episode could not be paired from
+    # anything this side stores. The origin rides in the token because the mint is the only moment
+    # both halves are known together.
+    context 'when the token carries the origin conversation' do
+      it 'records it on the widget conversation, as the display_id' do
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'message' => 'Hello', 'origin_display_id' => 77 }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(contact.reload.conversations.last.redirect_origin_display_id).to eq(77)
+      end
+
+      it 'ships it to the consumers on push_data, and leaves it out when there is none' do
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'message' => 'Hello', 'origin_display_id' => 77 }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        redirected = contact.reload.conversations.last
+        expect(redirected.push_event_data[:redirect_origin_display_id]).to eq(77)
+        # A conversation outside a redirect episode does not carry the key at all.
+        expect(create(:conversation, account: account).push_event_data).not_to have_key(:redirect_origin_display_id)
+      end
+
+      it 'takes the newest origin on re-entry, and a token without one leaves the old standing' do
+        first = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 77 }
+        )
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: first },
+             headers: { 'X-Auth-Token' => token }, as: :json
+
+        second = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 91 }
+        )
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: second },
+             headers: { 'X-Auth-Token' => token }, as: :json
+        expect(contact.reload.conversations.last.redirect_origin_display_id).to eq(91)
+
+        third = Widget::RedirectToken.generate({ 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42' })
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: third },
+             headers: { 'X-Auth-Token' => token }, as: :json
+        expect(contact.reload.conversations.last.redirect_origin_display_id).to eq(91)
+      end
+    end
+
     context 'when the token carries no identifier and the session contact is already identified' do
       let(:contact) { create(:contact, account: account, identifier: 'existing-id') }
 

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
 
       # The consumer acts on the FIRST event it receives, which is the cloned message. AgentBotListener
       # is on the SYNC dispatcher, so that payload is built inside Message.create!, and the pairing has
-      # to be on the row before the message exists — a later update carries no correcting event, since
-      # the column is not in Conversation#list_of_keys.
+      # to be on the row before the message exists. The conversation_updated that follows is a second
+      # witness, not a substitute: a consumer that answered the message already used the old pairing.
       it 'is already on the conversation the first webhook payload carries' do
         agent_bot = create(:agent_bot, account: account, outgoing_url: 'https://bot.test/hook')
         create(:agent_bot_inbox, inbox: web_widget.inbox, agent_bot: agent_bot, account: account)
@@ -142,6 +142,36 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         message_created = payloads.find { |pl| pl[:event] == 'message_created' }
         expect(message_created).to be_present
         expect(message_created[:conversation][:redirect_origin_display_id]).to eq(77)
+      end
+
+      # The message-less resume path (cloneWaMessage off, or a media-only WhatsApp message) writes the
+      # pairing onto a conversation that ALREADY exists, so neither a creation event nor a cloned
+      # message carries it. Unless that write is observable on its own, a consumer keeps the previous
+      # episode's origin and acts on the wrong WhatsApp conversation (fazer-ai/agents#355, round 1).
+      it 'emits an event carrying the new origin when a message-less token re-enters a conversation' do
+        agent_bot = create(:agent_bot, account: account, outgoing_url: 'https://bot.test/hook')
+        create(:agent_bot_inbox, inbox: web_widget.inbox, agent_bot: agent_bot, account: account)
+
+        first = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 77 }
+        )
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: first },
+             headers: { 'X-Auth-Token' => token }, as: :json
+
+        payloads = []
+        allow(AgentBots::WebhookJob).to receive(:perform_later) { |_url, payload, *| payloads << payload }
+
+        second = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 91 }
+        )
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: second },
+             headers: { 'X-Auth-Token' => token }, as: :json
+
+        updated = payloads.find { |pl| pl[:event] == 'conversation_updated' }
+        expect(updated).to be_present
+        expect(updated[:redirect_origin_display_id]).to eq(91)
       end
 
       it 'takes the newest origin on re-entry, and a token without one leaves the old standing' do

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -259,6 +259,49 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(contact.reload.conversations.last.redirect_origin_display_id).to be_nil
       end
 
+      # Review round 7 of #418. "Last write wins" is the contract this endpoint states, and the guard
+      # below it was comparing against an ActiveRecord instance loaded before the token was even
+      # resolved. Two links clicked into the same widget conversation at once, and the request that
+      # finishes LAST can find its own origin already in memory, skip both the write and the event,
+      # and leave the other request's origin standing.
+      #
+      # The rendezvous is the row moving between the load and the guard, which is exactly what a
+      # concurrent resume does to it. `update_all` is the right tool: it changes the row without
+      # touching the instance the controller is holding.
+      it 'writes the origin its own token names even if the row moved under it' do
+        first = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 77 }
+        )
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: first },
+             headers: { 'X-Auth-Token' => token }, as: :json
+        conversation = contact.reload.conversations.last
+        expect(conversation.redirect_origin_display_id).to eq(77)
+
+        # any_instance because a request spec never holds the controller, and the rendezvous has to sit
+        # between the conversation load and the guard — the only two statements the window spans.
+        # update_all for the same reason it is the defect: it moves the ROW without telling the
+        # instance the controller is holding, which is exactly what a concurrent request does.
+        # rubocop:disable RSpec/AnyInstance, Rails/SkipsModelValidations
+        allow_any_instance_of(Api::V1::Widget::RedirectTokensController)
+          .to receive(:record_redirect_origin).and_wrap_original do |original, *args|
+          Conversation.where(id: conversation.id).update_all(redirect_origin_display_id: 91)
+          original.call(*args)
+        end
+        # rubocop:enable RSpec/AnyInstance, Rails/SkipsModelValidations
+
+        again = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 77 }
+        )
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: again },
+             headers: { 'X-Auth-Token' => token }, as: :json
+
+        # This request's token named 77 and it ran last, so 77 is the pairing. Without the lock the
+        # stale instance answers "already 77" and 91 survives.
+        expect(conversation.reload.redirect_origin_display_id).to eq(77)
+      end
+
       # And the clear is announced, on the same terms as a change: it moves the column, so it emits
       # its own conversation_updated. A consumer that only ever hears about origins it can act on
       # would keep acting on the one this token just invalidated.

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -116,8 +116,12 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
 
         redirected = contact.reload.conversations.last
         expect(redirected.push_event_data[:redirect_origin_display_id]).to eq(77)
-        # A conversation outside a redirect episode does not carry the key at all.
-        expect(create(:conversation, account: account).push_event_data).not_to have_key(:redirect_origin_display_id)
+        # A conversation outside a redirect episode carries the key with nil — NOT absent. Absent is
+        # reserved for a Chatwoot that does not speak about pairings at all, so a consumer can tell
+        # "there is no pairing" from "this instance said nothing", and can therefore mirror a CLEAR.
+        unpaired = create(:conversation, account: account).push_event_data
+        expect(unpaired).to have_key(:redirect_origin_display_id)
+        expect(unpaired[:redirect_origin_display_id]).to be_nil
       end
 
       # The consumer acts on the FIRST event it receives, which is the cloned message. AgentBotListener
@@ -278,8 +282,9 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
 
         updated = payloads.find { |pl| pl[:event] == 'conversation_updated' }
         expect(updated).to be_present
-        # Absent rather than nil, the same shape a conversation outside an episode has.
-        expect(updated).not_to have_key(:redirect_origin_display_id)
+        # Stated as nil, so a consumer can mirror the clear instead of keeping what it had.
+        expect(updated).to have_key(:redirect_origin_display_id)
+        expect(updated[:redirect_origin_display_id]).to be_nil
       end
     end
 

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -279,14 +279,14 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(conversation.redirect_origin_display_id).to eq(77)
 
         # any_instance because a request spec never holds the controller, and the rendezvous has to sit
-        # between the conversation load and the guard — the only two statements the window spans.
-        # update_all for the same reason it is the defect: it moves the ROW without telling the
-        # instance the controller is holding, which is exactly what a concurrent request does.
+        # between the conversation LOAD and the lock that reloads it — the window a concurrent resume
+        # actually lands in. update_all for the same reason it is the defect: it moves the ROW without
+        # telling the instance the controller is holding.
         # rubocop:disable RSpec/AnyInstance, Rails/SkipsModelValidations
         allow_any_instance_of(Api::V1::Widget::RedirectTokensController)
-          .to receive(:record_redirect_origin).and_wrap_original do |original, *args|
+          .to receive(:with_episode_lock).and_wrap_original do |original, *args, &block|
           Conversation.where(id: conversation.id).update_all(redirect_origin_display_id: 91)
-          original.call(*args)
+          original.call(*args, &block)
         end
         # rubocop:enable RSpec/AnyInstance, Rails/SkipsModelValidations
 

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -120,6 +120,30 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(create(:conversation, account: account).push_event_data).not_to have_key(:redirect_origin_display_id)
       end
 
+      # The consumer acts on the FIRST event it receives, which is the cloned message. AgentBotListener
+      # is on the SYNC dispatcher, so that payload is built inside Message.create!, and the pairing has
+      # to be on the row before the message exists — a later update carries no correcting event, since
+      # the column is not in Conversation#list_of_keys.
+      it 'is already on the conversation the first webhook payload carries' do
+        agent_bot = create(:agent_bot, account: account, outgoing_url: 'https://bot.test/hook')
+        create(:agent_bot_inbox, inbox: web_widget.inbox, agent_bot: agent_bot, account: account)
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'message' => 'Hello', 'origin_display_id' => 77 }
+        )
+
+        payloads = []
+        allow(AgentBots::WebhookJob).to receive(:perform_later) { |_url, payload, *| payloads << payload }
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        message_created = payloads.find { |pl| pl[:event] == 'message_created' }
+        expect(message_created).to be_present
+        expect(message_created[:conversation][:redirect_origin_display_id]).to eq(77)
+      end
+
       it 'takes the newest origin on re-entry, and a token without one leaves the old standing' do
         first = Widget::RedirectToken.generate(
           { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'user-42', 'origin_display_id' => 77 }

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -809,7 +809,10 @@ RSpec.describe Conversation do
         waiting_since: conversation.waiting_since.to_i,
         priority: nil,
         unread_count: 0,
-        group_type: 'individual'
+        group_type: 'individual',
+        # Present on every conversation, nil included: its absence is what tells a consumer this
+        # Chatwoot does not speak about redirect pairings at all (fazer-ai/agents#222).
+        redirect_origin_display_id: nil
       }
     end
 


### PR DESCRIPTION
## What is missing

A redirect episode spans two conversations — the WhatsApp entry thread and the website-chat thread the lead lands on — and nothing tied them together. The merge happens inside the token resolve, and what it identifies is the **contact**; a contact does not say which of its conversations minted the link.

Measured on this fork before the change, with a real mint + resolve over HTTP:

```
conv pk=86 display=85 inbox=4 (Whatsapp)   additional_attributes={} custom_attributes={}
conv pk=87 display=86 inbox=1 (WebWidget)  additional_attributes={} custom_attributes={}
                                            messages=["oi, quero agendar uma visita"]
```

The cloned message crossed, the merge happened, and neither side names the other.

The consumer downstream is `fazer-ai/agents#222`, which had written five different predicates over the rows it mirrors and found each one wrong for its own reason (activity is not the funnel; an older unconsumed link is still live; `/reset` clears the anchor without revoking the link; the sibling lookup needs the anchor it clears; uniqueness is not origin). It acts on the answer destructively — the follow-up ladder **resolves** the conversation it picks.

## The change

The mint is the one moment both halves are known together, so the origin rides in the token and the resolve writes it onto the widget conversation:

- `origin_display_id` is accepted by the accounts endpoint and carried in the token payload;
- the widget endpoint stamps it on the conversation it resumed or created;
- `push_data` ships it, so a consumer reading the webhook needs no extra call.

It is the **display id**, never the primary key: the two are different numbers for the same conversation, and the primary key is what a consumer silently mis-joins on. The live exercise below is on a conversation whose display id is `1` and whose primary key is `17`, so the two cannot be confused in the evidence.

**Last write wins**, because a token is burned by exactly one click: the value is always the origin of the redirect that just happened, which is the episode the ladder acts on.

**A token that names no origin clears the pairing** rather than leaving the previous one standing. Consuming a token is the one event that sets this column, so a re-entry that cannot say where it came from leaves the stored answer with nothing behind it — the lead came back through a link this instance cannot attribute. Keeping it handed a consumer that messages **and resolves** the named conversation full confidence in a previous episode's answer, and on the message-bearing path that stale origin rode out on the cloned message's own webhook. The clear is announced like any other change, and the key then drops out of the payload entirely.

Note the asymmetry with the consumer's own `/reset`, which deliberately **keeps** the pairing (fazer-ai/agents#355): a reset is not a redirect and does not un-click the link, so the stored answer is still the last true one. Here a redirect did happen and did not name an origin.

**Absent rather than nil** on `push_data` for everything that is not the widget half of an episode, on the same terms as `group_left`.

**The column is in `Conversation#list_of_keys`**, and that is load-bearing. A token with no cloned message (the consumer's `cloneWaMessage` off, or a media-only WhatsApp message) resumes a conversation that already exists, so recording the pairing creates nothing and sends nothing: without an event of its own, the write is invisible and the consumer keeps acting on the previous episode's origin. Listing the column makes the update emit its own `conversation_updated`, carrying the new pairing and a fresh `updated_at` for consumers to order it by.

Note for consumers: that event's `last_activity_at` is **frozen** — a column write does not advance it — so the pairing has to be ordered by `updated_at`, never by recency. Measured below.

### Why not `custom_attributes`

It was the cheaper shape — already carried end to end by `push_data` — and it is wrong here: the consumer's `/reset` command calls `POST /conversations/:id/custom_attributes` with `{}`, which the endpoint **assigns** rather than merges. The pairing would live in the bag that one of the very consumers it exists for wipes, and it would disappear the first time an operator typed `/reset`, silently falling back to the inference this change removes.

## Validation scope

**Proven live**, on this worktree at 4.17.0, its own database, port 13222:

```
mint    POST /api/v1/accounts/45/redirect_tokens   origin_display_id=1
resolve POST /api/v1/widget/redirect_token         => {"conversation_id":2}

conv pk=17 display=1 inbox=46 (Api)        redirect_origin_display_id=nil
conv pk=18 display=2 inbox=47 (WebWidget)  redirect_origin_display_id=1
push_data[:redirect_origin_display_id]=1
entry conversation push_data has the key: false
```

The defect half was reproduced the same way against the unchanged code (the first block above).

**The message-less resume path**, mint + resolve over HTTP on the same instance, with an agent bot bound to the widget inbox and Sidekiq paused so the enqueued payload could be read:

```
without list_of_keys:  db origin=2   webhooks enqueued=0
with    list_of_keys:  db origin=2   webhooks enqueued=1
  event=conversation_updated
  redirect_origin_display_id=2
  updated_at=1787752427.514484      <- fresh, sub-second
  last_activity_at=1787748061       <- frozen, 4366s behind
```

Zero events is the defect exactly: Chatwoot knew, and no consumer could.

**Proven by spec**: nine new examples across the two controller specs — the payload carries the origin, it is omitted when the caller sends none, the widget conversation records it, `push_data` ships it and omits it outside an episode, and re-entry takes the newest origin while a token without one leaves the old standing. Four fail against `main`; the fifth guards the absent case, which `main` already satisfies. The sixth is the message-less re-entry above: it reads the enqueued payload rather than the row, and it is the one that caught this. The last three pin the origin-less clear, that the clear is announced, and every event shape this endpoint can produce:

```
origin changes, cloned message   ->  conversation_updated, then message_created
origin changes, no message       ->  conversation_updated
origin unchanged, cloned message ->  message_created
origin unchanged, no message     ->  nothing
no origin at all                 ->  conversation_updated (key now absent)
```

Every payload each path emits names the current pairing, the widget's email-collect templates included.

### Last write wins needs the row, not the instance

Review round 7. The endpoint promises that the origin of the redirect that just happened is the one stored, and the equality guard was comparing against an ActiveRecord instance loaded before the token was even resolved. Two links clicked into one widget conversation at once, and the request that finishes **last** finds its own origin already in memory, skips both the write and the `conversation_updated`, and leaves the other request's origin standing.

Reproduced with the row moved between the load and the guard, which is what a concurrent resume does to that instance:

```
first token  (origin 77)          -> stored 77
row moves to 91 under the request
second token (origin 77), last    -> stored 91   x   expected 77
```

The guard is not what loses it. `update!(redirect_origin_display_id: 77)` on an instance that already believes it holds 77 marks nothing dirty, so ActiveRecord issues no UPDATE at all: removing the early return leaves the same skip and the same 91. The compare-and-write now runs inside `with_lock`, which reloads under `SELECT ... FOR UPDATE`.

A conversation **born in this request** is skipped rather than locked. `start_conversation` already wrote the origin from the same payload, nothing could have raced a row that did not exist, and a just-created `Conversation` still carries an unpersisted `display_id` change that `with_lock` refuses to lock over — without that guard, five specs go to 500.

Mutations, all killed: dropping `with_lock` (1), dropping the born-here guard (5), forcing it always-true (5). Live: a real resume over HTTP after the change returned 200 and the conversation took `redirect_origin_display_id=1`.

**Full suite**: green on 16 shards.

### The lock reaches the conversation this request created

Round 9. The born-here skip was reasoned from "nothing could have raced a row that did not exist", and that stops being true the moment the INSERT commits: a second resume can load the same conversation and move its origin, and this request would then build its cloned message from a cached origin the row no longer holds.

The reload is the whole fix. That case never needed to skip the lock, it needed the unpersisted `display_id` gone — `with_lock` refuses to lock a record holding unpersisted changes rather than discard them silently, and `reload` discards exactly that, for one SELECT on the path that creates a row. Creation now goes through the same lock as every other path, which also carries it across the cloned message.

Mutations: restoring the skip fails the new example; dropping the reload and keeping the lock fails six with `Locking a record with unpersisted changes is not supported`.

### What creation does NOT emit

Also measured this round, and pinned rather than changed: `AgentBotListener` handles `conversation_resolved`, `conversation_opened`, `conversation_status_changed`, `conversation_updated`, `message_created`, `message_updated` and `webwidget_triggered` — no `conversation_created`. A message-less token that creates the conversation delivers `bot_events=[]`.

Nothing is lost by it. The pairing is on the row from the INSERT, so the first event a bot does receive carries it, and until a message exists there is no episode for a consumer to act on — both the closing and the follow-up ladder are driven by the lead's messages. A spec now asserts both halves, because a comment here used to say "even the `conversation_created` event names its origin", which is true of the payload and misleading about who receives it. Making creation bot-visible would change the agent-bot contract for every inbox in the account, which is not this change's to make.

### A note on running the specs in this tree

`RAILS_ENV=test` resolves `POSTGRES_DATABASE` to the **development** database here, so a plain `bundle exec rspec` runs against whatever the local instance holds. It produced 18 phantom failures in `conversation_spec`'s sort examples, which read every conversation in the database and compared the list to their own fixtures. Nothing was written — the specs are transactional — but nothing was isolated either. With `POSTGRES_DATABASE=chatwoot_222_redirect_origin_test` the same 319 examples across the touched files are green, and that is where every number in this section was measured.

**Not validated**: the SDK side. The widget JS was not touched — the origin never reaches the browser, by design — so nothing in `app/javascript` changed and nothing there was exercised.

## Consumer

`fazer-ai/agents#222` reads `redirect_origin_display_id` off the webhook payload. That side is a separate PR and needs this one deployed first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/418)
<!-- Reviewable:end -->




