### PR TITLE
fix(reports): stop HTML-escaping the CSV exports

### DIFF
--- a/app/views/api/v1/accounts/csat_survey_responses/download.csv.erb
+++ b/app/views/api/v1/accounts/csat_survey_responses/download.csv.erb
@@ -29,7 +29,7 @@
   ]
   row << csat_response.csat_review_notes if ChatwootApp.enterprise?
 -%>
-<%= CSVSafe.generate_line(row).html_safe -%>
+<%= CSVSafe.generate_line(row) -%>
 <% end %>
 <%=
   CSVSafe.generate_line([

--- a/app/views/api/v2/accounts/reports/conversation_traffic.csv.erb
+++ b/app/views/api/v2/accounts/reports/conversation_traffic.csv.erb
@@ -1,0 +1,5 @@
+<%= CSVSafe.generate_line [I18n.t('reports.conversation_traffic_csv.timezone'), @timezone] %>
+
+<% @report_data.each do |row| %>
+<%= CSVSafe.generate_line row -%>
+<% end %>

--- a/app/views/api/v2/accounts/reports/conversation_traffic.erb
+++ b/app/views/api/v2/accounts/reports/conversation_traffic.erb
@@ -1,5 +1,0 @@
-<%= CSV.generate_line [I18n.t('reports.conversation_traffic_csv.timezone'), @timezone] %>
-
-<% @report_data.each do |row| %>
-<%= CSVSafe.generate_line row -%>
-<% end %>

--- a/config/initializers/csv_erb_escaping.rb
+++ b/config/initializers/csv_erb_escaping.rb
@@ -1,0 +1,13 @@
+# ActionView escapes the output of `<%= %>` in every ERB template whose type is not on
+# this list, and CSV was never on it. An apostrophe in an agent's name reached the file as
+# `&#39;`, and so did the quote CSVSafe prefixes onto a field that would otherwise read as
+# a formula, which left the guard visible in the cell.
+#
+# HTML escaping buys a CSV nothing, because the file is not markup. What a CSV needs is
+# quoting, which the CSV library does, and a defused leading `=`, which CSVSafe does. Both
+# happen before the value reaches this buffer.
+ActiveSupport.on_load(:action_view) do
+  csv_type = Mime[:csv].to_s
+  ignore_list = ActionView::Template::Handlers::ERB.escape_ignore_list
+  ignore_list << csv_type unless ignore_list.include?(csv_type)
+end

--- a/enterprise/app/views/api/v1/accounts/applied_slas/download.csv.erb
+++ b/enterprise/app/views/api/v1/accounts/applied_slas/download.csv.erb
@@ -8,12 +8,12 @@
   I18n.t('reports.sla_csv.conversation_link'),
   I18n.t('reports.sla_csv.breached_events')
 ] %>
-<%= CSV.generate_line headers %>
+<%= CSVSafe.generate_line headers %>
 
 <% @missed_applied_slas.each do |sla| %>
   <% missed_events = sla.sla_events.map(&:event_type).join(', ') %>
   <% conversation = sla.conversation %>
-  <%= CSV.generate_line([
+  <%= CSVSafe.generate_line([
     conversation.display_id,
     sla.sla_policy.name,
     conversation.assignee&.name,

--- a/spec/controllers/api/v2/accounts/reports_csv_escaping_spec.rb
+++ b/spec/controllers/api/v2/accounts/reports_csv_escaping_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+# Every CSV export is an ERB template, and ActionView escapes `<%= %>` output for any
+# template type outside its ignore list. `text/csv` is not in it, so an apostrophe in a
+# name used to reach the file as `&#39;`.
+RSpec.describe 'Reports CSV escaping', type: :request do
+  let(:hostile_name) { %(O'Keefe & <Sons>) }
+  let(:account) { create(:account) }
+  let(:admin) { create(:user, account: account, role: :administrator) }
+  let!(:agent) { create(:user, account: account, name: hostile_name) }
+  let!(:inbox) { create(:inbox, account: account, name: hostile_name) }
+  let!(:team) { create(:team, account: account, name: hostile_name) }
+  let(:params) { { timezone_offset: 0, since: 1.day.ago.to_i.to_s, until: Time.current.to_i.to_s } }
+
+  before do
+    create(:inbox_member, user: agent, inbox: inbox)
+    create_list(:conversation, 2, account: account, inbox: inbox, assignee: agent, team: team,
+                                  created_at: Time.current)
+  end
+
+  # Only these three carry free text. A label title is restricted to letters, numbers,
+  # hyphen and underscore, and the summary and traffic exports are counts and timestamps.
+  %w[agents inboxes teams].each do |report|
+    it "leaves the #{report} export unescaped" do
+      get "/api/v2/accounts/#{account.id}/reports/#{report}.csv", params: params, headers: admin.create_new_auth_token
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).not_to include('&#39;', '&amp;', '&lt;', '&gt;', '&quot;')
+    end
+  end
+
+  it 'leaves the CSAT export unescaped' do
+    conversation = account.conversations.first
+    create(:csat_survey_response, account: account, conversation: conversation, assigned_agent: agent,
+                                  feedback_message: hostile_name)
+
+    get "/api/v1/accounts/#{account.id}/csat_survey_responses/download.csv", params: params,
+                                                                             headers: admin.create_new_auth_token
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).not_to include('&#39;', '&amp;', '&lt;', '&gt;', '&quot;')
+  end
+
+  # The rename that put `conversation_traffic` under `.csv.erb` is what the ignore list
+  # keys on, so a template added without the format in its name would silently opt out.
+  it 'resolves every report template as text/csv' do
+    lookup = ApplicationController.new.lookup_context
+
+    %w[agents inboxes labels teams conversations_summary conversation_traffic].each do |report|
+      template = lookup.find_template("api/v2/accounts/reports/#{report}", [], false, [], formats: [:csv])
+
+      expect(template.type.to_s).to eq('text/csv'), "#{report} resolves as #{template.type.inspect}"
+    end
+  end
+
+  it 'still defuses a formula in a name' do
+    agent.update!(name: '=cmd|calc')
+
+    get "/api/v2/accounts/#{account.id}/reports/agents.csv", params: params, headers: admin.create_new_auth_token
+
+    expect(response.body).to include(%('=cmd|calc))
+  end
+end

--- a/spec/enterprise/controllers/api/v1/accounts/applied_slas_controller_spec.rb
+++ b/spec/enterprise/controllers/api/v1/accounts/applied_slas_controller_spec.rb
@@ -161,6 +161,20 @@ RSpec.describe 'Applied SLAs API', type: :request do
         expect(conversation_ids).to contain_exactly(conversation1.display_id, conversation2.display_id)
       end
 
+      # This export was the one CSV template still on plain CSV.generate_line, so a name
+      # starting with `=` reached the spreadsheet as a live formula.
+      it 'defuses a formula and leaves the rest of the name alone' do
+        conversation1.assignee.update!(name: "=cmd|calc O'Keefe")
+        create(:applied_sla, sla_policy: sla_policy1, conversation: conversation1, sla_status: 'missed')
+
+        get "/api/v1/accounts/#{account.id}/applied_slas/download",
+            headers: administrator.create_new_auth_token
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(%('=cmd|calc O'Keefe))
+        expect(response.body).not_to include('&#39;')
+      end
+
       it 'excludes conversations with blocked contacts from the CSV file' do
         create(:applied_sla, sla_policy: sla_policy1, conversation: conversation1, sla_status: 'missed')
         create(:applied_sla, sla_policy: sla_policy1, conversation: conversation2, sla_status: 'missed')


### PR DESCRIPTION
Closes #436.

Saiu de investigar a falha que derrubou um shard da CI do Pro: o Faker sorteou um agente chamado `Shawn O'Keefe` e o CSV saiu `Shawn O&#39;Keefe`. Não era flakiness de teste, e a investigação achou mais duas coisas junto.

## 1. O escape corrompe todo export CSV

Os exports são templates ERB, e o ActionView escapa a saída de `<%= %>` em todo template cujo tipo não esteja na lista de isentos:

```ruby
ActionView::Template::Handlers::ERB.escape_ignore_list
# => ["text/plain"]
```

`text/csv` não está lá. Um agente `O'Keefe` chega ao arquivo como `O&#39;Keefe`, uma caixa `Vendas & Marketing` como `Vendas &amp; Marketing`.

Dos seis templates, só três carregam texto livre: agentes, caixas e equipes. Título de rótulo é validado contra letras, números, hífen e sublinhado, e resumo e tráfego são contagens e horários.

## 2. O escudo contra fórmula era corrompido junto

O `CSVSafe` prefixa uma aspa simples no campo que começaria com `=`, `+`, `-`, `@`. Essa aspa era escapada por sua vez, então a célula mostrava `&#39;=cmd|calc`.

A fórmula seguia inerte, porque `&` não abre uma. É corrupção de dado, não brecha. Mas o valor deixava de ser o valor.

## 3. O export de SLA do enterprise não tinha escudo nenhum

`enterprise/app/views/api/v1/accounts/applied_slas/download.csv.erb` usava `CSV.generate_line` puro, não `CSVSafe`. Responsável, equipe, caixa e nome da política são texto livre, e um deles chamado `=cmd|calc` saía com o `=` intacto:

```
CSV.generate_line       -> "=cmd|calc '!A1,O'Keefe\n"
apos o escape do ERB    -> "=cmd|calc &#39;!A1,O&#39;Keefe\n"
CSVSafe.generate_line   -> "'=cmd|calc '!A1,O'Keefe\n"
```

O escape de HTML nunca cobriu esse caso, porque `=cmd|calc` não tem caractere para escapar. Esse export está assim hoje, em produção.

## A correção

Um initializer põe `text/csv` na lista de isentos. Escape de HTML não compra nada para um CSV, porque o arquivo não é marcação: o aspeamento é trabalho da biblioteca CSV e o `=` neutralizado é do `CSVSafe`, os dois antes de o valor chegar ao buffer do template.

Junto vão três coisas que apareceram no caminho:

- `conversation_traffic.erb` não tinha o formato no nome, então resolvia com tipo vazio e ficaria de fora da regra. Renomeado para `.csv.erb`, e a primeira linha dele passou de `CSV` para `CSVSafe`.
- O SLA do enterprise passou a usar `CSVSafe`.
- O `.html_safe` que o upstream pôs numa linha do export de CSAT (chatwoot/chatwoot#15335) saiu: é a mesma correção aplicada uma linha por vez, e virou desnecessária.

## Verificação

Cada spec novo foi checado contra a árvore sem a correção:

- os três exports com texto livre falham com `&#39;`, `&amp;` e `&lt;`;
- o teste de fórmula falha com `&#39;=cmd|calc`;
- o teste do SLA falha com `=cmd|calc O'Keefe`, o `=` na frente, confirmado revertendo só aquele arquivo.

Tem também um spec que resolve os seis templates de relatório e exige tipo `text/csv`, que é o que teria pego o `conversation_traffic` sem sufixo.

Suíte completa local (`TZ=UTC`, com o overlay `enterprise/`): 11418 exemplos, 2 falhas, as duas o `check_new_versions_job` da divergência CE/Pro conhecida da #421.

## Vem do upstream

A árvore do `chatwoot/chatwoot` tem os mesmos templates e também não configura a lista de isentos, e o `CSV.generate_line` do SLA é de lá. A correção cabe como PR upstream; não abri.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/437)
<!-- Reviewable:end -->
