### PR TITLE
fix(widget): let a redirect token say whose identity it carries

### DIFF
--- a/app/controllers/api/v1/accounts/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/accounts/redirect_tokens_controller.rb
@@ -22,31 +22,37 @@ class Api::V1::Accounts::RedirectTokensController < Api::V1::Accounts::BaseContr
       inbox_id: inbox.id,
       identifier: permitted_params[:identifier],
       message: permitted_params[:message],
-      origin_display_id: origin&.display_id
-    }.compact.merge(identified_contact)
+      origin_display_id: origin&.display_id,
+      identified_contact_id: named_contact&.id
+    }.compact
   end
 
-  # WHICH CONTACT THIS LINK IS FOR, settled here because here is where it can be trusted.
+  # WHICH CONTACT THIS LINK IS FOR, named by the caller because only the caller knows.
   #
-  # The resolve side had only the `identifier` to go on, and that is not enough to say whose identity
-  # it is: the value is derived from a sequential contact id, so it is guessable, and it can move off
-  # the contact between the mint and the click a day later. When it has moved,
-  # `ContactIdentifyAction` finds nobody holding it and ASSIGNS it to the widget visitor instead of
-  # merging onto the lead — which is how a lead ends up with two contacts, one of them squatting the
-  # identifier of the other (fazer-ai/agents#286).
+  # `identifier` alone cannot answer it. The value the redirect funnel uses is derived from a
+  # sequential contact id, so it is guessable, and it can move off the contact between the mint and a
+  # click a day later. When it has moved, the resolve side finds nobody holding it and ASSIGNS it to
+  # the widget visitor instead of merging onto the lead — which is how a lead ends up with two
+  # contacts, one of them squatting the identifier of the other (fazer-ai/agents#286).
   #
-  # This endpoint is account-authenticated, so the contact it resolves is a fact rather than a claim,
-  # and it rides in the token, which is single-use, server-side and never seen by the widget.
+  # This endpoint is account-authenticated, so a contact it is told to name is a fact the widget side
+  # can spend, and one nothing reaching the widget can forge. It travels in a token that is
+  # single-use, server-side and never readable by the widget.
   #
-  # The key is written whenever an identifier is asked for, INCLUDING when nobody holds it — a nil
-  # says "the mint looked and found none", which is a different answer from a token minted before
-  # this existed, whose key is absent and which keeps the old behaviour for the day its TTL leaves it
-  # live.
-  def identified_contact
-    identifier = permitted_params[:identifier].presence
-    return {} if identifier.blank?
+  # OPTIONAL, and the omission is meaningful rather than a default. A caller minting a
+  # pre-authenticated deep link for an identity that has no contact yet (a CRM handing off a user
+  # this account has never seen) wants the resolve to CREATE it, which is what this endpoint has
+  # always done. Only a caller that names a contact is asking for the stricter rule, so an absent
+  # `contact_id` leaves that flow exactly as it was.
+  #
+  # `find` rather than `find_by`: a caller naming a contact that does not exist in this account has a
+  # bug, and a token minted with the field silently dropped would resolve as the loose flow without
+  # anything saying so.
+  def named_contact
+    id = permitted_params[:contact_id].presence
+    return if id.blank?
 
-    { identified_contact_id: Current.account.contacts.find_by(identifier: identifier)&.id }
+    Current.account.contacts.find(id)
   end
 
   # The mint is the earliest shared entry point for the pairing, so the caller's right to name that
@@ -65,6 +71,6 @@ class Api::V1::Accounts::RedirectTokensController < Api::V1::Accounts::BaseContr
   end
 
   def permitted_params
-    params.permit(:inbox_id, :identifier, :message, :ttl_seconds, :origin_display_id)
+    params.permit(:inbox_id, :identifier, :contact_id, :message, :ttl_seconds, :origin_display_id)
   end
 end

--- a/app/controllers/api/v1/accounts/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/accounts/redirect_tokens_controller.rb
@@ -23,7 +23,30 @@ class Api::V1::Accounts::RedirectTokensController < Api::V1::Accounts::BaseContr
       identifier: permitted_params[:identifier],
       message: permitted_params[:message],
       origin_display_id: origin&.display_id
-    }.compact
+    }.compact.merge(identified_contact)
+  end
+
+  # WHICH CONTACT THIS LINK IS FOR, settled here because here is where it can be trusted.
+  #
+  # The resolve side had only the `identifier` to go on, and that is not enough to say whose identity
+  # it is: the value is derived from a sequential contact id, so it is guessable, and it can move off
+  # the contact between the mint and the click a day later. When it has moved,
+  # `ContactIdentifyAction` finds nobody holding it and ASSIGNS it to the widget visitor instead of
+  # merging onto the lead — which is how a lead ends up with two contacts, one of them squatting the
+  # identifier of the other (fazer-ai/agents#286).
+  #
+  # This endpoint is account-authenticated, so the contact it resolves is a fact rather than a claim,
+  # and it rides in the token, which is single-use, server-side and never seen by the widget.
+  #
+  # The key is written whenever an identifier is asked for, INCLUDING when nobody holds it — a nil
+  # says "the mint looked and found none", which is a different answer from a token minted before
+  # this existed, whose key is absent and which keeps the old behaviour for the day its TTL leaves it
+  # live.
+  def identified_contact
+    identifier = permitted_params[:identifier].presence
+    return {} if identifier.blank?
+
+    { identified_contact_id: Current.account.contacts.find_by(identifier: identifier)&.id }
   end
 
   # The mint is the earliest shared entry point for the pairing, so the caller's right to name that

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -24,12 +24,52 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
     end
     @contact_inbox.update!(hmac_verified: true)
     return if payload['identifier'].blank?
