### PR TITLE
chore(super-admin): tidy the account form's standalone switches

### DIFF
--- a/app/assets/stylesheets/administrate/components/_field-unit.scss
+++ b/app/assets/stylesheets/administrate/components/_field-unit.scss
@@ -37,6 +37,53 @@
   }
 }
 
+// Standalone switches on the account form, as a checkbox list: box first, its
+// own label right after it, the whole run sitting in the input column. The
+// label gutter the rest of the form uses is too narrow for these names and
+// wraps them, and a full-height row each is mostly empty space. Scoped to that
+// form (both classes, which also puts it above the utility classes the view
+// applies to every field-unit) so no other dashboard changes.
+.main-content__body.account-form {
+  .field-unit--boolean,
+  .field-unit--hide-agent-all-tab-field {
+    // Width only, so the colour the view's utility class puts on every
+    // field-unit survives for the one row that keeps the rule.
+    border-bottom-width: 0;
+    margin-bottom: 0;
+    padding: 0.125rem 0 0.125rem calc(15% + 1.25rem);
+
+    .field-unit__label {
+      margin-left: $small-spacing;
+      order: 2;
+      text-align: left;
+      width: auto;
+    }
+
+    .field-unit__field {
+      margin-left: 0;
+      order: 1;
+      width: auto;
+    }
+  }
+
+  // The rule the rest of the form carries under every field belongs under the
+  // run as a whole rather than between its own rows, so the last switch keeps
+  // it and picks up the padding that goes with it. "Last" is whichever one no
+  // other switch follows.
+  .field-unit--boolean:not(:has(+ .field-unit--boolean)):not(:has(+ .field-unit--hide-agent-all-tab-field)),
+  .field-unit--hide-agent-all-tab-field:not(:has(+ .field-unit--boolean)):not(:has(+ .field-unit--hide-agent-all-tab-field)) {
+    border-bottom-width: 1px;
+    padding-bottom: $base-spacing;
+  }
+
+  // The run carries no gap between its own rows, so the gap goes back on
+  // whatever field follows it.
+  .field-unit--boolean + .field-unit:not(.field-unit--boolean):not(.field-unit--hide-agent-all-tab-field),
+  .field-unit--hide-agent-all-tab-field + .field-unit:not(.field-unit--boolean):not(.field-unit--hide-agent-all-tab-field) {
+    margin-top: $base-spacing;
+  }
+}
+
 .field-unit--required {
   label::after {
     color: $red;

--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -39,9 +39,7 @@ class AccountDashboard < Administrate::BaseDashboard
     custom_attributes: Field::String,
     hide_agent_unassigned_tab: Field::Boolean,
     hide_agent_all_tab: HideAgentAllTabField,
-    disable_agent_message_deletion: Field::Boolean,
-    whatsapp_native_disabled: Field::Boolean,
-    whatsapp_uazapi_disabled: Field::Boolean
+    disable_agent_message_deletion: Field::Boolean
   }.merge(enterprise_attribute_types).freeze
 
   # COLLECTION_ATTRIBUTES
@@ -82,8 +80,6 @@ class AccountDashboard < Administrate::BaseDashboard
     hide_agent_unassigned_tab
     hide_agent_all_tab
     disable_agent_message_deletion
-    whatsapp_native_disabled
-    whatsapp_uazapi_disabled
   ] + enterprise_show_page_attributes).freeze
 
   # FORM_ATTRIBUTES
@@ -105,8 +101,6 @@ class AccountDashboard < Administrate::BaseDashboard
     hide_agent_unassigned_tab
     hide_agent_all_tab
     disable_agent_message_deletion
-    whatsapp_native_disabled
-    whatsapp_uazapi_disabled
   ] + enterprise_form_attributes).freeze
 
   # COLLECTION_FILTERS

--- a/app/views/super_admin/accounts/edit.html.erb
+++ b/app/views/super_admin/accounts/edit.html.erb
@@ -14,6 +14,6 @@
   </div>
 </header>
 
-<section class="main-content__body [&_.field-unit]:border-b [&_.field-unit]:border-n-weak [&_.field-unit]:pb-6">
+<section class="main-content__body account-form [&_.field-unit]:border-b [&_.field-unit]:border-n-weak [&_.field-unit]:pb-6">
   <%= render "form", page: page %>
 </section>


### PR DESCRIPTION
Tira do formulário de conta do super admin os dois campos de opt-out por conta dos provedores de sessão do WhatsApp (`Whatsapp native disabled` e `Whatsapp uazapi disabled`), e deixa as três opções restantes como uma lista de checkboxes compacta em vez de três linhas de altura cheia.

Os toggles do WhatsApp eram chaves de rollout de um provedor que hoje é oferecido a toda conta, e o formulário não é onde eles pertencem. O mecanismo continua inteiro: `AccountWhatsappProviders`, as chaves no `SETTINGS_PARAMS_SCHEMA` e os dois pontos que consultam `whatsapp_session_provider_enabled?` estão intocados, então uma conta que já carrega uma dessas flags segue com o provedor desligado, e ainda dá para ajustar via console.

As três que ficam (`hide_agent_unassigned_tab`, `hide_agent_all_tab`, `disable_agent_message_deletion`) passam a ocupar uma linha só: caixa primeiro, o nome ao lado dela, o bloco alinhado na coluna dos inputs, e a régua que o resto do formulário carrega embaixo de cada campo colocada embaixo do grupo inteiro. A coluna de labels é estreita demais para esses nomes e os quebrava em duas linhas, que era o que deixava as linhas altas. O bloco passou de ~200px para ~95px.

## How to test

1. Super admin → Accounts → editar uma conta.
2. Os dois campos do WhatsApp não aparecem mais, nem no formulário nem na página de detalhes.
3. As três opções restantes ficam numa linha só cada, alinhadas com os inputs acima, com uma régua separando o grupo da seção de limites.
4. Marcar `Hide agent unassigned tab` continua marcando e travando `Hide agent all tab`; salvar preserva os três valores.

## What changed

- `app/dashboards/account_dashboard.rb`: os dois campos saem de `ATTRIBUTE_TYPES`, `FORM_ATTRIBUTES` e `SHOW_PAGE_ATTRIBUTES`.
- `app/assets/stylesheets/administrate/components/_field-unit.scss`: regra escopada em `.main-content__body.account-form`, para nenhum outro dashboard ter seus booleanos mudados de forma.
- `app/views/super_admin/accounts/edit.html.erb`: a classe `account-form` que escopa a regra acima.

O mesmo já está em `fazer-ai/chatwoot-pro` (PR #81 de lá). Trazer para cá evita que os dois repos divirjam justamente em arquivos que o próximo merge CE → Pro tem que reconciliar.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/438)
<!-- Reviewable:end -->
