### PR TITLE
fix(whatsapp): stop reading a LID as a phone number

### DIFF
--- a/app/services/whatsapp/baileys_handlers/concerns/group_contact_message_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/group_contact_message_handler.rb
@@ -181,30 +181,19 @@ module Whatsapp::BaileysHandlers::Concerns::GroupContactMessageHandler # rubocop
     @raw_message[:key][:participantAlt]
   end
 
+  # Whichever of the author's two addresses is the phone one. Which field holds it
+  # depends on how the group is addressed -- `participantAlt` for a LID-addressed group,
+  # `participant` for a phone-addressed one -- and neither may be read as a phone number
+  # on the strength of being digits, since a LID is digits too. See `phone_from_jid`.
   def baileys_sender_phone
-    alt_jid = extract_sender_jid_alt
-    if alt_jid.present?
-      phone = alt_jid.split('@').first
-      return phone if phone.match?(/^\d+$/)
-    end
-
-    sender_jid = extract_sender_jid
-    return if sender_jid.blank?
-
-    jid_part = sender_jid.split('@').first
-    parts = jid_part.split(':')
-    parts.first if parts.first.match?(/^\d+$/)
+    phone_from_jid(extract_sender_jid_alt) || phone_from_jid(extract_sender_jid)
   end
 
+  # The mirror of `baileys_sender_phone`: the author's other address, wherever the group's
+  # addressing put it. Read from `participant` first, since that is where a LID-addressed
+  # group carries it and where the alt field is the phone number.
   def baileys_sender_lid
-    sender_jid = extract_sender_jid
-    return if sender_jid.blank?
-
-    jid_part, jid_suffix = sender_jid.split('@')
-    return jid_part if jid_suffix == 'lid' && jid_part.match?(/^\d+$/)
-
-    parts = jid_part.split(':')
-    parts.last if parts.length > 1 && parts.last.match?(/^\d+$/)
+    lid_from_jid(extract_sender_jid) || lid_from_jid(extract_sender_jid_alt)
   end
 
   def baileys_sender_identifier

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -10,6 +10,11 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
   # normalizeMessageContent).
   MESSAGE_WRAPPER_KEYS = %i[ephemeralMessage associatedChildMessage lottieStickerMessage].freeze
 
+  # The servers a phone-addressed jid lives on, `c.us` being the legacy form. The same
+  # pair `jid_type` reads as a `user` chat.
+  PHONE_JID_SERVERS = %w[s.whatsapp.net c.us].freeze
+  LID_JID_SERVER = 'lid'.freeze
+
   def unwrap_message_content(msg)
     5.times do
       wrapper_key = MESSAGE_WRAPPER_KEYS.find { |key| msg.key?(key) }
@@ -218,10 +223,40 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
 
     jid = @raw_message[:key][reference_field]
     return unless jid
+    return phone_from_jid(jid) if type == 'pn'
 
-    # NOTE: jid shape is `<user>_<agent>:<device>@<server>`
-    # https://github.com/WhiskeySockets/Baileys/blob/v7.0.0-rc.6/src/WABinary/jid-utils.ts#L52
+    jid_user(jid)
+  end
+
+  # The account a jid names, without the device and agent suffixes.
+  # NOTE: jid shape is `<user>_<agent>:<device>@<server>`
+  # https://github.com/WhiskeySockets/Baileys/blob/v7.0.0-rc.6/src/WABinary/jid-utils.ts#L52
+  def jid_user(jid)
     jid.split('@').first.split(':').first.split('_').first