+    return unless identity_claimable?(payload)
 
     @contact = ContactIdentifyAction.new(
       contact: @contact,
       params: { identifier: payload['identifier'] },
       discard_invalid_attrs: true
     ).perform
+  end
+
+  # WHOSE IDENTITY THIS TOKEN CARRIES, and the reason the question has to be asked at all.
+  #
+  # `ContactIdentifyAction` MERGES the visitor onto whoever holds the identifier and ASSIGNS the
+  # identifier to the visitor when nobody does. The assigning half is wrong for a redirect: the value
+  # belongs to the contact the link was minted for, so handing it to a browser session that merely
+  # presented a token leaves the lead with two contacts — the WhatsApp one it keeps writing on, and a
+  # widget one squatting its identifier, which every later redirect for that lead then collides with
+  # (fazer-ai/agents#286, and the orphan #269 measured in production).
+  #
+  # The mint names the contact, and it is the half of the flow that can: it is account-authenticated,
+  # so what it resolved is a fact, and it travels in a token that is single-use, server-side and never
+  # readable by the widget. So this asks the token, not the identifier.
+  #
+  # Restoring the value on the named contact is what lets the action take its merging branch, rather
+  # than duplicating the merge here: after this, somebody DOES hold the identifier, and it is the
+  # right somebody.
+  #
+  # An ABSENT key means a token minted before this field existed. Those stay live for up to their
+  # 24h TTL, and refusing them would break links already in customers' hands for a day, so they keep
+  # the old behaviour. A key present and nil is the opposite answer — this mint looked and found
+  # nobody — and it is refused, because that is the case that creates the orphan.
+  def identity_claimable?(payload)
+    return true unless payload.key?('identified_contact_id')
+
+    target = @web_widget.inbox.account.contacts.find_by(id: payload['identified_contact_id'])
+    return false if target.blank?
+
+    return true if target.identifier == payload['identifier']
+
+    # `update`, not `update!`: a THIRD contact can be holding the value right now — an earlier
+    # resolve of this same lead already created the orphan this change exists to prevent, and its
+    # token can still be live. `identifier` is unique per account, so restoring would raise, and a
+    # 422 out of this endpoint is worse than the state it was trying to repair: the lead cannot even
+    # enter the widget. Measured — without this the spec above answers 422 instead of 200.
+    return false unless target.update(identifier: payload['identifier'])
+
+    true
   end
 
   # The order here is load-bearing. AgentBotListener is on the SYNC dispatcher, so the payload a

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -23,8 +23,9 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
       @contact = @contact_inbox.contact
     end
     @contact_inbox.update!(hmac_verified: true)
+
+    return unify_with_named_contact(payload) if payload['identified_contact_id'].present?
     return if payload['identifier'].blank?
-    return unless identity_claimable?(payload)
 
     @contact = ContactIdentifyAction.new(
       contact: @contact,
@@ -33,43 +34,45 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
     ).perform
   end
 
-  # WHOSE IDENTITY THIS TOKEN CARRIES, and the reason the question has to be asked at all.
+  # THE VISITOR JOINS THE CONTACT THE TOKEN NAMES, and does not merely claim to be it.
   #
-  # `ContactIdentifyAction` MERGES the visitor onto whoever holds the identifier and ASSIGNS the
-  # identifier to the visitor when nobody does. The assigning half is wrong for a redirect: the value
-  # belongs to the contact the link was minted for, so handing it to a browser session that merely
-  # presented a token leaves the lead with two contacts — the WhatsApp one it keeps writing on, and a
-  # widget one squatting its identifier, which every later redirect for that lead then collides with
+  # `ContactIdentifyAction` decides by the identifier: it merges the visitor onto whoever holds the
+  # value and ASSIGNS the value when nobody does. Assigning is right for a self-declared `setUser`
+  # identity and wrong for a redirect a contact was named for — the value belongs to that contact by
+  # construction, so handing it to a browser session that merely presented a token leaves the lead
+  # with two contacts, the second squatting the identifier every later redirect for it needs
   # (fazer-ai/agents#286, and the orphan #269 measured in production).
   #
-  # The mint names the contact, and it is the half of the flow that can: it is account-authenticated,
-  # so what it resolved is a fact, and it travels in a token that is single-use, server-side and never
-  # readable by the widget. So this asks the token, not the identifier.
+  # So the merge is done against the NAMED contact rather than against whoever the identifier
+  # currently points at. A contact that is gone identifies nobody: the visitor stays anonymous, which
+  # is the same place a failed crossing already left it, rather than being handed a dead lead's value.
   #
-  # Restoring the value on the named contact is what lets the action take its merging branch, rather
-  # than duplicating the merge here: after this, somebody DOES hold the identifier, and it is the
-  # right somebody.
-  #
-  # An ABSENT key means a token minted before this field existed. Those stay live for up to their
-  # 24h TTL, and refusing them would break links already in customers' hands for a day, so they keep
-  # the old behaviour. A key present and nil is the opposite answer — this mint looked and found
-  # nobody — and it is refused, because that is the case that creates the orphan.
-  def identity_claimable?(payload)
-    return true unless payload.key?('identified_contact_id')
-
+  # The identifier is written only onto a contact that has NONE. A named contact carrying a different
+  # value has been re-identified since the token was minted — identifiers are mutable through the
+  # contacts API and the ingestion services — and a link from yesterday is not evidence about today,
+  # so it unifies without touching what the contact now says it is.
+  def unify_with_named_contact(payload)
     target = @web_widget.inbox.account.contacts.find_by(id: payload['identified_contact_id'])
