### PR TITLE
fix(mailer): give the caller its Current back after building a mail

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,7 +2,7 @@ class ApplicationMailer < ActionMailer::Base
   include ActionView::Helpers::SanitizeHelper
 
   default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
-  before_action { ensure_current_account(params.try(:[], :account)) }
+  around_action :with_isolated_current
   around_action :switch_locale
   layout 'mailer/base'
   # Fetch template from Database if available
@@ -73,9 +73,15 @@ class ApplicationMailer < ActionMailer::Base
     I18n.available_locales.map(&:to_s).include?(account.locale) ? account.locale : nil
   end
 
-  def ensure_current_account(account)
-    Current.reset
-    Current.account = account if account.present?
+  # Current is thread-local and nothing downstream resets it, so a mailer that left the
+  # account set would hand it to whatever ran next on the same thread -- the rest of an
+  # automation rule inline, or the next Sidekiq job on that worker thread.
+  def with_isolated_current
+    Current.isolate do
+      account = params.try(:[], :account)
+      Current.account = account if account.present?
+      yield
+    end
   end
 
   def switch_locale(&)

--- a/lib/current.rb
+++ b/lib/current.rb
@@ -1,17 +1,21 @@
 module Current
-  thread_mattr_accessor :user
-  thread_mattr_accessor :account
-  thread_mattr_accessor :account_user
-  thread_mattr_accessor :executed_by
-  thread_mattr_accessor :contact
-  thread_mattr_accessor :inbox
+  ATTRIBUTES = %i[user account account_user executed_by contact inbox].freeze
+
+  ATTRIBUTES.each { |attribute| thread_mattr_accessor attribute }
 
   def self.reset
-    Current.user = nil
-    Current.account = nil
-    Current.account_user = nil
-    Current.executed_by = nil
-    Current.contact = nil
-    Current.inbox = nil
+    ATTRIBUTES.each { |attribute| public_send(:"#{attribute}=", nil) }
+  end
+
+  # Runs the block against a clean Current and gives the caller its own values back
+  # afterwards. Mailers need both halves: a mail is rendered for one account, not for
+  # whoever happened to ask for it, and the code that asked is still running once the
+  # mail is built.
+  def self.isolate
+    previous = ATTRIBUTES.index_with { |attribute| public_send(attribute) }
+    reset
+    yield
+  ensure
+    previous.each { |attribute, value| public_send(:"#{attribute}=", value) }
   end
 end

--- a/spec/lib/current_spec.rb
+++ b/spec/lib/current_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Current do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+
+  describe '.isolate' do
+    before do
+      described_class.account = account
+      described_class.user = user
+    end
+
+    it 'runs the block against a clean Current' do
+      inside = nil
+
+      described_class.isolate { inside = [described_class.account, described_class.user] }
+
+      expect(inside).to eq([nil, nil])
+    end
+
+    it 'restores what the caller had set' do
+      described_class.isolate { described_class.account = create(:account) }
+
+      expect(described_class.account).to eq(account)
+      expect(described_class.user).to eq(user)
+    end
+
+    it 'restores it even when the block raises' do
+      expect { described_class.isolate { raise 'boom' } }.to raise_error('boom')
+
+      expect(described_class.account).to eq(account)
+    end
+  end
+end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join 'spec/mailers/administrator_notifications/shared/smtp_config_shared.rb'
+
+RSpec.describe ApplicationMailer do
+  include_context 'with smtp config'
+
+  let!(:account) { create(:account) }
+  let!(:administrator) { create(:user, :administrator, email: 'admin@example.com', account: account) }
+  let!(:inbox) { create(:inbox, account: account) }
+
+  # AdministratorNotifications::BaseMailer picks its recipients off Current.account, so the
+  # address list says which account was in Current while the mail rendered.
+  def deliver
+    AdministratorNotifications::ChannelNotificationsMailer
+      .with(account: account)
+      .whatsapp_disconnect(inbox)
+      .deliver_now
+  end
+
+  it 'renders against the account it was parameterized with, not the caller one' do
+    Current.account = create(:account)
+
+    expect(deliver.to).to eq([administrator.email])
+  end
+
+  it 'gives the caller its Current back once the mail is built' do
+    caller_account = create(:account)
+    rule = create(:automation_rule, account: caller_account)
+    Current.account = caller_account
+    Current.executed_by = rule
+
+    deliver
+
+    expect(Current.account).to eq(caller_account)
+    expect(Current.executed_by).to eq(rule)
+  end
+
+  it 'leaves Current empty for a caller that had nothing set' do
+    deliver
+
+    expect(Current.account).to be_nil
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,6 +81,11 @@ RSpec.configure do |config|
   config.include ActionCable::TestHelper
   config.include ActiveJob::TestHelper
 
+  # Current is thread-local and lives for the whole process, so anything an example leaves
+  # behind is read by the next one -- usually as a record the transaction has since rolled
+  # back, which is far from where it was set.
+  config.before { Current.reset }
+
   # OpenAPI response validation via Skooma
   path_to_openapi = Rails.root.join('swagger/swagger.json')
   config.include Skooma::RSpec[path_to_openapi], type: :request

