### PR TITLE
fix(reports): build the spec window from one clock

### DIFF
--- a/spec/builders/v2/reports/label_summary_builder_spec.rb
+++ b/spec/builders/v2/reports/label_summary_builder_spec.rb
@@ -325,8 +325,11 @@ RSpec.describe V2::Reports::LabelSummaryBuilder do
       let(:account2_builder) do
         described_class.new(account: account2, params: {
                               business_hours: false,
-                              since: test_date.to_time.to_i.to_s,
-                              until: test_date.end_of_day.to_time.to_i.to_s,
+                              # Date#to_time reads the system zone while Date#end_of_day reads Time.zone, so
+                              # the two ends of this window came from different clocks. Anywhere west of UTC
+                              # that pushed `since` past the events travel_to had just written.
+                              since: test_date.in_time_zone.to_i.to_s,
+                              until: test_date.in_time_zone.end_of_day.to_i.to_s,
                               timezone_offset: 0
                             })
       end


### PR DESCRIPTION
Closes #433.

`label_summary_builder_spec` fixa um dia só e lia as duas pontas da janela de relógios diferentes: `Date#to_time` é Ruby core e responde no fuso do sistema, `Date#end_of_day` é ActiveSupport e responde no `Time.zone`. Os eventos que o exemplo checa são escritos dentro de `travel_to`, que também usa `Time.zone`.

A oeste de UTC isso empurra o `since` para depois dos eventos e a contagem de resolução volta 0. O CI roda em UTC, onde os dois relógios concordam, então só falhava na máquina de quem desenvolve.

## Verificação

O arquivo passa nos três fusos, e antes da correção falhava no primeiro:

```
America/Sao_Paulo (-03)  10 examples, 0 failures
UTC                      10 examples, 0 failures
Asia/Kolkata (+0530)     10 examples, 0 failures
```

A suíte completa já tinha rodado no fuso local antes disso: entre 11399 exemplos, esse era o único spec de relatório que caía. Os outros usam janelas de vários dias, onde um deslocamento de horas não muda nada.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/434)
<!-- Reviewable:end -->