-    return false if target.blank?
+    return if target.blank?
 
-    return true if target.identifier == payload['identifier']
+    if target.id != @contact.id
+      @contact = ContactMergeAction.new(
+        account: @web_widget.inbox.account,
+        base_contact: target,
+        mergee_contact: @contact
+      ).perform
+    end
+    return if payload['identifier'].blank? || @contact.identifier.present?
 
-    # `update`, not `update!`: a THIRD contact can be holding the value right now — an earlier
-    # resolve of this same lead already created the orphan this change exists to prevent, and its
-    # token can still be live. `identifier` is unique per account, so restoring would raise, and a
-    # 422 out of this endpoint is worse than the state it was trying to repair: the lead cannot even
-    # enter the widget. Measured — without this the spec above answers 422 instead of 200.
-    return false unless target.update(identifier: payload['identifier'])
-
-    true
+    # Deliberately not `update!`, and the result is deliberately not checked: a THIRD contact can be
+    # holding this value right now — an earlier resolve of this same lead may have created exactly the
+    # orphan this prevents, and its token can still be live. `identifier` is unique per account, so a
+    # bang answers 422 out of the widget endpoint, which is worse than the state it was repairing:
+    # the lead cannot enter the chat at all. The unification already happened above and stands either
+    # way; the identifier is a convenience for the next mint, which settles it again anyway.
+    # rubocop:disable Rails/SaveBang
+    @contact.update(identifier: payload['identifier'])
+    # rubocop:enable Rails/SaveBang
   end
 
   # The order here is load-bearing. AgentBotListener is on the SYNC dispatcher, so the payload a

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   private
 
   def identify_from_token(payload)
-    if payload['identifier'].present? && @contact.identifier.present? && @contact.identifier != payload['identifier']
+    if another_identity?(payload)
       @contact_inbox, @widget_auth_token = build_contact_inbox_with_token(@web_widget)
       @contact = @contact_inbox.contact
     end
@@ -32,6 +32,25 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
       params: { identifier: payload['identifier'] },
       discard_invalid_attrs: true
     ).perform
+  end
+
+  # IS THIS BROWSER ALREADY SOMEBODY ELSE? If so the redirect starts a fresh session rather than
+  # writing over the identity sitting there.
+  #
+  # It has to ask BOTH ways the token can name an identity. Keying on the identifier alone was enough
+  # while that was the only one, and stopped being enough the moment a token could name a contact
+  # without carrying an identifier at all: an already-identified customer then walked past this guard
+  # and became the MERGEE below, so its conversations, inboxes and messages moved onto the named
+  # target and its contact was destroyed — a link meant for someone else taking a customer's history
+  # with it.
+  def another_identity?(payload)
+    return false if @contact.identifier.blank?
+
+    if payload['identified_contact_id'].present?
+      @contact.id != payload['identified_contact_id']
+    else
+      payload['identifier'].present? && @contact.identifier != payload['identifier']
+    end
   end
 
   # THE VISITOR JOINS THE CONTACT THE TOKEN NAMES, and does not merely claim to be it.
@@ -70,9 +89,14 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
     # bang answers 422 out of the widget endpoint, which is worse than the state it was repairing:
     # the lead cannot enter the chat at all. The unification already happened above and stands either
     # way; the identifier is a convenience for the next mint, which settles it again anyway.
-    # rubocop:disable Rails/SaveBang
-    @contact.update(identifier: payload['identifier'])
-    # rubocop:enable Rails/SaveBang
+    return if @contact.update(identifier: payload['identifier'])
+
+    # A refused write leaves the attempted value DIRTY on this instance, and this instance is what
+    # the cloned message is created with. `Message.create!` builds its payload from it and the SYNC
+    # dispatcher hands that to agent bots and websockets, so the rejected identifier would be
+    # announced as though it had been stored — and the message's own save re-runs the uniqueness
+    # validation and answers 422, which is what the spec measured before this line existed.
+    @contact.restore_attributes
   end
 
   # The order here is load-bearing. AgentBotListener is on the SYNC dispatcher, so the payload a

--- a/app/controllers/api/v1/widget/redirect_tokens_controller.rb
+++ b/app/controllers/api/v1/widget/redirect_tokens_controller.rb
@@ -44,13 +44,24 @@ class Api::V1::Widget::RedirectTokensController < Api::V1::Widget::BaseControlle
   # target and its contact was destroyed — a link meant for someone else taking a customer's history
   # with it.
   def another_identity?(payload)
-    return false if @contact.identifier.blank?
+    return established_identity? && @contact.id != payload['identified_contact_id'] if payload['identified_contact_id'].present?
 
-    if payload['identified_contact_id'].present?
-      @contact.id != payload['identified_contact_id']
-    else
-      payload['identifier'].present? && @contact.identifier != payload['identifier']
-    end
+    payload['identifier'].present? && @contact.identifier.present? && @contact.identifier != payload['identifier']
+  end
+
+  # WHAT COUNTS AS "already somebody", and why it is three fields rather than one.
+  #
+  # `ContactIdentifyAction` merges on identifier, email AND phone_number, so all three are identities
+  # this account already resolved — a pre-chat form leaves a contact carrying an email or a phone and
+  # no identifier at all. Asking only about the identifier read that contact as anonymous, and
+  # anonymous is the one thing the named-contact branch may consume, so a customer established by the
+  # pre-chat form had its conversations moved onto an unrelated contact and its own row destroyed.
+  #
+  # Only the named-contact branch asks this. The identifier-only path above keeps the exact predicate
+  # it always had: there, a contact carrying an email and no identifier is SUPPOSED to fall through to
+  # the action, which may then merge it by email.
+  def established_identity?
+    @contact.identifier.present? || @contact.email.present? || @contact.phone_number.present?
   end
 
   # THE VISITOR JOINS THE CONTACT THE TOKEN NAMES, and does not merely claim to be it.

