### PR TITLE
fix(sidekiq): clear Current at the job boundary

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,6 @@
 require Rails.root.join('lib/redis/config')
 require Rails.root.join('lib/captain_response_dequeued_logger')
+require Rails.root.join('lib/current_reset_middleware')
 require Rails.root.join('lib/sidekiq_death_handler')
 
 schedule_file = 'config/schedule.yml'
@@ -26,6 +27,9 @@ Sidekiq.configure_server do |config|
   config.death_handlers << SidekiqDeathHandler.method(:call)
 
   config.server_middleware do |chain|
+    # Outermost, so Current is cleared after everything else in the chain has run.
+    chain.prepend CurrentResetMiddleware
+
     chain.add CaptainResponseDequeuedLogger
 
     chain.add ChatwootDequeuedLogger if ActiveModel::Type::Boolean.new.cast(ENV.fetch('ENABLE_SIDEKIQ_DEQUEUE_LOGGER', false))

--- a/lib/current_reset_middleware.rb
+++ b/lib/current_reset_middleware.rb
@@ -1,0 +1,16 @@
+# Current is thread-local and a Sidekiq thread outlives the jobs that run on it, so a job
+# that writes Current without cleaning up hands its values to whatever runs next on that
+# thread -- as a record that may not even be reachable any more.
+#
+# The web side already closes this at the request boundary, in
+# RequestExceptionHandler#handle_with_exception. This is the same boundary for jobs.
+#
+# Deliberately only on the way out: a job that needs Current sets its own, since nothing
+# about Current crosses the queue. Clearing on entry would say otherwise.
+class CurrentResetMiddleware
+  def call(_worker, _job, _queue)
+    yield
+  ensure
+    Current.reset
+  end
+end

--- a/spec/lib/current_reset_middleware_spec.rb
+++ b/spec/lib/current_reset_middleware_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CurrentResetMiddleware do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+
+  def run(&)
+    described_class.new.call(nil, {}, 'default', &)
+  end
+
+  it 'clears what the job left behind' do
+    run do
+      Current.account = account
+      Current.user = user
+    end
+
+    expect(Current.account).to be_nil
+    expect(Current.user).to be_nil
+  end
+
+  it 'clears it even when the job raises' do
+    expect { run { Current.account = account and raise 'boom' } }.to raise_error('boom')
+
+    expect(Current.account).to be_nil
+  end
+
+  it 'returns what the job returned' do
+    expect(run { :done }).to eq(:done)
+  end
+
+  # Only on the way out. Nothing about Current crosses the queue, so a job that needs it
+  # sets its own; clearing on entry would suggest a caller could hand one down.
+  it 'leaves Current alone on the way in' do
+    Current.account = account
+    seen = nil
+
+    run { seen = Current.account }
+
+    expect(seen).to eq(account)
+  end
+end


### PR DESCRIPTION
Closes #432.

`Current` é `thread_mattr_accessor` e a thread do Sidekiq vive mais que os jobs que rodam nela. Um job que escreve em `Current` sem limpar entrega os valores dele para o que rodar em seguida naquela thread, muitas vezes como um registro que a transação de quem chamou já soltou.

A maioria dos escritores limpa: `AutomationRules::ActionService`, `AutoAssignment::AssignmentService`, `BulkActionsJob` e `ScheduledMessages::SendScheduledMessageJob` todos resetam num `ensure`. Só que depender de cada escritor lembrar é justamente o que continua produzindo esse bug: o `ApplicationMailer` esqueceu, e precisou de um spec flaky (#428) para alguém notar.

O lado web já resolveu isso na fronteira, não no escritor. `RequestExceptionHandler#handle_with_exception` faz `Current.reset` no `ensure`, e o comentário no código nomeia o vazamento de thread do Puma direto. Este PR é a mesma fronteira para jobs.

## Detalhes

`chain.prepend`, não `chain.add`: a fronteira precisa ser a mais externa da chain, para limpar depois de tudo que os outros middlewares fizerem.

Só na saída, espelhando o lado web. Nada de `Current` atravessa a fila, então um job que precisa dele seta o seu próprio. Limpar na entrada sugeriria que quem enfileira pode passar um valor adiante, o que não é verdade.

Não mexi no `Message#reopen_resolved_conversation`, que seta `Current.executed_by = sender` sem limpar. Dentro do job aquele valor é intencional (é o que faz a mensagem de atividade dizer que o contato reabriu), e com esta fronteira no lugar ele para de escapar do job. Estreitar o escopo dele mudaria atribuição em código que lê o valor mais adiante na mesma cadeia de callbacks, o que é uma mudança de comportamento e não uma correção de vazamento.

## Verificação

O registro foi conferido num boot real do servidor, do jeito que produção sobe (`bundle exec sidekiq -e test`), imprimindo a chain de dentro do `on(:startup)`:

```
["CurrentResetMiddleware", "Sidekiq::Metrics::Middleware", "Sidekiq::Job::InterruptHandler", "CaptainResponseDequeuedLogger"]
```

Mais externo, como pretendido. Isso importa: um `chain.add` que não pega não dá erro nenhum, o middleware simplesmente não roda.

`spec/lib/current_reset_middleware_spec.rb` cobre limpar depois do job, limpar quando o job levanta, devolver o retorno do job, e não tocar em `Current` na entrada. `spec/jobs` e `spec/services/automation_rules` passam: 580 exemplos, 0 falhas.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/435)
<!-- Reviewable:end -->