+  end
+
+  # The phone number a jid carries, or nothing when the jid is not a phone address.
+  # A LID is digits too, so `235085806727321@lid` reads as a phone number to anything
+  # that looks only at the part before the `@`: the server is the one thing that tells
+  # them apart. Live messages name the pair (`addressingMode` plus an alt jid) and the
+  # question rarely comes up, but a history message is raw protobuf -- four fields, no
+  # addressing mode -- so its chat arrives addressed by LID alone, and reading that as
+  # a phone number is how a contact ends up with `+235085806727321`.
+  def phone_from_jid(jid)
+    jid_user_on(jid, PHONE_JID_SERVERS)
+  end
+
+  # The LID a jid carries, asked the same way and for the same reason.
+  def lid_from_jid(jid)
+    jid_user_on(jid, [LID_JID_SERVER])
+  end
+
+  def jid_user_on(jid, servers)
+    return if jid.blank?
+    return unless jid.split('@').last.in?(servers)
+
+    user = jid_user(jid)
+    user if user.match?(/\A\d+\z/)
   end
 
   def contact_name

--- a/app/services/whatsapp/baileys_handlers/presence_update.rb
+++ b/app/services/whatsapp/baileys_handlers/presence_update.rb
@@ -28,8 +28,9 @@ module Whatsapp::BaileysHandlers::PresenceUpdate
   def extract_presence_identifiers(data)
     jid = data[:id]
     lid = extract_jid_user(jid) if jid&.include?('@lid')
-    phone = extract_jid_user(jid) if jid&.include?('@s.whatsapp.net')
-    phone ||= extract_jid_user(data[:jidAlt]) if data[:jidAlt].present?
+    # Whichever of the two addresses is a phone one, asked the same way everywhere else:
+    # a phone number is what a phone jid carries, never what a digit string looks like.
+    phone = phone_from_jid(jid) || phone_from_jid(data[:jidAlt])
     [lid, phone]
   end
 

--- a/spec/services/whatsapp/baileys/history_importer_spec.rb
+++ b/spec/services/whatsapp/baileys/history_importer_spec.rb
@@ -266,6 +266,58 @@ describe Whatsapp::Baileys::HistoryImporter do
     end
   end
 
+  # The shape every other example here skips: a history key is raw protobuf, four fields,
+  # and the addressing a live key carries is stamped by the decoder from a stanza a dump
+  # does not have. So on an account addressed by LID the chat arrives as `<lid>@lid` alone,
+  # and the LID is digits -- which is how it used to be filed as the contact's phone
+  # number. Reported at fazer-ai/chatwoot#408, with contacts created as `+235085806727321`.
+  describe 'a chat addressed by LID with no mapping alongside it' do
+    def bare_message(id, sent_at:)
+      {
+        key: { id: id, remoteJid: jid, fromMe: false },
+        messageTimestamp: sent_at.to_i,
+        message: { conversation: "message #{id}" }
+      }.with_indifferent_access
+    end
+
+    it 'files the chat without inventing a phone number for it' do
+      import([bare_message('RAW', sent_at: 10.days.ago)], watermark: 3.days.ago)
+
+      contact = inbox.messages.find_by(source_id: 'RAW').conversation.contact
+      expect(contact.phone_number).to be_nil
+      expect(contact.identifier).to eq("#{lid}@lid")
+    end
+
+    # The LID is still the address, so the chat is keyed by it and the import proceeds --
+    # only the phone number is withheld, and the first live message fills it in.
+    it 'keys the chat by its LID' do
+      import([bare_message('RAW', sent_at: 10.days.ago)], watermark: 3.days.ago)
+
+      expect(inbox.contact_inboxes.pluck(:source_id)).to eq([lid])
+    end
+  end
+
+  # Same class, one level down: a group's author is addressed the same two ways, and its
+  # LID is digits too.
+  describe 'a group author addressed by LID with no mapping alongside it' do
+    before { allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:groups_enabled?).and_return(true) }
+
+    it 'files the author without inventing a phone number for them' do
+      import(
+        [{
+          key: { id: 'GRP', remoteJid: '120363000000000000@g.us', participant: jid, fromMe: false },
+          messageTimestamp: 10.days.ago.to_i,
+          message: { conversation: 'hello group' }
+        }.with_indifferent_access],
+        watermark: 3.days.ago
+      )
+
+      sender = inbox.messages.find_by(source_id: 'GRP').sender
+      expect(sender.phone_number).to be_nil
+      expect(sender.identifier).to eq("#{lid}@lid")
+    end
+  end
+
   # Not filed: they mutate a row that has to exist, and replaying them out of a dump either
   # no-ops or acts on a row a later message in the same dump has not written yet.
   it 'skips the entries that are not messages' do

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -783,6 +783,27 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       expect(conversation.contact.group_type).to eq('group')
     end
 