--- a/spec/controllers/api/v1/accounts/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/redirect_tokens_controller_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe 'Api::V1::Accounts::RedirectTokensController', type: :request do
         expect(body['expires_in']).to eq(Widget::RedirectToken::DEFAULT_TTL)
         expect(body['website_url']).to eq(web_widget.website_url)
         expect(Widget::RedirectToken.consume(body['token']))
-          .to eq('inbox_id' => web_widget.inbox.id, 'identifier' => 'user-1', 'message' => 'Hi')
+          .to eq('inbox_id' => web_widget.inbox.id, 'identifier' => 'user-1', 'message' => 'Hi',
+                 'identified_contact_id' => nil)
       end
 
       it 'honours a custom ttl_seconds' do
@@ -67,7 +68,10 @@ RSpec.describe 'Api::V1::Accounts::RedirectTokensController', type: :request do
              as: :json
 
         token = response.parsed_body['token']
-        expect(Widget::RedirectToken.consume(token)).to eq('inbox_id' => web_widget.inbox.id, 'identifier' => 'user-1')
+        # `identified_contact_id` is not one of them: a nil there is this endpoint's ANSWER, and the
+        # resolve side reads its absence as "minted before the field existed".
+        expect(Widget::RedirectToken.consume(token))
+          .to eq('inbox_id' => web_widget.inbox.id, 'identifier' => 'user-1', 'identified_contact_id' => nil)
       end
 
       it 'rejects a non web widget inbox' do
@@ -148,6 +152,57 @@ RSpec.describe 'Api::V1::Accounts::RedirectTokensController', type: :request do
              as: :json
 
         expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    # THE CONTACT THE LINK IS FOR, NAMED AT THE ONE MOMENT IT IS KNOWN (fazer-ai/agents#286).
+    #
+    # `identifier` is the only thing the resolve side had to go on, and it is derived from a
+    # sequential contact id, so it is guessable and it can move. The mint is the account-authenticated
+    # half of the flow: whoever calls it already proved they may act on this account, so the contact
+    # it resolves here is a fact the widget side can spend, and one nothing reaching the widget can
+    # forge.
+    context 'when the identifier belongs to a contact' do
+      let!(:holder) { create(:contact, account: account, identifier: 'fzwa:99') }
+
+      it 'names that contact in the token payload' do
+        post "/api/v1/accounts/#{account.id}/redirect_tokens",
+             headers: admin.create_new_auth_token,
+             params: { inbox_id: web_widget.inbox.id, identifier: 'fzwa:99' },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(Widget::RedirectToken.consume(response.parsed_body['token'])['identified_contact_id'])
+          .to eq(holder.id)
+      end
+
+      it 'never names a contact from another account' do
+        other = create(:contact, account: create(:account), identifier: 'fzwa:99')
+
+        post "/api/v1/accounts/#{account.id}/redirect_tokens",
+             headers: admin.create_new_auth_token,
+             params: { inbox_id: web_widget.inbox.id, identifier: 'fzwa:99' },
+             as: :json
+
+        payload = Widget::RedirectToken.consume(response.parsed_body['token'])
+        expect(payload['identified_contact_id']).to eq(holder.id)
+        expect(payload['identified_contact_id']).not_to eq(other.id)
+      end
+    end
+
+    context 'when no contact holds the identifier' do
+      # A nil, not an absent key: the resolve side has to tell "this mint looked and found nobody"
+      # from "this token predates the field", and only the second one may keep the old behaviour.
+      it 'says so with a nil, rather than leaving the question unasked' do
+        post "/api/v1/accounts/#{account.id}/redirect_tokens",
+             headers: admin.create_new_auth_token,
+             params: { inbox_id: web_widget.inbox.id, identifier: 'fzwa:nobody' },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        payload = Widget::RedirectToken.consume(response.parsed_body['token'])
+        expect(payload).to have_key('identified_contact_id')
+        expect(payload['identified_contact_id']).to be_nil
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/redirect_tokens_controller_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe 'Api::V1::Accounts::RedirectTokensController', type: :request do
         expect(body['expires_in']).to eq(Widget::RedirectToken::DEFAULT_TTL)
         expect(body['website_url']).to eq(web_widget.website_url)
         expect(Widget::RedirectToken.consume(body['token']))
-          .to eq('inbox_id' => web_widget.inbox.id, 'identifier' => 'user-1', 'message' => 'Hi',
-                 'identified_contact_id' => nil)
+          .to eq('inbox_id' => web_widget.inbox.id, 'identifier' => 'user-1', 'message' => 'Hi')
       end
 
       it 'honours a custom ttl_seconds' do
@@ -68,10 +67,7 @@ RSpec.describe 'Api::V1::Accounts::RedirectTokensController', type: :request do
              as: :json
 
         token = response.parsed_body['token']
