### PR TITLE
fix(enterprise): repair the specs no CI has been running

### DIFF
--- a/enterprise/app/controllers/enterprise/devise_overrides/omniauth_callbacks_controller.rb
+++ b/enterprise/app/controllers/enterprise/devise_overrides/omniauth_callbacks_controller.rb
@@ -53,7 +53,11 @@ module Enterprise::DeviseOverrides::OmniauthCallbacksController
     return sign_in_saml_user(relay_state) if @resource.persisted?
 
     handle_saml_auth_error(relay_state, 'saml-authentication-failed')
-  rescue SamlUserBuilder::AuthenticationFailed
+  # `create_user` builds the record straight off the assertion and saves it with `User.create!`,
+  # so an IdP sending an address Rails will not accept raises out of the builder rather than
+  # coming back unsaved. That is a failed sign-in like any other: without this it leaves the
+  # browser on a 500 instead of the login page, and the `persisted?` branch above is unreachable.
+  rescue SamlUserBuilder::AuthenticationFailed, ActiveRecord::RecordInvalid
     handle_saml_auth_error(relay_state, 'saml-authentication-failed')
   end
 

--- a/spec/enterprise/builders/saml_user_builder_spec.rb
+++ b/spec/enterprise/builders/saml_user_builder_spec.rb
@@ -283,16 +283,20 @@ RSpec.describe SamlUserBuilder do
       end
     end
 
-    context 'when there are errors' do
-      it 'returns unsaved user object when user creation fails' do
-        allow(User).to receive(:create).and_return(User.new(email: email))
-        user = builder.perform
-        expect(user.persisted?).to be false
+    # `create_user` saves with `User.create!`, so a record Rails refuses raises instead of
+    # coming back unsaved. The controller turns that into the ordinary failed-sign-in
+    # redirect; see the omniauth callbacks spec.
+    context 'when the user cannot be created' do
+      before { allow(User).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(User.new)) }
+
+      it 'raises instead of returning an unsaved user' do
+        expect { builder.perform }.to raise_error(ActiveRecord::RecordInvalid)
       end
 
-      it 'does not create account association for failed user' do
-        allow(User).to receive(:create).and_return(User.new(email: email))
-        expect { builder.perform }.not_to change(AccountUser, :count)
+      it 'does not create an account association' do
+        expect do
+          expect { builder.perform }.to raise_error(ActiveRecord::RecordInvalid)
+        end.not_to change(AccountUser, :count)
       end
     end
   end

--- a/spec/enterprise/controllers/enterprise/devise_overrides/omniauth_callbacks_controller_spec.rb
+++ b/spec/enterprise/controllers/enterprise/devise_overrides/omniauth_callbacks_controller_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe 'Enterprise SAML OmniAuth Callbacks', type: :request do
       end
     end
 
+    it 'redirects to the login error when the assertion cannot produce a valid user' do
+      with_modified_env FRONTEND_URL: 'http://www.example.com' do
+        set_saml_config('broken@example.com')
+        allow(User).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(User.new))
+
+        get "/omniauth/saml/callback?account_id=#{account.id}"
+
+        expect(response).to redirect_to('http://www.example.com/app/login?error=saml-authentication-failed')
+      end
+    end
+
     it 'rejects an existing user from another account' do
       with_modified_env FRONTEND_URL: 'http://www.example.com' do
         other_account = create(:account)

--- a/spec/enterprise/models/account_saml_settings_spec.rb
+++ b/spec/enterprise/models/account_saml_settings_spec.rb
@@ -57,11 +57,15 @@ RSpec.describe AccountSamlSettings, type: :model do
   end
 
   describe 'sp_entity_id auto-generation' do
+    # Built from FRONTEND_URL, so asserting the fallback would only pass where nobody set
+    # one. Name the value instead: any dev machine with a .env has FRONTEND_URL set.
     it 'automatically generates sp_entity_id when creating' do
-      settings = build(:account_saml_settings, account: account, sp_entity_id: nil)
-      expect(settings).to be_valid
-      settings.save!
-      expect(settings.sp_entity_id).to eq("http://localhost:3000/saml/sp/#{account.id}")
+      with_modified_env FRONTEND_URL: 'https://chat.example.com' do
+        settings = build(:account_saml_settings, account: account, sp_entity_id: nil)
+        expect(settings).to be_valid
+        settings.save!
+        expect(settings.sp_entity_id).to eq("https://chat.example.com/saml/sp/#{account.id}")
+      end
     end
 
     it 'does not override existing sp_entity_id' do

--- a/spec/enterprise/models/applied_sla_spec.rb
+++ b/spec/enterprise/models/applied_sla_spec.rb
@@ -72,20 +72,24 @@ RSpec.describe AppliedSla, type: :model do
   end
 
   describe '.with_sla_applicable_conversation' do
