### PR TITLE
fix(saml): report only a rejected assertion as a failed sign-in

### DIFF
--- a/enterprise/app/builders/saml_user_builder.rb
+++ b/enterprise/app/builders/saml_user_builder.rb
@@ -64,6 +64,14 @@ class SamlUserBuilder
       password: SecureRandom.hex(32),
       confirmed_at: Time.current
     )
+  # The only attributes here that come from the assertion are the email and the name, so a
+  # record Rails refuses is the IdP sending something unusable -- a failed sign-in, which is
+  # what `AuthenticationFailed` already means. Deliberately narrow: `add_user_to_account`
+  # and the two existing-user updates raise the same class for reasons that are ours (a
+  # missing custom role, a callback, a user row that was already invalid), and those must
+  # keep failing loudly instead of being answered with a login error.
+  rescue ActiveRecord::RecordInvalid
+    raise AuthenticationFailed, I18n.t('auth.saml.authentication_failed')
   end
 
   def add_user_to_account

--- a/enterprise/app/controllers/enterprise/devise_overrides/omniauth_callbacks_controller.rb
+++ b/enterprise/app/controllers/enterprise/devise_overrides/omniauth_callbacks_controller.rb
@@ -53,11 +53,7 @@ module Enterprise::DeviseOverrides::OmniauthCallbacksController
     return sign_in_saml_user(relay_state) if @resource.persisted?
 
     handle_saml_auth_error(relay_state, 'saml-authentication-failed')
-  # `create_user` builds the record straight off the assertion and saves it with `User.create!`,
-  # so an IdP sending an address Rails will not accept raises out of the builder rather than
-  # coming back unsaved. That is a failed sign-in like any other: without this it leaves the
-  # browser on a 500 instead of the login page, and the `persisted?` branch above is unreachable.
-  rescue SamlUserBuilder::AuthenticationFailed, ActiveRecord::RecordInvalid
+  rescue SamlUserBuilder::AuthenticationFailed
     handle_saml_auth_error(relay_state, 'saml-authentication-failed')
   end
 

--- a/spec/enterprise/builders/saml_user_builder_spec.rb
+++ b/spec/enterprise/builders/saml_user_builder_spec.rb
@@ -284,19 +284,31 @@ RSpec.describe SamlUserBuilder do
     end
 
     # `create_user` saves with `User.create!`, so a record Rails refuses raises instead of
-    # coming back unsaved. The controller turns that into the ordinary failed-sign-in
-    # redirect; see the omniauth callbacks spec.
+    # coming back unsaved. Reported as a rejected assertion, which is what it is; the
+    # controller answers that with the ordinary login error.
     context 'when the user cannot be created' do
       before { allow(User).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(User.new)) }
 
-      it 'raises instead of returning an unsaved user' do
-        expect { builder.perform }.to raise_error(ActiveRecord::RecordInvalid)
+      it 'reports a failed authentication instead of returning an unsaved user' do
+        expect { builder.perform }.to raise_error(described_class::AuthenticationFailed)
       end
 
       it 'does not create an account association' do
         expect do
-          expect { builder.perform }.to raise_error(ActiveRecord::RecordInvalid)
+          expect { builder.perform }.to raise_error(described_class::AuthenticationFailed)
         end.not_to change(AccountUser, :count)
+      end
+    end
+
+    # The mirror of the above, and the reason the rescue sits on `create_user` rather than
+    # around the whole builder: a failure here is ours, not the IdP's, and it happens after
+    # the user has already been committed. Answering it with a login error would hide a
+    # broken role mapping or a failing callback behind "authentication failed".
+    context 'when adding the user to the account fails' do
+      it 'lets the failure through instead of reporting a failed authentication' do
+        allow(AccountUser).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordInvalid.new(AccountUser.new))
+
+        expect { builder.perform }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end


### PR DESCRIPTION
Follow-up on #423, from a review round that only ran after it merged (the reviewer was out of quota at merge time). The finding is correct and the fix in #423 was too broad.

## What was wrong

#423 fixed a real bug: `SamlUserBuilder` saves with `User.create!`, so an IdP sending an address Rails will not accept raised out of the builder and left the browser on a 500 instead of the login page. It fixed it by widening the controller's rescue:

```ruby
rescue SamlUserBuilder::AuthenticationFailed, ActiveRecord::RecordInvalid
```

That rescue covers the whole of `handle_saml_auth`, and `SamlUserBuilder#perform` does considerably more than read the assertion. `confirm_user_if_required` calls `user.save!`, `convert_existing_user_to_saml` calls `user.update!`, and `add_user_to_account` calls `AccountUser.find_or_create_by!` plus `account_user.update!` for the role mapping. Every one of those raises `ActiveRecord::RecordInvalid`, and every one of them does so for a reason that is ours, not the IdP's: a role mapping pointing at a custom role that does not exist, a failing callback, a user row that was already invalid.

`add_user_to_account` is the sharp one. It runs *after* the user has been created and committed, so a broken role mapping produced `?error=saml-authentication-failed` while the user it claims not to have authenticated sits in the database. A setup bug wearing an authentication error's clothes.

## The change

The rescue moves onto `create_user`, the single place whose input comes from the assertion, and reports it as `AuthenticationFailed` -- which is the vocabulary the builder already has for "this assertion cannot sign anybody in", and which the controller has always handled. The controller goes back to its original single rescue.

Checked the other three bang calls in the builder one at a time; all three are ours to fix loudly, so none of them is included.

## Tests

The two builder examples now assert `AuthenticationFailed`. A new one asserts the mirror: a failure in `add_user_to_account` comes through as `ActiveRecord::RecordInvalid` rather than being converted. The request spec for the redirect is unchanged and still passes, which is the point -- the user-visible behaviour #423 fixed is preserved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/427)
<!-- Reviewable:end -->