-        # `identified_contact_id` is not one of them: a nil there is this endpoint's ANSWER, and the
-        # resolve side reads its absence as "minted before the field existed".
-        expect(Widget::RedirectToken.consume(token))
-          .to eq('inbox_id' => web_widget.inbox.id, 'identifier' => 'user-1', 'identified_contact_id' => nil)
+        expect(Widget::RedirectToken.consume(token)).to eq('inbox_id' => web_widget.inbox.id, 'identifier' => 'user-1')
       end
 
       it 'rejects a non web widget inbox' do
@@ -155,54 +151,50 @@ RSpec.describe 'Api::V1::Accounts::RedirectTokensController', type: :request do
       end
     end
 
-    # THE CONTACT THE LINK IS FOR, NAMED AT THE ONE MOMENT IT IS KNOWN (fazer-ai/agents#286).
+    # THE CONTACT THE LINK IS FOR (fazer-ai/agents#286).
     #
-    # `identifier` is the only thing the resolve side had to go on, and it is derived from a
-    # sequential contact id, so it is guessable and it can move. The mint is the account-authenticated
-    # half of the flow: whoever calls it already proved they may act on this account, so the contact
-    # it resolves here is a fact the widget side can spend, and one nothing reaching the widget can
-    # forge.
-    context 'when the identifier belongs to a contact' do
-      let!(:holder) { create(:contact, account: account, identifier: 'fzwa:99') }
+    # Named by the caller, because only the caller knows: the resolve side had the `identifier` to go
+    # on, and that value is derived from a sequential contact id, so it is guessable and it can move.
+    # This endpoint is account-authenticated, so what it is told here is a fact the widget side can
+    # spend.
+    context 'when the caller names the contact the link is for' do
+      let(:lead) { create(:contact, account: account, identifier: 'fzwa:99') }
 
-      it 'names that contact in the token payload' do
+      it 'carries it in the token payload' do
         post "/api/v1/accounts/#{account.id}/redirect_tokens",
              headers: admin.create_new_auth_token,
-             params: { inbox_id: web_widget.inbox.id, identifier: 'fzwa:99' },
+             params: { inbox_id: web_widget.inbox.id, identifier: 'fzwa:99', contact_id: lead.id },
              as: :json
 
         expect(response).to have_http_status(:success)
         expect(Widget::RedirectToken.consume(response.parsed_body['token'])['identified_contact_id'])
-          .to eq(holder.id)
+          .to eq(lead.id)
       end
 
-      it 'never names a contact from another account' do
-        other = create(:contact, account: create(:account), identifier: 'fzwa:99')
+      it 'refuses a contact from another account instead of naming it' do
+        theirs = create(:contact, account: create(:account))
 
         post "/api/v1/accounts/#{account.id}/redirect_tokens",
              headers: admin.create_new_auth_token,
-             params: { inbox_id: web_widget.inbox.id, identifier: 'fzwa:99' },
+             params: { inbox_id: web_widget.inbox.id, identifier: 'fzwa:99', contact_id: theirs.id },
              as: :json
 
-        payload = Widget::RedirectToken.consume(response.parsed_body['token'])
-        expect(payload['identified_contact_id']).to eq(holder.id)
-        expect(payload['identified_contact_id']).not_to eq(other.id)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
-    context 'when no contact holds the identifier' do
-      # A nil, not an absent key: the resolve side has to tell "this mint looked and found nobody"
-      # from "this token predates the field", and only the second one may keep the old behaviour.
-      it 'says so with a nil, rather than leaving the question unasked' do
+    # The omission is the older, looser contract and it stays: a caller minting a deep link for an
+    # identity this account has never seen wants the resolve to create it.
+    context 'when the caller names no contact' do
+      it 'leaves the key out of the payload' do
         post "/api/v1/accounts/#{account.id}/redirect_tokens",
              headers: admin.create_new_auth_token,
-             params: { inbox_id: web_widget.inbox.id, identifier: 'fzwa:nobody' },
+             params: { inbox_id: web_widget.inbox.id, identifier: 'crm-user-42' },
              as: :json
 
         expect(response).to have_http_status(:success)
-        payload = Widget::RedirectToken.consume(response.parsed_body['token'])
-        expect(payload).to have_key('identified_contact_id')
-        expect(payload['identified_contact_id']).to be_nil
+        expect(Widget::RedirectToken.consume(response.parsed_body['token']))
+          .not_to have_key('identified_contact_id')
       end
     end
   end

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -415,21 +415,35 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
 
     # THE ORPHAN THIS ENDPOINT USED TO CREATE (fazer-ai/agents#286, split out of #269).
     #
-    # `ContactIdentifyAction` MERGES when somebody already holds the identifier and ASSIGNS when
-    # nobody does. A `fzwa:` value belongs to one WhatsApp contact by construction, so the assigning
-    # half hands the widget visitor a value that is not its own: the lead ends up with two contacts,
-    # and every later redirect for it collides on an identifier its own earlier crossing is squatting.
+    # `ContactIdentifyAction` decides by the identifier: it MERGES the visitor onto whoever holds the
+    # value and ASSIGNS the value when nobody does. For a redirect minted FOR a contact, assigning is
+    # wrong — the value belongs to that contact by construction, so a browser session that merely
+    # presented a token walks away holding it, and the lead ends up with two contacts, the second
+    # squatting the identifier every later redirect for it needs.
     #