-    # The contactless half of this used to live here, writing `contact_id: nil` straight past
-    # the model. `conversations.contact_id` is `null: false` since the orphan cleanup
-    # (20260422170000), so that state is no longer representable and the write raises. The
-    # scope's own `left_joins` and `blocked: [false, nil]` still tolerate a missing contact;
-    # nothing can produce one to test it with.
-    it 'excludes blocked contacts' do
+    # This used to reach the contactless case by writing `contact_id: nil`, which
+    # `null: false` has refused since the orphan cleanup (20260422170000). The case itself is
+    # still live, just shaped differently: `Contact has_many :conversations,
+    # dependent: :destroy_async` deletes the contact and cleans its conversations up in a job,
+    # and no foreign key closes that window -- one cannot exist, since it would make the
+    # contact's own delete raise. So the id stays, the row goes, and the scope's `left_joins`
+    # plus `blocked: [false, nil]` is what keeps those conversations in.
+    it 'excludes blocked contacts and keeps conversations whose contact row is gone' do
       applied_sla = create(:applied_sla)
       blocked_applied_sla = create(:applied_sla)
+      dangling_applied_sla = create(:applied_sla)
 
       blocked_applied_sla.conversation.contact.update!(blocked: true)
+      dangling_applied_sla.conversation.contact.delete
 
       applicable_sla_ids = described_class.with_sla_applicable_conversation.ids
 
-      expect(applicable_sla_ids).to include(applied_sla.id)
+      expect(applicable_sla_ids).to include(applied_sla.id, dangling_applied_sla.id)
       expect(applicable_sla_ids).not_to include(blocked_applied_sla.id)
     end
   end

--- a/spec/enterprise/models/applied_sla_spec.rb
+++ b/spec/enterprise/models/applied_sla_spec.rb
@@ -72,17 +72,20 @@ RSpec.describe AppliedSla, type: :model do
   end
 
   describe '.with_sla_applicable_conversation' do
-    it 'excludes blocked contacts and keeps conversations with missing contacts' do
+    # The contactless half of this used to live here, writing `contact_id: nil` straight past
+    # the model. `conversations.contact_id` is `null: false` since the orphan cleanup
+    # (20260422170000), so that state is no longer representable and the write raises. The
+    # scope's own `left_joins` and `blocked: [false, nil]` still tolerate a missing contact;
+    # nothing can produce one to test it with.
+    it 'excludes blocked contacts' do
       applied_sla = create(:applied_sla)
       blocked_applied_sla = create(:applied_sla)
-      missing_contact_applied_sla = create(:applied_sla)
 
       blocked_applied_sla.conversation.contact.update!(blocked: true)
-      missing_contact_applied_sla.conversation.update_columns(contact_id: nil, contact_inbox_id: nil) # rubocop:disable Rails/SkipsModelValidations
 
       applicable_sla_ids = described_class.with_sla_applicable_conversation.ids
 
-      expect(applicable_sla_ids).to include(applied_sla.id, missing_contact_applied_sla.id)
+      expect(applicable_sla_ids).to include(applied_sla.id)
       expect(applicable_sla_ids).not_to include(blocked_applied_sla.id)
     end
   end

--- a/spec/enterprise/models/conversation_spec.rb
+++ b/spec/enterprise/models/conversation_spec.rb
@@ -120,12 +120,6 @@ RSpec.describe Conversation, type: :model do
 
         expect(conversation.applied_sla.sla_policy_id).to eq(sla_policy.id)
       end
-
-      it 'keeps existing behavior when contact is missing' do
-        conversation.update_columns(contact_id: nil, contact_inbox_id: nil) # rubocop:disable Rails/SkipsModelValidations
-
-        expect(conversation.reload.sla_applicable?).to be true
-      end
     end
 
     context 'when conversation already has a different sla' do

--- a/spec/enterprise/models/conversation_spec.rb
+++ b/spec/enterprise/models/conversation_spec.rb
@@ -111,6 +111,15 @@ RSpec.describe Conversation, type: :model do
         expect(conversation.errors[:sla_policy]).to eq(['cannot be assigned to conversations with blocked contacts'])
       end
 
+      # `dependent: :destroy_async` leaves the conversation pointing at a deleted contact
+      # until the cleanup job runs, and nothing enforces otherwise -- see the AppliedSla spec.
+      # `contact&.blocked?` is what has to hold up there.
+      it 'keeps existing behavior when the contact row is gone' do
+        conversation.contact.delete
+
+        expect(conversation.reload.sla_applicable?).to be true
+      end
+
       it 'allows assigning sla after contact is unblocked' do
         conversation.contact.update!(blocked: true)
         conversation.contact.update!(blocked: false)

