### PR TITLE
fix(conversations): reconcile the tab when the socket comes back

### DIFF
--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -44,6 +44,7 @@ import { useEmitter } from 'dashboard/composables/emitter';
 import { useConversationRequiredAttributes } from 'dashboard/composables/useConversationRequiredAttributes';
 
 import { emitter } from 'shared/helpers/mitt';
+import { BUS_EVENTS } from 'shared/constants/busEvents';
 
 import ConversationAPI from 'dashboard/api/inbox/conversation';
 import wootConstants from 'dashboard/constants/globals';
@@ -897,6 +898,13 @@ watch(conversationList, list => {
     .forEach(deSelectConversation);
 });
 
+// Reconciliation removed the conversation the panel is showing: the server no longer serves it to
+// this agent, deleted or no longer permitted, so leaving it open would keep a panel the next action
+// on it would fail against.
+useEmitter(BUS_EVENTS.OPEN_CONVERSATION_GONE, () =>
+  redirectToConversationList()
+);
+
 useEmitter('fetch_conversation_stats', () => {
   if (hasAppliedFiltersOrActiveFolders.value) return;
   store.dispatch('conversationStats/get', conversationFilters.value);
@@ -919,21 +927,7 @@ const reconcileTab = debounce(
     if (chatListLoading.value || hasAppliedFiltersOrActiveFolders.value) return;
     if (conversationList.value.length <= activeAssigneeTabCount.value) return;
 
-    const removed = await store.dispatch(
-      'reconcileConversationTab',
-      conversationFilters.value
-    );
-    if (!removed.length) return;
-
-    // Removed means the server no longer serves it to this agent, deleted or no longer permitted,
-    // so leaving it open would keep a panel the next action on it would fail against.
-    // Half the conversation routes name it `conversationId` (team, mentions, unattended,
-    // participating) and half `conversation_id`; reading one leaves the panel pointed at a
-    // conversation the store no longer has.
-    const openId = Number(
-      route.params.conversation_id ?? route.params.conversationId
-    );
-    if (removed.some(({ id }) => id === openId)) redirectToConversationList();
+    await store.dispatch('reconcileConversationTab', conversationFilters.value);
   },
   2000,
   false

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -919,9 +919,6 @@ const reconcileTab = debounce(
     if (chatListLoading.value || hasAppliedFiltersOrActiveFolders.value) return;
     if (conversationList.value.length <= activeAssigneeTabCount.value) return;
 
-    const { MENTION, PARTICIPATING } = wootConstants.CONVERSATION_TYPE;
-    if ([MENTION, PARTICIPATING].includes(props.conversationType)) return;
-
     const removed = await store.dispatch(
       'reconcileConversationTab',
       conversationFilters.value

--- a/app/javascript/dashboard/helper/ReconnectService.js
+++ b/app/javascript/dashboard/helper/ReconnectService.js
@@ -59,6 +59,22 @@ class ReconnectService {
     await this.store.dispatch('updateChatListFilters', {
       updatedWithin: null,
     });
+    await this.reconcileConversationTab();
+  };
+
+  // The fetch above asks for one tab, so a conversation that LEFT that tab while the socket was
+  // down is not in the answer, and the merge that applies it only ever adds or replaces. The stale
+  // copy stays on the list.
+  //
+  // The list watcher normally catches that, but only when the list ends up longer than the tab's
+  // count, which needs the whole tab to fit in what the agent has loaded. On a tab of several
+  // pages the residue hides inside the count and nothing on screen contradicts anything, so the
+  // one moment we know events were missed is the moment to ask outright.
+  reconcileConversationTab = async () => {
+    await this.store.dispatch(
+      'reconcileConversationTab',
+      this.store.getters.getChatListFilters
+    );
   };
 
   fetchFilteredOrSavedConversations = async queryData => {

--- a/app/javascript/dashboard/helper/specs/ReconnectService.spec.js
+++ b/app/javascript/dashboard/helper/specs/ReconnectService.spec.js
@@ -30,6 +30,7 @@ const storeMock = {
     getAppliedConversationFiltersQuery: [],
     'customViews/getActiveConversationFolder': { query: {} },
     'notifications/getNotificationFilters': {},
+    getChatListFilters: { assigneeType: 'unassigned', status: 'open' },
   },
 };
 
@@ -153,6 +154,19 @@ describe('ReconnectService', () => {
       expect(storeMock.dispatch).toHaveBeenCalledWith('updateChatListFilters', {
         updatedWithin: null,
       });
+    });
+
+    // The fetch asks for one tab, so a conversation that left it while the socket was down is not
+    // in the answer and its stale copy survives the merge. A reconnect is the one moment we know
+    // events were missed, so the tab is reconciled outright rather than waiting for the list to
+    // outgrow its badge, which never happens on a tab of several pages.
+    it('should reconcile the current tab after refetching', async () => {
+      reconnectService.getSecondsSinceDisconnect = vi.fn().mockReturnValue(100);
+      await reconnectService.fetchConversations();
+      expect(storeMock.dispatch).toHaveBeenCalledWith(
+        'reconcileConversationTab',
+        storeMock.getters.getChatListFilters
+      );
     });
   });
 

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -4,6 +4,7 @@ import MessageApi from '../../../api/inbox/message';
 import { MESSAGE_STATUS, MESSAGE_TYPE } from 'shared/constants/messages';
 import { createPendingMessage } from 'dashboard/helper/commons';
 import { isStaleConversation } from './helpers';
+import wootConstants from 'dashboard/constants/globals';
 import {
   buildConversationList,
   isOnMentionsView,
@@ -33,14 +34,21 @@ export const hasMessageFailedWithExternalError = pendingMessage => {
 };
 
 // The getter behind each assignee tab is the same predicate the list on screen uses, so what it
-// returns is exactly what the agent is looking at. The other views (mentions, participating, saved
-// filters, folders) narrow the list with a rule the store does not reproduce locally, so they are
-// left out: reconciling them would judge conversations against the wrong tab.
+// returns is exactly what the agent is looking at. Saved filters and folders narrow the list with
+// a rule of their own and have no assigneeType, so they fall out here.
 const TAB_GETTERS = {
   me: 'getMineChats',
   unassigned: 'getUnAssignedChats',
   all: 'getAllStatusChats',
 };
+
+// Mentions and participating do carry an assigneeType, but the server narrows those lists by a
+// membership the store cannot reproduce, so what is on screen there is not the tab a reconciliation
+// would judge it against.
+const UNRECONCILABLE_VIEWS = [
+  wootConstants.CONVERSATION_TYPE.MENTION,
+  wootConstants.CONVERSATION_TYPE.PARTICIPATING,
+];
 
 // The trigger fires from a watcher, which can fire again while the request is still out.
 const tabsBeingReconciled = new Set();
@@ -110,7 +118,10 @@ const actions = {
   // by them.
   reconcileConversationTab: async ({ commit, getters }, filters) => {
     const tabGetter = TAB_GETTERS[filters.assigneeType];
-    if (!tabGetter || tabsBeingReconciled.has(filters.assigneeType)) return [];
+    if (!tabGetter || UNRECONCILABLE_VIEWS.includes(filters.conversationType)) {
+      return [];
+    }
+    if (tabsBeingReconciled.has(filters.assigneeType)) return [];
 
     tabsBeingReconciled.add(filters.assigneeType);
     try {

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -5,6 +5,8 @@ import { MESSAGE_STATUS, MESSAGE_TYPE } from 'shared/constants/messages';
 import { createPendingMessage } from 'dashboard/helper/commons';
 import { isStaleConversation } from './helpers';
 import wootConstants from 'dashboard/constants/globals';
+import { emitter } from 'shared/helpers/mitt';
+import { BUS_EVENTS } from 'shared/constants/busEvents';
 import {
   buildConversationList,
   isOnMentionsView,
@@ -116,7 +118,7 @@ const actions = {
   //
   // Returns what it removed, so the caller can drop the same conversations from anything keyed
   // by them.
-  reconcileConversationTab: async ({ commit, getters }, filters) => {
+  reconcileConversationTab: async ({ commit, getters, state }, filters) => {
     const tabGetter = TAB_GETTERS[filters.assigneeType];
     if (!tabGetter || UNRECONCILABLE_VIEWS.includes(filters.conversationType)) {
       return [];
@@ -153,6 +155,12 @@ const actions = {
           types.REMOVE_CONVERSATIONS,
           removed.map(c => c.id)
         );
+      }
+      // The panel is showing a conversation the server just refused to serve. Announced rather
+      // than acted on here, because the store has no router, and announced from here rather than
+      // left to each caller, because it is a fact about the removal and not about who asked.
+      if (removed.some(c => c.id === state.selectedChatId)) {
+        emitter.emit(BUS_EVENTS.OPEN_CONVERSATION_GONE);
       }
       return removed;
     } catch (error) {

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -3,6 +3,8 @@ import actions, {
   hasMessageFailedWithExternalError,
 } from '../../conversations/actions';
 import types from '../../../mutation-types';
+import { emitter } from 'shared/helpers/mitt';
+import { BUS_EVENTS } from 'shared/constants/busEvents';
 const dataToSend = {
   payload: [
     {
@@ -19,6 +21,7 @@ const commit = vi.fn();
 const dispatch = vi.fn();
 global.axios = axios;
 vi.mock('axios');
+vi.mock('shared/helpers/mitt', () => ({ emitter: { emit: vi.fn() } }));
 
 describe('#hasMessageFailedWithExternalError', () => {
   it('returns false if message is sent', () => {
@@ -658,10 +661,16 @@ describe('#deleteMessage', () => {
     });
     const inStore = { 1: { id: 1, updated_at: 100 } };
 
-    const contextWith = (payload, chats = onScreen, stored = inStore) => {
+    const contextWith = (
+      payload,
+      chats = onScreen,
+      stored = inStore,
+      selectedChatId = null
+    ) => {
       axios.post.mockResolvedValue({ data: { payload } });
       return {
         commit,
+        state: { selectedChatId },
         getters: {
           getUnAssignedChats: () => chats,
           getConversationById: id => stored[id],
@@ -760,6 +769,7 @@ describe('#deleteMessage', () => {
       const removed = await actions.reconcileConversationTab(
         {
           commit,
+          state: { selectedChatId: null },
           getters: {
             getUnAssignedChats: () => chats,
             getConversationById: () => undefined,
@@ -793,6 +803,30 @@ describe('#deleteMessage', () => {
         [types.SET_ALL_CONVERSATION, [fresh(1, 500)]],
         [types.REMOVE_CONVERSATIONS, [2, 3]],
       ]);
+    });
+
+    // The store has no router, so removing the conversation the panel is showing is announced and
+    // the component that owns the route acts on it.
+    it('announces when it removed the conversation the panel is showing', async () => {
+      await actions.reconcileConversationTab(
+        contextWith([fresh(2)], onScreen, inStore, 3),
+        filters
+      );
+
+      expect(emitter.emit).toHaveBeenCalledWith(
+        BUS_EVENTS.OPEN_CONVERSATION_GONE
+      );
+    });
+
+    it('stays quiet when the open conversation survived', async () => {
+      await actions.reconcileConversationTab(
+        contextWith([fresh(2), fresh(3)], onScreen, inStore, 3),
+        filters
+      );
+
+      expect(emitter.emit).not.toHaveBeenCalledWith(
+        BUS_EVENTS.OPEN_CONVERSATION_GONE
+      );
     });
 
     it('does not call out when the tab is empty on screen', async () => {
@@ -832,6 +866,7 @@ describe('#deleteMessage', () => {
       const removed = await actions.reconcileConversationTab(
         {
           commit,
+          state: { selectedChatId: null },
           getters: {
             getUnAssignedChats: () => onScreen,
             getConversationById: () => undefined,

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -805,6 +805,18 @@ describe('#deleteMessage', () => {
       expect(removed).toEqual([]);
     });
 
+    // Mentions and participating carry an assigneeType but are narrowed by a membership the store
+    // cannot reproduce, so what is on screen there is not the tab this would judge it against.
+    it('does nothing on a view the store cannot reproduce', async () => {
+      const removed = await actions.reconcileConversationTab(contextWith([]), {
+        ...filters,
+        conversationType: 'mention',
+      });
+
+      expect(axios.post).not.toHaveBeenCalled();
+      expect(removed).toEqual([]);
+    });
+
     it('does nothing on a view that has no tab getter', async () => {
       const removed = await actions.reconcileConversationTab(contextWith([]), {
         assigneeType: 'appliedFilters',

--- a/app/javascript/shared/constants/busEvents.js
+++ b/app/javascript/shared/constants/busEvents.js
@@ -16,5 +16,6 @@ export const BUS_EVENTS = {
   INSERT_INTO_NORMAL_EDITOR: 'insertIntoNormalEditor',
   NAVIGATE_TO_GROUP: 'navigateToGroup',
   ASSIGNMENT_CONFLICT: 'assignmentConflict',
+  OPEN_CONVERSATION_GONE: 'openConversationGone',
   MFA_STATE_CHANGED: 'MFA_STATE_CHANGED',
 };


### PR DESCRIPTION
Fecha o buraco que a #426 deixou declarado: uma conversa já atribuída podia continuar aparecendo em Não atribuídas sem que nada na tela denunciasse, e ficava lá até alguém recarregar a página.

A correção anterior percebe o problema quando a lista fica maior que o número ao lado da aba. Isso só acontece quando a aba inteira cabe no que o agente carregou. Numa caixa com várias páginas, o resto se esconde dentro da contagem: 24 conversas na tela contra um contador de 29, uma delas já com dono, e nenhum número desmente o outro.

Agora, quando a conexão volta, o painel confere a lista com o servidor de uma vez. É justamente o momento em que os avisos se perdem, então é onde vale perguntar sem esperar contradição nenhuma.

## Closes

- Closes #429

## How to reproduce

Numa caixa com mais de 25 conversas abertas e sem responsável, na aba **Abertas → Não atribuídas**:

1. Deixe o navegador offline por alguns segundos (DevTools → Network → Offline).
2. Ainda offline, atribua a um agente uma das conversas que estão visíveis na lista.
3. Volte a rede.

Antes: a conversa continuava listada como não atribuída, com 24 linhas contra um contador de 29, e assim ficava. Depois: ela sai da lista sozinha, em segundos.

## What changed

`ReconnectService#fetchConversations` reconcilia a aba corrente depois de refazer a lista. O fetch dela usa `assignee_type`, então uma conversa que saiu da aba durante a queda não vem na resposta, e `SET_ALL_CONVERSATION` só adiciona ou substitui: a cópia velha sobrevive. O `/conversations/sync` não aplica filtro de aba, então responde justamente sobre essas.

O guarda de view saiu do `ChatList` e foi para a action. Mentions e participating têm `assigneeType` mas são recortadas por uma participação que o store não reproduz, e isso é um fato sobre reconciliar, não sobre o componente que perguntou primeiro. O `ReconnectService` é o segundo chamador e herda a regra.

## Limitação restante

Um evento perdido **sem** queda de socket, numa aba de várias páginas, continua invisível: não há contradição de contagem nem reconexão para servir de gatilho. Não é um caminho que se saiba ocorrer (o cable entrega enquanto está de pé, e uma aba em segundo plano suspensa derruba o socket, o que cai neste gatilho), então fica sem tratamento até que apareça relato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/430)
<!-- Reviewable:end -->