-    # Reproduced against this controller before the fix: with nobody holding the identifier, the
-    # resolve left 2 contacts, the WhatsApp one carrying no identifier and the visitor holding the
-    # `fzwa:` value derived from its id. That is the state the report measured in production and that
-    # #272 could not reproduce.
-    #
-    # The token is what closes it, because the mint is account-authenticated and names the contact.
+    # Reproduced against this controller before the fix: with nobody holding the identifier, a resolve
+    # left 2 contacts, the lead carrying none and the visitor holding the lead's `fzwa:` value. That is
+    # the production state #269 measured and #272 could not reproduce.
     context 'when the token names the contact it was minted for' do
       let(:lead) { create(:contact, account: account, identifier: 'fzwa:77') }
 
-      it 'unifies the visitor onto it even when the identifier is no longer there' do
+      it 'unifies the visitor onto it when the identifier is where it should be' do
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:77', 'identified_contact_id' => lead.id }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(Contact.exists?(contact.id)).to be(false)
+        expect(account.contacts.count).to eq(1)
+      end
+
+      it 'unifies onto it even when the identifier is no longer there, and restores the value' do
         lead.update!(identifier: nil)
         contact_inbox
         redirect_token = Widget::RedirectToken.generate(
@@ -447,8 +461,28 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(lead.reload.identifier).to eq('fzwa:77')
       end
 
-      it 'still unifies on the ordinary path, where the identifier is where it should be' do
-        lead
+      # Identifiers are mutable through the contacts API and the ingestion services, and a link from
+      # yesterday is not evidence about who this contact says it is today.
+      it 'never overwrites an identifier the contact has since been given' do
+        lead.update!(identifier: 'crm-7788')
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:77', 'identified_contact_id' => lead.id }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(lead.reload.identifier).to eq('crm-7788')
+        expect(Contact.exists?(contact.id)).to be(false)
+      end
+
+      it 'unifies without raising when a third contact took the value meanwhile' do
+        lead.update!(identifier: nil)
+        squatter = create(:contact, account: account, identifier: 'fzwa:77')
         contact_inbox
         redirect_token = Widget::RedirectToken.generate(
           { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:77', 'identified_contact_id' => lead.id }
@@ -461,10 +495,14 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
 
         expect(response).to have_http_status(:success)
         expect(Contact.exists?(contact.id)).to be(false)
-        expect(account.contacts.count).to eq(1)
+        # WHERE the visitor landed is the whole assertion: identifying by the identifier would have
+        # merged it onto the squatter, which holds the value and is not this lead.
+        expect(contact_inbox.reload.contact_id).to eq(lead.id)
+        expect(lead.reload.identifier).to be_nil
+        expect(squatter.reload.identifier).to eq('fzwa:77')
       end
 
-      it 'leaves the visitor unidentified when the named contact is gone' do
+      it 'identifies nobody when the named contact is gone' do
         gone_id = lead.id
         lead.destroy!
         contact_inbox
@@ -480,31 +518,15 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(response).to have_http_status(:success)
         expect(contact.reload.identifier).to be_nil
       end
-
-      it 'refuses rather than raising when a third contact took the value meanwhile' do
-        lead.update!(identifier: nil)
-        create(:contact, account: account, identifier: 'fzwa:77')
-        contact_inbox
-        redirect_token = Widget::RedirectToken.generate(
-          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:77', 'identified_contact_id' => lead.id }
-        )
-
-        post '/api/v1/widget/redirect_token',
-             params: { website_token: web_widget.website_token, token: redirect_token },
-             headers: { 'X-Auth-Token' => token },
-             as: :json
-
-        expect(response).to have_http_status(:success)
-        expect(contact.reload.identifier).to be_nil
-        expect(lead.reload.identifier).to be_nil
-      end
     end
 
-    context 'when the mint found no contact holding the identifier' do
-      it 'does not hand the visitor an identifier nobody holds' do
+    # The older, looser contract, and it is the reason the field is optional: a deep link minted for
+    # an identity this account has never seen still creates it.
+    context 'when the token names no contact' do
+      it 'still establishes a brand-new identity on the visitor' do
         contact_inbox
         redirect_token = Widget::RedirectToken.generate(
-          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:404', 'identified_contact_id' => nil }
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'crm-user-42' }
         )
 
         post '/api/v1/widget/redirect_token',
@@ -513,28 +535,7 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
              as: :json
 
         expect(response).to have_http_status(:success)
-        expect(contact.reload.identifier).to be_nil
-        expect(account.contacts.where(identifier: 'fzwa:404')).to be_empty
-      end
-    end
-
-    # Tokens live up to 24h, so a deploy leaves links already in customers' hands carrying a payload
-    # minted before the field existed. Those keep identifying, because breaking a day of live links
-    # to close a hole is a worse trade than the hole staying open for that day.
-    context 'when the token predates the identified-contact field' do
-      it 'identifies the way it always did' do
-        contact_inbox
-        redirect_token = Widget::RedirectToken.generate(
-          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:legacy' }
-        )
-
-        post '/api/v1/widget/redirect_token',
-             params: { website_token: web_widget.website_token, token: redirect_token },
-             headers: { 'X-Auth-Token' => token },
-             as: :json
-
-        expect(response).to have_http_status(:success)
-        expect(contact.reload.identifier).to eq('fzwa:legacy')
+        expect(contact.reload.identifier).to eq('crm-user-42')
       end
     end
   end

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -412,5 +412,130 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(contact.contact_inboxes.count).to eq(1)
       end
     end
+
+    # THE ORPHAN THIS ENDPOINT USED TO CREATE (fazer-ai/agents#286, split out of #269).
+    #
+    # `ContactIdentifyAction` MERGES when somebody already holds the identifier and ASSIGNS when
+    # nobody does. A `fzwa:` value belongs to one WhatsApp contact by construction, so the assigning
+    # half hands the widget visitor a value that is not its own: the lead ends up with two contacts,
+    # and every later redirect for it collides on an identifier its own earlier crossing is squatting.
+    #
+    # Reproduced against this controller before the fix: with nobody holding the identifier, the
+    # resolve left 2 contacts, the WhatsApp one carrying no identifier and the visitor holding the
+    # `fzwa:` value derived from its id. That is the state the report measured in production and that
+    # #272 could not reproduce.
+    #
+    # The token is what closes it, because the mint is account-authenticated and names the contact.
+    context 'when the token names the contact it was minted for' do
+      let(:lead) { create(:contact, account: account, identifier: 'fzwa:77') }
+
+      it 'unifies the visitor onto it even when the identifier is no longer there' do
+        lead.update!(identifier: nil)
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:77', 'identified_contact_id' => lead.id }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(Contact.exists?(contact.id)).to be(false)
+        expect(account.contacts.count).to eq(1)
+        expect(lead.reload.identifier).to eq('fzwa:77')
+      end
+
+      it 'still unifies on the ordinary path, where the identifier is where it should be' do
+        lead
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:77', 'identified_contact_id' => lead.id }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(Contact.exists?(contact.id)).to be(false)
+        expect(account.contacts.count).to eq(1)
+      end
+
+      it 'leaves the visitor unidentified when the named contact is gone' do
+        gone_id = lead.id
+        lead.destroy!
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:77', 'identified_contact_id' => gone_id }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(contact.reload.identifier).to be_nil
+      end
+
+      it 'refuses rather than raising when a third contact took the value meanwhile' do
+        lead.update!(identifier: nil)
+        create(:contact, account: account, identifier: 'fzwa:77')
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:77', 'identified_contact_id' => lead.id }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(contact.reload.identifier).to be_nil
+        expect(lead.reload.identifier).to be_nil
+      end
+    end
+
+    context 'when the mint found no contact holding the identifier' do
+      it 'does not hand the visitor an identifier nobody holds' do
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:404', 'identified_contact_id' => nil }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(contact.reload.identifier).to be_nil
+        expect(account.contacts.where(identifier: 'fzwa:404')).to be_empty
+      end
+    end
+
+    # Tokens live up to 24h, so a deploy leaves links already in customers' hands carrying a payload
+    # minted before the field existed. Those keep identifying, because breaking a day of live links
+    # to close a hole is a worse trade than the hole staying open for that day.
+    context 'when the token predates the identified-contact field' do
+      it 'identifies the way it always did' do
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:legacy' }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(contact.reload.identifier).to eq('fzwa:legacy')
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -529,6 +529,58 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(stranger.reload.identifier).to eq('crm-stranger')
       end
 
+      # The lead clicking its own link again, in the browser it already crossed on. There is no other
+      # identity to protect here, so the session is kept rather than replaced: without the id
+      # comparison this branch would mint a throwaway contact and a fresh auth token on every click,
+      # and then merge it straight back.
+      it 'keeps the session when it is already the named contact' do
+        contact.update!(identifier: 'fzwa:55')
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identified_contact_id' => contact.id }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body['widget_auth_token']).to be_nil
+        expect(Contact.exists?(contact.id)).to be(true)
+        expect(contact_inbox.reload.contact_id).to eq(contact.id)
+      end
+
+      # THE SAME QUESTION, ASKED OF EVERY FIELD THAT ANSWERS IT.
+      #
+      # `ContactIdentifyAction` merges on three attributes — identifier, email and phone_number — so
+      # those three are what \"this browser is already somebody\" means. Asking only about the
+      # identifier left a pre-chat contact (email or phone, no identifier) reading as anonymous, and
+      # an anonymous session is the one thing this branch may consume: it became the mergee and its
+      # history moved onto a contact it has nothing to do with.
+      %i[email phone_number].each do |field|
+        it "does not swallow a customer established by #{field} alone" do
+          value = field == :email ? 'someone@example.com' : '+553299887766'
+          stranger = create(:contact, :account => account, field => value)
+          stranger_inbox = create(:contact_inbox, contact: stranger, inbox: web_widget.inbox)
+          stranger_token = Widget::TokenService.new(
+            payload: { source_id: stranger_inbox.source_id, inbox_id: web_widget.inbox.id }
+          ).generate_token
+          redirect_token = Widget::RedirectToken.generate(
+            { 'inbox_id' => web_widget.inbox.id, 'identified_contact_id' => lead.id }
+          )
+
+          post '/api/v1/widget/redirect_token',
+               params: { website_token: web_widget.website_token, token: redirect_token },
+               headers: { 'X-Auth-Token' => stranger_token },
+               as: :json
+
+          expect(response).to have_http_status(:success)
+          expect(Contact.exists?(stranger.id)).to be(true)
+          expect(stranger.reload.public_send(field)).to eq(value)
+        end
+      end
+
       # The rejected value must not ride out on the cloned message either: `Message.create!` builds
       # its payload from this very object, and the SYNC dispatcher hands it to agent bots and
       # websockets before anything reloads.

--- a/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/widget/redirect_tokens_controller_spec.rb
@@ -502,6 +502,56 @@ RSpec.describe 'Api::V1::Widget::RedirectTokensController', type: :request do
         expect(squatter.reload.identifier).to eq('fzwa:77')
       end
 
+      # A SESSION ALREADY LOGGED IN AS SOMEBODY ELSE IS NOT THE MERGEE.
+      #
+      # The fresh-session guard above keys on the identifier, so a token that names a contact and
+      # carries no identifier walked straight past it: the browser's own identified customer became
+      # the mergee, and the merge moved ITS conversations, inboxes and messages onto the named target
+      # and destroyed it. Clicking a link meant for someone else would take a customer's history with
+      # it.
+      it 'does not swallow a customer who is already identified as somebody else' do
+        stranger = create(:contact, account: account, identifier: 'crm-stranger')
+        stranger_inbox = create(:contact_inbox, contact: stranger, inbox: web_widget.inbox)
+        stranger_token = Widget::TokenService.new(
+          payload: { source_id: stranger_inbox.source_id, inbox_id: web_widget.inbox.id }
+        ).generate_token
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identified_contact_id' => lead.id }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => stranger_token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(Contact.exists?(stranger.id)).to be(true)
+        expect(stranger.reload.identifier).to eq('crm-stranger')
+      end
+
+      # The rejected value must not ride out on the cloned message either: `Message.create!` builds
+      # its payload from this very object, and the SYNC dispatcher hands it to agent bots and
+      # websockets before anything reloads.
+      it 'does not announce an identifier the database refused' do
+        lead.update!(identifier: nil)
+        create(:contact, account: account, identifier: 'fzwa:77')
+        contact_inbox
+        redirect_token = Widget::RedirectToken.generate(
+          { 'inbox_id' => web_widget.inbox.id, 'identifier' => 'fzwa:77',
+            'identified_contact_id' => lead.id, 'message' => 'Hello' }
+        )
+
+        post '/api/v1/widget/redirect_token',
+             params: { website_token: web_widget.website_token, token: redirect_token },
+             headers: { 'X-Auth-Token' => token },
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        conversation = Conversation.find_by(display_id: response.parsed_body['conversation_id'])
+        cloned = conversation.messages.find_by(content: 'Hello')
+        expect(cloned.sender.identifier).to be_nil
+      end
+
       it 'identifies nobody when the named contact is gone' do
         gone_id = lead.id
         lead.destroy!


### PR DESCRIPTION
A lead that crosses from WhatsApp into the website chat is supposed to come out the other side as one
person. Sometimes it came out as two: the WhatsApp contact it keeps writing on, plus a widget contact
holding the identifier that belonged to the first one — carrying a slice of history connected to
nothing, and squatting the value every later redirect for that lead needs.

## How to reproduce

Resolve a redirect token whose identifier no contact holds at that moment.

`ContactIdentifyAction` decides by the identifier: it **merges** the visitor onto whoever holds the
value and **assigns** the value when nobody does. Assigning is right for a self-declared `setUser`
identity and wrong for a link minted *for* a contact — the value belongs to that contact, so a browser
session that merely presented a token walks away holding it.

Measured against this endpoint before the change: with nobody holding the identifier, the resolve left
**2 contacts**, the lead carrying none and the visitor holding the lead's `fzwa:` value. That is the
production state reported in fazer-ai/agents#269.

## What changed

The mint already knows whose identity the link carries, and it is the half of the flow that can be
trusted with it: `POST /api/v1/accounts/:id/redirect_tokens` is account-authenticated. It now accepts
an optional `contact_id`, records it in the token payload (single-use, server-side, never readable by
the widget), and the resolve merges onto **that contact** rather than onto whoever the identifier
currently points at.

| the token says | the resolve does |
| --- | --- |
| a contact that still holds the identifier | merges the visitor onto it, as before |
| a contact that no longer holds it | merges onto it anyway, and restores the value if the contact has none |
| a contact carrying a *different* identifier | merges onto it and leaves that identifier alone |
| a contact that no longer exists | identifies nobody |
| no `contact_id` at all | identifies exactly as it always did |

**The omission is the older contract, and it stays.** A caller minting a pre-authenticated deep link
for an identity this account has never seen (a CRM handing off `crm-user-42`) wants the resolve to
create it. Only a caller that names a contact is asking for the stricter rule.

Two things the named-contact branch has to get right, both of which destroy data if it does not:

- **A browser already identified as somebody else is never the mergee.** The fresh-session guard used
  to key on the identifier alone, so a token naming a contact and carrying no identifier walked past
  it and the merge moved that customer's conversations, inboxes and messages onto the named target
  before destroying its contact. "Already somebody" now means the three attributes
  `ContactIdentifyAction` itself merges on — identifier, email, phone_number — because a pre-chat
  contact carries an email or a phone and no identifier at all.
- **A refused identifier write does not ride out on the message.** Restoring the value is best-effort
  (`update`, not `update!`) because a third contact can be holding it — an earlier resolve may have
  created exactly the orphan this prevents. A refused write leaves the attempted value dirty on the
  in-memory contact, and the cloned message is created from that object: its own save re-runs the
  uniqueness validation and answers 422. `restore_attributes` closes it.

No migration, no upstream file touched, and `ContactIdentifyAction` is unchanged — its other four
callers (widget messages, contacts, conversations, public inboxes) keep the behaviour they have.

## Related

- fazer-ai/agents#286 — the issue both halves close; the agents side is fazer-ai/agents#383, which
  names the contact when it mints. That PR carries the `Fixes`, since the repair only exists once
  both are deployed.
- fazer-ai/agents#272 — kept the funnel alive by taking `fzwa:<X>:<random>` when the value was
  squatted, and recorded that it could not reproduce how the identifier got there. This is that path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/425)
<!-- Reviewable:end -->