--- a/spec/enterprise/services/cloudflare/check_custom_hostname_service_spec.rb
+++ b/spec/enterprise/services/cloudflare/check_custom_hostname_service_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Cloudflare::CheckCustomHostnameService do
           stub_request(:get, 'https://api.cloudflare.com/client/v4/zones/test-zone-id/custom_hostnames?hostname=test.example.com')
             .to_return(status: 200, body: success_response.to_json, headers: { 'Content-Type' => 'application/json' })
 
-          expect(portal).to receive(:update).with(
+          expect(portal).to receive(:update!).with(
             ssl_settings: {
               'cf_verification_id' => 'verification-id',
               'cf_verification_body' => 'verification-body',

--- a/spec/enterprise/services/voice/call_transcription_service_spec.rb
+++ b/spec/enterprise/services/voice/call_transcription_service_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe Voice::CallTranscriptionService, type: :service do
     it 'reindexes before broadcasting so a retry after a reindex failure does not resend the update event' do
       call.update!(transcript: 'Existing transcript')
       allow(ChatwootApp).to receive(:advanced_search_allowed?).and_return(true)
+      # `Message` mixes searchkick in at class-load time, and only when
+      # `advanced_search_allowed?` -- which needs OPENSEARCH_URL, absent in test. So the
+      # method the service calls does not exist on the class here and a verified double
+      # refuses to stub it. Defining it completes the "search is on" simulation the stub
+      # above starts, instead of the service dying on NoMethodError before the point.
+      message.define_singleton_method(:reindex) { |*| nil }
       allow(message).to receive(:reindex).and_raise(StandardError, 'reindex boom')
 
       expect(message).not_to receive(:send_update_event)


### PR DESCRIPTION
`spec/enterprise` is deleted before every CI run (`run_foss_spec.yml` does `rm -rf enterprise spec/enterprise`), here and on Pro. Run by hand it came back with nine failures. That is the same as having no gate: whoever runs it cannot separate what they just broke from what was already broken, so the whole result gets ignored.

Seven are fixed here. Two of them are real defects, not stale expectations.

Closes #421

## A malformed SAML assertion returned a 500 instead of the login page

A rubocop `Rails/SaveBang` pass turned `SamlUserBuilder`'s `User.create` into `User.create!`. A record Rails refuses now raises out of the builder instead of coming back unsaved, which means:

- the controller's `return sign_in_saml_user(relay_state) if @resource.persisted?` guard is unreachable, and
- `ActiveRecord::RecordInvalid` escapes `handle_saml_auth`, so an IdP sending an address Rails will not accept leaves the browser on a 500 instead of `?error=saml-authentication-failed`.

The rescue covers it now. The two builder specs stubbed `User.create`, a method the builder stopped calling, which is why they were passing a real user through and asserting it was unsaved; they describe the actual behaviour instead. A request spec covers the redirect.

## Two examples wrote `contact_id: nil` straight past the model

`conversations.contact_id` has been `null: false` since `20260422170000`, so `update_columns(contact_id: nil)` raises. Since nothing in CI runs these, that has been true and unnoticed since April.

The state they were reaching for is still live, just shaped differently. Despite its name, `EnforceContactFkOnConversations` only ran `change_column_null` -- there is no `add_foreign_key` for `conversations.contact_id`, and there cannot be one: `Contact has_many :conversations, dependent: :destroy_async` deletes the contact first and cleans its conversations up in a job, so a foreign key would make that first delete raise. The window between the two is exactly a non-null `contact_id` pointing at a row that is gone.

So both examples are kept, reaching that state the way production does (`contact.delete`) instead of the way the column now refuses. They hold real behaviour: dropping the `nil` from the scope's `blocked: [false, nil]` and the `&.` from `sla_applicable?` fails both.

## The rest were stale against upstream

- `check_custom_hostname_service_spec` expected `portal.update`; `Cloudflare::BaseCloudflareZoneService` calls `update!`.
- `call_transcription_service_spec` stubbed `Message#reindex`. Searchkick is mixed into `Message` at class-load time and only when `advanced_search_allowed?`, i.e. with `OPENSEARCH_URL` set, so the method does not exist in test and a verified double refuses it. The spec defines it, completing the "search is on" simulation its `ChatwootApp` stub already starts.
- `account_saml_settings_spec` asserted the `http://localhost:3000` **fallback** of `GlobalConfigService.load('FRONTEND_URL', …)`, so it failed on any machine with a `.env`. It names a value now and tests the generation rather than the ambient environment.

## Not in here

`check_new_versions_job_spec` (2 failures). CE deliberately fetches its version from our own GitHub releases (#105) while the enterprise override still reads what the hub returned, so in this tree the spec describes code that does not exist. It is answered on `chatwoot-pro-main`, where the job it tests actually lives, together with the CI workflow that will run all of this from now on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/423)
<!-- Reviewable:end -->