+    # The mirror of the shape above: a phone-addressed group carries the author's phone in
+    # `participant` and their LID in `participantAlt`. Reading the alt as a phone number
+    # because it is digits put the LID in the contact's phone field and left the LID field
+    # empty, swapping the two.
+    it 'reads the author of a phone-addressed group by the address that is a phone number' do
+      params = build_params(
+        build_group_raw_message(
+          id: 'grp_pn_001',
+          text: 'Hello from a phone-addressed group',
+          sender_participant: "#{sender_phone}@s.whatsapp.net",
+          sender_alt: "#{sender_lid}@lid"
+        )
+      )
+
+      Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+      sender = inbox.messages.find_by(source_id: 'grp_pn_001').sender
+      expect(sender.phone_number).to eq("+#{sender_phone}")
+      expect(sender.identifier).to eq("#{sender_lid}@lid")
+    end
+
     it 'processes a group image message with attachment' do
       stub_request(:get, whatsapp_channel.media_url('grp_img_001'))
         .to_return(status: 200, body: 'fake image data')


### PR DESCRIPTION
A WhatsApp number whose account has migrated to LID addressing synced its history and every contact came back with a phone number nobody can dial: a fifteen-digit string that is the contact's LID, not their number. With the number wrong, the contact could not be identified in the inbox at all.

Contacts imported this way now arrive with no phone number instead of a wrong one, and the first live message from that contact fills the real one in.

## Closes

Closes #419. Reported in #408. The other half is fazer-ai/baileys-api#386, which makes the bridge ship the phone number alongside the history it already sends; this PR is what stops the address being mistaken for a number in the first place, and it fixes the symptom on its own.

## How to reproduce

Pair a `baileys` inbox with a LID-addressed account and let the history sync land. Before this change, contacts are created with `phone_number` set to their LID (`+235085806727321`) and named after it. After, the phone field is empty and the contact is keyed by its LID, which is what the identifier already said.

## What changed

A LID is digits, so `235085806727321@lid` reads as a phone number to anything that looks only at the part before the `@`. A live message names the pair — `addressingMode` plus an alt jid — so the question rarely comes up. A history key cannot: it is a raw protobuf `MessageKey`, which defines `remoteJid`, `fromMe`, `id` and `participant` and nothing else, so a LID-addressed chat arrives with the LID as its only address.

The server is now what decides, at each of the three points that turn an address into a phone number:

- `extract_from_jid(type: 'pn')`, which is what `set_contact` writes to `phone_number`.
- The author of a group message. This one was swapped in live traffic too: a phone-addressed group carries the author's phone in `participant` and their LID in `participantAlt`, and reading the alt as a phone because it is digits put the LID in the phone field and left the identifier empty. Both sides now read whichever of the two addresses is the kind they want, so the pair can no longer come out reversed.
- The phone side of a presence event, for uniformity — its input is a phone jid by construction on our own bridge, so no behavior there changes today.

Where no phone address is present the number is withheld rather than guessed. The LID is still the address, so the chat is keyed by it and the import proceeds exactly as before; only the number is left for a live message to supply.

## Contacts already imported wrong

A live message from the contact corrects the number on its own, since `update_contact_info` overwrites it once a phone address arrives. Contacts who never write again keep the wrong number, and a backfill for those is still open on #419: a contact whose `phone_number` minus the `+` equals its `identifier` minus the `@lid` is an artifact of this bug and nothing else.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/420)
<!-- Reviewable:end -->