--- a/spec/services/automation_rules/action_service_spec.rb
+++ b/spec/services/automation_rules/action_service_spec.rb
@@ -86,6 +86,24 @@ RSpec.describe AutomationRules::ActionService do
         expect(TeamNotifications::AutomationNotificationMailer).to receive(:conversation_creation).with(conversation, team, 'Hello').and_call_original
         described_class.new(rule, account, conversation).perform
       end
+
+      # The mailer clears Current so it renders for one account only. It used to leave it
+      # cleared, which cost every later action in the same rule its actor.
+      it 'still runs the actions that follow as the rule' do
+        rule.actions = [
+          { action_name: 'send_email_to_team', action_params: [{ team_ids: [team.id], message: 'Hello' }] },
+          { action_name: 'send_message', action_params: { message: 'Hello again' } }
+        ]
+        actor = nil
+        allow(Messages::MessageBuilder).to receive(:new) do
+          actor = Current.executed_by
+          instance_double(Messages::MessageBuilder, perform: nil)
+        end
+
+        described_class.new(rule, account, conversation).perform
+
+        expect(actor).to eq(rule)
+      end
     end
 
     describe '#perform with remove assignment actions' do


### PR DESCRIPTION
Closes #428.

## O que estava acontecendo

Dois bugs empilhados, e a hipótese registrada na issue (`.with(...)` deixando estado, ou o `allow(described_class).to receive(:new)`) não era nenhum dos dois.

**1. O mailer deixa `Current` sujo.** `ApplicationMailer` tinha `before_action { ensure_current_account(...) }`, que faz `Current.reset` e depois `Current.account = account`. Nada nunca desfaz isso. `Current` é `thread_mattr_accessor`, vive enquanto a thread viver, então o valor fica pendurado para o que rodar em seguida na mesma thread.

No spec, o exemplo do `conversation_notifications_mailer_spec` termina com `Current.account` apontando para uma conta que a transação do RSpec já reverteu. O exemplo seguinte (`agent_builder_spec`) cria um usuário, e `User#send_devise_notification` faz `Current.account || accounts.first`: pega a conta fantasma e serializa `gid://chatwoot/Account/<id apagado>` no job.

**2. O rspec-rails corrompe o job ao falhar de desserializar.** `ActiveJob::Base#deserialize_arguments` faz `ActiveJob::Arguments.deserialize(job[:args])` e, no `rescue ActiveJob::DeserializationError`, devolve **o próprio `job[:args]`**. O `HaveEnqueuedMail` então chama `args.pop` nesse retorno, ou seja, muta em disco o job guardado no adapter e some com o hash `{params:, args:}`. Toda leitura seguinte enxerga 3 elementos, o matcher extrai zero argumentos de mailer e reporta `Expected 2 to 3, got 0` no lugar de "não consegui desserializar". Isso é bug do rspec-rails, não nosso; a correção aqui é não gerar o GlobalID podre.

## Correção

`Current.isolate` roda o bloco contra um `Current` limpo e devolve ao chamador os valores dele no `ensure`. `ApplicationMailer` passa a usar um `around_action` em cima disso: continua renderizando para uma conta só, e para de sequestrar o `Current` de quem pediu o e-mail.

Isso não é só teste. `AutomationRules::ActionService` seta `Current.executed_by = rule` no construtor e itera as ações; qualquer regra com `send_email_to_team` no meio perdia a atribuição de todas as ações seguintes, porque o mailer (`deliver_now`) zerava o `Current` e nunca devolvia. As mensagens de atividade criadas depois saíam sem o "Automation System". Tem spec cobrindo isso agora.

O `config.before { Current.reset }` no `rails_helper` é rede de proteção: mesmo que outro ponto vaze, nenhum exemplo herda `Current` do anterior.

## Verificação

- A repro da issue passa.
- Os 3 specs novos que apontam para o comportamento novo falham sem a correção do mailer (2 no `application_mailer_spec`, 1 no `action_service_spec`); confirmei revertendo o arquivo.
- Suíte completa local (`TZ=UTC`, com o overlay `enterprise/` no lugar): 11407 exemplos, 2 falhas, ambas o `check_new_versions_job` do enterprise. É a divergência CE/Pro já conhecida da #421 (o stub de `ChatwootHub.sync_with_hub` vive no Pro, e o CI do CE apaga `enterprise/`), não tem relação com esta mudança.

## Fica de fora

O Sidekiq não tem fronteira de `Current`. O lado web tem: `RequestExceptionHandler#handle_with_exception` faz `Current.reset` no `ensure`, com comentário citando exatamente o vazamento de thread no Puma. Já o `server_middleware` do Sidekiq não faz nada disso, e `Message#reopen_resolved_conversation` seta `Current.executed_by = sender` sem nunca limpar. Abri issue separada para isso.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/431)
<!-- Reviewable:end -->

