### PR TITLE
feat(import): backfill an inbox from IMAP and from a ticketing export

### DIFF
--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -12,6 +12,7 @@
 #  imap_login                :string           default("")
 #  imap_password             :string           default("")
 #  imap_port                 :integer          default(0)
+#  import_cursor             :jsonb            not null
 #  provider                  :string
 #  provider_config           :jsonb
 #  smtp_address              :string           default("")

--- a/app/services/import.rb
+++ b/app/services/import.rb
@@ -9,6 +9,13 @@
 #
 # `content_attributes` is a text column holding JSON, hence the cast, and the key is absent
 # on every row written before imports existed, hence the default.
+#
+# `content_attributes.imported_text_only` says the row was filed from a lean fetch, with
+# its attachments deliberately left in the mailbox. It exists because "this Message-ID is
+# already stored" is not the same question as "this message is fully imported": without it
+# a first pass under a narrow cutoff makes every later pass skip the row, and the
+# attachments become unreachable on a mailbox the import exists to preserve.
 module Import
   IMPORTED_SQL = "COALESCE((content_attributes#>>'{}')::jsonb->>'imported', 'false') = 'true'".freeze
+  TEXT_ONLY_SQL = "COALESCE((content_attributes#>>'{}')::jsonb->>'imported_text_only', 'false') = 'true'".freeze
 end

--- a/app/services/import.rb
+++ b/app/services/import.rb
@@ -1,0 +1,14 @@
+# The namespace every importer lives in, and the one flag they all share.
+#
+# `content_attributes.imported` says a row was filed after the fact rather than received.
+# Two things read it and they are in different layers, which is why the predicate lives
+# here rather than beside either of them: Inbound::Coverage measures where an inbox stopped
+# covering its channel and has to exclude backfilled rows, or the second frame of a sync
+# would read the first frame's own writes as coverage; HistorySettlement asks whether a
+# thread holds anything but imported traffic before it stamps the unread clock.
+#
+# `content_attributes` is a text column holding JSON, hence the cast, and the key is absent
+# on every row written before imports existed, hence the default.
+module Import
+  IMPORTED_SQL = "COALESCE((content_attributes#>>'{}')::jsonb->>'imported', 'false') = 'true'".freeze
+end

--- a/app/services/import/email/attachment_policy.rb
+++ b/app/services/import/email/attachment_policy.rb
@@ -58,4 +58,13 @@ class Import::Email::AttachmentPolicy
 
     "a partir de #{@value.to_date}"
   end
+
+  # What the policy is, for a caller that has to tell two of them apart and store the
+  # answer. Kept separate from `to_s`, which is a line an operator reads: rewording that
+  # line would otherwise invalidate every stored cursor.
+  def key
+    return @value.to_s if none? || all?
+
+    @value.utc.iso8601
+  end
 end

--- a/app/services/import/email/attachment_policy.rb
+++ b/app/services/import/email/attachment_policy.rb
@@ -35,12 +35,42 @@ class Import::Email::AttachmentPolicy
     new(at)
   end
 
+  # What an operator wrote in `ATTACHMENTS`: `all`, an ISO date, or nothing at all. Read
+  # here rather than in the task, next to the three states it produces.
+  #
+  # ISO strictly, not `Time.zone.parse`, which reads far more than the documented format and
+  # reads some of it as something else: `01/02/03` parses without complaint into the year 1,
+  # a cutoff below every message in the mailbox -- which is `all`, arrived at by typo, and
+  # hundreds of gigabytes of provider budget. A setting this expensive to get wrong is one
+  # to refuse rather than interpret.
+  def self.from_setting(raw)
+    return build(nil) if raw.blank?
+    return build(ALL) if raw.to_s.casecmp(ALL.to_s).zero?
+
+    build(iso_date(raw).in_time_zone)
+  end
+
+  def self.iso_date(raw)
+    Date.iso8601(raw.to_s)
+  rescue Date::Error
+    raise ArgumentError, "ATTACHMENTS: use `all` ou uma data ISO (YYYY-MM-DD), veio #{raw.inspect}"
+  end
+  private_class_method :iso_date
+
   def initialize(value)
     @value = value
   end
 
   def none? = @value == NONE
   def all? = @value == ALL
+
+  # The cutoff itself, for the one caller that has to ask the database the question `skip?`
+  # answers per message: which stored rows a further pass would still do something with.
+  def cutoff
+    return if none? || all?
+
+    @value
+  end
 
   # An unknown date is treated as out of scope under a cutoff: the message is older than
   # nothing that can be checked, and spending the budget on a maybe is the expensive way

--- a/app/services/import/email/attachment_policy.rb
+++ b/app/services/import/email/attachment_policy.rb
@@ -24,6 +24,7 @@ class Import::Email::AttachmentPolicy
   # policy that is neither none, all, nor a cutoff -- and fails much later, at the first
   # message it is asked about.
   def self.build(value)
+    return value if value.is_a?(self)
     return new(NONE) if value.blank?
     return new(ALL) if value.to_s.casecmp(ALL.to_s).zero?
     return new(NONE) if value.to_s.casecmp(NONE.to_s).zero?

--- a/app/services/import/email/attachment_policy.rb
+++ b/app/services/import/email/attachment_policy.rb
@@ -17,17 +17,25 @@ class Import::Email::AttachmentPolicy
   ALL = :all
 
   # Accepts what a caller naturally has: a symbol, a Time, or nil for the default.
+  #
+  # The time is converted here rather than trusted, because `respond_to?(:to_time)` is not
+  # the test it looks like: ActiveSupport puts `to_time` on String, so any word at all
+  # answers to it and answers nil, and a typo in the setting would otherwise become a
+  # policy that is neither none, all, nor a cutoff -- and fails much later, at the first
+  # message it is asked about.
   def self.build(value)
     return new(NONE) if value.blank?
     return new(ALL) if value.to_s.casecmp(ALL.to_s).zero?
     return new(NONE) if value.to_s.casecmp(NONE.to_s).zero?
-    return new(value) if value.respond_to?(:to_time)
 
-    raise ArgumentError, "attachments must be :none, :all or a time, got #{value.inspect}"
+    at = value.try(:to_time)
+    raise ArgumentError, "attachments must be :none, :all or a time, got #{value.inspect}" if at.nil?
+
+    new(at)
   end
 
   def initialize(value)
-    @value = value.is_a?(Symbol) ? value : value.to_time
+    @value = value
   end
 
   def none? = @value == NONE

--- a/app/services/import/email/attachment_policy.rb
+++ b/app/services/import/email/attachment_policy.rb
@@ -1,0 +1,52 @@
+# Whether a message's attachments are in scope, asked in one place because two callers
+# have to give the same answer about the same message.
+#
+# The backfill asks before it fetches and the importer asks before it attaches, and the
+# cost the cutoff exists to control is paid at the fetch: a policy the two read separately
+# would eventually disagree, and the way it would show is a run that spends its whole
+# provider budget on attachments it then declines to keep.
+#
+# Three states, spelled out rather than inferred from nil, because "no cutoff given" reads
+# as both "all of them" and "none of them" and the two are hundreds of gigabytes apart:
+#
+#   :none    the default. Nothing is fetched beyond the text.
+#   :all     every attachment, whatever the message's date.
+#   a Time   attachments on messages newer than it, nothing older.
+class Import::Email::AttachmentPolicy
+  NONE = :none
+  ALL = :all
+
+  # Accepts what a caller naturally has: a symbol, a Time, or nil for the default.
+  def self.build(value)
+    return new(NONE) if value.blank?
+    return new(ALL) if value.to_s.casecmp(ALL.to_s).zero?
+    return new(NONE) if value.to_s.casecmp(NONE.to_s).zero?
+    return new(value) if value.respond_to?(:to_time)
+
+    raise ArgumentError, "attachments must be :none, :all or a time, got #{value.inspect}"
+  end
+
+  def initialize(value)
+    @value = value.is_a?(Symbol) ? value : value.to_time
+  end
+
+  def none? = @value == NONE
+  def all? = @value == ALL
+
+  # An unknown date is treated as out of scope under a cutoff: the message is older than
+  # nothing that can be checked, and spending the budget on a maybe is the expensive way
+  # to be wrong.
+  def skip?(occurred_at)
+    return true if none?
+    return false if all?
+
+    occurred_at.blank? || occurred_at < @value
+  end
+
+  def to_s
+    return 'nenhum' if none?
+    return 'todos' if all?
+
+    "a partir de #{@value.to_date}"
+  end
+end

--- a/app/services/import/email/authentication.rb
+++ b/app/services/import/email/authentication.rb
@@ -1,0 +1,23 @@
+# Logging a rake task into a mail channel.
+#
+# The same three cases the live fetch services split into, because a channel does not stop
+# being an OAuth channel when a backfill is the one connecting: on Google and Microsoft the
+# stored `imap_password` is empty or stale and only a refreshed XOAUTH2 token
+# authenticates. Reading the column would fail every run against those providers with
+# nothing but a login error to say why.
+#
+# Its own class because it is about credentials rather than about walking a mailbox, and
+# because it is the piece a second importer would need first.
+class Import::Email::Authentication
+  def self.perform(imap, channel)
+    case channel.provider
+    when 'google'
+      imap.authenticate('XOAUTH2', channel.imap_login, Google::RefreshOauthTokenService.new(channel: channel).access_token)
+    when 'microsoft'
+      imap.authenticate('XOAUTH2', channel.imap_login,
+                        Microsoft::RefreshOauthTokenService.new(channel: channel).access_token)
+    else
+      Imap::Authentication.authenticate!(imap, channel.imap_authentication, channel.imap_login, channel.imap_password)
+    end
+  end
+end

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -45,6 +45,11 @@ class Import::Email::Backfill
   # :imported, :error. Held on the instance rather than threaded through every frame,
   # because the loop is three levels deep and passing a block down all of them says
   # nothing about what the loop does.
+  # `Array(...)` around the search rather than trusting it to be one: net-imap 0.6 answers
+  # a rev2-capable server with an `ESearchResult`, which carries `each` and `to_a` and none
+  # of `length`, `select` or `each_slice`. Gmail is rev1 so today it is a plain Array, but
+  # the walk would break on the first server that is not -- at the progress line, before
+  # anything it could report.
   def perform(&progress)
     @progress = progress || ->(*) {}
     imap = connect
@@ -54,7 +59,7 @@ class Import::Email::Backfill
       imap.examine(folder)
       @folder = folder
       @uidvalidity = imap.responses('UIDVALIDITY', &:last)
-      uids = @cursor.unseen(folder, @uidvalidity, imap.uid_search(@terms))
+      uids = @cursor.unseen(folder, @uidvalidity, Array(imap.uid_search(@terms)))
       @progress.call(:folder, folder: folder, total: uids.length)
       walk(imap, uids)
     end

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -18,21 +18,7 @@ class Import::Email::Backfill
   SPECIAL_ATTRS = %i[All Junk].freeze
   HEADER_BATCH = 200
 
-  # Kinds a scan counts and a run may not take, because this importer files everything
-  # through the incoming mailbox pipeline and neither of these is incoming.
-  #
-  # `sent` is the mailbox's own outgoing mail. It matters more than it looks: Gmail's \All
-  # is the union of everything except Spam and Trash, so it contains the Sent folder
-  # whole, which on a long-lived support mailbox is a sizeable share of every message in it.
-  # Run through the pipeline each one invents a contact for the company's own address and
-  # files the company's own words as something a customer wrote.
-  #
-  # `relay` is the ticketing system writing to the mailbox about a reply it sent elsewhere.
-  # The words inside are typed by whoever spoke last: an agent on some threads, the customer
-  # on others, with nothing in the notification that separates the two.
-  #
-  # Both are recognised rather than hidden, so a scan reports what a run is leaving behind.
-  UNIMPORTABLE = %i[sent relay].freeze
+  UNIMPORTABLE = Import::Email::Classifier::UNIMPORTABLE
 
   attr_reader :stats, :pacer, :stopped_by, :cursor
 
@@ -42,10 +28,7 @@ class Import::Email::Backfill
   def initialize(inbox:, kinds:, pacer:, folders: nil, terms: ['ALL'], attachments: nil, limit: nil)
     @inbox = inbox
     @channel = inbox.channel
-    @kinds = Array(kinds).map(&:to_sym)
-    refused = @kinds & UNIMPORTABLE
-    raise ArgumentError, "these kinds cannot be imported: #{refused.join(', ')}" if refused.any?
-
+    @kinds = Import::Email::Classifier.importable!(kinds)
     @pacer = pacer
     @folders = folders
     @terms = terms
@@ -296,9 +279,9 @@ class Import::Email::Backfill
   end
 
   def classify(mail)
-    presenter = MailPresenter.new(mail, @channel.account)
-    text = (presenter.text_content.presence && presenter.text_content[:full]).presence ||
-           ActionView::Base.full_sanitizer.sanitize((presenter.html_content.presence && presenter.html_content[:full]).to_s)
-    Import::Email::Classifier.new(mail: mail, text: text, own_address: @channel.email).kind
+    body = Import::Email::Body.new(MailPresenter.new(mail, @channel.account))
+    Import::Email::Classifier.new(
+      mail: mail, text: body[:full], reply: body[:reply], own_address: @channel.email
+    ).kind
   end
 end

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -18,12 +18,21 @@ class Import::Email::Backfill
   SPECIAL_ATTRS = %i[All Junk].freeze
   HEADER_BATCH = 200
 
-  # `relay` is counted but never imported. The wrapper is the ticketing system writing to
-  # the mailbox, and the words inside it were typed by whoever spoke last: an agent on some
-  # threads, the customer on others, with nothing in the notification that separates the
-  # two. Filing them all in one direction would put words in somebody's mouth, so the kind
-  # exists to be seen in a scan and left out of a run.
-  UNIMPORTABLE = %i[relay].freeze
+  # Kinds a scan counts and a run may not take, because this importer files everything
+  # through the incoming mailbox pipeline and neither of these is incoming.
+  #
+  # `sent` is the mailbox's own outgoing mail. It matters more than it looks: Gmail's \All
+  # is the union of everything except Spam and Trash, so it contains the Sent folder
+  # whole -- measured on one support mailbox, about a fifth of it.
+  # Run through the pipeline each one invents a contact for the company's own address and
+  # files the company's own words as something a customer wrote.
+  #
+  # `relay` is the ticketing system writing to the mailbox about a reply it sent elsewhere.
+  # The words inside are typed by whoever spoke last: an agent on some threads, the customer
+  # on others, with nothing in the notification that separates the two.
+  #
+  # Both are recognised rather than hidden, so a scan reports what a run is leaving behind.
+  UNIMPORTABLE = %i[sent relay].freeze
 
   attr_reader :stats, :pacer, :stopped_by
 
@@ -129,15 +138,25 @@ class Import::Email::Backfill
 
   # Headers first, and cheap: a mailbox this size is walked many times over a run, and a
   # message the inbox already holds must not be paid for twice at full size.
+  #
+  # One query per batch rather than one per header. Every pass re-walks the whole mailbox
+  # and asks about everything it has already filed, so an `exists?` per message is a round
+  # trip per message for the life of the import -- hundreds of thousands of them before a
+  # single byte is fetched, and they grow as the inbox fills.
   def unstored(imap, batch)
     heads = imap.uid_fetch(batch, 'BODY.PEEK[HEADER.FIELDS (MESSAGE-ID)]') || []
-    heads.filter_map do |data|
-      id = Mail.read_from_string(data.attr['BODY[HEADER.FIELDS (MESSAGE-ID)]'].to_s).message_id
-      next skip(:sem_message_id) if id.blank?
-      next skip(:ja_importadas) if @inbox.messages.exists?(source_id: id)
+    seen = heads.to_h { |data| [data.attr['UID'], message_id_of(data)] }
+    @stats[:sem_message_id] += seen.count { |_, id| id.blank? }
+    wanted = seen.compact_blank
+    stored = @inbox.messages.where(source_id: wanted.values).pluck(:source_id).to_set
+    @stats[:ja_importadas] += wanted.count { |_, id| stored.include?(id) }
+    wanted.filter_map { |uid, id| uid unless stored.include?(id) }
+  end
 
-      data.attr['UID']
-    end
+  def message_id_of(data)
+    Mail.read_from_string(data.attr['BODY[HEADER.FIELDS (MESSAGE-ID)]'].to_s).message_id
+  rescue StandardError
+    nil
   end
 
   def halt?
@@ -227,6 +246,6 @@ class Import::Email::Backfill
     presenter = MailPresenter.new(mail, @channel.account)
     text = (presenter.text_content.presence && presenter.text_content[:full]).presence ||
            ActionView::Base.full_sanitizer.sanitize((presenter.html_content.presence && presenter.html_content[:full]).to_s)
-    Import::Email::Classifier.new(mail: mail, text: text).kind
+    Import::Email::Classifier.new(mail: mail, text: text, own_address: @channel.email).kind
   end
 end

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -23,7 +23,7 @@ class Import::Email::Backfill
   #
   # `sent` is the mailbox's own outgoing mail. It matters more than it looks: Gmail's \All
   # is the union of everything except Spam and Trash, so it contains the Sent folder
-  # whole -- measured on one support mailbox, about a fifth of it.
+  # whole, which on a long-lived support mailbox is a sizeable share of every message in it.
   # Run through the pipeline each one invents a contact for the company's own address and
   # files the company's own words as something a customer wrote.
   #
@@ -135,22 +135,31 @@ class Import::Email::Backfill
     uids.each_slice(HEADER_BATCH) do |batch|
       break if @stopped_by
 
-      finished = true
-      last = nil
-      unstored(imap, batch).each do |uid|
-        if halt?
-          finished = false
-          break
-        end
-
-        @pacer.wait_for_room { |load| @progress.call(:paused, load: load) }
-        handle(imap, uid)
-        last = uid
-      end
-      mark = finished ? batch.last : last
-      @cursor.advance(@folder, @uidvalidity, mark) if mark
+      finished, mark = consume(imap, batch)
+      at = finished ? batch.last : mark
+      @cursor.advance(@folder, @uidvalidity, at) if at
       @cursor.flush
     end
+  end
+
+  # How far a batch got: the last UID it settled, and whether it settled all of them. The
+  # mark freezes at the first message it could not settle, so nothing above that is ever
+  # marked as read even though the run carries on past it.
+  def consume(imap, batch)
+    finished = true
+    mark = nil
+    unstored(imap, batch).each do |uid|
+      if halt?
+        finished = false
+        break
+      end
+
+      @pacer.wait_for_room { |load| @progress.call(:paused, load: load) }
+      handled = handle(imap, uid)
+      mark = uid if handled && finished
+      finished &&= handled
+    end
+    [finished, mark]
   end
 
   # Headers first, and cheap: a mailbox this size is walked many times over a run, and a
@@ -182,20 +191,27 @@ class Import::Email::Backfill
     @stopped_by.present?
   end
 
+  # Answers whether the message was settled one way or the other, which is what the cursor
+  # is allowed to move past. A message that raised is not settled: left marked as read it
+  # would be skipped by every later pass, so a transient failure -- a timeout, a malformed
+  # part, a lock -- would quietly cost a message forever. The run keeps going past it; only
+  # the mark stops.
   def handle(imap, uid)
     raw = fetch(imap, uid)
-    return if raw.blank?
+    return true if raw.blank?
 
     mail = Mail.read_from_string(raw)
     kind = classify(mail)
     @stats[:"visto_#{kind}"] += 1
-    return unless @kinds.include?(kind)
+    return true unless @kinds.include?(kind)
 
     @stats[@importer.import(mail, @channel) ? :importadas : :recusadas] += 1
     @progress.call(:imported, kind: kind, stats: @stats)
+    true
   rescue StandardError => e
     @stats[:erros] += 1
     @progress.call(:error, uid: uid, error: e)
+    false
   end
 
   # The cutoff is decided before any of the message is downloaded, because the cost it

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -253,6 +253,7 @@ class Import::Email::Backfill
   # the mark stops.
   def handle(imap, uid)
     raw = @download.perform(imap, uid)
+    return out_of_budget if @download.declined?
     return skip_empty if raw.blank?
 
     mail = Mail.read_from_string(raw)
@@ -267,6 +268,16 @@ class Import::Email::Backfill
   rescue StandardError => e
     @stats[:erros] += 1
     @progress.call(:error, uid: uid, error: e)
+    false
+  end
+
+  # A message larger than what is left of the budget. Not settled, so the mark stays below
+  # it and the next run reaches it first; and the pass ends here rather than walking on in
+  # search of something smaller, because ending a pass is what the budget is for. A run
+  # that skipped every message it could not afford would spend the rest of a mailbox on
+  # header fetches it has to repeat tomorrow anyway.
+  def out_of_budget
+    @stopped_by = :orcamento
     false
   end
 

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -228,8 +228,12 @@ class Import::Email::Backfill
     lean.rebuild(header, body)
   end
 
+  # The same reading the importer will take of the same message. A header carries its
+  # `Received` lines too, so the fallback is available here and has to be used: deciding the
+  # cutoff on `Date` alone strips the attachments off every mail with an unreadable one,
+  # including the mail the fallback would have placed inside the window.
   def header_date(header)
-    Mail.read_from_string(header).date&.to_time
+    Import::Email::Timestamp.of(Mail.read_from_string(header))
   rescue StandardError
     nil
   end

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -172,8 +172,27 @@ class Import::Email::Backfill
   # Under the default the two questions coincide, and the query stays the one it was.
   def settled(ids)
     rows = @inbox.messages.where(source_id: ids)
-    rows = rows.where.not(Import::TEXT_ONLY_SQL) unless @attachments.none?
-    rows.pluck(:source_id).to_set
+    return rows.pluck(:source_id).to_set if @attachments.none?
+
+    (rows.pluck(:source_id) - rework(rows).pluck(:source_id)).to_set
+  end
+
+  # Of the incomplete rows, the ones this run's policy would actually take attachments for.
+  # Under a cutoff the older ones are not work: the importer declines them at
+  # `skip_attachments?`, so calling them unsettled buys nothing and costs a full re-fetch of
+  # the message -- on a mailbox where the byte budget is what ends the run, and where a
+  # decade sits below any cutoff worth setting.
+  #
+  # `created_at` is the mail's own date, which `HistoryImporter` writes onto the row, so
+  # this is the same comparison `skip?` makes. The one row the two read differently is one
+  # whose headers carried no date at all: it is stored at the time of the import, which is
+  # newer than any cutoff, so it is re-offered and declined on every pass. That was already
+  # true before this and is bounded by how rare a mail with no Date header is.
+  def rework(rows)
+    incomplete = rows.where(Import::TEXT_ONLY_SQL)
+    return incomplete if @attachments.all?
+
+    incomplete.where(created_at: @attachments.cutoff..)
   end
 
   def message_id_of(data)

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -252,7 +252,7 @@ class Import::Email::Backfill
     lean = Import::Email::TextOnly.new(meta.attr['BODYSTRUCTURE'])
     return whole(imap, uid) unless text_only?(header, lean)
 
-    text_only(imap, uid, header, lean) || whole(imap, uid)
+    text_only(imap, uid, header, lean)
   end
 
   def whole(imap, uid)
@@ -269,20 +269,26 @@ class Import::Email::Backfill
     @attachments.skip?(header_date(header)) && lean.attachments?
   end
 
-  # Returns nil when the structure names no text part worth taking, and the caller falls
-  # back to the whole message: a body that cannot be located is not a body worth guessing.
+  # Only ever reached when the cutoff excludes this message's attachments, which decides
+  # what to do about a body it cannot find: nothing. Falling back to the whole message here
+  # would download every attachment the policy just excluded and then discard them, which is
+  # the one thing the lean path exists to prevent -- and on a message that is nothing but
+  # attachments, the fallback is the entire message. The row goes in on its header alone,
+  # marked as withholding what it has, so the pass that wants the files finds it and fills
+  # it in.
   def text_only(imap, uid, header, lean)
-    part = lean.part
-    return if part.nil?
-
-    section = part[:section]
-    body = imap.uid_fetch(uid, "BODY.PEEK[#{section}]")&.first&.attr&.dig("BODY[#{section}]").to_s
-    return if body.blank?
-
-    @pacer.spend(body.bytesize)
     @stats[:sem_anexos] += 1
     @lean = true
-    lean.rebuild(header, body)
+    lean.rebuild(header, body_of(imap, uid, lean))
+  end
+
+  def body_of(imap, uid, lean)
+    section = lean.part&.fetch(:section, nil)
+    return '' if section.nil?
+
+    body = imap.uid_fetch(uid, "BODY.PEEK[#{section}]")&.first&.attr&.dig("BODY[#{section}]").to_s
+    @pacer.spend(body.bytesize)
+    body
   end
 
   # The same reading the importer will take of the same message. A header carries its

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -80,24 +80,8 @@ class Import::Email::Backfill
   # somebody's unread mail as seen or expunge anything.
   def connect
     imap = Net::IMAP.new(@channel.imap_address, port: @channel.imap_port, ssl: @channel.imap_enable_ssl, open_timeout: 30)
-    authenticate(imap)
+    Import::Email::Authentication.perform(imap, @channel)
     imap
-  end
-
-  # The same three cases the live fetch services split into, because a channel does not
-  # stop being an OAuth channel when a rake task is the one connecting: on Google and
-  # Microsoft the stored `imap_password` is empty or stale and only a refreshed XOAUTH2
-  # token authenticates, so reading the column would fail every run against those
-  # providers with nothing but a login error to say why.
-  def authenticate(imap)
-    case @channel.provider
-    when 'google'
-      imap.authenticate('XOAUTH2', @channel.imap_login, Google::RefreshOauthTokenService.new(channel: @channel).access_token)
-    when 'microsoft'
-      imap.authenticate('XOAUTH2', @channel.imap_login, Microsoft::RefreshOauthTokenService.new(channel: @channel).access_token)
-    else
-      Imap::Authentication.authenticate!(imap, @channel.imap_authentication, @channel.imap_login, @channel.imap_password)
-    end
   end
 
   def close(imap)
@@ -114,14 +98,26 @@ class Import::Email::Backfill
   # the loop ran out is considered whole, including the messages `unstored` filtered on the
   # way; a batch it stopped inside is considered only up to the last message handled, so
   # nothing above the stopping point is ever marked as read.
+  #
+  # And the mark stays there for the rest of the folder. The run carries on past a message
+  # it could not settle, which is right -- one malformed part should not end a pass over
+  # hundreds of thousands of messages -- but the batches after it are above the failure, so
+  # letting them advance would bury the very UID the freeze exists to keep reachable. Every
+  # later pass would then start above it and the message would be lost without an error
+  # anywhere. The cost of freezing is re-reading headers already walked, which is cheap;
+  # the cost of not freezing is a message.
   def walk(imap, uids)
+    frozen = false
     uids.each_slice(HEADER_BATCH) do |batch|
       break if @stopped_by
 
       finished, mark = consume(imap, batch)
       at = finished ? batch.last : mark
-      @cursor.advance(@folder, @uidvalidity, at) if at
-      @cursor.flush
+      unless frozen
+        @cursor.advance(@folder, @uidvalidity, at) if at
+        @cursor.flush
+      end
+      frozen ||= !finished
     end
   end
 

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -34,7 +34,7 @@ class Import::Email::Backfill
   # Both are recognised rather than hidden, so a scan reports what a run is leaving behind.
   UNIMPORTABLE = %i[sent relay].freeze
 
-  attr_reader :stats, :pacer, :stopped_by
+  attr_reader :stats, :pacer, :stopped_by, :cursor
 
   # rubocop:disable Metrics/ParameterLists -- every one of these is an independent knob on
   # a run that is meant to be started, stopped and restarted with different settings; an
@@ -52,6 +52,7 @@ class Import::Email::Backfill
     @limit = limit
     @attachments = Import::Email::AttachmentPolicy.build(attachments)
     @importer = Import::Email::HistoryImporter.new(attachments: @attachments)
+    @cursor = Import::Email::Cursor.new(@channel)
     @stats = Hash.new(0)
     @stopped_by = nil
   end
@@ -68,12 +69,15 @@ class Import::Email::Backfill
       break if @stopped_by
 
       imap.examine(folder)
-      uids = imap.uid_search(@terms)
+      @folder = folder
+      @uidvalidity = imap.responses('UIDVALIDITY', &:last)
+      uids = @cursor.unseen(folder, @uidvalidity, imap.uid_search(@terms))
       @progress.call(:folder, folder: folder, total: uids.length)
       walk(imap, uids)
     end
     self
   ensure
+    @cursor.flush
     close(imap)
   end
 
@@ -123,16 +127,29 @@ class Import::Email::Backfill
 
   private
 
+  # The cursor moves to the highest UID this pass is done with, and no further. A batch
+  # the loop ran out is considered whole, including the messages `unstored` filtered on the
+  # way; a batch it stopped inside is considered only up to the last message handled, so
+  # nothing above the stopping point is ever marked as read.
   def walk(imap, uids)
     uids.each_slice(HEADER_BATCH) do |batch|
       break if @stopped_by
 
+      finished = true
+      last = nil
       unstored(imap, batch).each do |uid|
-        break if halt?
+        if halt?
+          finished = false
+          break
+        end
 
         @pacer.wait_for_room { |load| @progress.call(:paused, load: load) }
         handle(imap, uid)
+        last = uid
       end
+      mark = finished ? batch.last : last
+      @cursor.advance(@folder, @uidvalidity, mark) if mark
+      @cursor.flush
     end
   end
 

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -66,6 +66,7 @@ class Import::Email::Backfill
     self
   ensure
     @cursor.flush
+    @importer.flush_search_index
     close(imap)
   end
 
@@ -117,6 +118,10 @@ class Import::Email::Backfill
       break if @stopped_by
 
       finished, mark = consume(imap, batch)
+      # The batch boundary the walk already has is the one the index wants too: the
+      # importer buffers a settlement at a time and something has to say when a run of them
+      # is a batch.
+      @importer.flush_search_index
       at = finished ? batch.last : mark
       unless frozen
         @cursor.advance(@folder, @uidvalidity, at) if at

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -174,9 +174,22 @@ class Import::Email::Backfill
     seen = heads.to_h { |data| [data.attr['UID'], message_id_of(data)] }
     @stats[:sem_message_id] += seen.count { |_, id| id.blank? }
     wanted = seen.compact_blank
-    stored = @inbox.messages.where(source_id: wanted.values).pluck(:source_id).to_set
+    stored = settled(wanted.values)
     @stats[:ja_importadas] += wanted.count { |_, id| stored.include?(id) }
     wanted.filter_map { |uid, id| uid unless stored.include?(id) }
+  end
+
+  # Which of these Message-IDs this run has nothing left to do about, which is not the same
+  # as which ones are stored. A row filed by a pass that left its attachments behind is
+  # stored and incomplete, and under a policy that now wants them it is work: skipping it
+  # here is what would make the attachments unreachable, since no later pass ever looks at
+  # a Message-ID this query has already answered for.
+  #
+  # Under the default the two questions coincide, and the query stays the one it was.
+  def settled(ids)
+    rows = @inbox.messages.where(source_id: ids)
+    rows = rows.where.not(Import::TEXT_ONLY_SQL) unless @attachments.none?
+    rows.pluck(:source_id).to_set
   end
 
   def message_id_of(data)
@@ -187,7 +200,7 @@ class Import::Email::Backfill
 
   def halt?
     @stopped_by = :orcamento if @pacer.over_budget?
-    @stopped_by = :limite if @limit && @stats[:importadas] >= @limit
+    @stopped_by = :limite if @limit && (@stats[:importadas] + @stats[:enriquecidas]) >= @limit
     @stopped_by.present?
   end
 
@@ -205,7 +218,8 @@ class Import::Email::Backfill
     @stats[:"visto_#{kind}"] += 1
     return true unless @kinds.include?(kind)
 
-    @stats[@importer.import(mail, @channel) ? :importadas : :recusadas] += 1
+    @importer.import(mail, @channel, text_only: @lean)
+    @stats[@importer.outcome_kind] += 1
     @progress.call(:imported, kind: kind, stats: @stats)
     true
   rescue StandardError => e
@@ -221,6 +235,7 @@ class Import::Email::Backfill
   # and the structure are a few kilobytes and answer both questions -- when the mail was
   # sent, and whether it carries anything besides text.
   def fetch(imap, uid)
+    @lean = false
     meta = imap.uid_fetch(uid, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE'])&.first
     return skip(:vazias) if meta.nil?
 
@@ -258,6 +273,7 @@ class Import::Email::Backfill
 
     @pacer.spend(body.bytesize)
     @stats[:sem_anexos] += 1
+    @lean = true
     lean.rebuild(header, body)
   end
 

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -52,7 +52,7 @@ class Import::Email::Backfill
     @limit = limit
     @attachments = Import::Email::AttachmentPolicy.build(attachments)
     @importer = Import::Email::HistoryImporter.new(attachments: @attachments)
-    @cursor = Import::Email::Cursor.new(@channel)
+    @cursor = Import::Email::Cursor.new(@channel, selection: [@terms, @kinds.sort])
     @stats = Hash.new(0)
     @stopped_by = nil
   end

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -282,7 +282,7 @@ class Import::Email::Backfill
   def classify(mail)
     body = Import::Email::Body.new(MailPresenter.new(mail, @channel.account))
     Import::Email::Classifier.new(
-      mail: mail, text: body[:full], reply: body[:reply], own_address: @channel.email
+      mail: mail, text: body[:full], reply: body[:reply], own_addresses: [@channel.email, @channel.imap_login]
     ).kind
   end
 end

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -35,9 +35,11 @@ class Import::Email::Backfill
     @limit = limit
     @attachments = Import::Email::AttachmentPolicy.build(attachments)
     @importer = Import::Email::HistoryImporter.new(attachments: @attachments)
-    @download = Import::Email::Download.new(pacer: @pacer, attachments: @attachments, stats: @stats)
     @cursor = Import::Email::Cursor.new(@channel, selection: selection)
     @stats = Hash.new(0)
+    # After `@stats`, which it shares rather than copies: a run's tallies are one hash and
+    # the collaborators write into it.
+    @download = Import::Email::Download.new(pacer: @pacer, attachments: @attachments, stats: @stats)
     @stopped_by = nil
   end
   # rubocop:enable Metrics/ParameterLists

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -52,7 +52,7 @@ class Import::Email::Backfill
     @limit = limit
     @attachments = Import::Email::AttachmentPolicy.build(attachments)
     @importer = Import::Email::HistoryImporter.new(attachments: @attachments)
-    @cursor = Import::Email::Cursor.new(@channel, selection: [@terms, @kinds.sort])
+    @cursor = Import::Email::Cursor.new(@channel, selection: [@terms, @kinds.sort, @attachments.key])
     @stats = Hash.new(0)
     @stopped_by = nil
   end

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -35,7 +35,8 @@ class Import::Email::Backfill
     @limit = limit
     @attachments = Import::Email::AttachmentPolicy.build(attachments)
     @importer = Import::Email::HistoryImporter.new(attachments: @attachments)
-    @cursor = Import::Email::Cursor.new(@channel, selection: [@terms, @kinds.sort, @attachments.key])
+    @download = Import::Email::Download.new(pacer: @pacer, attachments: @attachments, stats: @stats)
+    @cursor = Import::Email::Cursor.new(@channel, selection: selection)
     @stats = Hash.new(0)
     @stopped_by = nil
   end
@@ -68,6 +69,37 @@ class Import::Email::Backfill
     @cursor.flush
     @importer.flush_search_index
     close(imap)
+  end
+
+  # What a stored mark means, and therefore what invalidates it.
+  #
+  # `BEFORE` is left out, and that is the whole of why this is not just `@terms`. It cuts
+  # the newer end, so moving it in either direction never makes an older message newly
+  # eligible -- and an older message hidden behind the mark is the only failure the stamp
+  # exists to prevent. Left in, it would be worse than useless: the default cutoff is a
+  # date, so it moves every midnight, and a run resumed the next day would find every mark
+  # stale, start each folder at UID 0 and spend the whole day's provider budget re-walking
+  # mail it has already declined. On a mailbox that takes weeks that is not a slow import,
+  # it is an import that never finishes.
+  #
+  # `SINCE` is the opposite and stays: widening it backwards is exactly how older, lower
+  # numbered mail becomes eligible under a mark that would hide it.
+  #
+  # The mailbox is part of the question too. `UIDVALIDITY` is unique inside one mailbox and
+  # commonly starts at 1, so a channel repointed at a different account can present a fresh
+  # folder whose stamp matches an old mark, and everything below it is filtered out before
+  # the Message-ID check ever runs -- silently, since nothing errors.
+  def selection
+    [without_before(@terms), @kinds.sort, @attachments.key, @channel.imap_address, @channel.imap_login]
+  end
+
+  # The keyword and the date after it. `ALL` stands alone in the same list, so the pairs
+  # cannot be sliced off blindly.
+  def without_before(terms)
+    at = terms.index('BEFORE')
+    return terms if at.nil?
+
+    terms[0...at] + terms[(at + 2)..].to_a
   end
 
   # Gmail is found by attribute; an ordinary server that advertises no special use is
@@ -218,15 +250,15 @@ class Import::Email::Backfill
   # part, a lock -- would quietly cost a message forever. The run keeps going past it; only
   # the mark stops.
   def handle(imap, uid)
-    raw = fetch(imap, uid)
-    return true if raw.blank?
+    raw = @download.perform(imap, uid)
+    return skip_empty if raw.blank?
 
     mail = Mail.read_from_string(raw)
     kind = classify(mail)
     @stats[:"visto_#{kind}"] += 1
     return true unless @kinds.include?(kind)
 
-    @importer.import(mail, @channel, text_only: @lean)
+    @importer.import(mail, @channel, text_only: @download.lean?)
     @stats[@importer.outcome_kind] += 1
     @progress.call(:imported, kind: kind, stats: @stats)
     true
@@ -236,77 +268,11 @@ class Import::Email::Backfill
     false
   end
 
-  # The cutoff is decided before any of the message is downloaded, because the cost it
-  # exists to control is paid at the fetch and nowhere else: `BODY.PEEK[]` pulls the
-  # encoded attachments along with the words, so a run that decides afterwards has already
-  # spent its whole provider budget on the megabytes it then declines to keep. The header
-  # and the structure are a few kilobytes and answer both questions -- when the mail was
-  # sent, and whether it carries anything besides text.
-  def fetch(imap, uid)
-    @lean = false
-    meta = imap.uid_fetch(uid, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE'])&.first
-    return skip(:vazias) if meta.nil?
-
-    header = meta.attr['BODY[HEADER]'].to_s
-    @pacer.spend(header.bytesize)
-    lean = Import::Email::TextOnly.new(meta.attr['BODYSTRUCTURE'])
-    return whole(imap, uid) unless text_only?(header, lean)
-
-    text_only(imap, uid, header, lean)
-  end
-
-  def whole(imap, uid)
-    raw = imap.uid_fetch(uid, 'BODY.PEEK[]')&.first&.attr&.dig('BODY[]').to_s
-    return skip(:vazias) if raw.blank?
-
-    @pacer.spend(raw.bytesize)
-    raw
-  end
-
-  # Worth a second round trip only when the cutoff excludes this message's attachments and
-  # it actually carries some.
-  def text_only?(header, lean)
-    @attachments.skip?(header_date(header)) && lean.attachments?
-  end
-
-  # Only ever reached when the cutoff excludes this message's attachments, which decides
-  # what to do about a body it cannot find: nothing. Falling back to the whole message here
-  # would download every attachment the policy just excluded and then discard them, which is
-  # the one thing the lean path exists to prevent -- and on a message that is nothing but
-  # attachments, the fallback is the entire message. The row goes in on its header alone,
-  # marked as withholding what it has, so the pass that wants the files finds it and fills
-  # it in.
-  def text_only(imap, uid, header, lean)
-    @stats[:sem_anexos] += 1
-    @lean = true
-    lean.rebuild(header, body_of(imap, uid, lean))
-  end
-
-  def body_of(imap, uid, lean)
-    section = lean.part&.fetch(:section, nil)
-    return '' if section.nil?
-
-    body = imap.uid_fetch(uid, "BODY.PEEK[#{section}]")&.first&.attr&.dig("BODY[#{section}]").to_s
-    @pacer.spend(body.bytesize)
-    body
-  end
-
-  # The same reading the importer will take of the same message. A header carries its
-  # `Received` lines too, so the fallback is available here and has to be used: deciding the
-  # cutoff on `Date` alone strips the attachments off every mail with an unreadable one,
-  # including the mail the fallback would have placed inside the window.
-  def header_date(header)
-    Import::Email::Timestamp.of(Mail.read_from_string(header))
-  rescue StandardError
-    nil
-  end
-
-  # Counts a record the run declined to write and yields nil, so the caller's
-  # `filter_map` drops it. Written out because `stats[key] += 1 && nil` reads like it
-  # does this and does not: `&&` binds tighter than `+=`, so it adds nil and raises.
-  def skip(key)
-    @stats[key] += 1
-    nil
+  # A message the server had nothing to give for is settled, not failed: the mark may pass
+  # it, and every later run would ask the same question and get the same nothing.
+  def skip_empty
+    @stats[:vazias] += 1
+    true
   end
 
   def classify(mail)

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -18,20 +18,31 @@ class Import::Email::Backfill
   SPECIAL_ATTRS = %i[All Junk].freeze
   HEADER_BATCH = 200
 
+  # `relay` is counted but never imported. The wrapper is the ticketing system writing to
+  # the mailbox, and the words inside it were typed by whoever spoke last: an agent on some
+  # threads, the customer on others, with nothing in the notification that separates the
+  # two. Filing them all in one direction would put words in somebody's mouth, so the kind
+  # exists to be seen in a scan and left out of a run.
+  UNIMPORTABLE = %i[relay].freeze
+
   attr_reader :stats, :pacer, :stopped_by
 
   # rubocop:disable Metrics/ParameterLists -- every one of these is an independent knob on
   # a run that is meant to be started, stopped and restarted with different settings; an
   # options object would only move the list one file over.
-  def initialize(inbox:, kinds:, pacer:, folders: nil, terms: ['ALL'], attachments_since: nil, limit: nil)
+  def initialize(inbox:, kinds:, pacer:, folders: nil, terms: ['ALL'], attachments: nil, limit: nil)
     @inbox = inbox
     @channel = inbox.channel
     @kinds = Array(kinds).map(&:to_sym)
+    refused = @kinds & UNIMPORTABLE
+    raise ArgumentError, "these kinds cannot be imported: #{refused.join(', ')}" if refused.any?
+
     @pacer = pacer
     @folders = folders
     @terms = terms
     @limit = limit
-    @importer = Import::Email::HistoryImporter.new(attachments_since: attachments_since)
+    @attachments = Import::Email::AttachmentPolicy.build(attachments)
+    @importer = Import::Email::HistoryImporter.new(attachments: @attachments)
     @stats = Hash.new(0)
     @stopped_by = nil
   end
@@ -57,19 +68,40 @@ class Import::Email::Backfill
     close(imap)
   end
 
+  # Gmail is found by attribute; an ordinary server that advertises no special use is
+  # walked from INBOX, which is the folder every server has. Without that fallback a
+  # perfectly valid channel scans nothing at all -- or, if it happens to flag only its spam
+  # folder, scans nothing but spam, which is worse because it looks like it worked.
   def folders(imap)
     return @folders if @folders.present?
 
     listed = imap.list('', '*') || []
-    @folders = SPECIAL_ATTRS.filter_map { |attr| listed.find { |f| f.attr.include?(attr) }&.name }
+    found = SPECIAL_ATTRS.index_with { |attr| listed.find { |f| f.attr.include?(attr) }&.name }
+    @folders = [found[:All] || 'INBOX', found[:Junk]].compact
   end
 
   # EXAMINE rather than SELECT everywhere: read-only, so nothing this runs can mark
   # somebody's unread mail as seen or expunge anything.
   def connect
     imap = Net::IMAP.new(@channel.imap_address, port: @channel.imap_port, ssl: @channel.imap_enable_ssl, open_timeout: 30)
-    Imap::Authentication.authenticate!(imap, @channel.imap_authentication || 'plain', @channel.imap_login, @channel.imap_password)
+    authenticate(imap)
     imap
+  end
+
+  # The same three cases the live fetch services split into, because a channel does not
+  # stop being an OAuth channel when a rake task is the one connecting: on Google and
+  # Microsoft the stored `imap_password` is empty or stale and only a refreshed XOAUTH2
+  # token authenticates, so reading the column would fail every run against those
+  # providers with nothing but a login error to say why.
+  def authenticate(imap)
+    case @channel.provider
+    when 'google'
+      imap.authenticate('XOAUTH2', @channel.imap_login, Google::RefreshOauthTokenService.new(channel: @channel).access_token)
+    when 'microsoft'
+      imap.authenticate('XOAUTH2', @channel.imap_login, Microsoft::RefreshOauthTokenService.new(channel: @channel).access_token)
+    else
+      Imap::Authentication.authenticate!(imap, @channel.imap_authentication, @channel.imap_login, @channel.imap_password)
+    end
   end
 
   def close(imap)
@@ -130,12 +162,57 @@ class Import::Email::Backfill
     @progress.call(:error, uid: uid, error: e)
   end
 
+  # The cutoff is decided before any of the message is downloaded, because the cost it
+  # exists to control is paid at the fetch and nowhere else: `BODY.PEEK[]` pulls the
+  # encoded attachments along with the words, so a run that decides afterwards has already
+  # spent its whole provider budget on the megabytes it then declines to keep. The header
+  # and the structure are a few kilobytes and answer both questions -- when the mail was
+  # sent, and whether it carries anything besides text.
   def fetch(imap, uid)
+    meta = imap.uid_fetch(uid, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE'])&.first
+    return skip(:vazias) if meta.nil?
+
+    header = meta.attr['BODY[HEADER]'].to_s
+    @pacer.spend(header.bytesize)
+    lean = Import::Email::TextOnly.new(meta.attr['BODYSTRUCTURE'])
+    return whole(imap, uid) unless text_only?(header, lean)
+
+    text_only(imap, uid, header, lean) || whole(imap, uid)
+  end
+
+  def whole(imap, uid)
     raw = imap.uid_fetch(uid, 'BODY.PEEK[]')&.first&.attr&.dig('BODY[]').to_s
     return skip(:vazias) if raw.blank?
 
     @pacer.spend(raw.bytesize)
     raw
+  end
+
+  # Worth a second round trip only when the cutoff excludes this message's attachments and
+  # it actually carries some.
+  def text_only?(header, lean)
+    @attachments.skip?(header_date(header)) && lean.attachments?
+  end
+
+  # Returns nil when the structure names no text part worth taking, and the caller falls
+  # back to the whole message: a body that cannot be located is not a body worth guessing.
+  def text_only(imap, uid, header, lean)
+    part = lean.part
+    return if part.nil?
+
+    section = part[:section]
+    body = imap.uid_fetch(uid, "BODY.PEEK[#{section}]")&.first&.attr&.dig("BODY[#{section}]").to_s
+    return if body.blank?
+
+    @pacer.spend(body.bytesize)
+    @stats[:sem_anexos] += 1
+    lean.rebuild(header, body)
+  end
+
+  def header_date(header)
+    Mail.read_from_string(header).date&.to_time
+  rescue StandardError
+    nil
   end
 
   # Counts a record the run declined to write and yields nil, so the caller's

--- a/app/services/import/email/backfill.rb
+++ b/app/services/import/email/backfill.rb
@@ -1,0 +1,155 @@
+# Walks a mailbox over IMAP and files what it finds.
+#
+# The loop, kept apart from the rake task so the pacing and the resume logic can be read
+# and tested on their own. What makes it a backfill rather than a fetch is that it is
+# built to be stopped: the byte budget ends a pass on purpose, a redeploy ends one by
+# accident, and both leave the same state behind. Every pass re-walks the folders and asks
+# the inbox what it already holds, keyed on Message-ID, so the only cost of stopping is
+# the header scan on the way back in.
+#
+# Message-ID rather than a stored cursor because a mailbox is not a log: mail arrives
+# out of order, folders are re-labelled, and a UID is only meaningful next to a
+# UIDVALIDITY that the provider may bump. What the inbox holds is the one fact that
+# survives all of that.
+class Import::Email::Backfill
+  # Gmail localises its special folders, so they are found by IMAP attribute rather than
+  # by name. \All is the union of everything except Spam and Trash, which makes it the one
+  # folder worth walking; Spam is added because a support mailbox misfiles real mail there.
+  SPECIAL_ATTRS = %i[All Junk].freeze
+  HEADER_BATCH = 200
+
+  attr_reader :stats, :pacer, :stopped_by
+
+  # rubocop:disable Metrics/ParameterLists -- every one of these is an independent knob on
+  # a run that is meant to be started, stopped and restarted with different settings; an
+  # options object would only move the list one file over.
+  def initialize(inbox:, kinds:, pacer:, folders: nil, terms: ['ALL'], attachments_since: nil, limit: nil)
+    @inbox = inbox
+    @channel = inbox.channel
+    @kinds = Array(kinds).map(&:to_sym)
+    @pacer = pacer
+    @folders = folders
+    @terms = terms
+    @limit = limit
+    @importer = Import::Email::HistoryImporter.new(attachments_since: attachments_since)
+    @stats = Hash.new(0)
+    @stopped_by = nil
+  end
+  # rubocop:enable Metrics/ParameterLists
+
+  # `progress` is called with (event, payload) as the run goes: :folder, :paused,
+  # :imported, :error. Held on the instance rather than threaded through every frame,
+  # because the loop is three levels deep and passing a block down all of them says
+  # nothing about what the loop does.
+  def perform(&progress)
+    @progress = progress || ->(*) {}
+    imap = connect
+    folders(imap).each do |folder|
+      break if @stopped_by
+
+      imap.examine(folder)
+      uids = imap.uid_search(@terms)
+      @progress.call(:folder, folder: folder, total: uids.length)
+      walk(imap, uids)
+    end
+    self
+  ensure
+    close(imap)
+  end
+
+  def folders(imap)
+    return @folders if @folders.present?
+
+    listed = imap.list('', '*') || []
+    @folders = SPECIAL_ATTRS.filter_map { |attr| listed.find { |f| f.attr.include?(attr) }&.name }
+  end
+
+  # EXAMINE rather than SELECT everywhere: read-only, so nothing this runs can mark
+  # somebody's unread mail as seen or expunge anything.
+  def connect
+    imap = Net::IMAP.new(@channel.imap_address, port: @channel.imap_port, ssl: @channel.imap_enable_ssl, open_timeout: 30)
+    Imap::Authentication.authenticate!(imap, @channel.imap_authentication || 'plain', @channel.imap_login, @channel.imap_password)
+    imap
+  end
+
+  def close(imap)
+    return if imap.nil?
+
+    imap.logout
+  rescue Net::IMAP::Error
+    imap.disconnect
+  end
+
+  private
+
+  def walk(imap, uids)
+    uids.each_slice(HEADER_BATCH) do |batch|
+      break if @stopped_by
+
+      unstored(imap, batch).each do |uid|
+        break if halt?
+
+        @pacer.wait_for_room { |load| @progress.call(:paused, load: load) }
+        handle(imap, uid)
+      end
+    end
+  end
+
+  # Headers first, and cheap: a mailbox this size is walked many times over a run, and a
+  # message the inbox already holds must not be paid for twice at full size.
+  def unstored(imap, batch)
+    heads = imap.uid_fetch(batch, 'BODY.PEEK[HEADER.FIELDS (MESSAGE-ID)]') || []
+    heads.filter_map do |data|
+      id = Mail.read_from_string(data.attr['BODY[HEADER.FIELDS (MESSAGE-ID)]'].to_s).message_id
+      next skip(:sem_message_id) if id.blank?
+      next skip(:ja_importadas) if @inbox.messages.exists?(source_id: id)
+
+      data.attr['UID']
+    end
+  end
+
+  def halt?
+    @stopped_by = :orcamento if @pacer.over_budget?
+    @stopped_by = :limite if @limit && @stats[:importadas] >= @limit
+    @stopped_by.present?
+  end
+
+  def handle(imap, uid)
+    raw = fetch(imap, uid)
+    return if raw.blank?
+
+    mail = Mail.read_from_string(raw)
+    kind = classify(mail)
+    @stats[:"visto_#{kind}"] += 1
+    return unless @kinds.include?(kind)
+
+    @stats[@importer.import(mail, @channel) ? :importadas : :recusadas] += 1
+    @progress.call(:imported, kind: kind, stats: @stats)
+  rescue StandardError => e
+    @stats[:erros] += 1
+    @progress.call(:error, uid: uid, error: e)
+  end
+
+  def fetch(imap, uid)
+    raw = imap.uid_fetch(uid, 'BODY.PEEK[]')&.first&.attr&.dig('BODY[]').to_s
+    return skip(:vazias) if raw.blank?
+
+    @pacer.spend(raw.bytesize)
+    raw
+  end
+
+  # Counts a record the run declined to write and yields nil, so the caller's
+  # `filter_map` drops it. Written out because `stats[key] += 1 && nil` reads like it
+  # does this and does not: `&&` binds tighter than `+=`, so it adds nil and raises.
+  def skip(key)
+    @stats[key] += 1
+    nil
+  end
+
+  def classify(mail)
+    presenter = MailPresenter.new(mail, @channel.account)
+    text = (presenter.text_content.presence && presenter.text_content[:full]).presence ||
+           ActionView::Base.full_sanitizer.sanitize((presenter.html_content.presence && presenter.html_content[:full]).to_s)
+    Import::Email::Classifier.new(mail: mail, text: text).kind
+  end
+end

--- a/app/services/import/email/body.rb
+++ b/app/services/import/email/body.rb
@@ -1,0 +1,28 @@
+# The words a message carries, whichever part is carrying them.
+#
+# Plain text when the message has it, the HTML stripped of its tags when it does not, and
+# empty when it has neither. Two readings, and the classifier needs both: `:full` is
+# everything the message carries and `:reply` is the same body with the quoted history
+# trimmed away.
+#
+# Its own class because the fallback is the whole point and it is easy to get half right.
+# Reading only `text_content` files every HTML-only message as empty, which on a mailbox
+# written by a ticketing system is most of the machine mail; reading only the `:full` part
+# classifies a customer's answer as the template they quoted.
+class Import::Email::Body
+  def initialize(presenter)
+    @presenter = presenter
+  end
+
+  def [](part)
+    text(part).presence || stripped_html(part)
+  end
+
+  private
+
+  def text(part) = (@presenter.text_content.presence && @presenter.text_content[part]).to_s
+
+  def stripped_html(part)
+    ActionView::Base.full_sanitizer.sanitize((@presenter.html_content.presence && @presenter.html_content[part]).to_s)
+  end
+end

--- a/app/services/import/email/body.rb
+++ b/app/services/import/email/body.rb
@@ -5,24 +5,35 @@
 # everything the message carries and `:reply` is the same body with the quoted history
 # trimmed away.
 #
-# Its own class because the fallback is the whole point and it is easy to get half right.
-# Reading only `text_content` files every HTML-only message as empty, which on a mailbox
-# written by a ticketing system is most of the machine mail; reading only the `:full` part
-# classifies a customer's answer as the template they quoted.
+# Its own class because both halves are easy to get half right. Reading only `text_content`
+# files every HTML-only message as empty, which on a mailbox written by a ticketing system
+# is most of the machine mail; reading the whole body rather than the reply classifies a
+# customer's answer as the template they quoted.
+#
+# And because the reading has to be translated. `MailPresenter` names its keys the other
+# way round: `text_content[:reply]` is `mail_content(text_part)`, byte for byte the same
+# value it returns for `:full`, while the result of `EmailReplyTrimmer.trim` is filed under
+# `:quoted`. The html pair is the same shape -- `:reply` is the parsed body and `:quoted` is
+# that body trimmed. So asking the presenter for `:reply` gets the untrimmed message and
+# quietly undoes the whole point. Upstream's names, our meaning, in one place.
 class Import::Email::Body
+  # What we call it, and the key it actually lives under.
+  KEYS = { full: :full, reply: :quoted }.freeze
+
   def initialize(presenter)
     @presenter = presenter
   end
 
   def [](part)
-    text(part).presence || stripped_html(part)
+    key = KEYS.fetch(part)
+    text(key).presence || stripped_html(key)
   end
 
   private
 
-  def text(part) = (@presenter.text_content.presence && @presenter.text_content[part]).to_s
+  def text(key) = (@presenter.text_content.presence && @presenter.text_content[key]).to_s
 
-  def stripped_html(part)
-    ActionView::Base.full_sanitizer.sanitize((@presenter.html_content.presence && @presenter.html_content[part]).to_s)
+  def stripped_html(key)
+    ActionView::Base.full_sanitizer.sanitize((@presenter.html_content.presence && @presenter.html_content[key]).to_s)
   end
 end

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -50,8 +50,22 @@ class Import::Email::Classifier
   TICKET_SUBJECT = /#(\d{2,9})\s*\z/
   TICKET_BODY    = /\bticket\s+(\d{2,9})\b/i
 
-  # A body this short says nothing a reader would want.
-  MIN_CONTENT = 40
+  # Below this a message says nothing a reader would want -- counted over `said`, which is
+  # the subject and the body together.
+  #
+  # Low on purpose, and it used to be high. Read against the body alone a threshold has to
+  # be generous, because a phone's signature is the whole body of a message whose request
+  # is on the subject line. Counting the subject removes that reason, and what a sample of
+  # a real support mailbox then shows is that there is no band of noise to cut: nothing at
+  # all lands in the first few characters, and every message under the old threshold is a
+  # legible request -- "Ingresso", "Nao chegou o codigo", "Quero cancela meu ingresso".
+  #
+  # So the floor sits just under the shortest thing anyone actually wrote. It still exists,
+  # because a bounce with no subject and no body is not archive and the guard is free, but
+  # it is a test for a blank message rather than for a short one. An archive pays for a thin
+  # row once; it pays for a dropped request forever, and silently -- `skip?` moves the cursor
+  # past it and no later pass looks again.
+  MIN_CONTENT = 6
 
   # Every answer this class gives. Exported so a caller can refuse a kind it does not
   # recognise before it connects to anything: a typo in `KINDS` otherwise matches nothing,
@@ -158,9 +172,34 @@ class Import::Email::Classifier
     return :csat if CSAT.match?(@reply)
     return :alert if ALERT.match?(@reply)
     return :relay if RELAY.match?(@reply)
-    return :empty if @text.length < MIN_CONTENT
+    return :empty if said.length < MIN_CONTENT
 
     :customer
+  end
+
+  # What the message actually says, which is not only its body.
+  #
+  # A support mailbox is written from phones, and a phone puts the whole request on the
+  # subject line and leaves the body to its own signature: "Enviado do meu iPhone" is
+  # twenty-one characters of nothing, and judged on the body alone the message reads as
+  # empty. `skip?` then drops it and the cursor moves past, so the customer's question is
+  # gone with no error anywhere, and on a mailbox written from phones that is a large share
+  # of what a first pass would have thrown away.
+  #
+  # Only the emptiness test reads this. Every kind above it is decided by who sent the
+  # message or by a template's fixed phrases, and both live in the body: a receipt whose
+  # subject happens to quote the customer is still a receipt.
+  def said
+    @said ||= [subject, @text].compact_blank.join(' ')
+  end
+
+  # The reply prefixes come off first because they are the one part of a subject that is
+  # never content: `Re: Fwd:` is nine characters that would rescue a message saying nothing.
+  # Folded like the body so the length being measured is the same kind of length.
+  def subject
+    self.class.fold(@mail.subject.to_s.sub(/\A(\s*(re|res|enc|fwd|fw)\s*:\s*)+/i, ''))
+  rescue StandardError
+    ''
   end
 
   # From one of our addresses, and not sent on somebody else's behalf.

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -1,0 +1,124 @@
+# What a message in an imported mailbox actually is.
+#
+# A support mailbox that sat behind a ticketing system is not a transcript. Measured on
+# one such mailbox, a bit over a quarter of it was written by the ticketing system
+# rather than by a person, in three shapes that want three different answers, and the
+# shapes are not separable by sender: the same `From` carries a receipt, an alert and an
+# agent's reply.
+#
+#   receipt        "Sua solicitação NNNN foi recebida e está sendo analisada". Fixed
+#                  text plus a re-quote of what the customer already sent. Nothing of its
+#                  own, and the customer's own email is in the mailbox beside it.
+#   alert          "Chegou um novo ticket NNNN que não foi atribuído para nenhum agente",
+#                  quoting the customer. By definition no agent has answered yet, so it
+#                  carries no reply -- but 3% of them quote a customer whose message came
+#                  in through another channel and exists nowhere else, which is why the
+#                  caller decides this one against the inbox rather than here.
+#   relay          the interesting one. "Por favor acesse o octadesk e verifique essa
+#                  solicitação. Seguem mais informações abaixo: <agente> 21/09/2023 13:30
+#                  Olá. Tudo bem? Para cancelamento...". The wrapper is machinery;
+#                  the payload is what the agent wrote, with a name and a timestamp. The
+#                  ticketing system sent that reply to the customer over its own SMTP, so
+#                  this notification is the only copy the mailbox holds of the agent's
+#                  half of the conversation.
+#
+# Everything else is a person writing to the company, which is the ordinary case and the
+# one the mail pipeline was built for.
+class Import::Email::Classifier
+  # Matched against text that has been folded to unaccented ASCII first, so the patterns
+  # are written without accents and stay readable. Folding rather than a wildcard per
+  # accented letter, because this mailbox does not agree with itself about how to spell
+  # one: the same sentence arrives as `solicitação`, as `solicita&ccedil;&atilde;o`, and
+  # as `solicitac&#807;a&#771;o` -- a base letter followed by a combining mark, encoded as
+  # a numeric entity. The last form is why a pattern like `solicita..o` silently stops
+  # matching: after unescaping, `ç` and `ã` are each two codepoints, not one.
+  RECEIPT = /mensagem automatica|solicitacao\s*\d+\s*foi recebida|sendo analisada por nossa equipe/i
+  ALERT   = /chegou um novo ticket|nao foi atribuido para nenhum agente/i
+  RELAY   = /acesse o octadesk e verifique|seguem mais informacoes abaixo/i
+  CSAT    = /pesquisa de satisfacao|avalie o atendimento/i
+
+  # The ticketing system's own number, which is what the operators searched by for four
+  # years and the only key that ties a thread here to a row in the export. In the subject
+  # as a trailing `#NNNN`, in the body as `ticket NNNN`.
+  TICKET_SUBJECT = /#(\d{2,9})\s*\z/
+  TICKET_BODY    = /\bticket\s+(\d{2,9})\b/i
+
+  # The line the relay puts above the agent's words: a display name, then a timestamp.
+  # Everything after it, up to the vendor's footer, is what the agent typed.
+  RELAY_PAYLOAD = /seguem mais informacoes abaixo:\s*(.*)/im
+  AGENT_LINE    = %r{\A\s*(.{2,60}?)\s+(\d{2}/\d{2}/\d{4}\s+\d{2}:\d{2})\s+(.*)\z}m
+  FOOTER        = /powered by octadesk|EmailUniqueArgumentsDTO|--- Por favor, escreva acima desta linha ---/i
+
+  # A body this short after the wrapper is stripped says nothing a reader would want.
+  MIN_CONTENT = 40
+
+  attr_reader :kind, :ticket, :agent_name, :agent_said, :agent_at
+
+  def initialize(mail:, text:)
+    @mail = mail
+    @text = self.class.fold(text)
+    classify
+  end
+
+  # Entities decoded, then decomposed and stripped of combining marks, so every spelling
+  # of the same sentence folds to the same ASCII.
+  #
+  # Decoded rather than blanked: replacing `&#807;` with a space is what splits
+  # `solicitação` into `solicitac a o`. Through Nokogiri rather than CGI.unescapeHTML,
+  # which only knows the five XML entities and leaves `&ccedil;` standing. Twice, because
+  # these templates are routinely double-encoded (`&amp;#xE7;`), and guarded on `&` so the
+  # parse is only paid for when there is something to decode.
+  def self.fold(text)
+    decoded = text.to_s
+    2.times { decoded = Nokogiri::HTML::DocumentFragment.parse(decoded).text if decoded.include?('&') }
+    decoded.unicode_normalize(:nfkd).gsub(/\p{Mn}/, '').gsub(/\s+/, ' ').strip
+  rescue ArgumentError, Encoding::CompatibilityError
+    # Mail that lies about its charset. Better a crude fold than a dropped message.
+    decoded.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '').gsub(/\s+/, ' ').strip
+  end
+
+  def skip? = %i[receipt csat empty].include?(kind)
+  def relay? = kind == :relay
+  def alert? = kind == :alert
+
+  private
+
+  def classify
+    @ticket = extract_ticket
+    @kind = kind_of_text
+  end
+
+  def kind_of_text
+    return :receipt if RECEIPT.match?(@text)
+    return :csat if CSAT.match?(@text)
+    return :alert if ALERT.match?(@text)
+    return classify_relay if RELAY.match?(@text)
+    return :empty if @text.length < MIN_CONTENT
+
+    :customer
+  end
+
+  # A relay whose payload will not come apart is filed as an alert instead of guessed at:
+  # both are wrappers around somebody else's words, and the caller already knows how to
+  # decide an alert against what the inbox holds.
+  def classify_relay
+    payload = @text[RELAY_PAYLOAD, 1].to_s.split(FOOTER).first.to_s.strip
+    return :alert if payload.length < MIN_CONTENT
+
+    name, at, said = payload.match(AGENT_LINE)&.captures
+    return :alert if said.to_s.strip.length < MIN_CONTENT
+
+    @agent_name = name.to_s.strip.presence
+    @agent_at   = (Time.zone.strptime(at, '%d/%m/%Y %H:%M') if at.present?)
+    @agent_said = said.strip
+    :relay
+  rescue ArgumentError
+    # An unparseable date is not a reason to drop what the agent wrote.
+    @agent_at = nil
+    :relay
+  end
+
+  def extract_ticket
+    @mail.subject.to_s[TICKET_SUBJECT, 1] || @text[TICKET_BODY, 1]
+  end
+end

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -14,13 +14,15 @@
 #                  carries no reply -- but 3% of them quote a customer whose message came
 #                  in through another channel and exists nowhere else, which is why the
 #                  caller decides this one against the inbox rather than here.
-#   relay          the interesting one. "Por favor acesse o octadesk e verifique essa
-#                  solicitação. Seguem mais informações abaixo: <agente> 21/09/2023 13:30
-#                  Olá. Tudo bem? Para cancelamento...". The wrapper is machinery;
-#                  the payload is what the agent wrote, with a name and a timestamp. The
-#                  ticketing system sent that reply to the customer over its own SMTP, so
-#                  this notification is the only copy the mailbox holds of the agent's
-#                  half of the conversation.
+#   relay          "Por favor acesse o octadesk e verifique essa solicitação. Seguem mais
+#                  informações abaixo: <nome> 21/09/2023 13:30 Olá. Tudo bem? Para
+#                  cancelamento...". The wrapper is machinery and the payload is a reply
+#                  the ticketing system sent over its own SMTP, so for some threads this
+#                  notification is the only copy the mailbox holds of it. Recognised so a
+#                  scan can count it and a run can leave it out, and no further: the name
+#                  above the payload is whoever spoke last, an agent on some threads and
+#                  the customer on others, and nothing in the wrapper tells them apart.
+#                  See Import::Email::Backfill::UNIMPORTABLE.
 #
 # Everything else is a person writing to the company, which is the ordinary case and the
 # one the mail pipeline was built for.
@@ -43,16 +45,10 @@ class Import::Email::Classifier
   TICKET_SUBJECT = /#(\d{2,9})\s*\z/
   TICKET_BODY    = /\bticket\s+(\d{2,9})\b/i
 
-  # The line the relay puts above the agent's words: a display name, then a timestamp.
-  # Everything after it, up to the vendor's footer, is what the agent typed.
-  RELAY_PAYLOAD = /seguem mais informacoes abaixo:\s*(.*)/im
-  AGENT_LINE    = %r{\A\s*(.{2,60}?)\s+(\d{2}/\d{2}/\d{4}\s+\d{2}:\d{2})\s+(.*)\z}m
-  FOOTER        = /powered by octadesk|EmailUniqueArgumentsDTO|--- Por favor, escreva acima desta linha ---/i
-
-  # A body this short after the wrapper is stripped says nothing a reader would want.
+  # A body this short says nothing a reader would want.
   MIN_CONTENT = 40
 
-  attr_reader :kind, :ticket, :agent_name, :agent_said, :agent_at
+  attr_reader :kind, :ticket
 
   def initialize(mail:, text:)
     @mail = mail
@@ -92,30 +88,10 @@ class Import::Email::Classifier
     return :receipt if RECEIPT.match?(@text)
     return :csat if CSAT.match?(@text)
     return :alert if ALERT.match?(@text)
-    return classify_relay if RELAY.match?(@text)
+    return :relay if RELAY.match?(@text)
     return :empty if @text.length < MIN_CONTENT
 
     :customer
-  end
-
-  # A relay whose payload will not come apart is filed as an alert instead of guessed at:
-  # both are wrappers around somebody else's words, and the caller already knows how to
-  # decide an alert against what the inbox holds.
-  def classify_relay
-    payload = @text[RELAY_PAYLOAD, 1].to_s.split(FOOTER).first.to_s.strip
-    return :alert if payload.length < MIN_CONTENT
-
-    name, at, said = payload.match(AGENT_LINE)&.captures
-    return :alert if said.to_s.strip.length < MIN_CONTENT
-
-    @agent_name = name.to_s.strip.presence
-    @agent_at   = (Time.zone.strptime(at, '%d/%m/%Y %H:%M') if at.present?)
-    @agent_said = said.strip
-    :relay
-  rescue ArgumentError
-    # An unparseable date is not a reason to drop what the agent wrote.
-    @agent_at = nil
-    :relay
   end
 
   def extract_ticket

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -1,7 +1,7 @@
 # What a message in an imported mailbox actually is.
 #
 # A support mailbox that sat behind a ticketing system is not a transcript. Measured on
-# one such mailbox, a bit over a quarter of it was written by the ticketing system
+# one such mailbox, better than a quarter of it was written by the ticketing system
 # rather than by a person, in three shapes that want three different answers, and the
 # shapes are not separable by sender: the same `From` carries a receipt, an alert and an
 # agent's reply.

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -94,9 +94,15 @@ class Import::Email::Classifier
 
   attr_reader :kind, :ticket
 
-  # `own_address` is the mailbox's own, and it is what separates a message the company
-  # received from one it sent. Optional, because a caller that does not pass it simply
+  # `own_addresses` are the mailbox's own, and they are what separates a message the company
+  # received from one it sent. Optional, because a caller that does not pass any simply
   # never sees the `sent` kind.
+  #
+  # Plural because a channel routinely has two. The address the inbox publishes and the one
+  # it authenticates as are separate columns and differ on legacy Google aliases and on
+  # Microsoft UPN setups, and it is the login that owns the Sent copies. Matching on the
+  # published address alone reads those as customer mail -- and since \All contains Sent
+  # whole, a default run would file the company's own replies as things customers wrote.
   #
   # `reply` is the body with the quoted history trimmed off, and the kind is read from it
   # rather than from the whole. A customer answering a receipt, a CSAT request or an alert
@@ -108,9 +114,9 @@ class Import::Email::Classifier
   #
   # The ticket number is still read from the whole body, because it usually lives in the
   # part that was quoted.
-  def initialize(mail:, text:, reply: nil, own_address: nil)
+  def initialize(mail:, text:, reply: nil, own_addresses: nil)
     @mail = mail
-    @own_address = own_address.to_s.downcase.strip.presence
+    @own_addresses = Array(own_addresses).map { |address| address.to_s.downcase.strip }.compact_blank.to_set
     @text = self.class.fold(text)
     @reply = self.class.fold(reply).presence || @text
     classify
@@ -158,9 +164,9 @@ class Import::Email::Classifier
   end
 
   def own_mail?
-    return false if @own_address.blank?
+    return false if @own_addresses.empty?
 
-    Array(@mail.from).any? { |address| address.to_s.downcase.strip == @own_address }
+    Array(@mail.from).any? { |address| @own_addresses.include?(address.to_s.downcase.strip) }
   end
 
   def extract_ticket

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -163,11 +163,26 @@ class Import::Email::Classifier
     :customer
   end
 
+  # From one of our addresses, and not sent on somebody else's behalf.
+  #
+  # The exception is not exotic: a website form posts as the company and points `Reply-To`
+  # at the customer, so `From` is ours and the message is inbound. Read on `From` alone it
+  # answers `:sent`, which a run refuses outright -- so every message the form ever
+  # generated is dropped and the cursor moves past it. `HistoryImporter#redirected_reply_to?`
+  # already reads this shape to name the contact; the classifier has to agree with it or
+  # those messages never reach the importer at all.
+  #
+  # A `Reply-To` that is also ours is a real outgoing mail with a routing header, so the
+  # test is that it points somewhere else.
   def own_mail?
     return false if @own_addresses.empty?
+    return false unless Array(@mail.from).any? { |address| ours?(address) }
 
-    Array(@mail.from).any? { |address| @own_addresses.include?(address.to_s.downcase.strip) }
+    reply_to = Array(@mail.reply_to)
+    reply_to.empty? || reply_to.any? { |address| ours?(address) }
   end
+
+  def ours?(address) = @own_addresses.include?(address.to_s.downcase.strip)
 
   def extract_ticket
     @mail.subject.to_s[TICKET_SUBJECT, 1] || @text[TICKET_BODY, 1]

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -14,6 +14,11 @@
 #                  carries no reply -- but 3% of them quote a customer whose message came
 #                  in through another channel and exists nowhere else, which is why the
 #                  caller decides this one against the inbox rather than here.
+#   sent           the mailbox writing, not being written to. Not a shape at all -- it is
+#                  read off `From` -- but it belongs in the same answer, because Gmail's
+#                  \All folder is the union of everything except Spam and Trash and
+#                  therefore holds the Sent folder whole. A fifth of the messages on this
+#                  mailbox are its own.
 #   relay          "Por favor acesse o octadesk e verifique essa solicitação. Seguem mais
 #                  informações abaixo: <nome> 21/09/2023 13:30 Olá. Tudo bem? Para
 #                  cancelamento...". The wrapper is machinery and the payload is a reply
@@ -50,8 +55,12 @@ class Import::Email::Classifier
 
   attr_reader :kind, :ticket
 
-  def initialize(mail:, text:)
+  # `own_address` is the mailbox's own, and it is what separates a message the company
+  # received from one it sent. Optional, because a caller that does not pass it simply
+  # never sees the `sent` kind.
+  def initialize(mail:, text:, own_address: nil)
     @mail = mail
+    @own_address = own_address.to_s.downcase.strip.presence
     @text = self.class.fold(text)
     classify
   end
@@ -84,7 +93,10 @@ class Import::Email::Classifier
     @kind = kind_of_text
   end
 
+  # Sender first, because it settles the question the text cannot: a copy of an outgoing
+  # reply reads exactly like the customer mail it quotes.
   def kind_of_text
+    return :sent if own_mail?
     return :receipt if RECEIPT.match?(@text)
     return :csat if CSAT.match?(@text)
     return :alert if ALERT.match?(@text)
@@ -92,6 +104,12 @@ class Import::Email::Classifier
     return :empty if @text.length < MIN_CONTENT
 
     :customer
+  end
+
+  def own_mail?
+    return false if @own_address.blank?
+
+    Array(@mail.from).any? { |address| address.to_s.downcase.strip == @own_address }
   end
 
   def extract_ticket

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -180,7 +180,29 @@ class Import::Email::Classifier
     return false if @own_addresses.empty?
     return false unless Array(@mail.from).any? { |address| ours?(address) }
 
-    Array(@mail.reply_to).all? { |address| ours?(address) }
+    delegated_to.all? { |address| ours?(address) }
+  end
+
+  # Who the mail is really from, read in the order `MailPresenter#original_sender` reads it:
+  # `Reply-To`, then `X-Original-Sender`, then `From`. Anything ahead of `From` is the
+  # sender saying the message belongs to somebody else, and a list or a forwarder says it
+  # that way -- our own address in `From`, the customer in `X-Original-Sender`. The
+  # classifier has to read the same order the importer will, or it answers `:sent` for a
+  # whole class of mail the importer would have filed as inbound from that customer, and a
+  # run refuses `:sent` outright and moves the cursor past it.
+  #
+  # Empty when the mail carries neither, which is an ordinary outgoing message: `all?` on
+  # nothing is true and it stays `:sent`.
+  def delegated_to
+    Array(@mail.reply_to).presence || Array(address_of(@mail['X-Original-Sender']))
+  end
+
+  def address_of(field)
+    return if field.nil?
+
+    Mail::Address.new(field.value).address
+  rescue StandardError
+    nil
   end
 
   def ours?(address) = @own_addresses.include?(address.to_s.downcase.strip)

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -53,15 +53,66 @@ class Import::Email::Classifier
   # A body this short says nothing a reader would want.
   MIN_CONTENT = 40
 
+  # Every answer this class gives. Exported so a caller can refuse a kind it does not
+  # recognise before it connects to anything: a typo in `KINDS` otherwise matches nothing,
+  # imports nothing, advances the cursor over the whole mailbox and reports it as done.
+  KINDS = %i[sent receipt csat alert relay empty customer].freeze
+
+  # Kinds a scan counts and a run may not take, because the importer files everything
+  # through the incoming mailbox pipeline and neither of these is incoming.
+  #
+  # `sent` is the mailbox's own outgoing mail. It matters more than it looks: Gmail's \All
+  # is the union of everything except Spam and Trash, so it contains the Sent folder whole,
+  # which on a long-lived support mailbox is a sizeable share of every message in it. Run
+  # through the pipeline each one invents a contact for the company's own address and files
+  # the company's own words as something a customer wrote.
+  #
+  # `relay` is the ticketing system writing to the mailbox about a reply it sent elsewhere.
+  # The words inside are typed by whoever spoke last: an agent on some threads, the
+  # customer on others, with nothing in the notification that separates the two.
+  #
+  # Both are recognised rather than hidden, so a scan reports what a run is leaving behind.
+  UNIMPORTABLE = %i[sent relay].freeze
+
+  # The kinds a run may take, or an exception naming what is wrong with the list. Refused
+  # before anything connects, because both mistakes are silent at run time: an unknown kind
+  # matches nothing, so the run downloads and classifies the whole mailbox, imports none of
+  # it, advances the cursor over all of it and reports the folder finished.
+  #
+  # An empty list is legitimate and means "classify, import nothing", which is what a scan
+  # asks for.
+  def self.importable!(kinds)
+    asked = Array(kinds).map(&:to_sym)
+    unknown = asked - KINDS
+    raise ArgumentError, "unknown kinds: #{unknown.join(', ')}" if unknown.any?
+
+    refused = asked & UNIMPORTABLE
+    raise ArgumentError, "these kinds cannot be imported: #{refused.join(', ')}" if refused.any?
+
+    asked
+  end
+
   attr_reader :kind, :ticket
 
   # `own_address` is the mailbox's own, and it is what separates a message the company
   # received from one it sent. Optional, because a caller that does not pass it simply
   # never sees the `sent` kind.
-  def initialize(mail:, text:, own_address: nil)
+  #
+  # `reply` is the body with the quoted history trimmed off, and the kind is read from it
+  # rather than from the whole. A customer answering a receipt, a CSAT request or an alert
+  # quotes the thing they are answering, so the whole body carries the template's own
+  # phrases and the message is classified as the machine mail it is a reply to -- which
+  # under the default `KINDS=customer` drops the customer's words and moves the cursor past
+  # them. The machine mail itself is unaffected: a receipt's fixed text is the unquoted top
+  # of it, which is exactly what survives the trim.
+  #
+  # The ticket number is still read from the whole body, because it usually lives in the
+  # part that was quoted.
+  def initialize(mail:, text:, reply: nil, own_address: nil)
     @mail = mail
     @own_address = own_address.to_s.downcase.strip.presence
     @text = self.class.fold(text)
+    @reply = self.class.fold(reply).presence || @text
     classify
   end
 
@@ -97,10 +148,10 @@ class Import::Email::Classifier
   # reply reads exactly like the customer mail it quotes.
   def kind_of_text
     return :sent if own_mail?
-    return :receipt if RECEIPT.match?(@text)
-    return :csat if CSAT.match?(@text)
-    return :alert if ALERT.match?(@text)
-    return :relay if RELAY.match?(@text)
+    return :receipt if RECEIPT.match?(@reply)
+    return :csat if CSAT.match?(@reply)
+    return :alert if ALERT.match?(@reply)
+    return :relay if RELAY.match?(@reply)
     return :empty if @text.length < MIN_CONTENT
 
     :customer

--- a/app/services/import/email/classifier.rb
+++ b/app/services/import/email/classifier.rb
@@ -173,13 +173,14 @@ class Import::Email::Classifier
   # those messages never reach the importer at all.
   #
   # A `Reply-To` that is also ours is a real outgoing mail with a routing header, so the
-  # test is that it points somewhere else.
+  # test is that it points somewhere else. `all?` and not `any?`: a form that lists both
+  # its own routing address and the customer is still delegating, and one owned address in
+  # the list would otherwise be enough to have the message refused.
   def own_mail?
     return false if @own_addresses.empty?
     return false unless Array(@mail.from).any? { |address| ours?(address) }
 
-    reply_to = Array(@mail.reply_to)
-    reply_to.empty? || reply_to.any? { |address| ours?(address) }
+    Array(@mail.reply_to).all? { |address| ours?(address) }
   end
 
   def ours?(address) = @own_addresses.include?(address.to_s.downcase.strip)

--- a/app/services/import/email/cursor.rb
+++ b/app/services/import/email/cursor.rb
@@ -25,8 +25,13 @@
 # lower UIDs: a pass restricted to recent mail leaves a high mark, and a later pass widened
 # to the whole mailbox would have every older UID filtered out by that mark and report the
 # folder exhausted without classifying one of them -- the silent version of the failure,
-# since nothing errors and the numbers look like a finished import. Change the search terms
-# or the kinds and the folder starts over.
+# since nothing errors and the numbers look like a finished import. Change the search
+# terms, the kinds or the attachment policy and the folder starts over.
+#
+# The attachment policy belongs in the selection even though it changes nothing about which
+# messages are imported. It changes which are *finished*: a row filed without its
+# attachments is work again once a run asks for them, and a mark left by the narrower pass
+# is what would keep every later pass from ever reaching it.
 class Import::Email::Cursor
   def initialize(channel, selection: nil)
     @channel = channel

--- a/app/services/import/email/cursor.rb
+++ b/app/services/import/email/cursor.rb
@@ -1,0 +1,75 @@
+# How far into a folder a run has already looked.
+#
+# The inbox is not enough to answer that. A resumable pass re-walks the folder and asks
+# what the inbox already holds, which works for messages it wrote and says nothing about
+# the ones it read and declined -- and on a support mailbox the declined ones are most of
+# it, since the default takes customer mail and leaves the outgoing copies, the receipts
+# and the ticketing system's own notifications behind.
+#
+# Left at that, the run never gets past them. Every pass re-downloads the same declined
+# mail, pays the same bytes for it, and stops in the same place when the daily budget runs
+# out, so a stretch of excluded traffic wider than one day's budget is a wall no number of
+# passes crosses.
+#
+# Kept on the channel, which already carries a JSON column for provider state, so this
+# needs no table of its own. Keyed by folder and stamped with `UIDVALIDITY`: a provider
+# that renumbers a folder invalidates its own cursor, and the run starts that folder over
+# rather than skipping into the middle of it.
+class Import::Email::Cursor
+  KEY = 'import_cursor'.freeze
+
+  def initialize(channel)
+    @channel = channel
+  end
+
+  # UIDs above the mark, in the order the caller gave them.
+  def unseen(folder, uidvalidity, uids)
+    mark = mark_for(folder, uidvalidity)
+    return uids if mark.zero?
+
+    uids.select { |uid| uid > mark }
+  end
+
+  # Advances only forward, and only to a UID the caller is done with. Writing is left to
+  # `flush`, so a run pays one update per batch rather than one per message.
+  def advance(folder, uidvalidity, uid)
+    current = pending[folder]
+    return if current && current['uidvalidity'] == uidvalidity && current['uid'] >= uid
+
+    pending[folder] = { 'uidvalidity' => uidvalidity, 'uid' => uid }
+  end
+
+  def flush
+    return if pending.empty?
+
+    config = @channel.provider_config.presence || {}
+    config[KEY] = (config[KEY] || {}).merge(pending)
+    @channel.update_column(:provider_config, config) # rubocop:disable Rails/SkipsModelValidations
+    @pending = {}
+  end
+
+  def reset
+    config = @channel.provider_config.presence || {}
+    return if config[KEY].blank?
+
+    @channel.update_column(:provider_config, config.except(KEY)) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def to_s
+    stored = (@channel.provider_config.presence || {})[KEY] || {}
+    return 'do inicio' if stored.empty?
+
+    stored.map { |folder, at| "#{folder}>#{at['uid']}" }.join(', ')
+  end
+
+  private
+
+  def pending = @pending ||= {}
+
+  def mark_for(folder, uidvalidity)
+    stored = ((@channel.provider_config.presence || {})[KEY] || {})[folder]
+    return 0 if stored.blank? || stored['uidvalidity'] != uidvalidity
+
+    stored['uid'].to_i
+  end
+end

--- a/app/services/import/email/cursor.rb
+++ b/app/services/import/email/cursor.rb
@@ -11,13 +11,15 @@
 # out, so a stretch of excluded traffic wider than one day's budget is a wall no number of
 # passes crosses.
 #
-# Kept on the channel, which already carries a JSON column for provider state, so this
-# needs no table of its own. Keyed by folder and stamped with `UIDVALIDITY`: a provider
-# that renumbers a folder invalidates its own cursor, and the run starts that folder over
-# rather than skipping into the middle of it.
+# Kept in a column of its own, and not in `provider_config`: the OAuth refresh services
+# replace that hash wholesale on every token renewal, so a Google or Microsoft inbox would
+# delete its own cursor long before a multi-day import finished -- and writing the cursor
+# back over the same hash could clobber credentials that had just been refreshed.
+#
+# Keyed by folder and stamped with `UIDVALIDITY`: a provider that renumbers a folder
+# invalidates its own cursor, and the run starts that folder over rather than skipping
+# into the middle of it.
 class Import::Email::Cursor
-  KEY = 'import_cursor'.freeze
-
   def initialize(channel)
     @channel = channel
   end
@@ -42,34 +44,32 @@ class Import::Email::Cursor
   def flush
     return if pending.empty?
 
-    config = @channel.provider_config.presence || {}
-    config[KEY] = (config[KEY] || {}).merge(pending)
-    @channel.update_column(:provider_config, config) # rubocop:disable Rails/SkipsModelValidations
+    @channel.update_column(:import_cursor, stored.merge(pending)) # rubocop:disable Rails/SkipsModelValidations
     @pending = {}
   end
 
   def reset
-    config = @channel.provider_config.presence || {}
-    return if config[KEY].blank?
+    @pending = {}
+    return if stored.blank?
 
-    @channel.update_column(:provider_config, config.except(KEY)) # rubocop:disable Rails/SkipsModelValidations
+    @channel.update_column(:import_cursor, {}) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def to_s
-    stored = (@channel.provider_config.presence || {})[KEY] || {}
-    return 'do inicio' if stored.empty?
+    return 'do inicio' if stored.blank?
 
     stored.map { |folder, at| "#{folder}>#{at['uid']}" }.join(', ')
   end
 
   private
 
+  def stored = @channel.import_cursor.presence || {}
   def pending = @pending ||= {}
 
   def mark_for(folder, uidvalidity)
-    stored = ((@channel.provider_config.presence || {})[KEY] || {})[folder]
-    return 0 if stored.blank? || stored['uidvalidity'] != uidvalidity
+    at = stored[folder]
+    return 0 if at.blank? || at['uidvalidity'] != uidvalidity
 
-    stored['uid'].to_i
+    at['uid'].to_i
   end
 end

--- a/app/services/import/email/cursor.rb
+++ b/app/services/import/email/cursor.rb
@@ -19,9 +19,18 @@
 # Keyed by folder and stamped with `UIDVALIDITY`: a provider that renumbers a folder
 # invalidates its own cursor, and the run starts that folder over rather than skipping
 # into the middle of it.
+#
+# Stamped with the selection for the same reason, because a mark only means anything
+# against the question that produced it. UIDs rise with arrival, so older mail carries
+# lower UIDs: a pass restricted to recent mail leaves a high mark, and a later pass widened
+# to the whole mailbox would have every older UID filtered out by that mark and report the
+# folder exhausted without classifying one of them -- the silent version of the failure,
+# since nothing errors and the numbers look like a finished import. Change the search terms
+# or the kinds and the folder starts over.
 class Import::Email::Cursor
-  def initialize(channel)
+  def initialize(channel, selection: nil)
     @channel = channel
+    @selection = Digest::SHA256.hexdigest(selection.to_json)[0, 16]
   end
 
   # UIDs above the mark, in the order the caller gave them.
@@ -38,7 +47,7 @@ class Import::Email::Cursor
     current = pending[folder]
     return if current && current['uidvalidity'] == uidvalidity && current['uid'] >= uid
 
-    pending[folder] = { 'uidvalidity' => uidvalidity, 'uid' => uid }
+    pending[folder] = { 'uidvalidity' => uidvalidity, 'uid' => uid, 'selection' => @selection }
   end
 
   def flush
@@ -68,7 +77,7 @@ class Import::Email::Cursor
 
   def mark_for(folder, uidvalidity)
     at = stored[folder]
-    return 0 if at.blank? || at['uidvalidity'] != uidvalidity
+    return 0 if at.blank? || at['uidvalidity'] != uidvalidity || at['selection'] != @selection
 
     at['uid'].to_i
   end

--- a/app/services/import/email/download.rb
+++ b/app/services/import/email/download.rb
@@ -1,0 +1,87 @@
+# How much of a message this run pulls off the server, and what that costs.
+#
+# Its own class because the decision is a policy with a price, not a step: `BODY.PEEK[]`
+# pulls the encoded attachments along with the words, and the provider meters bytes over a
+# rolling day, so what is asked for here is what ends a run early. The walk above is about
+# where to look next and has none of this in it.
+#
+# Every branch spends through the pacer as it goes, so the budget is measured against what
+# was actually transferred rather than against what was kept.
+class Import::Email::Download
+  # `lean?` answers the message just fetched: whether it went in without attachments it
+  # actually has, which the importer records on the row so a later pass knows to come back.
+  attr_reader :lean
+
+  alias lean? lean
+
+  def initialize(pacer:, attachments:, stats:)
+    @pacer = pacer
+    @attachments = attachments
+    @stats = stats
+  end
+
+  # The cutoff is decided before any of the message is downloaded, because the cost it
+  # exists to control is paid at the fetch and nowhere else: a run that decides afterwards
+  # has already spent its whole provider budget on the megabytes it then declines to keep.
+  # The header and the structure are a few kilobytes and answer both questions -- when the
+  # mail was sent, and whether it carries anything besides text.
+  def perform(imap, uid)
+    @lean = false
+    meta = imap.uid_fetch(uid, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE'])&.first
+    return if meta.nil?
+
+    header = meta.attr['BODY[HEADER]'].to_s
+    @pacer.spend(header.bytesize)
+    lean = Import::Email::TextOnly.new(meta.attr['BODYSTRUCTURE'])
+    return whole(imap, uid) unless text_only?(header, lean)
+
+    text_only(imap, uid, header, lean)
+  end
+
+  private
+
+  def whole(imap, uid)
+    raw = imap.uid_fetch(uid, 'BODY.PEEK[]')&.first&.attr&.dig('BODY[]').to_s
+    return if raw.blank?
+
+    @pacer.spend(raw.bytesize)
+    raw
+  end
+
+  # Worth a second round trip only when the cutoff excludes this message's attachments and
+  # it actually carries some.
+  def text_only?(header, lean)
+    @attachments.skip?(header_date(header)) && lean.attachments?
+  end
+
+  # Only ever reached when the cutoff excludes this message's attachments, which decides
+  # what to do about a body it cannot find: nothing. Falling back to the whole message here
+  # would download every attachment the policy just excluded and then discard them, which is
+  # the one thing this path exists to prevent -- and on a message that is nothing but
+  # attachments, the fallback is the entire message. The row goes in on its header alone,
+  # marked as withholding what it has, so the pass that wants the files finds it.
+  def text_only(imap, uid, header, lean)
+    @stats[:sem_anexos] += 1
+    @lean = true
+    lean.rebuild(header, body_of(imap, uid, lean))
+  end
+
+  def body_of(imap, uid, lean)
+    section = lean.part&.fetch(:section, nil)
+    return '' if section.nil?
+
+    body = imap.uid_fetch(uid, "BODY.PEEK[#{section}]")&.first&.attr&.dig("BODY[#{section}]").to_s
+    @pacer.spend(body.bytesize)
+    body
+  end
+
+  # The same reading the importer will take of the same message. A header carries its
+  # `Received` lines too, so the fallback is available here and has to be used: deciding the
+  # cutoff on `Date` alone strips the attachments off every mail with an unreadable one,
+  # including the mail the fallback would have placed inside the window.
+  def header_date(header)
+    Import::Email::Timestamp.of(Mail.read_from_string(header))
+  rescue StandardError
+    nil
+  end
+end

--- a/app/services/import/email/download.rb
+++ b/app/services/import/email/download.rb
@@ -14,6 +14,13 @@ class Import::Email::Download
 
   alias lean? lean
 
+  # `declined?` answers the message just refused: too large for what is left of the budget,
+  # so nothing was transferred and nothing was decided about it. The caller ends the pass
+  # there and leaves its mark below the message, which is the whole point of refusing.
+  attr_reader :declined
+
+  alias declined? declined
+
   def initialize(pacer:, attachments:, stats:)
     @pacer = pacer
     @attachments = attachments
@@ -27,25 +34,41 @@ class Import::Email::Download
   # mail was sent, and whether it carries anything besides text.
   def perform(imap, uid)
     @lean = false
-    meta = imap.uid_fetch(uid, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE'])&.first
+    @declined = false
+    meta = imap.uid_fetch(uid, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE', 'RFC822.SIZE'])&.first
     return if meta.nil?
 
     header = meta.attr['BODY[HEADER]'].to_s
     @pacer.spend(header.bytesize)
     lean = Import::Email::TextOnly.new(meta.attr['BODYSTRUCTURE'])
-    return whole(imap, uid) unless text_only?(header, lean)
+    return whole(imap, uid, meta.attr['RFC822.SIZE']) unless text_only?(header, lean)
 
     text_only(imap, uid, header, lean)
   end
 
   private
 
-  def whole(imap, uid)
+  # The size arrives with the header and the structure, in the round trip already being
+  # made, so asking what a message weighs costs nothing. Refusing here rather than letting
+  # `over_budget?` notice afterwards is the difference between a ceiling and a ceiling plus
+  # one message -- and the message that crosses it is exactly the kind this branch exists
+  # for, the one carrying the attachments.
+  #
+  # A server that reports no size is fetched as it was. This sharpens the ceiling; it is
+  # not a precondition for having one, and no mailbox is worth refusing to walk over it.
+  def whole(imap, uid, size)
+    return decline if size.to_i.positive? && !@pacer.room_for?(size.to_i)
+
     raw = imap.uid_fetch(uid, 'BODY.PEEK[]')&.first&.attr&.dig('BODY[]').to_s
     return if raw.blank?
 
     @pacer.spend(raw.bytesize)
     raw
+  end
+
+  def decline
+    @declined = true
+    nil
   end
 
   # Worth a second round trip only when the cutoff excludes this message's attachments and

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -42,10 +42,8 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
 
   attr_reader :opened, :outcome
 
-  # `attachments_since` is nil to take every attachment, or a Time to take only those on
-  # messages newer than it.
-  def initialize(attachments_since: nil)
-    @attachments_since = attachments_since
+  def initialize(attachments: nil)
+    @attachments = attachments.is_a?(Import::Email::AttachmentPolicy) ? attachments : Import::Email::AttachmentPolicy.build(attachments)
     @opened = Set.new
     super()
   end
@@ -55,7 +53,7 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   def import(mail, channel)
     return if stored?(mail, channel)
 
-    @occurred_at = mail.date&.to_time
+    @occurred_at = occurred_at(mail)
     @outcome = nil
     Import::SilentWrite.wrap do
       process(mail, channel)
@@ -78,16 +76,34 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
     channel.inbox.messages.exists?(source_id: id)
   end
 
-  # The two dates a conversation is asked for. `occurred_at` is when the mail was sent;
-  # falling back to now would be the bug this class exists to fix, so a mail without a
-  # parseable Date is filed at the epoch of its own thread instead of at today.
+  # When the mail was sent. A mail whose `Date` will not parse still says when it moved:
+  # every relay that touched it stamped a `Received` line on the way, and the oldest of
+  # those is the closest thing the message has to a send time. Falling back to now would be
+  # the bug this class exists to fix.
+  def occurred_at(mail)
+    mail.date&.to_time || received_at(mail)
+  end
+
+  def received_at(mail)
+    Array(mail.received).filter_map { |field| field.date_time&.to_time }.min
+  rescue StandardError
+    nil
+  end
+
+  # Resolved unconditionally, dated when there is a date. The two are separate decisions
+  # and only one of them depends on the clock: a thread out of the archive is not somebody's
+  # open work whatever its headers say, and leaving it open because its `Date` was
+  # unreadable would put it in the queue as live traffic -- which is the one outcome the
+  # whole import is built to avoid.
   def find_or_create_conversation
     super
     return if @conversation.blank?
 
     if @conversation.previously_new_record?
       @opened << @conversation.id
-      @conversation.update_columns(created_at: @occurred_at, status: :resolved) if @occurred_at # rubocop:disable Rails/SkipsModelValidations
+      stamps = { status: :resolved }
+      stamps[:created_at] = @occurred_at if @occurred_at
+      @conversation.update_columns(stamps) # rubocop:disable Rails/SkipsModelValidations
     end
     @conversation
   end
@@ -145,21 +161,23 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
     super
   end
 
-  def skip_attachments?
-    return false if @attachments_since.blank?
-    return false if @occurred_at.blank?
-
-    @occurred_at < @attachments_since
-  end
+  def skip_attachments? = @attachments.skip?(@occurred_at)
 
   # `HistorySettlement` works a batch at a time because a WhatsApp dump arrives that way.
   # A mailbox arrives one message at a time, so the batch here is the single row just
   # written -- correct, and idempotent across the run: every stamp it sets only ever moves
   # in the direction the newest row justifies.
+  # Settled row by row, and the conversation leaves `opened` as soon as it has been: that
+  # set says "these stamps are the import's own artifacts, take the batch outright", which
+  # is true exactly once. IMAP hands out UIDs in arrival order and a thread is filed in the
+  # order its messages were sent, so the two disagree routinely -- and while a conversation
+  # stays in the set, a later UID carrying an older date bypasses the monotonic guard and
+  # drags `last_activity_at` backwards, one row at a time, for the whole run.
   def settle_thread
     return if @outcome.blank? || @conversation.blank?
 
     settle([@outcome], [])
+    @opened.delete(@conversation.id)
   end
 
   # Nothing about a bulk backfill is worth pushing to a screen. The level exists for the

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -195,8 +195,20 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   def settle_thread
     return if @outcome.blank? || @conversation.blank?
 
-    settle([@outcome], [])
+    settle(settleable, [])
     @opened.delete(@conversation.id)
+  end
+
+  # A resolved thread runs no waiting clock, so the row just written is the whole story and
+  # the batch is that row. An open one is somebody's live queue, and there `first_unanswered`
+  # has to see the replies already stored after this message: settled on the new row alone it
+  # reads an answered conversation as pending and moves `waiting_since` back to a date in the
+  # archive, which files a thread somebody already handled into the unattended and SLA
+  # reports. Only that path pays for the extra read, and only that path needs it.
+  def settleable
+    return [@outcome] if @conversation.resolved?
+
+    @conversation.messages.to_a
   end
 
   # Nothing about a bulk backfill is worth pushing to a screen. The level exists for the

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -57,6 +57,7 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   def import(mail, channel, text_only: false)
     @occurred_at = occurred_at(mail)
     @text_only = text_only || withholding?(mail)
+    promote_delegated(mail, channel)
     @outcome = nil
     existing = stored(mail, channel)
     return enrich(mail, channel, existing) if existing
@@ -136,6 +137,32 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   # Shared with the backfill, which reads it off the header alone to decide the attachment
   # cutoff. Falling back to now would be the bug this class exists to fix.
   def occurred_at(mail) = Import::Email::Timestamp.of(mail)
+
+  # Puts the party actually being written to first in `Reply-To`.
+  #
+  # A website form posts as the company and names the customer in the routing header, and
+  # some of them list their own address there as well. Every reader downstream takes the
+  # first address it finds -- `MailPresenter#original_sender`, which the contact lookup and
+  # the contact creation both go through, and `redirected_reply_to?`, which decides where
+  # the display name comes from -- so with ours listed first the whole thread is filed under
+  # the company's own contact. There is no second chance at it either: the dedupe is by
+  # Message-ID, so every later pass sees the row and skips it.
+  #
+  # Reordered once, here, rather than overridden in each reader: an override would fix the
+  # one that was overridden and leave the others answering something else about the same
+  # message, which is the disagreement this class exists to avoid.
+  def promote_delegated(mail, channel)
+    addresses = Array(mail.reply_to).map { |address| address.to_s.downcase.strip }.compact_blank
+    delegated = addresses.find { |address| !own_address?(address, channel) }
+    return if delegated.blank? || addresses.first == delegated
+
+    mail.reply_to = [delegated] + (addresses - [delegated])
+  end
+
+  def own_address?(address, channel)
+    [channel.email, channel.imap_login].compact_blank
+                                       .map { |own| own.to_s.downcase.strip }.include?(address)
+  end
 
   # Resolved unconditionally, dated when there is a date. The two are separate decisions
   # and only one of them depends on the clock: a thread out of the archive is not somebody's

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -67,7 +67,7 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
     # import, and the next pass skips that Message-ID in `unstored` and never comes back to
     # it. Together they either both land or neither does, and neither leaves a row the
     # resume cannot see.
-    Import::SilentWrite.wrap do
+    Import::SilentWrite.wrap(indexing: true) do
       ActiveRecord::Base.transaction do
         process(mail, channel)
         settle_thread
@@ -115,7 +115,7 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
     decorate_mail
     @message = message
     @conversation = message.conversation
-    Import::SilentWrite.wrap { fill_attachments }
+    Import::SilentWrite.wrap(indexing: true) { fill_attachments }
     @outcome_kind = :enriquecidas
     @outcome = @message
   end

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -45,6 +45,7 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   def initialize(attachments: nil)
     @attachments = attachments.is_a?(Import::Email::AttachmentPolicy) ? attachments : Import::Email::AttachmentPolicy.build(attachments)
     @opened = Set.new
+    @created = Set.new
     super()
   end
 
@@ -120,11 +121,33 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
 
     if @conversation.previously_new_record?
       @opened << @conversation.id
+      @created << @conversation.id
       stamps = { status: :resolved }
       stamps[:created_at] = @occurred_at if @occurred_at
       @conversation.update_columns(stamps) # rubocop:disable Rails/SkipsModelValidations
+    else
+      backdate_conversation
     end
     @conversation
+  end
+
+  # A thread opens on the first of its messages this run happens to see, and IMAP hands
+  # them out in arrival order rather than in the order they were written -- so the message
+  # that opens a conversation is routinely not its oldest, and the thread ends up dated
+  # after mail it contains. Only ever moved earlier, and only on a thread with no live
+  # traffic in it: on one somebody is working, the creation date is real.
+  #
+  # `@created` rather than `@opened`, which the settlement empties as it goes. The query is
+  # the resume path only, and reached only when there is actually a date to correct.
+  def backdate_conversation
+    return if @occurred_at.blank? || @conversation.created_at <= @occurred_at
+    return unless @created.include?(@conversation.id) || imported_only?(@conversation)
+
+    @conversation.update_columns(created_at: @occurred_at) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def imported_only?(conversation)
+    conversation.messages.where.not(Import::IMPORTED_SQL).none?
   end
 
   # Address from `Reply-To`, name from `From`. See the class comment.

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -55,9 +55,16 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
 
     @occurred_at = occurred_at(mail)
     @outcome = nil
+    # One transaction around the write and the settlement, because the dedupe key is the
+    # row: a run that commits the message and then stops leaves stamps describing the
+    # import, and the next pass skips that Message-ID in `unstored` and never comes back to
+    # it. Together they either both land or neither does, and neither leaves a row the
+    # resume cannot see.
     Import::SilentWrite.wrap do
-      process(mail, channel)
-      settle_thread
+      ActiveRecord::Base.transaction do
+        process(mail, channel)
+        settle_thread
+      end
     end
     @outcome
   end
@@ -80,8 +87,20 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   # every relay that touched it stamped a `Received` line on the way, and the oldest of
   # those is the closest thing the message has to a send time. Falling back to now would be
   # the bug this class exists to fix.
+  #
+  # `Mail` is not consistent about how it refuses a bad `Date`: an unreadable field comes
+  # back as the raw String, and one that parses into an impossible time raises from the
+  # reader itself. Both are the same thing here -- the header says nothing usable -- and
+  # neither is a reason to count the message as an error and retry it on every pass.
   def occurred_at(mail)
-    mail.date&.to_time || received_at(mail)
+    sent_at(mail) || received_at(mail)
+  end
+
+  def sent_at(mail)
+    date = mail.date
+    date.to_time if date.respond_to?(:to_time)
+  rescue StandardError
+    nil
   end
 
   def received_at(mail)

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -40,7 +40,7 @@
 class Import::Email::HistoryImporter < Imap::ImapMailbox
   include Import::HistorySettlement
 
-  attr_reader :opened, :outcome
+  attr_reader :opened, :outcome, :outcome_kind
 
   def initialize(attachments: nil)
     @attachments = Import::Email::AttachmentPolicy.build(attachments)
@@ -51,11 +51,16 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
 
   # Returns the message it wrote, or nil when the pipeline declined the mail (an invalid
   # sender, a duplicate Message-ID, a notification of our own).
-  def import(mail, channel)
-    return if stored?(mail, channel)
-
+  #
+  # `text_only` is the caller saying it fetched a lean copy and left this message's
+  # attachments in the mailbox, which is recorded on the row. See Import::TEXT_ONLY_SQL.
+  def import(mail, channel, text_only: false)
     @occurred_at = occurred_at(mail)
+    @text_only = text_only
     @outcome = nil
+    existing = stored(mail, channel)
+    return enrich(mail, channel, existing) if existing
+
     # One transaction around the write and the settlement, because the dedupe key is the
     # row: a run that commits the message and then stops leaves stamps describing the
     # import, and the next pass skips that Message-ID in `unstored` and never comes back to
@@ -67,6 +72,7 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
         settle_thread
       end
     end
+    @outcome_kind = @outcome ? :importadas : :recusadas
     @outcome
   end
 
@@ -77,11 +83,54 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   # whose References no longer resolve opens a fresh conversation, and the check then runs
   # against a thread that is empty by construction and passes. Measured on 29 real
   # messages, a second pass duplicated 25 of them.
-  def stored?(mail, channel)
+  def stored(mail, channel)
     id = sanitize_mailbox_value(mail.message_id)
-    return false if id.blank?
+    return if id.blank?
 
-    channel.inbox.messages.exists?(source_id: id)
+    channel.inbox.messages.find_by(source_id: id)
+  end
+
+  # The attachments a narrower pass left behind, fetched onto the row that is already
+  # filed.
+  #
+  # Without this the archive cannot be widened. A first pass under `ATTACHMENTS=none`
+  # files every message text-only; a second pass under a cutoff finds the Message-ID
+  # already stored, calls it done, and the attachments stay in a mailbox nobody will read
+  # again -- silently, and with no setting that recovers them, since resetting the cursor
+  # only re-walks UIDs the stored check will refuse a second time.
+  #
+  # It runs the same `add_attachments_to_message` over the same `MailPresenter` the live
+  # path runs, which is the whole reason this class subclasses the mailbox: an attachment
+  # filed here is the one the pipeline would have filed. Nothing else about the message is
+  # touched -- it already has its body, its date, its thread and its contact.
+  def enrich(mail, channel, message)
+    @outcome_kind = :inalteradas
+    return if skip_attachments? || !incomplete?(message)
+
+    @inbound_mail = mail
+    @channel = channel
+    load_account
+    load_inbox
+    decorate_mail
+    @message = message
+    @conversation = message.conversation
+    Import::SilentWrite.wrap { fill_attachments }
+    @outcome_kind = :enriquecidas
+    @outcome = @message
+  end
+
+  # The flag is cleared in the same transaction that writes the attachments, so a run that
+  # dies between them leaves the row still asking to be enriched rather than claiming to be
+  # complete while holding nothing.
+  def fill_attachments
+    ActiveRecord::Base.transaction do
+      add_attachments_to_message
+      @message.update!(content_attributes: @message.content_attributes.except('imported_text_only'))
+    end
+  end
+
+  def incomplete?(message)
+    ActiveModel::Type::Boolean.new.cast(message.content_attributes['imported_text_only']) == true
   end
 
   # Shared with the backfill, which reads it off the header alone to decide the attachment
@@ -160,7 +209,10 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   # Says the row was filed after the fact. Read by Inbound::Coverage and HistorySettlement,
   # and by any report that means to exclude backfilled traffic. See Import::IMPORTED_SQL.
   def sanitized_content_attributes
-    super.merge(imported: true)
+    attributes = super.merge(imported: true)
+    return attributes unless @text_only
+
+    attributes.merge(imported_text_only: true)
   end
 
   def create_message

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -84,31 +84,9 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
     channel.inbox.messages.exists?(source_id: id)
   end
 
-  # When the mail was sent. A mail whose `Date` will not parse still says when it moved:
-  # every relay that touched it stamped a `Received` line on the way, and the oldest of
-  # those is the closest thing the message has to a send time. Falling back to now would be
-  # the bug this class exists to fix.
-  #
-  # `Mail` is not consistent about how it refuses a bad `Date`: an unreadable field comes
-  # back as the raw String, and one that parses into an impossible time raises from the
-  # reader itself. Both are the same thing here -- the header says nothing usable -- and
-  # neither is a reason to count the message as an error and retry it on every pass.
-  def occurred_at(mail)
-    sent_at(mail) || received_at(mail)
-  end
-
-  def sent_at(mail)
-    date = mail.date
-    date.to_time if date.respond_to?(:to_time)
-  rescue StandardError
-    nil
-  end
-
-  def received_at(mail)
-    Array(mail.received).filter_map { |field| field.date_time&.to_time }.min
-  rescue StandardError
-    nil
-  end
+  # Shared with the backfill, which reads it off the header alone to decide the attachment
+  # cutoff. Falling back to now would be the bug this class exists to fix.
+  def occurred_at(mail) = Import::Email::Timestamp.of(mail)
 
   # Resolved unconditionally, dated when there is a date. The two are separate decisions
   # and only one of them depends on the clock: a thread out of the archive is not somebody's

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -56,7 +56,7 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   # attachments in the mailbox, which is recorded on the row. See Import::TEXT_ONLY_SQL.
   def import(mail, channel, text_only: false)
     @occurred_at = occurred_at(mail)
-    @text_only = text_only
+    @text_only = text_only || withholding?(mail)
     @outcome = nil
     existing = stored(mail, channel)
     return enrich(mail, channel, existing) if existing
@@ -234,6 +234,13 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   end
 
   def skip_attachments? = @attachments.skip?(@occurred_at)
+
+  # Whether this row is going in without attachments it actually has. Two ways to get
+  # there and both have to be recorded, or the row claims to be complete and no later pass
+  # goes back for it: the caller fetched a lean copy and says so, or it fetched the whole
+  # message -- because the structure named no text part worth taking -- and we are the ones
+  # dropping the attachments here.
+  def withholding?(mail) = skip_attachments? && mail.attachments.present?
 
   # `HistorySettlement` works a batch at a time because a WhatsApp dump arrives that way.
   # A mailbox arrives one message at a time, so the batch here is the single row just

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -279,6 +279,10 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   # order its messages were sent, so the two disagree routinely -- and while a conversation
   # stays in the set, a later UID carrying an older date bypasses the monotonic guard and
   # drags `last_activity_at` backwards, one row at a time, for the whole run.
+  # A backfill outlives its settlements, so it buffers and the walker empties it. The size
+  # only bounds the buffer: the flush happens at the batch boundary the walk already has.
+  def search_index_batch = SEARCH_INDEX_BATCH
+
   def settle_thread
     return if @outcome.blank? || @conversation.blank?
 

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -1,0 +1,169 @@
+# Files one historical email into an email inbox.
+#
+# A subclass of the live mailbox, and that is the whole design, for the same reason
+# Whatsapp::Baileys::HistoryImporter subclasses the webhook service: a message from 2023
+# and a message from this morning are the same RFC822 document, so an imported row is made
+# indistinguishable from a live one by running the code a live one runs -- the same body
+# extraction, the same threading by In-Reply-To and References, the same attachment
+# handling, the same contact resolution. A parallel reader written alongside it would be a
+# second interpretation of the same bytes, and the day the two disagree is the day the
+# archive stops matching what the inbox already holds.
+#
+# What it changes, and why each one has to change:
+#
+#   the date          `create_message` stamps `created_at` at insert time, so a mailbox
+#                     replayed today would stack four years of conversation on top of this
+#                     afternoon. Applied after the insert because the attribute builder
+#                     takes no date, and safe there because SilentWrite has already
+#                     suppressed the callbacks that would have read the wrong one.
+#   the thread        born resolved and dated to its first message, never resolved
+#                     afterwards. `notify_status_change` and `create_activity` are
+#                     after_update callbacks, so a thread born in this state fires no
+#                     resolution event and writes no "resolved by" line into itself;
+#                     transitioning to the same state would do both and file every
+#                     imported thread into today's figures.
+#   the contact name  the live path reads the display name off `Reply-To` when there is
+#                     one. A web form that sends as the company and points `Reply-To` at
+#                     the customer therefore names every contact after the form. The
+#                     address still has to come from `Reply-To` -- that is the customer --
+#                     so only the name falls back to `From`.
+#   the attachments   optional, and off for anything older than the caller's cutoff. The
+#                     attachments on a mailbox this size outweigh its bodies by fifty to
+#                     one, against a provider that allows 2.5 GB a day, so fetching all of
+#                     them is a months-long job. Skipped ones stay reachable: the row keeps its
+#                     Message-ID, which is what `rfc822msgid:` searches by.
+#
+# Everything the write may set off is suppressed by Import::SilentWrite for the whole run:
+# no dashboard push, no automations, no outgoing webhooks, no bots, no notifications, no
+# auto-replies to a message that was answered in 2023. Unlike the on-demand WhatsApp
+# import there is nobody watching a screen, so this never announces.
+class Import::Email::HistoryImporter < Imap::ImapMailbox
+  include Import::HistorySettlement
+
+  attr_reader :opened, :outcome
+
+  # `attachments_since` is nil to take every attachment, or a Time to take only those on
+  # messages newer than it.
+  def initialize(attachments_since: nil)
+    @attachments_since = attachments_since
+    @opened = Set.new
+    super()
+  end
+
+  # Returns the message it wrote, or nil when the pipeline declined the mail (an invalid
+  # sender, a duplicate Message-ID, a notification of our own).
+  def import(mail, channel)
+    return if stored?(mail, channel)
+
+    @occurred_at = mail.date&.to_time
+    @outcome = nil
+    Import::SilentWrite.wrap do
+      process(mail, channel)
+      settle_thread
+    end
+    @outcome
+  end
+
+  private
+
+  # Asked of the inbox, not of the conversation. The live pipeline dedupes inside the
+  # thread it just picked, which is right for an arrival and wrong for a replay: a mail
+  # whose References no longer resolve opens a fresh conversation, and the check then runs
+  # against a thread that is empty by construction and passes. Measured on 29 real
+  # messages, a second pass duplicated 25 of them.
+  def stored?(mail, channel)
+    id = sanitize_mailbox_value(mail.message_id)
+    return false if id.blank?
+
+    channel.inbox.messages.exists?(source_id: id)
+  end
+
+  # The two dates a conversation is asked for. `occurred_at` is when the mail was sent;
+  # falling back to now would be the bug this class exists to fix, so a mail without a
+  # parseable Date is filed at the epoch of its own thread instead of at today.
+  def find_or_create_conversation
+    super
+    return if @conversation.blank?
+
+    if @conversation.previously_new_record?
+      @opened << @conversation.id
+      @conversation.update_columns(created_at: @occurred_at, status: :resolved) if @occurred_at # rubocop:disable Rails/SkipsModelValidations
+    end
+    @conversation
+  end
+
+  # Address from `Reply-To`, name from `From`. See the class comment.
+  def identify_contact_name
+    return super unless redirected_reply_to?
+
+    sanitize_mailbox_value(from_display_name.presence || super)
+  end
+
+  # A `Reply-To` that points somewhere other than `From`: the mail was sent on the
+  # customer's behalf, so `From` holds who it is about and `Reply-To` holds where to write.
+  def redirected_reply_to?
+    reply_to = address_of(@inbound_mail[:reply_to])
+    from = address_of(@inbound_mail[:from])
+    reply_to.present? && from.present? && reply_to != from
+  end
+
+  def from_display_name = address(@inbound_mail[:from])&.name
+  def address_of(field) = address(field)&.address
+
+  # `MailPresenter` keeps its own parser private, and the mailbox never needed one because
+  # the live path only ever reads the presenter's `sender_name`. Same shape, same rescue:
+  # a malformed From is a header this run declines to read, not a message it drops.
+  def address(field)
+    return if field.nil?
+
+    Mail::Address.new(field.value)
+  rescue Mail::Field::ParseError, Mail::Field::IncompleteParseError, NoMethodError
+    nil
+  end
+
+  # Says the row was filed after the fact. Read by Inbound::Coverage and HistorySettlement,
+  # and by any report that means to exclude backfilled traffic. See Import::IMPORTED_SQL.
+  def sanitized_content_attributes
+    super.merge(imported: true)
+  end
+
+  def create_message
+    super
+    return if @message.blank?
+
+    @message.update_column(:created_at, @occurred_at) if @occurred_at # rubocop:disable Rails/SkipsModelValidations
+    @outcome = @message
+  end
+
+  # An attachment older than the cutoff is not fetched at all, rather than fetched and
+  # dropped: the cost this avoids is the provider's daily byte budget, and that is spent at
+  # the fetch. The caller does not hand us the parts in that case, so there is nothing to
+  # attach and the message keeps its text.
+  def add_attachments_to_message
+    return if skip_attachments?
+
+    super
+  end
+
+  def skip_attachments?
+    return false if @attachments_since.blank?
+    return false if @occurred_at.blank?
+
+    @occurred_at < @attachments_since
+  end
+
+  # `HistorySettlement` works a batch at a time because a WhatsApp dump arrives that way.
+  # A mailbox arrives one message at a time, so the batch here is the single row just
+  # written -- correct, and idempotent across the run: every stamp it sets only ever moves
+  # in the direction the newest row justifies.
+  def settle_thread
+    return if @outcome.blank? || @conversation.blank?
+
+    settle([@outcome], [])
+  end
+
+  # Nothing about a bulk backfill is worth pushing to a screen. The level exists for the
+  # on-demand WhatsApp case; here it stays silent, so the hook the settlement calls
+  # through resolves to a plain yield.
+  def announcing(&) = yield
+end

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -43,7 +43,7 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
   attr_reader :opened, :outcome
 
   def initialize(attachments: nil)
-    @attachments = attachments.is_a?(Import::Email::AttachmentPolicy) ? attachments : Import::Email::AttachmentPolicy.build(attachments)
+    @attachments = Import::Email::AttachmentPolicy.build(attachments)
     @opened = Set.new
     @created = Set.new
     super()

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -116,6 +116,13 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
     @message = message
     @conversation = message.conversation
     Import::SilentWrite.wrap(indexing: true) { fill_attachments }
+    # The enrichment is a write like any other and the index has to hear about it: the row
+    # gains attachments, which `Messages::SearchDataPresenter` reads. `indexing: true` above
+    # silences the per-row callback the update would otherwise fire, and this path settles
+    # nothing -- the stamps are already right, only the row changed -- so the backlog is
+    # asked for by hand. Without it the flag buys silence and gives nothing back, and the
+    # indexed document keeps describing a message that no longer exists.
+    index_for_search([@message])
     @outcome_kind = :enriquecidas
     @outcome = @message
   end

--- a/app/services/import/email/history_importer.rb
+++ b/app/services/import/email/history_importer.rb
@@ -59,6 +59,14 @@ class Import::Email::HistoryImporter < Imap::ImapMailbox
     @text_only = text_only || withholding?(mail)
     promote_delegated(mail, channel)
     @outcome = nil
+    # The mailbox this subclasses keeps the row it wrote in `@message`, and this instance is
+    # reused for every mail of the run. `create_message` returns early on a source id it
+    # already holds without clearing it -- so if the live poller files this mail between the
+    # check below and the write, the previous mail's row is still sitting there and takes
+    # this one's attachments and date. Minutes pass inside a batch of two hundred and the
+    # inbox goes on being polled the whole time, so the window is real rather than notional.
+    @message = nil
+    @conversation = nil
     existing = stored(mail, channel)
     return enrich(mail, channel, existing) if existing
 

--- a/app/services/import/email/pacer.rb
+++ b/app/services/import/email/pacer.rb
@@ -26,6 +26,13 @@ class Import::Email::Pacer
   end
 
   def spend(count) = @bytes += count.to_i
+
+  # Whether a transfer of this size still fits. Asked before a fetch, because
+  # `over_budget?` can only ever be true of bytes already on the wire: a run that only
+  # looks back overshoots the ceiling by whatever it just pulled down, and the ceiling is
+  # there to sit under a provider limit whose answer to an overdraft is locking IMAP for
+  # the account.
+  def room_for?(count) = @bytes + count.to_i <= @budget
   def budget_mb_left = ((@budget - @bytes) / 1.megabyte).round
   def spent_mb = (@bytes / 1.megabyte.to_f).round(1)
   def over_budget? = @bytes >= @budget

--- a/app/services/import/email/pacer.rb
+++ b/app/services/import/email/pacer.rb
@@ -1,0 +1,54 @@
+# Yields to the machine the backfill runs on.
+#
+# Two independent ceilings, because the two things a long backfill can exhaust are
+# unrelated and want opposite responses. The provider meters bytes over a rolling day and
+# answers an overdraft by locking IMAP for the whole account, which would take the live
+# fetch down with it, so the budget *stops* the run and it resumes tomorrow. The host
+# meters nothing and simply gets slower, which the agents feel as latency long before
+# anything errors, so the load average only *pauses* it.
+#
+# The load is read from /proc, which inside a container is still the host's: that is the
+# number the agents' latency tracks, not this process's share of it.
+class Import::Email::Pacer
+  # Checking every message would be a syscall per message for a number that moves on a
+  # one-minute average; this is often enough to catch a spike within a few seconds of work.
+  CHECK_EVERY = 25
+  BACKOFF = 20.seconds
+
+  attr_reader :bytes, :paused_for
+
+  def initialize(budget_mb:, max_load:)
+    @budget = budget_mb.to_f.megabytes
+    @max_load = max_load.to_f
+    @bytes = 0
+    @seen = 0
+    @paused_for = 0
+  end
+
+  def spend(count) = @bytes += count.to_i
+  def budget_mb_left = ((@budget - @bytes) / 1.megabyte).round
+  def spent_mb = (@bytes / 1.megabyte.to_f).round(1)
+  def over_budget? = @bytes >= @budget
+
+  def load_average
+    File.read('/proc/loadavg').split.first.to_f
+  rescue StandardError
+    0.0
+  end
+
+  # Blocks while the host is busy. Returns the seconds it waited, so the caller can report
+  # a run that took six hours of which five were spent standing aside.
+  def wait_for_room
+    @seen += 1
+    return 0 unless (@seen % CHECK_EVERY).zero?
+
+    waited = 0
+    while load_average > @max_load
+      yield(load_average) if block_given?
+      sleep BACKOFF
+      waited += BACKOFF
+      @paused_for += BACKOFF
+    end
+    waited
+  end
+end

--- a/app/services/import/email/text_only.rb
+++ b/app/services/import/email/text_only.rb
@@ -30,13 +30,17 @@ class Import::Email::TextOnly
     leaves.any? { |part, _| !text?(part) }
   end
 
-  # Plain when it says anything, the largest text part otherwise, and nil when even that is
-  # under the floor -- the caller then takes the whole message, which is cheap to do and
-  # always holds the words somewhere.
+  # Plain when it says anything, the largest text part otherwise, and nil only when the
+  # structure names no text part at all.
+  #
+  # The floor decides the preference and nothing else. Applied to the result it would send
+  # "See attached" back to the whole message, attachment and all -- the exact download the
+  # cutoff exists to refuse, on precisely the messages where the text is small and the
+  # attachment is not. A short body is the message's own text, and taking it is honest.
   def part
     @part ||= begin
       chosen = preferred_plain || texts.max_by { |candidate, _| candidate.size.to_i }
-      describe(*chosen) if chosen && chosen.first.size.to_i >= MIN_PART_OCTETS
+      describe(*chosen) if chosen
     end
   end
 

--- a/app/services/import/email/text_only.rb
+++ b/app/services/import/email/text_only.rb
@@ -1,0 +1,85 @@
+# The text-only version of a message, worked out from its `BODYSTRUCTURE` alone.
+#
+# Exists so the backfill can decide what a message costs before it downloads any of it.
+# `BODY.PEEK[]` pulls the encoded attachments along with the words, so a run that fetches
+# whole messages and drops the attachments afterwards has already spent the provider
+# budget the cutoff was written to protect. The structure is a few hundred bytes and says
+# where the words are.
+#
+# What comes back from `rebuild` is a smaller true copy: the message's own headers, so the
+# dedupe key and the threading are untouched, and one text part standing in for the body,
+# announced by its own Content-Type so the pipeline parses it as the single-part message it
+# now is.
+class Import::Email::TextOnly
+  # Below this a text part is treated as saying nothing. A message written in HTML alone
+  # still carries a `text/plain` alternative and it is routinely an empty stub of two
+  # octets, so preferring plain by subtype alone picks the stub and files the message with
+  # no body at all. `BODYSTRUCTURE` reports each part's octets, so the test costs nothing.
+  MIN_PART_OCTETS = 32
+
+  # Replaced by the standing-in part's own.
+  DROPPED_HEADERS = /\A(content-type|content-transfer-encoding):/i
+
+  def initialize(structure)
+    @structure = structure
+  end
+
+  # Nothing to save on a message that is only text: both fetches cost the same bytes and
+  # one of them costs an extra round trip.
+  def attachments?
+    leaves.any? { |part, _| !text?(part) }
+  end
+
+  # Plain when it says anything, the largest text part otherwise, and nil when even that is
+  # under the floor -- the caller then takes the whole message, which is cheap to do and
+  # always holds the words somewhere.
+  def part
+    @part ||= begin
+      chosen = preferred_plain || texts.max_by { |candidate, _| candidate.size.to_i }
+      describe(*chosen) if chosen && chosen.first.size.to_i >= MIN_PART_OCTETS
+    end
+  end
+
+  # The message's own headers with the two that described the multipart envelope replaced.
+  # Split on a newline that no whitespace follows, so a folded header stays one entry and
+  # is dropped or kept whole.
+  def rebuild(header, body)
+    kept = header.split(/\r?\n(?![ \t])/).grep_v(DROPPED_HEADERS)
+    kept << "Content-Type: #{[part[:type], part[:charset] && "charset=#{part[:charset]}"].compact.join('; ')}"
+    kept << "Content-Transfer-Encoding: #{part[:encoding]}" if part[:encoding].present?
+    "#{kept.join("\r\n").rstrip}\r\n\r\n#{body}"
+  end
+
+  private
+
+  def texts = leaves.select { |candidate, _| text?(candidate) }
+
+  def preferred_plain
+    texts.find { |candidate, _| candidate.subtype.to_s.casecmp('PLAIN').zero? && candidate.size.to_i >= MIN_PART_OCTETS }
+  end
+
+  def describe(chosen, section)
+    { section: section, encoding: chosen.encoding,
+      type: "#{chosen.media_type.to_s.downcase}/#{chosen.subtype.to_s.downcase}",
+      charset: chosen.param&.[]('CHARSET') }
+  end
+
+  # Text offered as a file is an attachment whatever its media type says: a .csv or a
+  # quoted .eml is exactly the weight the cutoff means to leave behind.
+  def text?(candidate)
+    return false unless candidate.media_type.to_s.casecmp('TEXT').zero?
+
+    (candidate.disposition&.dsp_type).to_s.casecmp('ATTACHMENT') != 0
+  end
+
+  # `BODYSTRUCTURE` is a tree: a multipart carries `parts`, a leaf carries its own media
+  # type, and sections are numbered the way `BODY[n.m]` addresses them. A single-part
+  # message has no parts and its body is section 1.
+  def leaves = @leaves ||= walk(@structure, [])
+
+  def walk(node, prefix)
+    return [[node, (prefix.presence || [1]).join('.')]] unless node.respond_to?(:parts) && node.parts.present?
+
+    node.parts.each_with_index.flat_map { |child, index| walk(child, prefix + [index + 1]) }
+  end
+end

--- a/app/services/import/email/text_only.rb
+++ b/app/services/import/email/text_only.rb
@@ -47,11 +47,23 @@ class Import::Email::TextOnly
   # The message's own headers with the two that described the multipart envelope replaced.
   # Split on a newline that no whitespace follows, so a folded header stays one entry and
   # is dropped or kept whole.
+  # `body` may be empty, and on a message that is nothing but attachments it always is:
+  # there is no text part to name, and under a cutoff that excludes the files there is
+  # nothing to fetch. What comes back is the message's own headers announcing an empty
+  # `text/plain`, which is a true copy of what this pass is keeping. The row goes in with a
+  # date, a sender and a thread, and marked as withholding what it has, so the pass that
+  # wants the files finds it.
   def rebuild(header, body)
     kept = header.split(/\r?\n(?![ \t])/).grep_v(DROPPED_HEADERS)
-    kept << "Content-Type: #{[part[:type], part[:charset] && "charset=#{part[:charset]}"].compact.join('; ')}"
-    kept << "Content-Transfer-Encoding: #{part[:encoding]}" if part[:encoding].present?
+    kept << "Content-Type: #{content_type}"
+    kept << "Content-Transfer-Encoding: #{part[:encoding]}" if part && part[:encoding].present?
     "#{kept.join("\r\n").rstrip}\r\n\r\n#{body}"
+  end
+
+  def content_type
+    return 'text/plain' if part.nil?
+
+    [part[:type], part[:charset] && "charset=#{part[:charset]}"].compact.join('; ')
   end
 
   private

--- a/app/services/import/email/text_only.rb
+++ b/app/services/import/email/text_only.rb
@@ -70,10 +70,21 @@ class Import::Email::TextOnly
 
   # Text offered as a file is an attachment whatever its media type says: a .csv or a
   # quoted .eml is exactly the weight the cutoff means to leave behind.
+  #
+  # A name is enough to say so, and the disposition is not required to agree. Legacy mail
+  # routinely offers a file as `Content-Type: text/plain; name="nota.csv"` with no
+  # disposition at all, or as `inline; filename=...`. Read on `dsp_type` alone those come
+  # back as ordinary text, which costs twice: the message looks free of attachments so the
+  # whole of it is downloaded, and the file can win `part` and stand in for the body.
   def text?(candidate)
     return false unless candidate.media_type.to_s.casecmp('TEXT').zero?
+    return false if named?(candidate)
 
     (candidate.disposition&.dsp_type).to_s.casecmp('ATTACHMENT') != 0
+  end
+
+  def named?(candidate)
+    candidate.param&.[]('NAME').present? || candidate.disposition&.param&.[]('FILENAME').present?
   end
 
   # `BODYSTRUCTURE` is a tree: a multipart carries `parts`, a leaf carries its own media

--- a/app/services/import/email/timestamp.rb
+++ b/app/services/import/email/timestamp.rb
@@ -1,0 +1,33 @@
+# When a mail was sent, answered the same way for everyone who asks.
+#
+# Two callers need it and they must not disagree: the backfill reads it off the header to
+# decide whether to fetch a message's attachments, and the importer reads it off the whole
+# mail to date the row. Derived separately, a message with no usable `Date` would be
+# stripped of its attachments by the first and then dated by the second into a window where
+# the cutoff would have kept them -- and the attachments are already gone by then.
+module Import::Email::Timestamp
+  module_function
+
+  def of(mail)
+    sent_at(mail) || received_at(mail)
+  end
+
+  # `Mail` is not consistent about how it refuses a bad `Date`: an unreadable field comes
+  # back as the raw String, whose `to_time` is ActiveSupport's and answers nil, and one that
+  # parses into an impossible time raises from the reader itself. Both mean the same thing
+  # here, and neither is a reason to count the message as an error and retry it forever.
+  def sent_at(mail)
+    date = mail.date
+    date.to_time if date.respond_to?(:to_time)
+  rescue StandardError
+    nil
+  end
+
+  # Every relay that touched the mail stamped a line on the way, and the oldest of those is
+  # the closest thing a message with no usable `Date` has to a send time.
+  def received_at(mail)
+    Array(mail.received).filter_map { |field| field.date_time&.to_time }.min
+  rescue StandardError
+    nil
+  end
+end

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -16,6 +16,24 @@
 # The includer provides two things: `opened`, the ids of conversations this run created,
 # and `announcing`, the block wrapper that lets the dashboard push through.
 module Import::HistorySettlement
+  # What a buffering importer lets pile up before it sends. Big enough that the job count
+  # is a thousandth of the message count, small enough that an interrupted run leaves at
+  # most this many rows for the next pass -- which finds them stored and re-settles them,
+  # so nothing is lost either way.
+  SEARCH_INDEX_BATCH = 500
+
+  # Everything still owed to the index, handed over. Public because it is a contract with
+  # whatever runs the import rather than a step inside a settlement: an importer that
+  # buffers has to be emptied by the thing that knows the run is over, and a buffer left
+  # unflushed is a row missing from the index with nothing anywhere to say so.
+  def flush_search_index
+    ids = @search_backlog.presence&.uniq
+    @search_backlog = []
+    return if ids.blank?
+
+    ActiveRecord.after_all_transactions_commit { ::Message.where(id: ids).reindex(mode: :async) }
+  end
+
   private
 
   # Both halves are settled together rather than one after the other, because a chat can
@@ -51,20 +69,31 @@ module Import::HistorySettlement
   # hook and Message defines it, so the relation form drops exactly the rows the callback
   # would have -- activity messages and, on cloud, an account without the flag.
   #
-  # After the transaction commits, and that is the whole of why this is not a one-liner.
-  # The IMAP importer settles inside a transaction with the write, and this app does not
-  # run `enqueue_after_transaction_commit`: a Sidekiq worker is free to pick the job up
-  # before the rows exist, find nothing, and leave them out of the index for good, since
-  # the per-row callback that would have caught it later is the one this replaced. Outside
-  # a transaction the block runs immediately, which is the other three importers.
+  # Buffered, because a settlement is not a batch. Searchkick splits rows within one
+  # `reindex` call and not across calls, so a job per settlement is a job per *message* on
+  # the IMAP path, which settles one mail at a time -- exactly the flood the guard was put
+  # in to stop, wearing a different job class.
+  #
+  # After the transaction commits, and that is the whole of why the send is not a one-liner.
+  # The IMAP importer settles inside a transaction with the write, and this app does not run
+  # `enqueue_after_transaction_commit`: a worker is free to pick the job up before the rows
+  # exist, find nothing, and leave them out of the index for good, since the per-row
+  # callback that would have caught it later is the one this replaced. Outside a transaction
+  # the block runs immediately.
   def index_for_search(rows)
     return unless ChatwootApp.advanced_search_allowed?
 
-    ids = rows.filter_map(&:id)
-    return if ids.empty?
-
-    ActiveRecord.after_all_transactions_commit { ::Message.where(id: ids).reindex(mode: :async) }
+    @search_backlog = Array(@search_backlog).concat(rows.filter_map(&:id))
+    flush_search_index if @search_backlog.length >= search_index_batch
   end
+
+  # How much to let pile up, and a knob rather than a number because the two shapes of
+  # importer want opposite answers. A WhatsApp importer is handed a webhook's worth of rows
+  # and thrown away, so a buffer there holds the tail of every batch until a request that
+  # may never come: it sends immediately, which is this default. A backfill outlives every
+  # settlement it makes and ends somewhere it can empty the buffer, so it raises this and
+  # takes on the flush.
+  def search_index_batch = 1
 
   # Where the inbox sorts, and where a thread appears in the list. `set_conversation_activity`
   # assigns whatever row it has just written, unconditionally: left to run over history it

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -100,14 +100,33 @@ module Import::HistorySettlement
   # date is the true answer, taken only from incoming rows because it is the contact's
   # activity and not ours, and only ever forwards -- a contact with live traffic has a real
   # clock and history must not drag it backwards.
-  def stamp_contact(conversation, rows)
-    newest = rows.select(&:incoming?).filter_map(&:created_at).max
-    return if newest.blank?
+  #
+  # Grouped by the row's own sender rather than taken from the conversation, because on a
+  # group chat those are different people: the conversation's contact is the group and each
+  # incoming row was written by a participant. Stamping the conversation's contact gives
+  # the group a clock it never earned and leaves every participant at null. Read off
+  # `sender_id` rather than `sender`, so the resume path -- which reads the thread back off
+  # the database -- costs one query for the batch instead of one per row.
+  def stamp_contact(_conversation, rows)
+    newest = newest_per_contact(rows)
+    return if newest.empty?
 
-    contact = conversation.contact
-    return if contact.blank? || (contact.last_activity_at.present? && contact.last_activity_at >= newest)
+    ::Contact.where(id: newest.keys).find_each do |contact|
+      at = newest[contact.id]
+      next if contact.last_activity_at.present? && contact.last_activity_at >= at
 
-    contact.update_columns(last_activity_at: newest) # rubocop:disable Rails/SkipsModelValidations
+      contact.update_columns(last_activity_at: at) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def newest_per_contact(rows)
+    written_by_contacts(rows).group_by(&:sender_id)
+                             .transform_values { |sent| sent.filter_map(&:created_at).max }
+                             .compact_blank
+  end
+
+  def written_by_contacts(rows)
+    rows.select { |row| row.incoming? && row.sender_type == 'Contact' && row.sender_id.present? }
   end
 
   def stamp_seen(conversation, _rows)

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -50,13 +50,20 @@ module Import::HistorySettlement
   # leaves indexed everything it settled. `should_index?` is Searchkick's own per-record
   # hook and Message defines it, so the relation form drops exactly the rows the callback
   # would have -- activity messages and, on cloud, an account without the flag.
+  #
+  # After the transaction commits, and that is the whole of why this is not a one-liner.
+  # The IMAP importer settles inside a transaction with the write, and this app does not
+  # run `enqueue_after_transaction_commit`: a Sidekiq worker is free to pick the job up
+  # before the rows exist, find nothing, and leave them out of the index for good, since
+  # the per-row callback that would have caught it later is the one this replaced. Outside
+  # a transaction the block runs immediately, which is the other three importers.
   def index_for_search(rows)
     return unless ChatwootApp.advanced_search_allowed?
 
     ids = rows.filter_map(&:id)
     return if ids.empty?
 
-    ::Message.where(id: ids).reindex(mode: :async)
+    ActiveRecord.after_all_transactions_commit { ::Message.where(id: ids).reindex(mode: :async) }
   end
 
   # Where the inbox sorts, and where a thread appears in the list. `set_conversation_activity`

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -81,19 +81,23 @@ module Import::HistorySettlement
   # callback that would have caught it later is the one this replaced. Outside a transaction
   # the block runs immediately.
   def index_for_search(rows)
+    return if search_index_batch.nil?
     return unless ChatwootApp.advanced_search_allowed?
 
     @search_backlog = Array(@search_backlog).concat(rows.filter_map(&:id))
     flush_search_index if @search_backlog.length >= search_index_batch
   end
 
-  # How much to let pile up, and a knob rather than a number because the two shapes of
-  # importer want opposite answers. A WhatsApp importer is handed a webhook's worth of rows
-  # and thrown away, so a buffer there holds the tail of every batch until a request that
-  # may never come: it sends immediately, which is this default. A backfill outlives every
-  # settlement it makes and ends somewhere it can empty the buffer, so it raises this and
-  # takes on the flush.
-  def search_index_batch = 1
+  # How much to let pile up, and `nil` for an importer that does not index at all. The two
+  # shapes want opposite answers. A WhatsApp importer is handed a webhook's worth of rows
+  # and thrown away: a buffer there would hold the tail of every batch until a request that
+  # may never come, and a batch that raised after some rows committed would lose them
+  # entirely -- they never reach here, and the retry filters them out as already stored. So
+  # it indexes nothing and keeps Message's own per-row callback, which is what the guard
+  # leaves alone for it. A backfill outlives every settlement it makes and ends somewhere it
+  # can empty the buffer, so it names a size, wraps its writes with `indexing: true` and
+  # takes on both the batching and the flush.
+  def search_index_batch = nil
 
   # Where the inbox sorts, and where a thread appears in the list. `set_conversation_activity`
   # assigns whatever row it has just written, unconditionally: left to run over history it

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -30,17 +30,18 @@ module Import::HistorySettlement
     ids = @search_backlog.presence&.uniq
     return if ids.blank?
 
-    @search_backlog = []
+    # Dropped from the backlog inside the handoff and nowhere else, which covers the two
+    # ways it can fail to happen. The enqueue can raise -- Redis away, Sidekiq away -- and
+    # the transaction this is called from can roll back, and Rails then discards the
+    # callback without running it. Cleared up front, either would take the ids with it: the
+    # rows are committed, their per-row callback was suppressed, and every later pass skips
+    # them as already stored, so a batch lost here is a batch nothing indexes again. The
+    # threshold flush makes that a live case rather than a careful one -- it fires inside
+    # the mail importer's transaction, carrying ids from hundreds of messages that
+    # committed long before it.
     ActiveRecord.after_all_transactions_commit do
       ::Message.where(id: ids).reindex(mode: :async)
-    rescue StandardError
-      # Put back and re-raise, rather than swallow: the rows are committed, and the next
-      # pass will skip them as already stored, so a batch dropped here is a batch nothing
-      # ever indexes again. Whatever stops the handoff -- Redis away, Sidekiq away -- is
-      # also a reason for the run to stop rather than carry on writing history it can no
-      # longer file.
-      @search_backlog = ids + Array(@search_backlog)
-      raise
+      @search_backlog -= ids
     end
   end
 

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -28,10 +28,20 @@ module Import::HistorySettlement
   # unflushed is a row missing from the index with nothing anywhere to say so.
   def flush_search_index
     ids = @search_backlog.presence&.uniq
-    @search_backlog = []
     return if ids.blank?
 
-    ActiveRecord.after_all_transactions_commit { ::Message.where(id: ids).reindex(mode: :async) }
+    @search_backlog = []
+    ActiveRecord.after_all_transactions_commit do
+      ::Message.where(id: ids).reindex(mode: :async)
+    rescue StandardError
+      # Put back and re-raise, rather than swallow: the rows are committed, and the next
+      # pass will skip them as already stored, so a batch dropped here is a batch nothing
+      # ever indexes again. Whatever stops the handoff -- Redis away, Sidekiq away -- is
+      # also a reason for the run to stop rather than carry on writing history it can no
+      # longer file.
+      @search_backlog = ids + Array(@search_backlog)
+      raise
+    end
   end
 
   private

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -6,14 +6,16 @@
 # once per conversation instead of once per message, and only in the direction that is
 # true.
 #
-# Shared because there are two importers and only one correct answer: the session layer
-# files the canonical providers, and the Baileys one runs the legacy pipeline for the
-# frozen provider. A copy in each would drift, and the drift would show up as a thread
-# sorted to the wrong place in the list, which nobody reads as a bug in an importer.
+# Shared because there are several importers and only one correct answer: the session
+# layer files the canonical WhatsApp providers, the Baileys one runs the legacy pipeline
+# for the frozen provider, and the IMAP one files a mailbox. None of this is channel
+# specific -- it is Conversation and Message bookkeeping -- so a copy in each would drift,
+# and the drift would show up as a thread sorted to the wrong place in the list, which
+# nobody reads as a bug in an importer.
 #
 # The includer provides two things: `opened`, the ids of conversations this run created,
 # and `announcing`, the block wrapper that lets the dashboard push through.
-module Whatsapp::Session::Inbound::HistorySettlement
+module Import::HistorySettlement
   private
 
   # Both halves are settled together rather than one after the other, because a chat can
@@ -89,7 +91,7 @@ module Whatsapp::Session::Inbound::HistorySettlement
   # land in any order and each one leaves the same answer.
   def stamp_seen(conversation, _rows)
     return unless conversation.resolved?
-    return if conversation.messages.incoming.where.not(Whatsapp::Session::Inbound::Coverage::IMPORTED_SQL).exists?
+    return if conversation.messages.incoming.where.not(Import::IMPORTED_SQL).exists?
 
     newest = conversation.messages.maximum(:created_at)
     return if newest.blank?

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -116,8 +116,17 @@ module Import::HistorySettlement
       next if contact.last_activity_at.present? && contact.last_activity_at >= at
 
       contact.update_columns(last_activity_at: at) # rubocop:disable Rails/SkipsModelValidations
+      roll_up(contact, at)
     end
   end
+
+  # A contact rolls its activity up to its company, on installations that have companies.
+  # `update_columns` skips the callback that would do it, which is the point everywhere
+  # else -- the import writes clocks without firing the machinery around them -- so the one
+  # part of that machinery which is itself a clock is asked for explicitly.
+  #
+  # A no-op here and overridden in the Enterprise tree, where `Company` exists.
+  def roll_up(contact, at); end
 
   def newest_per_contact(rows)
     written_by_contacts(rows).group_by(&:sender_id)
@@ -158,3 +167,5 @@ module Import::HistorySettlement
     pending.first&.created_at
   end
 end
+
+Import::HistorySettlement.prepend_mod_with('Import::HistorySettlement')

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -28,6 +28,7 @@ module Import::HistorySettlement
       stamp_activity(conversation, rows)
       stamp_waiting(conversation, rows)
       stamp_seen(conversation, rows)
+      stamp_contact(conversation, rows)
       if announced.include?(conversation)
         announcing { Whatsapp::Session::Inbound::ChatList.refresh(conversation) }
       else
@@ -89,6 +90,26 @@ module Import::HistorySettlement
   #
   # Read off the thread rather than off `rows`, and never moved backwards, so frames may
   # land in any order and each one leaves the same answer.
+  # When the contact last said anything, which the dashboard sorts and filters contacts by.
+  # Live traffic keeps it in `Message#update_contact_activity`, inside the after-create
+  # callbacks the import suppresses wholesale -- so without this an imported contact has a
+  # decade of mail and a null clock, and sorts below people who have never written.
+  #
+  # Not the value the live path would have written, which is `DateTime.now`: on a replay
+  # that stamps every contact in the archive with the moment of the import. The row's own
+  # date is the true answer, taken only from incoming rows because it is the contact's
+  # activity and not ours, and only ever forwards -- a contact with live traffic has a real
+  # clock and history must not drag it backwards.
+  def stamp_contact(conversation, rows)
+    newest = rows.select(&:incoming?).filter_map(&:created_at).max
+    return if newest.blank?
+
+    contact = conversation.contact
+    return if contact.blank? || (contact.last_activity_at.present? && contact.last_activity_at >= newest)
+
+    contact.update_columns(last_activity_at: newest) # rubocop:disable Rails/SkipsModelValidations
+  end
+
   def stamp_seen(conversation, _rows)
     return unless conversation.resolved?
     return if conversation.messages.incoming.where.not(Import::IMPORTED_SQL).exists?

--- a/app/services/import/history_settlement.rb
+++ b/app/services/import/history_settlement.rb
@@ -24,7 +24,8 @@ module Import::HistorySettlement
   # Which conversations may announce is therefore carried separately from the rows.
   def settle(archived, gap)
     announced = gap.compact.filter_map(&:conversation).uniq
-    (archived + gap).compact.group_by(&:conversation).each do |conversation, rows|
+    settled = (archived + gap).compact
+    settled.group_by(&:conversation).each do |conversation, rows|
       stamp_activity(conversation, rows)
       stamp_waiting(conversation, rows)
       stamp_seen(conversation, rows)
@@ -35,6 +36,27 @@ module Import::HistorySettlement
         Whatsapp::Session::Inbound::ChatList.refresh(conversation)
       end
     end
+    index_for_search(settled)
+  end
+
+  # The archive's half of advanced search. `Message#reindex_for_search` fires per record
+  # and enqueues a Searchkick job for each, which the guards stop precisely so this can
+  # happen instead: the batch goes over whole, and Searchkick splits it into a bulk job per
+  # thousand rows. What that buys is not import speed, it is the live queue -- half a
+  # million single-row jobs sit ahead of the reply an agent sends while the import runs.
+  #
+  # Async rather than inline, so an import does not fail because the search cluster is
+  # having a bad afternoon. Per batch rather than once at the end, so an interrupted run
+  # leaves indexed everything it settled. `should_index?` is Searchkick's own per-record
+  # hook and Message defines it, so the relation form drops exactly the rows the callback
+  # would have -- activity messages and, on cloud, an account without the flag.
+  def index_for_search(rows)
+    return unless ChatwootApp.advanced_search_allowed?
+
+    ids = rows.filter_map(&:id)
+    return if ids.empty?
+
+    ::Message.where(id: ids).reindex(mode: :async)
   end
 
   # Where the inbox sorts, and where a thread appears in the list. `set_conversation_activity`
@@ -107,13 +129,20 @@ module Import::HistorySettlement
   # the group a clock it never earned and leaves every participant at null. Read off
   # `sender_id` rather than `sender`, so the resume path -- which reads the thread back off
   # the database -- costs one query for the batch instead of one per row.
+  #
+  # Strictly greater rather than greater-or-equal, because the clock and the roll-up under
+  # it are two writes with nothing holding them together: a run that stops between them
+  # leaves the contact stamped and the company stale, and `>=` would then make every retry
+  # skip both -- the contact is already current, so the roll-up it never got is never asked
+  # for again. Falling through costs a write of the value already there and a company rule
+  # that refuses to move backwards; skipping costs a company clock wrong forever.
   def stamp_contact(_conversation, rows)
     newest = newest_per_contact(rows)
     return if newest.empty?
 
     ::Contact.where(id: newest.keys).find_each do |contact|
       at = newest[contact.id]
-      next if contact.last_activity_at.present? && contact.last_activity_at >= at
+      next if contact.last_activity_at.present? && contact.last_activity_at > at
 
       contact.update_columns(last_activity_at: at) # rubocop:disable Rails/SkipsModelValidations
       roll_up(contact, at)

--- a/app/services/import/octadesk/activity_writer.rb
+++ b/app/services/import/octadesk/activity_writer.rb
@@ -26,20 +26,35 @@ class Import::Octadesk::ActivityWriter
   # database. The two must agree, or a re-run moves the stamp and the import stops being
   # something that can be repeated.
   def perform(conversation, ticket)
-    Array(ticket['Interactions']).reject { |interaction| commented?(interaction) }
+    Array(ticket['Interactions']).reject { |interaction| message?(interaction) }
                                  .filter_map { |interaction| write(conversation, interaction) }
   end
 
-  # Shared with the message importer, which selects on the opposite answer.
+  # Whether the interaction is somebody saying something, which is the line between the two
+  # writers: a message row or an activity row, never both. Shared with the message importer,
+  # which selects on the same answer from the other side.
+  #
+  # Files count. A reply that is only a photo is an ordinary thing for a customer to send,
+  # and read as "no comment" it becomes a status line at best and nothing at all at worst --
+  # taking the attachment with it, to a bucket that stops existing when the subscription
+  # does, which makes that loss permanent rather than late.
+  def self.message?(interaction)
+    commented?(interaction) || attached?(interaction)
+  end
+
   def self.commented?(interaction)
     Array(interaction['Comments']).any? { |comment| comment['Content'].to_s.strip.present? }
+  end
+
+  def self.attached?(interaction)
+    Array(interaction['Attachments']).any? { |attachment| attachment['Url'].to_s.strip.present? }
   end
 
   # Whether this interaction would become an activity row, answered without writing one, so
   # a caller can tell a ticket carrying only status changes from one carrying nothing at
   # all. The first is history and belongs in the archive; only the second is empty.
   def self.writable?(interaction)
-    !commented?(interaction) &&
+    !message?(interaction) &&
       line_for(interaction['PropertiesChanges'] || {}, interaction['Person'] || {}).present?
   end
 
@@ -60,7 +75,7 @@ class Import::Octadesk::ActivityWriter
 
   private
 
-  def commented?(interaction) = self.class.commented?(interaction)
+  def message?(interaction) = self.class.message?(interaction)
 
   def write(conversation, interaction)
     line = self.class.line_for(interaction['PropertiesChanges'] || {}, interaction['Person'] || {})

--- a/app/services/import/octadesk/activity_writer.rb
+++ b/app/services/import/octadesk/activity_writer.rb
@@ -20,10 +20,14 @@ class Import::Octadesk::ActivityWriter
     @stats = stats
   end
 
+  # Returns the rows it wrote, because the settlement has to see them: an activity carries
+  # a date like any other row, and a settlement that took only the messages would put
+  # `last_activity_at` in a different place than one that reads the thread back off the
+  # database. The two must agree, or a re-run moves the stamp and the import stops being
+  # something that can be repeated.
   def perform(conversation, ticket)
-    Array(ticket['Interactions']).reject { |interaction| commented?(interaction) }.each do |interaction|
-      write(conversation, interaction)
-    end
+    Array(ticket['Interactions']).reject { |interaction| commented?(interaction) }
+                                 .filter_map { |interaction| write(conversation, interaction) }
   end
 
   # Shared with the message importer, which selects on the opposite answer.
@@ -48,12 +52,13 @@ class Import::Octadesk::ActivityWriter
     source_id = "#{Import::Octadesk::TicketImporter::SOURCE_PREFIX}:#{id}:act"
     return if conversation.messages.exists?(source_id: source_id)
 
-    conversation.messages.create!(
+    row = conversation.messages.create!(
       account_id: @account.id, inbox_id: @inbox.id, source_id: source_id,
       message_type: :activity, content: line, content_attributes: { imported: true },
       created_at: Import::Octadesk::Stream.time(interaction['DateCreation']) || conversation.created_at
     )
     @stats[:atividades] += 1
+    row
   end
 
   # Only the two changes a reader of an archive asks about: where the thread went and who

--- a/app/services/import/octadesk/activity_writer.rb
+++ b/app/services/import/octadesk/activity_writer.rb
@@ -35,12 +35,35 @@ class Import::Octadesk::ActivityWriter
     Array(interaction['Comments']).any? { |comment| comment['Content'].to_s.strip.present? }
   end
 
+  # Whether this interaction would become an activity row, answered without writing one, so
+  # a caller can tell a ticket carrying only status changes from one carrying nothing at
+  # all. The first is history and belongs in the archive; only the second is empty.
+  def self.writable?(interaction)
+    !commented?(interaction) &&
+      line_for(interaction['PropertiesChanges'] || {}, interaction['Person'] || {}).present?
+  end
+
+  # Only the two changes a reader of an archive asks about: where the thread went and who
+  # took it. The rest of `PropertiesChanges` restates fields the conversation already
+  # carries. On the class because it reads nothing but its arguments.
+  def self.line_for(changes, person)
+    return if person['Type'] == TRIGGER
+
+    parts = []
+    parts << "Status: #{changes['Status']}" if changes['Status'].present?
+    parts << "Atribuido a #{changes['AssignedName']}" if changes['AssignedName'].present?
+    return if parts.empty?
+
+    who = person['Name'].to_s.squish.presence
+    [parts.join(' - '), who && "(por #{who})"].compact.join(' ')
+  end
+
   private
 
   def commented?(interaction) = self.class.commented?(interaction)
 
   def write(conversation, interaction)
-    line = line_for(interaction['PropertiesChanges'] || {}, interaction['Person'] || {})
+    line = self.class.line_for(interaction['PropertiesChanges'] || {}, interaction['Person'] || {})
     return if line.blank?
 
     # One value, built once and used for both the check and the write: computing it twice
@@ -59,20 +82,5 @@ class Import::Octadesk::ActivityWriter
     )
     @stats[:atividades] += 1
     row
-  end
-
-  # Only the two changes a reader of an archive asks about: where the thread went and who
-  # took it. The rest of `PropertiesChanges` restates fields the conversation already
-  # carries.
-  def line_for(changes, person)
-    return if person['Type'] == TRIGGER
-
-    parts = []
-    parts << "Status: #{changes['Status']}" if changes['Status'].present?
-    parts << "Atribuido a #{changes['AssignedName']}" if changes['AssignedName'].present?
-    return if parts.empty?
-
-    who = person['Name'].to_s.squish.presence
-    [parts.join(' - '), who && "(por #{who})"].compact.join(' ')
   end
 end

--- a/app/services/import/octadesk/activity_writer.rb
+++ b/app/services/import/octadesk/activity_writer.rb
@@ -1,0 +1,73 @@
+# Writes the parts of a ticket's history that were never messages.
+#
+# Roughly half of an exported ticket's interactions carry no comment: they are the
+# ticketing system recording that somebody took the thread, moved it between groups, or
+# closed it. Dropping them leaves a transcript that never says who resolved anything,
+# which for an archive built to be consulted is most of what a reader came for.
+#
+# So they become activity rows, the same kind Chatwoot writes for itself when a
+# conversation is marked resolved. Kept apart from the message importer because the two
+# have nothing in common but the conversation they attach to: one carries what a person
+# said, the other what the system observed.
+class Import::Octadesk::ActivityWriter
+  # A trigger firing is not history anybody reads: "Gatilho executado: notificar o
+  # solicitante" is the automation narrating itself.
+  TRIGGER = 3
+
+  def initialize(inbox:, stats:)
+    @inbox = inbox
+    @account = inbox.account
+    @stats = stats
+  end
+
+  def perform(conversation, ticket)
+    Array(ticket['Interactions']).reject { |interaction| commented?(interaction) }.each do |interaction|
+      write(conversation, interaction)
+    end
+  end
+
+  # Shared with the message importer, which selects on the opposite answer.
+  def self.commented?(interaction)
+    Array(interaction['Comments']).any? { |comment| comment['Content'].to_s.strip.present? }
+  end
+
+  private
+
+  def commented?(interaction) = self.class.commented?(interaction)
+
+  def write(conversation, interaction)
+    line = line_for(interaction['PropertiesChanges'] || {}, interaction['Person'] || {})
+    return if line.blank?
+
+    # One value, built once and used for both the check and the write: computing it twice
+    # is how an importer ends up looking for a row it will not find and writing it again on
+    # every pass.
+    id = Import::Octadesk::Stream.oid(interaction['_id'])
+    return if id.blank?
+
+    source_id = "#{Import::Octadesk::TicketImporter::SOURCE_PREFIX}:#{id}:act"
+    return if conversation.messages.exists?(source_id: source_id)
+
+    conversation.messages.create!(
+      account_id: @account.id, inbox_id: @inbox.id, source_id: source_id,
+      message_type: :activity, content: line, content_attributes: { imported: true },
+      created_at: Import::Octadesk::Stream.time(interaction['DateCreation']) || conversation.created_at
+    )
+    @stats[:atividades] += 1
+  end
+
+  # Only the two changes a reader of an archive asks about: where the thread went and who
+  # took it. The rest of `PropertiesChanges` restates fields the conversation already
+  # carries.
+  def line_for(changes, person)
+    return if person['Type'] == TRIGGER
+
+    parts = []
+    parts << "Status: #{changes['Status']}" if changes['Status'].present?
+    parts << "Atribuido a #{changes['AssignedName']}" if changes['AssignedName'].present?
+    return if parts.empty?
+
+    who = person['Name'].to_s.squish.presence
+    [parts.join(' - '), who && "(por #{who})"].compact.join(' ')
+  end
+end

--- a/app/services/import/octadesk/attachment_fetcher.rb
+++ b/app/services/import/octadesk/attachment_fetcher.rb
@@ -39,17 +39,34 @@ class Import::Octadesk::AttachmentFetcher
 
   private
 
+  # Streamed and abandoned the moment it passes the cap, so an oversized object costs the
+  # cap rather than its own size. Reading the response whole and measuring afterwards would
+  # have the gigabyte in memory before the check could run, which is the failure the cap
+  # was written for and not a thing a cap can undo.
   def fetch(uri)
-    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: TIMEOUT, read_timeout: TIMEOUT) do |http|
-      http.get(uri.request_uri)
-    end
-    return unless response.is_a?(Net::HTTPSuccess)
-    # Capped rather than streamed: the largest measured is under 7 MB, and a cap keeps one
-    # malformed record from pulling a gigabyte into memory.
-    return if response.body.bytesize > MAX_BYTES
+    Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: TIMEOUT, read_timeout: TIMEOUT) do |http|
+      http.request(Net::HTTP::Get.new(uri.request_uri)) do |response|
+        return nil unless response.is_a?(Net::HTTPSuccess)
+        return nil if response['content-length'].to_i > MAX_BYTES
 
-    @content_type = response['content-type'].to_s.split(';').first
-    response.body
+        body = read_capped(response)
+        return nil if body.nil?
+
+        @content_type = response['content-type'].to_s.split(';').first
+        return body
+      end
+    end
+  end
+
+  # Binary from the start: chunks arrive as ASCII-8BIT and appending them to a UTF-8 buffer
+  # raises on the first byte that is not valid UTF-8, which for an image is immediately.
+  def read_capped(response)
+    body = String.new(encoding: Encoding::BINARY)
+    response.read_body do |chunk|
+      body << chunk
+      return nil if body.bytesize > MAX_BYTES
+    end
+    body
   end
 
   def filename(uri)

--- a/app/services/import/octadesk/attachment_fetcher.rb
+++ b/app/services/import/octadesk/attachment_fetcher.rb
@@ -37,6 +37,15 @@ class Import::Octadesk::AttachmentFetcher
     @message.save!
   end
 
+  # The name an attachment is stored under. On the class because the importer needs the same
+  # answer without fetching anything: it is how a second pass tells an attachment it already
+  # stored from one it still owes.
+  def self.filename_for(url, name)
+    name.presence&.tr('/', '_') || File.basename(URI.parse(url.to_s).path)
+  rescue URI::InvalidURIError
+    name.to_s.tr('/', '_').presence
+  end
+
   private
 
   # Streamed and abandoned the moment it passes the cap, so an oversized object costs the
@@ -69,9 +78,7 @@ class Import::Octadesk::AttachmentFetcher
     body
   end
 
-  def filename(uri)
-    @name.presence&.tr('/', '_') || File.basename(uri.path)
-  end
+  def filename(uri) = self.class.filename_for(uri, @name)
 
   # Falls back on the declared type, then on the extension, which is what the mail
   # pipeline's FileTypeHelper does with an attachment whose headers say nothing useful.

--- a/app/services/import/octadesk/attachment_fetcher.rb
+++ b/app/services/import/octadesk/attachment_fetcher.rb
@@ -32,7 +32,7 @@ class Import::Octadesk::AttachmentFetcher
     body = fetch(uri)
     return if body.blank?
 
-    attachment = @message.attachments.new(account_id: @message.account_id, file_type: file_type(body))
+    attachment = @message.attachments.new(account_id: @message.account_id, file_type: file_type(uri))
     attachment.file.attach(io: StringIO.new(body), filename: filename(uri), content_type: @content_type)
     @message.save!
   end
@@ -80,10 +80,16 @@ class Import::Octadesk::AttachmentFetcher
 
   def filename(uri) = self.class.filename_for(uri, @name)
 
-  # Falls back on the declared type, then on the extension, which is what the mail
-  # pipeline's FileTypeHelper does with an attachment whose headers say nothing useful.
-  def file_type(_body)
+  # The declared type, then the extension. A bucket that answers `application/octet-stream`
+  # or nothing at all is answering about every file the same way, and taken at its word it
+  # files images, audio and video as `:file` -- which is the one thing the dashboard will
+  # not preview. The name is right there and says more than the header does.
+  GENERIC_TYPES = ['', 'application/octet-stream', 'binary/octet-stream'].freeze
+
+  def file_type(uri)
     helper = Class.new { include FileTypeHelper }.new
-    helper.file_type(@content_type)
+    return helper.file_type(@content_type) unless GENERIC_TYPES.include?(@content_type.to_s.downcase)
+
+    helper.file_type(Rack::Mime.mime_type(File.extname(filename(uri)), nil))
   end
 end

--- a/app/services/import/octadesk/attachment_fetcher.rb
+++ b/app/services/import/octadesk/attachment_fetcher.rb
@@ -33,13 +33,17 @@ class Import::Octadesk::AttachmentFetcher
     return if body.blank?
 
     attachment = @message.attachments.new(account_id: @message.account_id, file_type: file_type(uri))
-    attachment.file.attach(io: StringIO.new(body), filename: filename(uri), content_type: @content_type)
+    attachment.file.attach(
+      io: StringIO.new(body), filename: filename(uri), content_type: @content_type,
+      metadata: { 'import_source' => @url }
+    )
     @message.save!
   end
 
-  # The name an attachment is stored under. On the class because the importer needs the same
-  # answer without fetching anything: it is how a second pass tells an attachment it already
-  # stored from one it still owes.
+  # The name an attachment is stored under. Public because the specs pin it and because the
+  # rule -- the vendor's name if there is one, the tail of the URL otherwise -- is worth
+  # asserting on its own. It is deliberately NOT what a second pass keys on: two files can
+  # share a name and only the source URL is one-to-one with the object.
   def self.filename_for(url, name)
     name.presence&.tr('/', '_') || File.basename(URI.parse(url.to_s).path)
   rescue URI::InvalidURIError

--- a/app/services/import/octadesk/attachment_fetcher.rb
+++ b/app/services/import/octadesk/attachment_fetcher.rb
@@ -1,0 +1,65 @@
+require 'net/http'
+
+# Pulls one attachment off the vendor's bucket and onto ours.
+#
+# The export carries pointers, not files: hundreds of thousands of URLs on
+# storage.googleapis.com under the tenant's own prefix, served without authentication and
+# running to hundreds of gigabytes in total. They are reachable
+# today and there is no reason to expect them to outlive the subscription, so every import
+# run that touches an attachment is also the only chance to keep it. Active Storage writes
+# the copy to our S3, which makes the mirror a side effect of the import rather than a
+# second project.
+#
+# No daily budget here, unlike the IMAP path: this is an ordinary bucket over HTTPS, and
+# the only limits are our own bandwidth and patience.
+class Import::Octadesk::AttachmentFetcher
+  TIMEOUT = 30
+  MAX_BYTES = 40.megabytes
+  # A vendor bucket and nothing else. The URL comes out of a data file, so it is input:
+  # without this an edited export could point the fetcher at an internal address.
+  ALLOWED_HOST = 'storage.googleapis.com'.freeze
+
+  def initialize(message:, url:, name: nil)
+    @message = message
+    @url = url
+    @name = name
+  end
+
+  def perform
+    uri = URI.parse(@url)
+    return unless uri.is_a?(URI::HTTPS) && uri.host == ALLOWED_HOST
+
+    body = fetch(uri)
+    return if body.blank?
+
+    attachment = @message.attachments.new(account_id: @message.account_id, file_type: file_type(body))
+    attachment.file.attach(io: StringIO.new(body), filename: filename(uri), content_type: @content_type)
+    @message.save!
+  end
+
+  private
+
+  def fetch(uri)
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: TIMEOUT, read_timeout: TIMEOUT) do |http|
+      http.get(uri.request_uri)
+    end
+    return unless response.is_a?(Net::HTTPSuccess)
+    # Capped rather than streamed: the largest measured is under 7 MB, and a cap keeps one
+    # malformed record from pulling a gigabyte into memory.
+    return if response.body.bytesize > MAX_BYTES
+
+    @content_type = response['content-type'].to_s.split(';').first
+    response.body
+  end
+
+  def filename(uri)
+    @name.presence&.tr('/', '_') || File.basename(uri.path)
+  end
+
+  # Falls back on the declared type, then on the extension, which is what the mail
+  # pipeline's FileTypeHelper does with an attachment whose headers say nothing useful.
+  def file_type(_body)
+    helper = Class.new { include FileTypeHelper }.new
+    helper.file_type(@content_type)
+  end
+end

--- a/app/services/import/octadesk/attachments.rb
+++ b/app/services/import/octadesk/attachments.rb
@@ -17,18 +17,10 @@ class Import::Octadesk::Attachments
   def perform(message, interaction)
     return unless @enabled
 
-    # Seeded from what is already on the message and added to as the loop goes, because an
-    # interaction can list the same URL twice: read only from the snapshot, every copy after
-    # the first is another download of a file we have just stored, on a run whose cost is
-    # the downloads.
-    held = stored_sources(message)
-    permitted(interaction).each do |attachment|
-      url = attachment['Url'].to_s
-      next if url.blank?
-      next if held.include?(url)
-
-      stored = Import::Octadesk::AttachmentFetcher.new(message: message, url: url, name: attachment['Name']).perform
-      held << url
+    wanted(interaction, stored_sources(message)).each do |attachment|
+      stored = Import::Octadesk::AttachmentFetcher.new(
+        message: message, url: attachment['Url'].to_s, name: attachment['Name']
+      ).perform
       @stats[stored ? :anexos : :anexos_recusados] += 1
     rescue StandardError
       @stats[:anexos_falharam] += 1
@@ -37,17 +29,28 @@ class Import::Octadesk::Attachments
 
   private
 
-  # `Message` refuses more than fifteen and the mail pipeline trims to that before it
-  # attaches anything; this had no cap at all. Trimmed before the fetch rather than left to
-  # the model, because the cap is cheap to apply and expensive to hit: past the sixteenth
-  # the bytes are spent on a download that produces a message the dashboard will not render.
-  # The count is kept so a run says out loud what it left behind.
-  def permitted(interaction)
+  # The files this message still needs, in the order the vendor listed them, and no more of
+  # them than it has room for.
+  #
+  # Everything that is not a candidate is dropped before the cap rather than after, which is
+  # the whole of the ordering here. A blank entry or a URL listed twice among the first
+  # fifteen would otherwise spend a slot, and the real file sitting at position sixteen is
+  # then never attempted -- not on this pass and not on any later one, because every pass
+  # reads the same list the same way. The message ends up holding fewer than the permitted
+  # number and still missing a file, which is the shape of a bug nobody goes looking for.
+  #
+  # `held` is both the filter and the arithmetic: what a previous pass already stored is not
+  # work, and it is also room already spent.
+  def wanted(interaction, held)
     listed = Array(interaction['Attachments'])
-    return listed if listed.length <= Message::NUMBER_OF_PERMITTED_ATTACHMENTS
+             .select { |attachment| attachment['Url'].to_s.present? }
+             .uniq { |attachment| attachment['Url'].to_s }
+             .reject { |attachment| held.include?(attachment['Url'].to_s) }
+    room = [Message::NUMBER_OF_PERMITTED_ATTACHMENTS - held.size, 0].max
+    return listed if listed.length <= room
 
-    @stats[:anexos_acima_do_teto] += listed.length - Message::NUMBER_OF_PERMITTED_ATTACHMENTS
-    listed.first(Message::NUMBER_OF_PERMITTED_ATTACHMENTS)
+    @stats[:anexos_acima_do_teto] += listed.length - room
+    listed.first(room)
   end
 
   # Keyed on the source URL kept in the blob's metadata rather than on the filename: two

--- a/app/services/import/octadesk/attachments.rb
+++ b/app/services/import/octadesk/attachments.rb
@@ -1,0 +1,64 @@
+# What one interaction's files owe one message, and the fetching of them.
+#
+# Its own class because it is a policy rather than a step: which of the listed URLs this
+# message still needs, how many of them a message may hold, and what a run reports about
+# the ones it did not take. The ticket importer asks once per interaction and does not
+# carry any of it.
+#
+# The vendor's URLs are public and die with the subscription, so a file missed here is
+# missed permanently rather than late. That is what makes every rule in this class about
+# not spending a download twice and not spending one that cannot land.
+class Import::Octadesk::Attachments
+  def initialize(enabled:, stats:)
+    @enabled = enabled
+    @stats = stats
+  end
+
+  def perform(message, interaction)
+    return unless @enabled
+
+    # Seeded from what is already on the message and added to as the loop goes, because an
+    # interaction can list the same URL twice: read only from the snapshot, every copy after
+    # the first is another download of a file we have just stored, on a run whose cost is
+    # the downloads.
+    held = stored_sources(message)
+    permitted(interaction).each do |attachment|
+      url = attachment['Url'].to_s
+      next if url.blank?
+      next if held.include?(url)
+
+      stored = Import::Octadesk::AttachmentFetcher.new(message: message, url: url, name: attachment['Name']).perform
+      held << url
+      @stats[stored ? :anexos : :anexos_recusados] += 1
+    rescue StandardError
+      @stats[:anexos_falharam] += 1
+    end
+  end
+
+  private
+
+  # `Message` refuses more than fifteen and the mail pipeline trims to that before it
+  # attaches anything; this had no cap at all. Trimmed before the fetch rather than left to
+  # the model, because the cap is cheap to apply and expensive to hit: past the sixteenth
+  # the bytes are spent on a download that produces a message the dashboard will not render.
+  # The count is kept so a run says out loud what it left behind.
+  def permitted(interaction)
+    listed = Array(interaction['Attachments'])
+    return listed if listed.length <= Message::NUMBER_OF_PERMITTED_ATTACHMENTS
+
+    @stats[:anexos_acima_do_teto] += listed.length - Message::NUMBER_OF_PERMITTED_ATTACHMENTS
+    listed.first(Message::NUMBER_OF_PERMITTED_ATTACHMENTS)
+  end
+
+  # Keyed on the source URL kept in the blob's metadata rather than on the filename: two
+  # different files under one name is ordinary, and keyed on the name the copy that got
+  # through would call the copy that did not done.
+  #
+  # A message this pass has just created holds nothing, and asking the association would be
+  # a query per message over the whole export.
+  def stored_sources(message)
+    return Set.new if message.previously_new_record?
+
+    message.attachments.filter_map { |a| a.file.blob&.metadata&.dig('import_source') if a.file.attached? }.to_set
+  end
+end

--- a/app/services/import/octadesk/backfill.rb
+++ b/app/services/import/octadesk/backfill.rb
@@ -10,7 +10,13 @@
 # resumed from a part rather than from the beginning. That is a convenience, not a
 # correctness requirement: starting over writes nothing twice, it only re-reads.
 class Import::Octadesk::Backfill
-  attr_reader :stats, :stopped_by
+  attr_reader :stopped_by
+
+  # The importer keeps the tally of what it wrote and the walker the tally of what it read,
+  # and a report showing only one of them would say a run of half a million tickets read
+  # them and leave out what it filed. Merged here rather than at each call site, so a caller
+  # asking a run how it went cannot get the half answer.
+  def stats = @stats.merge(@importer.stats)
 
   # rubocop:disable Metrics/ParameterLists -- independent knobs on a run meant to be
   # started and restarted with different settings; an options object only moves the list.
@@ -66,14 +72,9 @@ class Import::Octadesk::Backfill
   def handle(ticket)
     @stats[:lidos] += 1
     @importer.import(ticket)
-    @progress.call(:ticket, stats: merged_stats)
+    @progress.call(:ticket, stats: stats)
   rescue StandardError => e
     @stats[:erros] += 1
     @progress.call(:error, ticket: ticket['Number'], error: e)
   end
-
-  # The importer keeps its own tally of what it wrote; the walker keeps the tally of what
-  # it read. Reported as one thing because the difference between them is the interesting
-  # number: tickets read that produced nothing.
-  def merged_stats = @stats.merge(@importer.stats)
 end

--- a/app/services/import/octadesk/backfill.rb
+++ b/app/services/import/octadesk/backfill.rb
@@ -70,17 +70,28 @@ class Import::Octadesk::Backfill
     end
   end
 
+  # Counted against what the pass actually filed, not against what it read. A limit on
+  # reads cannot advance: the next run starts at the same part, re-reads the same first
+  # `LIMIT` tickets -- already imported, so they write nothing -- and stops before reaching
+  # anything new, which makes "run it again to continue" a loop that never moves. Reading
+  # past what is already filed costs an indexed lookup each and is the cheap half.
   def halt?
-    @stopped_by = :limite if @limit && @stats[:lidos] >= @limit
+    @stopped_by = :limite if @limit && @stats[:novos] >= @limit
     @stopped_by.present?
   end
 
+  WRITTEN = %i[mensagens respostas atividades].freeze
+
   def handle(ticket)
     @stats[:lidos] += 1
+    before = filed
     @importer.import(ticket)
+    @stats[:novos] += 1 if filed > before
     @progress.call(:ticket, stats: stats)
   rescue StandardError => e
     @stats[:erros] += 1
     @progress.call(:error, ticket: ticket['Number'], error: e)
   end
+
+  def filed = WRITTEN.sum { |key| @importer.stats[key] }
 end

--- a/app/services/import/octadesk/backfill.rb
+++ b/app/services/import/octadesk/backfill.rb
@@ -44,6 +44,8 @@ class Import::Octadesk::Backfill
       walk(part)
     end
     self
+  ensure
+    @importer.flush_search_index
   end
 
   # `from_part` names a member, and a name that is not one is a typo in the command that

--- a/app/services/import/octadesk/backfill.rb
+++ b/app/services/import/octadesk/backfill.rb
@@ -1,0 +1,79 @@
+# Walks the exported ticket collection and files what it finds.
+#
+# Built to be stopped, like its IMAP counterpart, but for a different reason: there is no
+# provider budget here, only gigabytes of JSON and a live box that must not feel it. So the
+# pacing is entirely the host's load average, and resuming is free because both keys the
+# importer writes on -- the ticket number and the interaction id -- already say what has
+# been filed.
+#
+# Parts are walked in order and the position is reported, so an interrupted run can be
+# resumed from a part rather than from the beginning. That is a convenience, not a
+# correctness requirement: starting over writes nothing twice, it only re-reads.
+class Import::Octadesk::Backfill
+  attr_reader :stats, :stopped_by
+
+  # rubocop:disable Metrics/ParameterLists -- independent knobs on a run meant to be
+  # started and restarted with different settings; an options object only moves the list.
+  def initialize(inbox:, zip_path:, pacer:, attachments: false, limit: nil, from_part: nil,
+                 form_address: nil, form_sender_name: nil)
+    @stream = Import::Octadesk::Stream.new(zip_path)
+    @pacer = pacer
+    @limit = limit
+    @from_part = from_part
+    @importer = Import::Octadesk::TicketImporter.new(
+      inbox: inbox, attachments: attachments,
+      form_address: form_address, form_sender_name: form_sender_name
+    )
+    @stats = Hash.new(0)
+    @stopped_by = nil
+  end
+  # rubocop:enable Metrics/ParameterLists
+
+  def perform(&progress)
+    @progress = progress || ->(*) {}
+    parts.each do |part|
+      break if @stopped_by
+
+      @progress.call(:part, part: part)
+      walk(part)
+    end
+    self
+  end
+
+  def parts
+    all = @stream.parts
+    return all if @from_part.blank?
+
+    all.drop_while { |part| part < @from_part }
+  end
+
+  private
+
+  def walk(part)
+    @stream.each_object(part) do |ticket|
+      raise StopIteration if halt?
+
+      @pacer.wait_for_room { |load| @progress.call(:paused, load: load) }
+      handle(ticket)
+    end
+  end
+
+  def halt?
+    @stopped_by = :limite if @limit && @stats[:lidos] >= @limit
+    @stopped_by.present?
+  end
+
+  def handle(ticket)
+    @stats[:lidos] += 1
+    @importer.import(ticket)
+    @progress.call(:ticket, stats: merged_stats)
+  rescue StandardError => e
+    @stats[:erros] += 1
+    @progress.call(:error, ticket: ticket['Number'], error: e)
+  end
+
+  # The importer keeps its own tally of what it wrote; the walker keeps the tally of what
+  # it read. Reported as one thing because the difference between them is the interesting
+  # number: tickets read that produced nothing.
+  def merged_stats = @stats.merge(@importer.stats)
+end

--- a/app/services/import/octadesk/backfill.rb
+++ b/app/services/import/octadesk/backfill.rb
@@ -46,9 +46,15 @@ class Import::Octadesk::Backfill
     self
   end
 
+  # `from_part` names a member, and a name that is not one is a typo in the command that
+  # started the run. Left to `drop_while` it would silently begin at whatever sorts after
+  # it and skip everything between, then report the export exhausted -- the shape of a
+  # misconfiguration that looks like a completed import.
   def parts
     all = @stream.parts
     return all if @from_part.blank?
+
+    raise ArgumentError, "FROM_PART #{@from_part.inspect} is not a member of this export" if all.exclude?(@from_part)
 
     all.drop_while { |part| part < @from_part }
   end

--- a/app/services/import/octadesk/contact_resolver.rb
+++ b/app/services/import/octadesk/contact_resolver.rb
@@ -37,7 +37,7 @@ class Import::Octadesk::ContactResolver
   # it is taken from.
   def customer_email(ticket, interactions)
     stated = ticket['RequesterMail'].to_s.downcase.strip
-    return stated if stated.present? && stated != @form_address
+    return stated if stated.present? && !from_form?(ticket, stated)
     return stated.presence unless configured?
 
     from_body = interactions.first(2).flat_map { |i| Array(i['Comments']).map { |c| c['Content'].to_s } }
@@ -62,6 +62,17 @@ class Import::Octadesk::ContactResolver
     return stated if stated.present? && !form_sender?(stated)
 
     body(interactions.first).to_s[NAME_IN_BODY, 1].to_s.squish.presence || email.split('@').first
+  end
+
+  # Whether the stated requester is the form rather than a person. Either configured value
+  # answers it on its own, which is the point of accepting either: a deployment that knows
+  # only the display name would otherwise take the company's address at face value on every
+  # form ticket and merge all of them into one contact -- the exact failure the recovery
+  # exists to prevent, with the setting for it switched on.
+  def from_form?(ticket, stated)
+    return true if @form_address.present? && stated == @form_address
+
+    @form_sender_name.present? && form_sender?(ticket['RequesterName'].to_s.strip)
   end
 
   # The two ways an export spells "this is the form, not the person": the display name the

--- a/app/services/import/octadesk/contact_resolver.rb
+++ b/app/services/import/octadesk/contact_resolver.rb
@@ -1,0 +1,76 @@
+# Who an exported ticket is from.
+#
+# Straightforward on most of them -- `RequesterMail` and `RequesterName` are the customer
+# and that is the end of it. The exception is the company's own website form, which posts
+# as the company and names the person in the body of the first comment, so a ticket that
+# came through it would otherwise file every customer under one contact with the company's
+# address and the company's name.
+#
+# Both form values are deployment-specific, so they are given rather than assumed: with
+# neither set the recovery never fires and every ticket is taken at its stated requester.
+class Import::Octadesk::ContactResolver
+  EMAIL_IN_BODY = /(?:^|\s)e-?mail:\s*([^\s,;<>()]+@[^\s,;<>()]+)/i
+  NAME_IN_BODY = /(?:^|\s)nome:\s*(.{2,80}?)\s*(?:\n|e-?mail:|fone:|telefone:|cidade:|\z)/i
+
+  def initialize(inbox:, form_address: nil, form_sender_name: nil)
+    @inbox = inbox
+    @form_address = form_address.to_s.downcase.strip.presence
+    @form_local = @form_address&.split('@')&.first
+    @form_sender_name = form_sender_name.to_s.strip.presence
+  end
+
+  # Returns the ContactInbox, or nil when the ticket names nobody at all.
+  def perform(ticket, interactions)
+    email = customer_email(ticket, interactions)
+    return if email.blank?
+
+    name = contact_name(ticket, email, interactions)
+    existing = @inbox.contacts.from_email(email)
+    return ContactInbox.find_by(inbox: @inbox, contact: existing) || build(email, name) if existing
+
+    build(email, name)
+  end
+
+  private
+
+  # The form posts as the company with the customer's address in the text, so that is where
+  # it is taken from.
+  def customer_email(ticket, interactions)
+    stated = ticket['RequesterMail'].to_s.downcase.strip
+    return stated if stated.present? && stated != @form_address
+
+    from_body = interactions.first(2).flat_map { |i| Array(i['Comments']).map { |c| c['Content'].to_s } }
+                            .join(' ')[EMAIL_IN_BODY, 1].to_s.downcase
+    from_body.presence || stated.presence
+  end
+
+  # Form tickets name the company rather than the person, so the stated name is trusted
+  # only when it is not that. What the form does carry is a `Nome:` line beside the
+  # `Email:` one, which is the person's own name and better than the local part of an
+  # address.
+  def contact_name(ticket, email, interactions)
+    stated = ticket['RequesterName'].to_s.strip
+    return stated if stated.present? && !form_sender?(stated)
+
+    body(interactions.first).to_s[NAME_IN_BODY, 1].to_s.squish.presence || email.split('@').first
+  end
+
+  # The two ways an export spells "this is the form, not the person": the display name the
+  # form posts under, and the local part of the address it posts from, which the exporter
+  # also uses as a name on its own.
+  def form_sender?(stated)
+    return true if @form_sender_name && stated.casecmp(@form_sender_name).zero?
+
+    @form_local.present? && stated.downcase.include?(@form_local)
+  end
+
+  def body(interaction)
+    Array(interaction&.dig('Comments')).map { |comment| comment['Content'].to_s }.join("\n")
+  end
+
+  def build(email, name)
+    ::ContactInboxWithContactBuilder.new(
+      source_id: email, inbox: @inbox, contact_attributes: { name: name, email: email }
+    ).perform
+  end
+end

--- a/app/services/import/octadesk/contact_resolver.rb
+++ b/app/services/import/octadesk/contact_resolver.rb
@@ -38,11 +38,20 @@ class Import::Octadesk::ContactResolver
   def customer_email(ticket, interactions)
     stated = ticket['RequesterMail'].to_s.downcase.strip
     return stated if stated.present? && stated != @form_address
+    return stated.presence unless configured?
 
     from_body = interactions.first(2).flat_map { |i| Array(i['Comments']).map { |c| c['Content'].to_s } }
                             .join(' ')[EMAIL_IN_BODY, 1].to_s.downcase
     from_body.presence || stated.presence
   end
+
+  # Reading an address out of a comment is only ever right for a deployment that has a form
+  # posting as itself. Ungated it fires on any ticket with no stated requester, and an
+  # `Email: ...` line in the text is as likely to be somebody the customer is writing
+  # about -- a colleague, a supplier, the address on an invoice -- as the customer. Filing
+  # the thread under that person is worse than filing it under nobody, which is what the
+  # caller counts and reports.
+  def configured? = @form_address.present? || @form_sender_name.present?
 
   # Form tickets name the company rather than the person, so the stated name is trusted
   # only when it is not that. What the form does carry is a `Nome:` line beside the

--- a/app/services/import/octadesk/stream.rb
+++ b/app/services/import/octadesk/stream.rb
@@ -75,12 +75,17 @@ class Import::Octadesk::Stream
   end
 
   # Member names in the archive, in order. A listing that fails is a setup problem -- a
-  # corrupt archive, a path that is not one, no `unzip` on the box -- and raises, because
-  # the alternative is an empty list that walks nothing and reports the export exhausted.
+  # corrupt archive, a path that is not one, no Info-ZIP `unzip` on the box -- and raises,
+  # because the alternative is an empty list that walks nothing and reports the export
+  # exhausted.
+  #
+  # `-Z1` is Info-ZIP's, and BusyBox's applet does not have it, so an image that ships only
+  # BusyBox fails here rather than half-reading the export. The production image installs
+  # the package for exactly this; see docker/Dockerfile.
   def parts
     @parts ||= begin
       listing = `unzip -Z1 #{Shellwords.escape(@zip_path)}`
-      raise "cannot read the archive at #{@zip_path}" unless $CHILD_STATUS.success?
+      raise "cannot read the archive at #{@zip_path} (is Info-ZIP `unzip` installed?)" unless $CHILD_STATUS.success?
 
       listing.split("\n").grep(/\.json\z/).sort
     end

--- a/app/services/import/octadesk/stream.rb
+++ b/app/services/import/octadesk/stream.rb
@@ -88,12 +88,25 @@ class Import::Octadesk::Stream
 
   # Yields every object in one member. `StopIteration` from the block ends the read
   # cleanly, which is what a `LIMIT` on the task raises.
+  #
+  # The exit status is checked for the same reason the listing checks it, and the failure
+  # is quieter here: a member that lists but will not extract -- encrypted, or truncated --
+  # sends `unzip` away with an error and leaves stdout empty, which Oj accepts as a
+  # well-formed nothing. The part is then reported as holding no tickets and the run moves
+  # on, so a whole gigabyte of the export goes missing with every number on the screen
+  # looking right.
+  #
+  # Only when the read ran to the end: a `StopIteration` closes the pipe early and `unzip`
+  # dies of SIGPIPE, which is the caller getting what it asked for rather than a failure.
   def each_object(part, &)
+    stopped = false
     IO.popen(['unzip', '-p', @zip_path, part], 'rb') do |io|
       Oj.saj_parse(Builder.new(&), io)
     rescue StopIteration
-      nil
+      stopped = true
     end
+    return if stopped
+    raise "cannot read #{part} in #{@zip_path}" unless $CHILD_STATUS.success?
   end
 
   # Mongo extended JSON wraps its scalars. These are the two shapes this export uses.

--- a/app/services/import/octadesk/stream.rb
+++ b/app/services/import/octadesk/stream.rb
@@ -1,0 +1,94 @@
+require 'oj'
+require 'shellwords'
+
+# Reads a MongoDB extended-JSON export one top-level object at a time.
+#
+# The export is a handful of zip archives holding a JSON array per part, and the parts run
+# to a gigabyte each, and a ticket collection runs to a dozen or more of them.
+# `JSON.parse` on that is an out-of-memory error, and a line reader does not work either
+# because the array is pretty-printed across lines. So the file is streamed through Oj's
+# SAJ callbacks and rebuilt one element at a time, which keeps exactly one ticket in
+# memory no matter how large the part is.
+#
+# Decompressed through `unzip -p` rather than a gem: there is no zip library in the
+# bundle, the archives are plain deflate, and a pipe streams where a gem would want the
+# member on disk first. That costs a subprocess per part and saves the whole export in
+# scratch space.
+class Import::Octadesk::Stream
+  # Rebuilds values as the parser walks them, emitting whole objects at the point the
+  # nesting returns to the top level.
+  #
+  # The subtlety worth naming, because getting it wrong is silent: a value's key has to be
+  # captured *before* it leaves the key stack. Reading `keys.last` after popping yields the
+  # parent's key instead, which attaches every nested array to the wrong name -- an object
+  # that parses without error and quietly has no `Interactions`.
+  class Builder < Oj::Saj
+    def initialize(&on_object)
+      super()
+      @on_object = on_object
+      @depth = 0
+      @stack = []
+      @keys = []
+    end
+
+    def hash_start(key)
+      @depth += 1
+      @stack.push({})
+      @keys.push(key)
+    end
+
+    def hash_end(_key)
+      object = @stack.pop
+      own = @keys.pop
+      @depth -= 1
+      return @on_object.call(object) if @depth.zero?
+
+      attach(object, own)
+    end
+
+    def array_start(key)
+      @stack.push([])
+      @keys.push(key)
+    end
+
+    def array_end(_key)
+      array = @stack.pop
+      attach(array, @keys.pop)
+    end
+
+    def add_value(value, key) = attach(value, key)
+
+    private
+
+    # Nil key inside an array, where position is the only name a value has.
+    def attach(value, key)
+      parent = @stack.last
+      return if parent.nil?
+
+      parent.is_a?(Array) ? parent << value : parent[key] = value
+    end
+  end
+
+  def initialize(zip_path)
+    @zip_path = zip_path
+  end
+
+  # Member names in the archive, in order.
+  def parts
+    @parts ||= `unzip -Z1 #{Shellwords.escape(@zip_path)}`.split("\n").grep(/\.json\z/).sort
+  end
+
+  # Yields every object in one member. `StopIteration` from the block ends the read
+  # cleanly, which is what a `LIMIT` on the task raises.
+  def each_object(part, &)
+    IO.popen(['unzip', '-p', @zip_path, part], 'rb') do |io|
+      Oj.saj_parse(Builder.new(&), io)
+    rescue StopIteration
+      nil
+    end
+  end
+
+  # Mongo extended JSON wraps its scalars. These are the two shapes this export uses.
+  def self.oid(value) = value.is_a?(Hash) ? (value.dig('$binary', 'base64') || value['$oid']) : value
+  def self.time(value) = (Time.zone.parse(value['$date']) if value.is_a?(Hash) && value['$date'].present?)
+end

--- a/app/services/import/octadesk/stream.rb
+++ b/app/services/import/octadesk/stream.rb
@@ -1,3 +1,4 @@
+require 'English'
 require 'oj'
 require 'shellwords'
 
@@ -73,9 +74,16 @@ class Import::Octadesk::Stream
     @zip_path = zip_path
   end
 
-  # Member names in the archive, in order.
+  # Member names in the archive, in order. A listing that fails is a setup problem -- a
+  # corrupt archive, a path that is not one, no `unzip` on the box -- and raises, because
+  # the alternative is an empty list that walks nothing and reports the export exhausted.
   def parts
-    @parts ||= `unzip -Z1 #{Shellwords.escape(@zip_path)}`.split("\n").grep(/\.json\z/).sort
+    @parts ||= begin
+      listing = `unzip -Z1 #{Shellwords.escape(@zip_path)}`
+      raise "cannot read the archive at #{@zip_path}" unless $CHILD_STATUS.success?
+
+      listing.split("\n").grep(/\.json\z/).sort
+    end
   end
 
   # Yields every object in one member. `StopIteration` from the block ends the read

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -7,9 +7,9 @@
 #
 # What the export settles that a mailbox could not:
 #
-#   direction     `Person.Type == 1` is an agent. Measured over the export: nearly all of those
-#                 carry the company's own mail domain, and the rest are an escalation bot
-#                 plus a handful of individual senders. Everything else is the
+#   direction     `Person.Type == 1` is an agent. Measured over a whole export, the vast
+#                 majority of those carry the company's own mail domain and the rest are
+#                 automation and agents on personal addresses. Everything else is the
 #                 customer. Reconstructing this from the mailbox meant reading
 #                 notification wrappers and guessing from name frequency.
 #   who wrote it  `Person.Name` and `Person.Email`, so an agent reply carries the agent.

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -125,10 +125,15 @@ class Import::Octadesk::TicketImporter
     [parts.join(' · '), who && "(por #{who})"].compact.join(' ')
   end
 
-  # An interaction with no comment is a status change or a trigger firing: real history,
-  # but not a message. Those are written separately by Import::Octadesk::ActivityWriter.
+  # An interaction with nothing said and nothing attached is a status change or a trigger
+  # firing: real history, but not a message. Those are written separately by
+  # Import::Octadesk::ActivityWriter, which draws the line in the same place.
+  #
+  # The row is written even on a pass that is not fetching attachments: it has the sender,
+  # the date and its place in the thread, and the pass that does fetch finds it by
+  # interaction id and fills it in.
   def writable(ticket)
-    Array(ticket['Interactions']).select { |i| Import::Octadesk::ActivityWriter.commented?(i) }
+    Array(ticket['Interactions']).select { |i| Import::Octadesk::ActivityWriter.message?(i) }
   end
 
   def any_activity?(ticket)

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -153,6 +153,14 @@ class Import::Octadesk::TicketImporter
     conversation.update_columns(status_changed_at: done) # rubocop:disable Rails/SkipsModelValidations
   end
 
+  # What is already on the row, by the same name the fetcher would give it. A message this
+  # pass just created has nothing, which is the ordinary path and costs no query.
+  def stored_filenames(message)
+    return Set.new if message.previously_new_record?
+
+    message.attachments.filter_map { |a| a.file.filename.to_s if a.file.attached? }.to_set
+  end
+
   # What the ticketing system knew about the thread and Chatwoot has no column for. Kept
   # as custom attributes rather than dropped, because this inbox exists to be searched: the
   # ticket number is what the operators looked things up by for four years, and the agent
@@ -206,7 +214,16 @@ class Import::Octadesk::TicketImporter
   def write(conversation, contact, interaction)
     source_id = message_source_id(interaction)
     return if source_id.blank?
-    return skip(:ja_tinha) if conversation.messages.exists?(source_id: source_id)
+
+    # A message whose attachments failed is still a message, so a later pass finds it here
+    # and would otherwise leave what it owes behind forever. The vendor's URLs die with the
+    # subscription, which makes a missed attachment permanent rather than late, so the
+    # existing row is offered to the fetcher again on the way past.
+    existing = conversation.messages.find_by(source_id: source_id)
+    if existing
+      attach(existing, interaction)
+      return skip(:ja_tinha)
+    end
 
     person = interaction['Person'] || {}
     message = conversation.messages.create!(message_attributes(conversation, contact, interaction, person, source_id))
@@ -271,9 +288,11 @@ class Import::Octadesk::TicketImporter
   def attach(message, interaction)
     return unless @attachments
 
+    held = stored_filenames(message)
     Array(interaction['Attachments']).each do |attachment|
       url = attachment['Url'].to_s
       next if url.blank?
+      next if held.include?(Import::Octadesk::AttachmentFetcher.filename_for(url, attachment['Name']))
 
       stored = Import::Octadesk::AttachmentFetcher.new(message: message, url: url, name: attachment['Name']).perform
       @stats[stored ? :anexos : :anexos_recusados] += 1

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -68,13 +68,21 @@ class Import::Octadesk::TicketImporter
   # already there -- so keying the settlement on "did I write something" would leave that
   # thread wrong forever, which is the one case resumability exists for.
   #
+  # "Wrote nothing" is not the only interrupted shape, which is why the test is whether
+  # this pass created the thread rather than whether it wrote a row. A run that stops
+  # between the comments and the activity rows leaves the next pass writing only the
+  # activities: a non-empty batch that is a fraction of the thread, and settling from it
+  # would stamp `last_activity_at` from an old status change while a newer message sits
+  # right there. This pass created the thread or it did not; only in the first case are the
+  # rows in hand the whole of it.
+  #
   # The conversation is put back in `opened` on that path, because it is: a thread carrying
   # nothing but imported rows still wears the stamps its creation left behind, and those
   # describe the interrupted run rather than the ticket. The test is the same one
   # `stamp_seen` makes, and for the same reason -- a thread that ever took live traffic has
   # real stamps, and overwriting those would be the worse error.
   def settle_ticket(conversation, rows)
-    stored = rows.presence || conversation.messages.to_a
+    stored = @opened.include?(conversation.id) ? rows : conversation.messages.to_a
     return if stored.empty?
 
     @opened << conversation.id if resumed?(conversation)
@@ -153,12 +161,19 @@ class Import::Octadesk::TicketImporter
     conversation.update_columns(status_changed_at: done) # rubocop:disable Rails/SkipsModelValidations
   end
 
-  # What is already on the row, by the same name the fetcher would give it. A message this
-  # pass just created has nothing, which is the ordinary path and costs no query.
-  def stored_filenames(message)
+  # Which of an interaction's attachments are already on the row, keyed by where each came
+  # from. The filename cannot answer this: one interaction can carry two different files
+  # under one name, and if the first is stored and the second is not, a filename test calls
+  # both of them done and the missing one is never fetched again. The fetcher stamps the
+  # source URL on the blob for exactly this, and that is the only key that is one-to-one
+  # with the object in the vendor's bucket.
+  #
+  # A message this pass just created has nothing, which is the ordinary path and costs no
+  # query.
+  def stored_sources(message)
     return Set.new if message.previously_new_record?
 
-    message.attachments.filter_map { |a| a.file.filename.to_s if a.file.attached? }.to_set
+    message.attachments.filter_map { |a| a.file.blob&.metadata&.dig('import_source') if a.file.attached? }.to_set
   end
 
   # What the ticketing system knew about the thread and Chatwoot has no column for. Kept
@@ -288,11 +303,11 @@ class Import::Octadesk::TicketImporter
   def attach(message, interaction)
     return unless @attachments
 
-    held = stored_filenames(message)
+    held = stored_sources(message)
     Array(interaction['Attachments']).each do |attachment|
       url = attachment['Url'].to_s
       next if url.blank?
-      next if held.include?(Import::Octadesk::AttachmentFetcher.filename_for(url, attachment['Name']))
+      next if held.include?(url)
 
       stored = Import::Octadesk::AttachmentFetcher.new(message: message, url: url, name: attachment['Name']).perform
       @stats[stored ? :anexos : :anexos_recusados] += 1

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -134,7 +134,7 @@ class Import::Octadesk::TicketImporter
   def conversation_for(ticket, contact_inbox)
     number = ticket['Number'].to_s
     existing = find_by_ticket(number)
-    return existing if existing
+    return reconcile(existing, ticket) if existing
 
     opened_at = Import::Octadesk::Stream.time(ticket['DateCreation'])
     conversation = ::Conversation.create!(
@@ -154,9 +154,22 @@ class Import::Octadesk::TicketImporter
   # would normally record when that happened is stamped by hand. Written with
   # `update_columns` for the same reason everything else here is: a save would wake the
   # callbacks the import exists to keep quiet.
+  # Everything a thread carries that is not a message, applied on the resumed path as well.
+  #
+  # A run that stops between the insert and these leaves a conversation with no labels and a
+  # resolution stamped at the moment of the import, and the next pass finds it, returns it
+  # and writes nothing -- the same resume hole `settle_ticket` closes for the clocks, two
+  # fields over. Both are idempotent and both compare before writing, so a pass over an
+  # archive that is already right costs a read and no writes.
+  def reconcile(conversation, ticket)
+    apply_tags(conversation, ticket)
+    stamp_resolution(conversation, ticket)
+    conversation
+  end
+
   def stamp_resolution(conversation, ticket)
     done = Import::Octadesk::Stream.time(ticket['DoneDate'])
-    return if done.blank?
+    return if done.blank? || conversation.status_changed_at == done
 
     conversation.update_columns(status_changed_at: done) # rubocop:disable Rails/SkipsModelValidations
   end
@@ -221,7 +234,9 @@ class Import::Octadesk::TicketImporter
 
   def apply_tags(conversation, ticket)
     tags = Array(ticket['Tags']).filter_map { |tag| tag.is_a?(Hash) ? tag['Name'] : tag }.compact_blank
-    conversation.add_labels(tags) if tags.any?
+    return if tags.empty? || (tags - conversation.label_list).empty?
+
+    conversation.add_labels(tags)
   rescue StandardError
     @stats[:tags_recusadas] += 1
   end

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -27,22 +27,16 @@ class Import::Octadesk::TicketImporter
   include Import::HistorySettlement
 
   SOURCE_PREFIX = 'octadesk'.freeze
-  EMAIL_IN_BODY = /(?:^|\s)e-?mail:\s*([^\s,;<>()]+@[^\s,;<>()]+)/i
-  NAME_IN_BODY = /(?:^|\s)nome:\s*(.{2,80}?)\s*(?:\n|e-?mail:|fone:|telefone:|cidade:|\z)/i
 
   attr_reader :opened, :stats
 
-  # `form_address` and `form_sender_name` are the address and display name the company's
-  # website form posts as. They are deployment-specific, so they are given rather than
-  # assumed: with neither set, every ticket is taken at its stated requester and the
-  # recovery below simply never fires.
   def initialize(inbox:, attachments: false, form_address: nil, form_sender_name: nil)
     @inbox = inbox
     @account = inbox.account
     @attachments = attachments
-    @form_address = form_address.to_s.downcase.strip.presence
-    @form_local = @form_address&.split('@')&.first
-    @form_sender_name = form_sender_name.to_s.strip.presence
+    @contacts = Import::Octadesk::ContactResolver.new(
+      inbox: inbox, form_address: form_address, form_sender_name: form_sender_name
+    )
     @opened = Set.new
     @stats = Hash.new(0)
   end
@@ -52,7 +46,7 @@ class Import::Octadesk::TicketImporter
     return @stats[:sem_conteudo] += 1 if interactions.empty?
 
     Import::SilentWrite.wrap do
-      contact_inbox = resolve_contact(ticket, interactions)
+      contact_inbox = @contacts.perform(ticket, interactions)
       return @stats[:sem_contato] += 1 if contact_inbox.nil?
 
       conversation = conversation_for(ticket, contact_inbox)
@@ -77,17 +71,26 @@ class Import::Octadesk::TicketImporter
   # `stamp_seen` makes, and for the same reason -- a thread that ever took live traffic has
   # real stamps, and overwriting those would be the worse error.
   def settle_ticket(conversation, rows)
-    return settle(rows, []) if rows.any?
-
-    stored = conversation.messages.to_a
+    stored = rows.presence || conversation.messages.to_a
     return if stored.empty?
 
-    @opened << conversation.id unless live_traffic?(conversation)
+    @opened << conversation.id if resumed?(conversation)
     settle(stored, [])
   end
 
-  def live_traffic?(conversation)
-    conversation.messages.where.not(Import::IMPORTED_SQL).exists?
+  # A conversation this run did not create still wears the stamps of the run that did, and
+  # those describe the import rather than the ticket -- so it has to take the batch outright
+  # the same way a new one does. This covers both interruption points: after the rows were
+  # written and before they were, since a run that stops between `conversation_for` and the
+  # first insert leaves a thread whose `last_activity_at` is newer than every row the next
+  # pass writes, which the monotonic guard would then refuse to move.
+  #
+  # The test is the one `stamp_seen` makes: a thread that ever took live traffic has real
+  # stamps, and overwriting those would be the worse error.
+  def resumed?(conversation)
+    return false if @opened.include?(conversation.id)
+
+    conversation.messages.where.not(Import::IMPORTED_SQL).none?
   end
 
   # Only the two changes a reader of an archive cares about. A person of type 3 is a
@@ -110,54 +113,6 @@ class Import::Octadesk::TicketImporter
     Array(ticket['Interactions']).select { |i| Import::Octadesk::ActivityWriter.commented?(i) }
   end
 
-  def resolve_contact(ticket, interactions)
-    email = customer_email(ticket, interactions)
-    return if email.blank?
-
-    name = contact_name(ticket, email, interactions)
-    existing = @inbox.contacts.from_email(email)
-    return ContactInbox.find_by(inbox: @inbox, contact: existing) || build_contact(email, name) if existing
-
-    build_contact(email, name)
-  end
-
-  # The website form posts as the company with the customer named in the body. Same shape
-  # the mailbox showed, and the same fix: take the address out of the text.
-  def customer_email(ticket, interactions)
-    stated = ticket['RequesterMail'].to_s.downcase.strip
-    return stated if stated.present? && stated != @form_address
-
-    from_body = interactions.first(2).flat_map { |i| Array(i['Comments']).map { |c| c['Content'].to_s } }
-                            .join(' ')[EMAIL_IN_BODY, 1].to_s.downcase
-    from_body.presence || stated.presence
-  end
-
-  def build_contact(email, name)
-    ::ContactInboxWithContactBuilder.new(
-      source_id: email, inbox: @inbox, contact_attributes: { name: name, email: email }
-    ).perform
-  end
-
-  # The form tickets name the company rather than the person, so the requester name is
-  # only trusted when it is not that. What the form does carry is a `Nome:` line in the
-  # body beside the `Email:` one, which is the person's own name and better than the local
-  # part of their address.
-  def contact_name(ticket, email, interactions)
-    stated = ticket['RequesterName'].to_s.strip
-    return stated if stated.present? && !form_sender?(stated)
-
-    body(interactions.first).to_s[NAME_IN_BODY, 1].to_s.squish.presence || email.split('@').first
-  end
-
-  # The two ways an export spells "this is the form, not the person": the display name the
-  # form posts under, and the local part of the address it posts from, which the exporter
-  # also uses as a name on its own.
-  def form_sender?(stated)
-    return true if @form_sender_name && stated.casecmp(@form_sender_name).zero?
-
-    @form_local.present? && stated.downcase.include?(@form_local)
-  end
-
   # Dated to the ticket and resolved from the start, never resolved afterwards: born in
   # that state it fires no resolution event and writes no "resolved by" line, where a
   # transition would do both and file every imported thread into today's figures.
@@ -170,7 +125,7 @@ class Import::Octadesk::TicketImporter
     conversation = ::Conversation.create!(
       account_id: @account.id, inbox_id: @inbox.id,
       contact_id: contact_inbox.contact_id, contact_inbox_id: contact_inbox.id,
-      status: :resolved, created_at: opened_at || Time.current,
+      status: :resolved, created_at: opened_at || Time.current, identifier: identifier_for(number),
       additional_attributes: { source: 'email', mail_subject: subject(ticket) }.compact,
       custom_attributes: ticket_attributes(ticket, number)
     )
@@ -219,10 +174,19 @@ class Import::Octadesk::TicketImporter
 
   # The number the operators searched by for four years, and the only key that ties a
   # thread here back to a row in the export.
+  #
+  # Read off `identifier`, which is indexed, rather than out of the JSON column, which is
+  # not: at half a million tickets an unindexed expression lookup once per record scans an
+  # inbox that grows as the run goes, and the import turns quadratic somewhere in the
+  # middle of it. The number is written to both -- `custom_attributes` is what an operator
+  # searches and a report groups by, `identifier` is what this lookup needs. The column is
+  # otherwise unused on an email inbox.
+  def identifier_for(number) = "#{SOURCE_PREFIX}:#{number}"
+
   def find_by_ticket(number)
     return if number.blank?
 
-    @inbox.conversations.where('custom_attributes ->> ? = ?', SOURCE_PREFIX, number).first
+    @inbox.conversations.find_by(identifier: identifier_for(number))
   end
 
   def apply_tags(conversation, ticket)
@@ -252,8 +216,18 @@ class Import::Octadesk::TicketImporter
       content: body(interaction), content_type: :incoming_email,
       sender: agent ? nil : contact,
       created_at: Import::Octadesk::Stream.time(interaction['DateCreation']) || conversation.created_at,
-      content_attributes: content_attributes(person, agent)
+      content_attributes: content_attributes(person, agent),
+      additional_attributes: agent ? sender_name(person) : {}
     }
+  end
+
+  # An outgoing message with no sender and no `sender_name` renders as the bot, so every
+  # agent reply in the archive would be attributed to one. `additional_attributes` is the
+  # contract the message component already reads for exactly this case, which is what makes
+  # it right here: the agent is a name on a historical row, not a seat somebody holds.
+  def sender_name(person)
+    name = person['Name'].to_s.squish.presence
+    name ? { sender_name: name } : {}
   end
 
   def message_source_id(interaction)
@@ -294,8 +268,8 @@ class Import::Octadesk::TicketImporter
       url = attachment['Url'].to_s
       next if url.blank?
 
-      Import::Octadesk::AttachmentFetcher.new(message: message, url: url, name: attachment['Name']).perform
-      @stats[:anexos] += 1
+      stored = Import::Octadesk::AttachmentFetcher.new(message: message, url: url, name: attachment['Name']).perform
+      @stats[stored ? :anexos : :anexos_recusados] += 1
     rescue StandardError
       @stats[:anexos_falharam] += 1
     end

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -57,13 +57,38 @@ class Import::Octadesk::TicketImporter
 
       conversation = conversation_for(ticket, contact_inbox)
       rows = interactions.filter_map { |interaction| write(conversation, contact_inbox.contact, interaction) }
-      activity_writer.perform(conversation, ticket)
-      settle(rows, []) if rows.any?
+      rows += activity_writer.perform(conversation, ticket)
+      settle_ticket(conversation, rows)
       @stats[:tickets] += 1
     end
   end
 
   private
+
+  # Settled from what the conversation holds, not from what this pass happened to write.
+  # A run that stops between the message insert and the settlement leaves the rows on disk
+  # and the stamps unset, and the next pass writes nothing because every source id is
+  # already there -- so keying the settlement on "did I write something" would leave that
+  # thread wrong forever, which is the one case resumability exists for.
+  #
+  # The conversation is put back in `opened` on that path, because it is: a thread carrying
+  # nothing but imported rows still wears the stamps its creation left behind, and those
+  # describe the interrupted run rather than the ticket. The test is the same one
+  # `stamp_seen` makes, and for the same reason -- a thread that ever took live traffic has
+  # real stamps, and overwriting those would be the worse error.
+  def settle_ticket(conversation, rows)
+    return settle(rows, []) if rows.any?
+
+    stored = conversation.messages.to_a
+    return if stored.empty?
+
+    @opened << conversation.id unless live_traffic?(conversation)
+    settle(stored, [])
+  end
+
+  def live_traffic?(conversation)
+    conversation.messages.where.not(Import::IMPORTED_SQL).exists?
+  end
 
   # Only the two changes a reader of an archive cares about. A person of type 3 is a
   # trigger, and "Gatilho executado: notificar o solicitante" is machinery, not an event.

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -1,0 +1,284 @@
+# Files one exported OctaDesk ticket as a Chatwoot conversation.
+#
+# Unlike the IMAP importer, this one does not run the live mail pipeline, because there is
+# no mail to run: the export is the ticketing system's own model, already parsed, already
+# threaded, already attributed. Rebuilding an RFC822 document from it so the mailbox could
+# take it apart again would be inventing a worse copy of data we already have structured.
+#
+# What the export settles that a mailbox could not:
+#
+#   direction     `Person.Type == 1` is an agent. Measured over the export: nearly all of those
+#                 carry the company's own mail domain, and the rest are an escalation bot
+#                 plus a handful of individual senders. Everything else is the
+#                 customer. Reconstructing this from the mailbox meant reading
+#                 notification wrappers and guessing from name frequency.
+#   who wrote it  `Person.Name` and `Person.Email`, so an agent reply carries the agent.
+#   the thread    `Interactions` is already the conversation, in order, so nothing depends
+#                 on In-Reply-To surviving four years of forwarding.
+#   identity      `RequesterMail` is the real customer on some 98% of tickets. The rest
+#                 came through the website form, which carries the company address there
+#                 instead and the customer's own address inside the first comment,
+#                 recoverable on nearly all of them.
+#
+# Idempotent on two keys, because a run over gigabytes will be interrupted: the conversation
+# is found by ticket number, and each message by the interaction's Mongo id. Re-running
+# costs a lookup per record and writes nothing twice.
+class Import::Octadesk::TicketImporter
+  include Import::HistorySettlement
+
+  SOURCE_PREFIX = 'octadesk'.freeze
+  EMAIL_IN_BODY = /(?:^|\s)e-?mail:\s*([^\s,;<>()]+@[^\s,;<>()]+)/i
+  NAME_IN_BODY = /(?:^|\s)nome:\s*(.{2,80}?)\s*(?:\n|e-?mail:|fone:|telefone:|cidade:|\z)/i
+
+  attr_reader :opened, :stats
+
+  # `form_address` and `form_sender_name` are the address and display name the company's
+  # website form posts as. They are deployment-specific, so they are given rather than
+  # assumed: with neither set, every ticket is taken at its stated requester and the
+  # recovery below simply never fires.
+  def initialize(inbox:, attachments: false, form_address: nil, form_sender_name: nil)
+    @inbox = inbox
+    @account = inbox.account
+    @attachments = attachments
+    @form_address = form_address.to_s.downcase.strip.presence
+    @form_local = @form_address&.split('@')&.first
+    @form_sender_name = form_sender_name.to_s.strip.presence
+    @opened = Set.new
+    @stats = Hash.new(0)
+  end
+
+  def import(ticket)
+    interactions = writable(ticket)
+    return @stats[:sem_conteudo] += 1 if interactions.empty?
+
+    Import::SilentWrite.wrap do
+      contact_inbox = resolve_contact(ticket, interactions)
+      return @stats[:sem_contato] += 1 if contact_inbox.nil?
+
+      conversation = conversation_for(ticket, contact_inbox)
+      rows = interactions.filter_map { |interaction| write(conversation, contact_inbox.contact, interaction) }
+      activity_writer.perform(conversation, ticket)
+      settle(rows, []) if rows.any?
+      @stats[:tickets] += 1
+    end
+  end
+
+  private
+
+  # Only the two changes a reader of an archive cares about. A person of type 3 is a
+  # trigger, and "Gatilho executado: notificar o solicitante" is machinery, not an event.
+  def activity_line(changes, person)
+    return if person['Type'] == 3
+
+    parts = []
+    parts << "Status: #{changes['Status']}" if changes['Status'].present?
+    parts << "Atribuído a #{changes['AssignedName']}" if changes['AssignedName'].present?
+    return if parts.empty?
+
+    who = person['Name'].to_s.squish.presence
+    [parts.join(' · '), who && "(por #{who})"].compact.join(' ')
+  end
+
+  # An interaction with no comment is a status change or a trigger firing: real history,
+  # but not a message. Those are written separately by Import::Octadesk::ActivityWriter.
+  def writable(ticket)
+    Array(ticket['Interactions']).select { |i| Import::Octadesk::ActivityWriter.commented?(i) }
+  end
+
+  def resolve_contact(ticket, interactions)
+    email = customer_email(ticket, interactions)
+    return if email.blank?
+
+    name = contact_name(ticket, email, interactions)
+    existing = @inbox.contacts.from_email(email)
+    return ContactInbox.find_by(inbox: @inbox, contact: existing) || build_contact(email, name) if existing
+
+    build_contact(email, name)
+  end
+
+  # The website form posts as the company with the customer named in the body. Same shape
+  # the mailbox showed, and the same fix: take the address out of the text.
+  def customer_email(ticket, interactions)
+    stated = ticket['RequesterMail'].to_s.downcase.strip
+    return stated if stated.present? && stated != @form_address
+
+    from_body = interactions.first(2).flat_map { |i| Array(i['Comments']).map { |c| c['Content'].to_s } }
+                            .join(' ')[EMAIL_IN_BODY, 1].to_s.downcase
+    from_body.presence || stated.presence
+  end
+
+  def build_contact(email, name)
+    ::ContactInboxWithContactBuilder.new(
+      source_id: email, inbox: @inbox, contact_attributes: { name: name, email: email }
+    ).perform
+  end
+
+  # The form tickets name the company rather than the person, so the requester name is
+  # only trusted when it is not that. What the form does carry is a `Nome:` line in the
+  # body beside the `Email:` one, which is the person's own name and better than the local
+  # part of their address.
+  def contact_name(ticket, email, interactions)
+    stated = ticket['RequesterName'].to_s.strip
+    return stated if stated.present? && !form_sender?(stated)
+
+    body(interactions.first).to_s[NAME_IN_BODY, 1].to_s.squish.presence || email.split('@').first
+  end
+
+  # The two ways an export spells "this is the form, not the person": the display name the
+  # form posts under, and the local part of the address it posts from, which the exporter
+  # also uses as a name on its own.
+  def form_sender?(stated)
+    return true if @form_sender_name && stated.casecmp(@form_sender_name).zero?
+
+    @form_local.present? && stated.downcase.include?(@form_local)
+  end
+
+  # Dated to the ticket and resolved from the start, never resolved afterwards: born in
+  # that state it fires no resolution event and writes no "resolved by" line, where a
+  # transition would do both and file every imported thread into today's figures.
+  def conversation_for(ticket, contact_inbox)
+    number = ticket['Number'].to_s
+    existing = find_by_ticket(number)
+    return existing if existing
+
+    opened_at = Import::Octadesk::Stream.time(ticket['DateCreation'])
+    conversation = ::Conversation.create!(
+      account_id: @account.id, inbox_id: @inbox.id,
+      contact_id: contact_inbox.contact_id, contact_inbox_id: contact_inbox.id,
+      status: :resolved, created_at: opened_at || Time.current,
+      additional_attributes: { source: 'email', mail_subject: subject(ticket) }.compact,
+      custom_attributes: ticket_attributes(ticket, number)
+    )
+    @opened << conversation.id
+    apply_tags(conversation, ticket)
+    stamp_resolution(conversation, ticket)
+    conversation
+  end
+
+  # The thread is created resolved rather than resolved afterwards, so the column that
+  # would normally record when that happened is stamped by hand. Written with
+  # `update_columns` for the same reason everything else here is: a save would wake the
+  # callbacks the import exists to keep quiet.
+  def stamp_resolution(conversation, ticket)
+    done = Import::Octadesk::Stream.time(ticket['DoneDate'])
+    return if done.blank?
+
+    conversation.update_columns(status_changed_at: done) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  # What the ticketing system knew about the thread and Chatwoot has no column for. Kept
+  # as custom attributes rather than dropped, because this inbox exists to be searched: the
+  # ticket number is what the operators looked things up by for four years, and the agent
+  # who handled it is what a report by agent would otherwise have no way to ask about.
+  #
+  # The agent is a name and an address, not an assignee. Assigning would need these people
+  # to be members of the archive account, and inventing seats for former staff to make a
+  # closed thread look assigned is a worse trade than a searchable attribute. It also keeps
+  # the archive out of everybody's queue, which is the point of importing it resolved.
+  def ticket_attributes(ticket, number)
+    {
+      SOURCE_PREFIX => number,
+      "#{SOURCE_PREFIX}_agent" => ticket['AssignedName'].to_s.squish.presence,
+      "#{SOURCE_PREFIX}_agent_email" => ticket['AssignedMail'].to_s.downcase.presence,
+      "#{SOURCE_PREFIX}_form" => ticket.dig('Form', 'Name').to_s.presence,
+      "#{SOURCE_PREFIX}_status" => ticket['CurrentStatusName'].to_s.presence
+    }.compact_blank
+  end
+
+  # A ticket whose summary is the whole first email, which some of them are: the column is
+  # jsonb with a 1500 character rule per key, and a subject long enough to break it is not
+  # a subject anybody reads to the end anyway.
+  def subject(ticket)
+    ticket['Summary'].to_s.squish.presence&.truncate(1_400)
+  end
+
+  # The number the operators searched by for four years, and the only key that ties a
+  # thread here back to a row in the export.
+  def find_by_ticket(number)
+    return if number.blank?
+
+    @inbox.conversations.where('custom_attributes ->> ? = ?', SOURCE_PREFIX, number).first
+  end
+
+  def apply_tags(conversation, ticket)
+    tags = Array(ticket['Tags']).filter_map { |tag| tag.is_a?(Hash) ? tag['Name'] : tag }.compact_blank
+    conversation.add_labels(tags) if tags.any?
+  rescue StandardError
+    @stats[:tags_recusadas] += 1
+  end
+
+  def write(conversation, contact, interaction)
+    source_id = message_source_id(interaction)
+    return if source_id.blank?
+    return skip(:ja_tinha) if conversation.messages.exists?(source_id: source_id)
+
+    person = interaction['Person'] || {}
+    message = conversation.messages.create!(message_attributes(conversation, contact, interaction, person, source_id))
+    attach(message, interaction)
+    @stats[person['Type'] == 1 ? :respostas : :mensagens] += 1
+    message
+  end
+
+  def message_attributes(conversation, contact, interaction, person, source_id)
+    agent = person['Type'] == 1
+    {
+      account_id: @account.id, inbox_id: @inbox.id, source_id: source_id,
+      message_type: agent ? :outgoing : :incoming,
+      content: body(interaction), content_type: :incoming_email,
+      sender: agent ? nil : contact,
+      created_at: Import::Octadesk::Stream.time(interaction['DateCreation']) || conversation.created_at,
+      content_attributes: content_attributes(person, agent)
+    }
+  end
+
+  def message_source_id(interaction)
+    id = Import::Octadesk::Stream.oid(interaction['_id'])
+    "#{SOURCE_PREFIX}:#{id}" if id.present?
+  end
+
+  # Counts a record the run declined to write and yields nil, so the caller's
+  # `filter_map` drops it. Written out because `stats[key] += 1 && nil` reads like it
+  # does this and does not: `&&` binds tighter than `+=`, so it adds nil and raises.
+  def skip(key)
+    @stats[key] += 1
+    nil
+  end
+
+  def body(interaction)
+    Array(interaction['Comments']).filter_map { |comment| comment['Content'].to_s.strip.presence }.join("\n\n")
+  end
+
+  # `imported` is what Inbound::Coverage and HistorySettlement read, and what a report
+  # excluding backfilled traffic filters on. The agent is kept as plain data rather than
+  # resolved to a User: most of these people were never Chatwoot users, and inventing
+  # accounts for them would put names in the agent list that cannot log in.
+  def content_attributes(person, agent)
+    attributes = { imported: true }
+    return attributes unless agent
+
+    attributes.merge(imported_agent: { name: person['Name'], email: person['Email'] }.compact_blank)
+  end
+
+  # Attachments live as public URLs on the vendor's bucket, which stops existing when the
+  # subscription does. Fetching them here is both the import and the mirror: Active Storage
+  # writes the copy to our own S3.
+  def attach(message, interaction)
+    return unless @attachments
+
+    Array(interaction['Attachments']).each do |attachment|
+      url = attachment['Url'].to_s
+      next if url.blank?
+
+      Import::Octadesk::AttachmentFetcher.new(message: message, url: url, name: attachment['Name']).perform
+      @stats[:anexos] += 1
+    rescue StandardError
+      @stats[:anexos_falharam] += 1
+    end
+  end
+
+  # No screen is watching a bulk backfill, so the settlement's announce hook is a plain
+  # yield. See Import::SilentWrite.
+  def activity_writer = @activity_writer ||= Import::Octadesk::ActivityWriter.new(inbox: @inbox, stats: @stats)
+
+  def announcing(&) = yield
+end

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -27,6 +27,9 @@ class Import::Octadesk::TicketImporter
   include Import::HistorySettlement
 
   SOURCE_PREFIX = 'octadesk'.freeze
+  # `Message` validates `content` at this, and the mail path is truncated to it by
+  # `MailboxSanitizer` before it ever reaches the model.
+  CONTENT_LIMIT = 150_000
 
   attr_reader :opened, :stats
 
@@ -301,8 +304,15 @@ class Import::Octadesk::TicketImporter
     nil
   end
 
+  # Truncated to what `Message` will accept, which is what the mail path gets for free from
+  # `MailboxSanitizer` and this one has to ask for. Over the limit `create!` raises, and the
+  # ticket is abandoned where it stands: the interactions before it stay committed, so every
+  # retry files nothing new, hits the same comment and gives up again -- the rest of that
+  # ticket lost for good, quietly, in a run whose whole point is completeness. A tail nobody
+  # would have read is the cheaper loss.
   def body(interaction)
-    Array(interaction['Comments']).filter_map { |comment| comment['Content'].to_s.strip.presence }.join("\n\n")
+    joined = Array(interaction['Comments']).filter_map { |comment| comment['Content'].to_s.strip.presence }.join("\n\n")
+    joined.truncate(CONTENT_LIMIT)
   end
 
   # `imported` is what Inbound::Coverage and HistorySettlement read, and what a report
@@ -322,6 +332,10 @@ class Import::Octadesk::TicketImporter
   def attach(message, interaction)
     return unless @attachments
 
+    # Seeded from what is already on the message and added to as the loop goes, because an
+    # interaction can list the same URL twice: read only from the snapshot, every copy after
+    # the first is another download of a file we have just stored, on a run whose cost is
+    # the downloads.
     held = stored_sources(message)
     Array(interaction['Attachments']).each do |attachment|
       url = attachment['Url'].to_s
@@ -329,6 +343,7 @@ class Import::Octadesk::TicketImporter
       next if held.include?(url)
 
       stored = Import::Octadesk::AttachmentFetcher.new(message: message, url: url, name: attachment['Name']).perform
+      held << url
       @stats[stored ? :anexos : :anexos_recusados] += 1
     rescue StandardError
       @stats[:anexos_falharam] += 1

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -51,7 +51,7 @@ class Import::Octadesk::TicketImporter
     # that would produce neither a message nor an activity is empty.
     return @stats[:sem_conteudo] += 1 if interactions.empty? && !any_activity?(ticket)
 
-    Import::SilentWrite.wrap do
+    Import::SilentWrite.wrap(indexing: true) do
       contact_inbox = @contacts.perform(ticket, interactions)
       return @stats[:sem_contato] += 1 if contact_inbox.nil?
 

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -81,6 +81,10 @@ class Import::Octadesk::TicketImporter
   # describe the interrupted run rather than the ticket. The test is the same one
   # `stamp_seen` makes, and for the same reason -- a thread that ever took live traffic has
   # real stamps, and overwriting those would be the worse error.
+  # A ticket is a real batch, but a job per ticket is still tens of thousands of them over
+  # an export. Buffered like the IMAP side; the walker empties it.
+  def search_index_batch = SEARCH_INDEX_BATCH
+
   def settle_ticket(conversation, rows)
     stored = @opened.include?(conversation.id) ? rows : conversation.messages.to_a
     return if stored.empty?

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -186,21 +186,6 @@ class Import::Octadesk::TicketImporter
     conversation.update_columns(status_changed_at: done) # rubocop:disable Rails/SkipsModelValidations
   end
 
-  # Which of an interaction's attachments are already on the row, keyed by where each came
-  # from. The filename cannot answer this: one interaction can carry two different files
-  # under one name, and if the first is stored and the second is not, a filename test calls
-  # both of them done and the missing one is never fetched again. The fetcher stamps the
-  # source URL on the blob for exactly this, and that is the only key that is one-to-one
-  # with the object in the vendor's bucket.
-  #
-  # A message this pass just created has nothing, which is the ordinary path and costs no
-  # query.
-  def stored_sources(message)
-    return Set.new if message.previously_new_record?
-
-    message.attachments.filter_map { |a| a.file.blob&.metadata&.dig('import_source') if a.file.attached? }.to_set
-  end
-
   # What the ticketing system knew about the thread and Chatwoot has no column for. Kept
   # as custom attributes rather than dropped, because this inbox exists to be searched: the
   # ticket number is what the operators looked things up by for four years, and the agent
@@ -263,13 +248,13 @@ class Import::Octadesk::TicketImporter
     # existing row is offered to the fetcher again on the way past.
     existing = conversation.messages.find_by(source_id: source_id)
     if existing
-      attach(existing, interaction)
+      files.perform(existing, interaction)
       return skip(:ja_tinha)
     end
 
     person = interaction['Person'] || {}
     message = conversation.messages.create!(message_attributes(conversation, contact, interaction, person, source_id))
-    attach(message, interaction)
+    files.perform(message, interaction)
     @stats[person['Type'] == 1 ? :respostas : :mensagens] += 1
     message
   end
@@ -331,28 +316,10 @@ class Import::Octadesk::TicketImporter
     attributes.merge(imported_agent: { name: person['Name'], email: person['Email'] }.compact_blank)
   end
 
-  # Attachments live as public URLs on the vendor's bucket, which stops existing when the
-  # subscription does. Fetching them here is both the import and the mirror: Active Storage
-  # writes the copy to our own S3.
-  def attach(message, interaction)
-    return unless @attachments
-
-    # Seeded from what is already on the message and added to as the loop goes, because an
-    # interaction can list the same URL twice: read only from the snapshot, every copy after
-    # the first is another download of a file we have just stored, on a run whose cost is
-    # the downloads.
-    held = stored_sources(message)
-    Array(interaction['Attachments']).each do |attachment|
-      url = attachment['Url'].to_s
-      next if url.blank?
-      next if held.include?(url)
-
-      stored = Import::Octadesk::AttachmentFetcher.new(message: message, url: url, name: attachment['Name']).perform
-      held << url
-      @stats[stored ? :anexos : :anexos_recusados] += 1
-    rescue StandardError
-      @stats[:anexos_falharam] += 1
-    end
+  # `@attachments` is the operator's yes-or-no and `@files` is what acts on it; the writer
+  # is asked for by name so the two do not share one.
+  def files
+    @files ||= Import::Octadesk::Attachments.new(enabled: @attachments, stats: @stats)
   end
 
   # No screen is watching a bulk backfill, so the settlement's announce hook is a plain

--- a/app/services/import/octadesk/ticket_importer.rb
+++ b/app/services/import/octadesk/ticket_importer.rb
@@ -43,7 +43,10 @@ class Import::Octadesk::TicketImporter
 
   def import(ticket)
     interactions = writable(ticket)
-    return @stats[:sem_conteudo] += 1 if interactions.empty?
+    # A ticket whose whole history is status changes is still history: it has a requester, a
+    # number, dates and a resolution, and the activity rows say where it went. Only a ticket
+    # that would produce neither a message nor an activity is empty.
+    return @stats[:sem_conteudo] += 1 if interactions.empty? && !any_activity?(ticket)
 
     Import::SilentWrite.wrap do
       contact_inbox = @contacts.perform(ticket, interactions)
@@ -111,6 +114,10 @@ class Import::Octadesk::TicketImporter
   # but not a message. Those are written separately by Import::Octadesk::ActivityWriter.
   def writable(ticket)
     Array(ticket['Interactions']).select { |i| Import::Octadesk::ActivityWriter.commented?(i) }
+  end
+
+  def any_activity?(ticket)
+    Array(ticket['Interactions']).any? { |i| Import::Octadesk::ActivityWriter.writable?(i) }
   end
 
   # Dated to the ticket and resolved from the start, never resolved afterwards: born in

--- a/app/services/import/options.rb
+++ b/app/services/import/options.rb
@@ -1,0 +1,56 @@
+# Settings an operator types, read strictly.
+#
+# Every one of these arrives as a string from the environment, and every lenient reading of
+# one fails in the expensive direction on this import.
+#
+#   `to_f` and `to_i` answer a typo with zero, and zero reads as an instruction to each
+#   setting that takes a number: no budget stops before importing anything, no `LIMIT`
+#   stops at the first message, and no load ceiling never finds room, so the run pauses
+#   against a load average that is never zero and stands there until somebody looks.
+#
+#   `ActiveModel::Type::Boolean` answers anything outside its own false list with true --
+#   `no` and `flase` included -- so `ATTACHMENTS=no` starts mirroring hundreds of gigabytes
+#   and `RESET_CURSOR=no` throws away the resume point, both while doing exactly the
+#   opposite of what was typed.
+#
+# So the words are listed rather than inferred, and anything else raises before the run
+# connects to anything. Shared by the two tasks because they take the same settings and a
+# copy in each would drift.
+module Import::Options
+  TRUE_WORDS = %w[1 true t yes y on sim s].freeze
+  FALSE_WORDS = %w[0 false f no n off nao não].freeze
+
+  module_function
+
+  def boolean(key, default: false)
+    raw = ENV[key].presence
+    return default if raw.nil?
+
+    word = raw.to_s.strip.downcase
+    return true if TRUE_WORDS.include?(word)
+    return false if FALSE_WORDS.include?(word)
+
+    raise ArgumentError, "#{key}: use #{TRUE_WORDS.first} ou #{FALSE_WORDS.first}, veio #{raw.inspect}"
+  end
+
+  # A count. Fractions are refused rather than truncated: `SAMPLE=0.5` truncates to zero and
+  # the scan classifies nothing while reporting a finished projection.
+  def integer(key, default: nil)
+    parse(key, default) { |raw| Integer(raw, exception: false) }
+  end
+
+  # A measurement -- bytes, or a load average -- where a fraction is meaningful.
+  def decimal(key, default: nil)
+    parse(key, default) { |raw| Float(raw, exception: false) }
+  end
+
+  def parse(key, default)
+    raw = ENV[key].presence
+    return default if raw.nil?
+
+    value = yield(raw)
+    raise ArgumentError, "#{key}: use um numero positivo, veio #{raw.inspect}" if value.nil? || !value.positive?
+
+    value
+  end
+end

--- a/app/services/import/silent_write.rb
+++ b/app/services/import/silent_write.rb
@@ -8,7 +8,8 @@
 # replies for messages that were answered long ago.
 #
 # One thing does have to run, though, and it is why this has two levels rather than a
-# boolean. Somebody pressed a button and is watching a screen. A gap thread that lands in
+# boolean. Somebody pressed a button and is watching a screen. An unattended bulk import
+# never wants this and stays `:silent` throughout; the level exists for the on-demand case. A gap thread that lands in
 # the queue while the list shows the queue from before the import is a thread nobody works
 # until they happen to reload, which defeats the point of importing it. So the gap half of
 # a run is written in `:announce`, where the dashboard push survives and everything else
@@ -16,7 +17,7 @@
 # have nothing to tell an operator now, and pushing one cable frame per row would be a
 # flood aimed at every agent in the account.
 #
-# Three guards read this flag, all declared in config/initializers/whatsapp_session_import.rb:
+# Three guards read this flag, all declared in config/initializers/import_guards.rb:
 #
 #   AsyncDispatcher#dispatch                 the listeners that act on the world:
 #                                            automations, campaigns, CSAT, webhooks,
@@ -35,8 +36,8 @@
 #
 # Scoped to the thread rather than to a request: the importer runs inside a Sidekiq job,
 # and the flag must not leak into whatever that worker picks up next.
-module Whatsapp::Session::SilentWrite
-  KEY = :whatsapp_session_silent_write
+module Import::SilentWrite
+  KEY = :import_silent_write
 
   module_function
 

--- a/app/services/import/silent_write.rb
+++ b/app/services/import/silent_write.rb
@@ -17,7 +17,16 @@
 # have nothing to tell an operator now, and pushing one cable frame per row would be a
 # flood aimed at every agent in the account.
 #
-# Three guards read this flag, all declared in config/initializers/import_guards.rb:
+# Which level a guard reads is the whole design, and getting it wrong is quiet in both
+# directions. A guard that suppresses *fan-out* -- work aimed at the world, or at a queue,
+# that a backdated row has no business doing -- belongs at `on?`, because that is true of
+# history however it arrived. A guard that suppresses *routing or status* belongs at
+# `archive?` alone: under `:announce` the thread is somebody's live work, recovered a
+# minute late, and it has to be assigned and statused the way any other arrival would be.
+# Suppressing those there leaves the gap thread sitting unrouted, which is the same "nobody
+# works it until they reload" failure the level was invented to avoid.
+#
+# The guards, all declared in config/initializers/import_guards.rb:
 #
 #   AsyncDispatcher#dispatch                 the listeners that act on the world:
 #                                            automations, campaigns, CSAT, webhooks,
@@ -33,6 +42,17 @@
 #                                            Under `:announce` it re-emits `message.created`
 #                                            on its own, so the thread an operator has open
 #                                            fills in rather than only the list card
+#   Contact#ip_lookup                        a job to resolve an address an imported contact
+#                                            does not carry. Useless at either level
+#   Conversation#run_auto_assignment         archive only: half a million archived threads
+#                                            asking the inbox to redistribute capacity, or
+#                                            landing outright in a working agent's queue
+#   Conversation#set_active_bot_conversation archive only: an inbox with a bot starts its
+#                                            conversations `pending` and overrides the
+#                                            status the importer asked for
+#   Contact#fetch_avatar_from_gravatar       archive only: one outbound request per contact
+#                                            created, which is a flood only when the
+#                                            contacts arrive by the hundred thousand
 #
 # Scoped to the thread rather than to a request: the importer runs inside a Sidekiq job,
 # and the flag must not leak into whatever that worker picks up next.
@@ -62,5 +82,12 @@ module Import::SilentWrite
   # "not importing at all", which is the ordinary case and must go through untouched.
   def announce?
     ActiveSupport::IsolatedExecutionState[KEY] == :announce
+  end
+
+  # Writing history nobody is waiting on. The level a guard should read when what it
+  # suppresses would change where a conversation goes or what state it is in, rather than
+  # merely stopping a side effect.
+  def archive?
+    ActiveSupport::IsolatedExecutionState[KEY] == :silent
   end
 end

--- a/app/services/import/silent_write.rb
+++ b/app/services/import/silent_write.rb
@@ -53,11 +53,31 @@
 #   Contact#fetch_avatar_from_gravatar       archive only: one outbound request per contact
 #                                            created, which is a flood only when the
 #                                            contacts arrive by the hundred thousand
+#   Message#hold_pending_scheduled_messages  archive only: an old incoming row satisfies
+#                                            `hold_on_reply` the way a live one does, and
+#                                            would hold every follow-up in the account
+#   Company#fetch_favicon                    archive only, Enterprise: Gravatar's shape,
+#                                            one request per company at a third party
+#   Attachment#enqueue_audio_transcription   archive only, Enterprise: Captain credits per
+#                                            file, spent on conversations closed before the
+#                                            feature existed
+#   Message#reindex_for_search               only where the writer says it indexes its own
+#                                            rows, which is the second flag below
 #
 # Scoped to the thread rather than to a request: the importer runs inside a Sidekiq job,
 # and the flag must not leak into whatever that worker picks up next.
+# The second flag is orthogonal to the level and answers a different question: not "how
+# loud is this write" but "who is going to index it". `Message#reindex_for_search` enqueues
+# one Searchkick job per row, which a backfill cannot afford and which
+# `Import::HistorySettlement` takes over in batches. So it is suppressed only for a writer
+# that has said it will do that, and left alone for one that has not -- the WhatsApp
+# importers, which are handed a webhook's worth of rows and thrown away. Read off the level
+# instead, a batch of theirs that raised after some rows committed would lose those rows
+# from the index for good: they never reach `settle`, and the retry filters them out as
+# already stored.
 module Import::SilentWrite
   KEY = :import_silent_write
+  INDEXING_KEY = :import_indexes_its_own_rows
 
   module_function
 
@@ -65,12 +85,15 @@ module Import::SilentWrite
   # importer running inside another silenced block does not un-silence it on the way out.
   # That restore is what lets the gap run raise the level for its own stretch and hand the
   # archive level back afterwards, inside one enclosing `wrap`.
-  def wrap(announce: false)
+  def wrap(announce: false, indexing: false)
     previous = ActiveSupport::IsolatedExecutionState[KEY]
+    previously_indexing = ActiveSupport::IsolatedExecutionState[INDEXING_KEY]
     ActiveSupport::IsolatedExecutionState[KEY] = announce ? :announce : :silent
+    ActiveSupport::IsolatedExecutionState[INDEXING_KEY] = true if indexing
     yield
   ensure
     ActiveSupport::IsolatedExecutionState[KEY] = previous
+    ActiveSupport::IsolatedExecutionState[INDEXING_KEY] = previously_indexing
   end
 
   def on?
@@ -89,5 +112,13 @@ module Import::SilentWrite
   # merely stopping a side effect.
   def archive?
     ActiveSupport::IsolatedExecutionState[KEY] == :silent
+  end
+
+  # Whether the writer has taken the search index on itself. Only the guard on
+  # `Message#reindex_for_search` reads this, and only a writer that batches sets it: an
+  # importer that does not is left with the ordinary per-row callback, which is the only
+  # thing that would index a row committed by a batch that then raised.
+  def indexing?
+    ActiveSupport::IsolatedExecutionState[INDEXING_KEY].present?
   end
 end

--- a/app/services/whatsapp/baileys/history_importer.rb
+++ b/app/services/whatsapp/baileys/history_importer.rb
@@ -25,13 +25,13 @@
 #                          archive: a message from last year must not reopen work, and the
 #                          reopen policy the live path follows would do exactly that.
 #
-# Everything the import may set off is suppressed by Whatsapp::Session::SilentWrite for the
+# Everything the import may set off is suppressed by Import::SilentWrite for the
 # whole run: no notifications, no automations, no outgoing webhooks, no bots, no
 # out-of-office replies, no read receipts on the contact's phone. The gap half runs one
 # level down, where the dashboard push survives, because somebody is watching the queue it
 # lands in.
 class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysService
-  include Whatsapp::Session::Inbound::HistorySettlement
+  include Import::HistorySettlement
 
   # A batch is up to a few hundred messages with a contact resolution behind the first of
   # them. The ordinary thirty seconds is a lease that would expire mid-import, and a lease
@@ -57,7 +57,7 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
       next if pending.empty?
 
       runs = pending.group_by { |raw| gap?(raw) }
-      Whatsapp::Session::SilentWrite.wrap do
+      Import::SilentWrite.wrap do
         # Archive first: the two halves land in different threads, and the older one has
         # to exist before the reopen policy is asked which thread is current.
         # An unrequested pile keeps only its gap. The phone offers its whole history at
@@ -238,6 +238,6 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   def try_update_contact_avatar(contact = nil); end
 
   # Raises the flag for the stretch it wraps. Only the gap ever asks for it, and only the
-  # dashboard push gets through: see Whatsapp::Session::SilentWrite.
-  def announcing(&) = Whatsapp::Session::SilentWrite.wrap(announce: true, &)
+  # dashboard push gets through: see Import::SilentWrite.
+  def announcing(&) = Import::SilentWrite.wrap(announce: true, &)
 end

--- a/app/services/whatsapp/session/channel_extension.rb
+++ b/app/services/whatsapp/session/channel_extension.rb
@@ -132,7 +132,7 @@ module Whatsapp::Session::ChannelExtension # rubocop:disable Metrics/ModuleLengt
   # writer stands down on its own (`MessageWriter#acknowledge`), so this is the only check
   # the Baileys import gets and it costs the live path a thread-local read.
   def received_messages(messages, conversation)
-    return if Whatsapp::Session::SilentWrite.on?
+    return if Import::SilentWrite.on?
 
     super
   end

--- a/app/services/whatsapp/session/inbound/coverage.rb
+++ b/app/services/whatsapp/session/inbound/coverage.rb
@@ -16,11 +16,6 @@
 # bootstrap dump. Uazapi does not pass the type through (the frames carry `messages`,
 # `chats` or `labels` and nothing else), so the line is redrawn here from what we hold.
 module Whatsapp::Session::Inbound::Coverage
-  # A row this inbox filed after the fact rather than received. `content_attributes` is a
-  # text column holding JSON, hence the cast, and the key is absent on every row written
-  # before imports existed, hence the default.
-  IMPORTED_SQL = "COALESCE((content_attributes#>>'{}')::jsonb->>'imported', 'false') = 'true'".freeze
-
   module_function
 
   # Nil when the inbox has never stored a provider message, which is a first connection:
@@ -46,7 +41,7 @@ module Whatsapp::Session::Inbound::Coverage
   def watermark(inbox)
     inbox.messages
          .where.not(source_id: nil)
-         .where.not(IMPORTED_SQL)
+         .where.not(Import::IMPORTED_SQL)
          .maximum(:created_at)
   end
 

--- a/app/services/whatsapp/session/inbound/history_importer.rb
+++ b/app/services/whatsapp/session/inbound/history_importer.rb
@@ -12,7 +12,7 @@
 #                    was known to be receiving. Newer means nobody has had the chance to
 #                    read it: that is late mail and it belongs in the queue. Older is
 #                    history and it belongs in the archive, filed resolved.
-#   what it may do   almost nothing. Whatsapp::Session::SilentWrite holds for the whole
+#   what it may do   almost nothing. Import::SilentWrite holds for the whole
 #                    run, so no imported message notifies, automates, posts a webhook,
 #                    wakes a bot or answers with a template, whichever half it lands in.
 #                    The one exception follows the same split: the gap half is written
@@ -20,7 +20,7 @@
 #                    while the archive stays silent because a reader has nothing to gain
 #                    from eight hundred backdated rows arriving one cable frame at a time.
 class Whatsapp::Session::Inbound::HistoryImporter
-  include Whatsapp::Session::Inbound::HistorySettlement
+  include Import::HistorySettlement
 
   # A chat's whole batch is written under one lock, and a batch can be two hundred
   # messages with an avatar lookup and a contact resolution behind the first of them. The
@@ -56,7 +56,7 @@ class Whatsapp::Session::Inbound::HistoryImporter
     # against the same boundary, or the first imported message would move the line the
     # rest of its own batch is measured against.
     watermark = inbound::Coverage.watermark(inbox)
-    Whatsapp::Session::SilentWrite.wrap do
+    Import::SilentWrite.wrap do
       batches.each_value { |batch| import_chat(batch, watermark) }
     end
     :handled
@@ -184,6 +184,6 @@ class Whatsapp::Session::Inbound::HistoryImporter
   # What the suppressed callbacks would have kept up to date, applied once per
   # conversation instead of once per message, and only in the direction that is true.
   # Raises the flag for the stretch it wraps. Only the gap ever asks for it, and only the
-  # dashboard push gets through: see Whatsapp::Session::SilentWrite.
-  def announcing(&) = Whatsapp::Session::SilentWrite.wrap(announce: true, &)
+  # dashboard push gets through: see Import::SilentWrite.
+  def announcing(&) = Import::SilentWrite.wrap(announce: true, &)
 end

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -58,39 +58,46 @@ module ImportGuards
   # this importer has taken over: the first-reply branch writes `first_reply_created_at` and
   # clears `waiting_since`, and the other branch recomputes `waiting_since` from a message
   # being written oldest first. Both would fight `settle` for the same columns.
-  # Assignment is the one side effect that does not travel through the dispatcher, so
-  # nothing above stops it. A backfilled thread is created resolved, and a status change to
-  # resolved is exactly what wakes the V2 assignment job -- once per conversation, half a
-  # million times over a full import, each one asking the inbox to redistribute capacity it
-  # has no reason to redistribute. The V1 path is worse: it assigns the thread outright, so
-  # a decade of somebody's history lands in a working agent's queue.
+  # The two things that decide where a conversation goes and what state it is in. Both are
+  # archive-only, and the level is the point: under `:announce` the thread is a gap somebody
+  # is waiting on, and a gap thread that is neither assigned nor statused is one nobody
+  # works until they happen to reload -- the exact failure the announcing level exists to
+  # prevent.
+  #
+  # Assignment does not travel through the dispatcher, so nothing above stops it. An archive
+  # thread is created resolved, and a status change to resolved is what wakes the V2
+  # assignment job: once per conversation, half a million times over a full import, each
+  # asking the inbox to redistribute capacity it has no reason to redistribute. The V1 path
+  # is worse -- it assigns the thread outright, so a decade of somebody's history lands in a
+  # working agent's queue.
+  #
+  # The bot override is narrower than the callback that carries it. `determine_conversation_status`
+  # also resolves a conversation whose contact is blocked, which is right at either level and
+  # is not the importer's business to undo, so only the bot half is stopped: an inbox with an
+  # agent bot starts its conversations `pending` and overrides the `resolved` an archive
+  # importer asked for on purpose.
   module SilentAutoAssignment
     def run_auto_assignment
-      return if Import::SilentWrite.on?
+      return if Import::SilentWrite.archive?
 
       super
     end
 
-    # An inbox with an agent bot starts its conversations `pending`, and the callback that
-    # does it overrides whatever status the creator asked for. An importer asks for
-    # `resolved` on purpose -- a thread born resolved fires no resolution event and files
-    # into no report -- so on an inbox that happens to have a bot the whole archive would
-    # land in the pending queue instead, assigned to the bot, with nothing in the importer
-    # to say why.
-    def determine_conversation_status
-      return if Import::SilentWrite.on?
+    def set_active_bot_conversation
+      return if Import::SilentWrite.archive?
 
       super
     end
   end
 
   # The two things a new contact does on its own, neither of which travels through the
-  # dispatcher, so nothing above stops them. Both are one job per contact created, which is
-  # ordinary at the rate people write in and half a million jobs when a mailbox is replayed.
+  # dispatcher, so nothing above stops them. Each is one job per contact created.
   #
-  # Gravatar is a queue flood aimed at a third party that never agreed to it, and the avatar
-  # is cosmetic: the next live message fills it in. The IP lookup is worse than useless --
-  # an imported contact carries no IP for it to look up.
+  # They sit at different levels because their reasons differ. Gravatar is a flood aimed at
+  # a third party that never agreed to it, and a flood is what half a million contacts make
+  # -- a gap sync creating one contact should fetch its avatar like any arrival, so that
+  # guard is archive-only. The IP lookup resolves an address an imported contact does not
+  # carry at either level, so it is stopped at both.
   #
   # `Message#reindex_for_search` is the one after-commit side effect deliberately left
   # alone. It is inert unless advanced search is configured, and guarding it would leave an
@@ -98,7 +105,7 @@ module ImportGuards
   # turns advanced search on wants one bulk reindex after the import, not a job per row.
   module SilentGravatar
     def fetch_avatar_from_gravatar
-      return if Import::SilentWrite.on?
+      return if Import::SilentWrite.archive?
 
       super
     end

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -152,6 +152,23 @@ module ImportGuards
     end
   end
 
+  # One transcription job per audio attachment, enqueued straight from the Attachment's own
+  # after_create_commit. Enterprise only, and it reaches neither the dispatcher guards nor
+  # the ones on Message: the job is not an event and the attachment is not the message.
+  #
+  # Archive only, and the reason is money rather than noise. Transcription spends Captain
+  # credits per file and rides the low-priority queue, so an archive carrying years of
+  # forwarded voice notes drains the account's balance transcribing conversations that were
+  # closed before the feature existed -- and crowds out the live traffic waiting behind it.
+  # A gap sync recovering one voice note wants it transcribed like any arrival.
+  module SilentTranscription
+    def enqueue_audio_transcription
+      return if Import::SilentWrite.archive?
+
+      super
+    end
+  end
+
   module SilentMessageCallbacks
     def execute_after_create_commit_callbacks
       return super unless Import::SilentWrite.on?
@@ -171,5 +188,8 @@ Rails.application.config.to_prepare do
   Message.prepend(ImportGuards::SilentScheduledMessages)
   Conversation.prepend(ImportGuards::SilentAutoAssignment)
   Contact.prepend(ImportGuards::SilentGravatar)
-  Company.prepend(ImportGuards::SilentFavicon) if ChatwootApp.enterprise?
+  if ChatwootApp.enterprise?
+    Company.prepend(ImportGuards::SilentFavicon)
+    Attachment.prepend(ImportGuards::SilentTranscription)
+  end
 end

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -72,12 +72,26 @@ module ImportGuards
     end
   end
 
-  # A contact is created per correspondent, and each one asks Gravatar for a picture.
-  # Ordinary at the rate people write in; half a million outbound HTTP requests when a
-  # mailbox is replayed, which is a queue flood aimed at a third party that never agreed to
-  # it. The avatar is cosmetic and the next live message fills it in.
+  # The two things a new contact does on its own, neither of which travels through the
+  # dispatcher, so nothing above stops them. Both are one job per contact created, which is
+  # ordinary at the rate people write in and half a million jobs when a mailbox is replayed.
+  #
+  # Gravatar is a queue flood aimed at a third party that never agreed to it, and the avatar
+  # is cosmetic: the next live message fills it in. The IP lookup is worse than useless --
+  # an imported contact carries no IP for it to look up.
+  #
+  # `Message#reindex_for_search` is the one after-commit side effect deliberately left
+  # alone. It is inert unless advanced search is configured, and guarding it would leave an
+  # archive that exists to be searched silently absent from the index. A deployment that
+  # turns advanced search on wants one bulk reindex after the import, not a job per row.
   module SilentGravatar
     def fetch_avatar_from_gravatar
+      return if Import::SilentWrite.on?
+
+      super
+    end
+
+    def ip_lookup
       return if Import::SilentWrite.on?
 
       super

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -99,6 +99,38 @@ module ImportGuards
     end
   end
 
+  # The line a conversation writes about itself when one of its own columns moves, and the
+  # one guard here that stops work rather than noise. `create_activity` does not act: it
+  # enqueues `Conversations::ActivityMessageJob`, which creates a real Message on a Sidekiq
+  # thread long after this one returned -- somewhere the flag is unset, so everything below
+  # runs live. The dispatcher fires `message.created`, an agent bot answers it, the row
+  # enqueues its own index job, and `set_conversation_activity` drags `last_activity_at` to
+  # the time of the import. A thread from 2021 arrives at the top of the inbox wearing
+  # today's date and a line nobody wrote.
+  #
+  # Stopped at both levels, unlike the guards around it, and the reason is not how loud the
+  # write is: the job runs where no level reaches. Under `:announce` the sync dispatcher
+  # lets exactly one listener through, and this path would hand the same event to all of
+  # them a second later.
+  #
+  # Nothing reaches it as the import is driven today, and it is worth saying why the guard
+  # is here anyway. One line comes close -- `apply_tags` calls `add_labels`, the single
+  # `save` in an importer that writes everything else with `update_columns` -- and it stops
+  # at `create_label_change`, which returns unless something named an actor. A rake task
+  # names none. But that is ambient state the import does not own: the same importer driven
+  # from a request carries the operator in `Current.user`, and then every tagged ticket
+  # fires. The guard costs an early return on a callback that would not have run; not having
+  # it costs an archive of activity lines nobody can take back.
+  module SilentActivityMessages
+    private
+
+    def create_activity
+      return if Import::SilentWrite.on?
+
+      super
+    end
+  end
+
   # The two things a new contact does on its own, neither of which travels through the
   # dispatcher, so nothing above stops them. Each is one job per contact created.
   #
@@ -232,6 +264,7 @@ Rails.application.config.to_prepare do
   Message.prepend(ImportGuards::SilentScheduledMessages)
   Message.prepend(ImportGuards::SilentSearchIndex)
   Conversation.prepend(ImportGuards::SilentAutoAssignment)
+  Conversation.prepend(ImportGuards::SilentActivityMessages)
   Contact.prepend(ImportGuards::SilentGravatar)
   if ChatwootApp.enterprise?
     Company.prepend(ImportGuards::SilentFavicon)

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -135,6 +135,23 @@ module ImportGuards
     end
   end
 
+  # A Company is created as a side effect of importing a contact with a business address,
+  # and its own after_create_commit fetches a favicon off the domain. Enterprise only, and
+  # reached through two callbacks in different models, so neither the dispatcher guards nor
+  # the two on Contact see it.
+  #
+  # The same shape as Gravatar and the same level: the association is real information
+  # about the contact and belongs in the archive, but one outbound request per company at a
+  # third party that never agreed to it is a flood when the archive is a decade of mail.
+  # A gap sync creating one company should fetch its favicon like any arrival.
+  module SilentFavicon
+    def fetch_favicon
+      return if Import::SilentWrite.archive?
+
+      super
+    end
+  end
+
   module SilentMessageCallbacks
     def execute_after_create_commit_callbacks
       return super unless Import::SilentWrite.on?
@@ -154,4 +171,5 @@ Rails.application.config.to_prepare do
   Message.prepend(ImportGuards::SilentScheduledMessages)
   Conversation.prepend(ImportGuards::SilentAutoAssignment)
   Contact.prepend(ImportGuards::SilentGravatar)
+  Company.prepend(ImportGuards::SilentFavicon) if ChatwootApp.enterprise?
 end

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -194,15 +194,18 @@ module ImportGuards
   # import, it is a queue the live traffic is now standing behind: Sidekiq drains in the
   # order it received, and the reply an agent just sent waits for the archive.
   #
-  # Both levels rather than archive-only, unlike the other floods here. The batch pass
-  # covers both and is cheaper at both, and `settle` runs outside the flag in one of the
-  # four importers -- a guard that read the level would have to be read back there, where
-  # it is unset, and the archive would be indexed nowhere.
+  # The one guard here that does not read the level, because the level is the wrong
+  # question: what matters is whether the writer has taken the index on itself. Only the two
+  # backfills have, and only they can afford to -- they outlive their settlements and end
+  # somewhere they can flush. An importer handed a webhook's worth of rows and thrown away
+  # keeps the per-row callback, and needs it: a batch of its that raised after some rows
+  # committed never reaches `settle`, and the retry filters those rows out as already
+  # stored, so the callback is the only thing that would ever index them.
   module SilentSearchIndex
     private
 
     def reindex_for_search
-      return if Import::SilentWrite.on?
+      return if Import::SilentWrite.indexing?
 
       super
     end

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -117,6 +117,24 @@ module ImportGuards
     end
   end
 
+  # A scheduled message with `hold_on_reply` is a promise an agent made about the future:
+  # if the customer writes back first, do not send it. An incoming row satisfying that test
+  # is the whole trigger, and an imported one satisfies it the same way a live one does.
+  #
+  # Archive only, and the level carries the whole argument. Under `:announce` the row is a
+  # real reply that arrived while the connection was down, and holding the follow-up is
+  # exactly right -- the customer did answer, we just learned about it late. Under
+  # `:archive` the row is years old, and `scheduled_at > created_at` is then true of every
+  # pending scheduled message in the account: importing one old ticket would hold every
+  # follow-up an agent has queued.
+  module SilentScheduledMessages
+    def hold_pending_scheduled_messages
+      return if Import::SilentWrite.archive?
+
+      super
+    end
+  end
+
   module SilentMessageCallbacks
     def execute_after_create_commit_callbacks
       return super unless Import::SilentWrite.on?
@@ -133,6 +151,7 @@ Rails.application.config.to_prepare do
   SyncDispatcher.prepend(ImportGuards::SilentSyncDispatch)
   AsyncDispatcher.prepend(ImportGuards::SilentAsyncDispatch)
   Message.prepend(ImportGuards::SilentMessageCallbacks)
+  Message.prepend(ImportGuards::SilentScheduledMessages)
   Conversation.prepend(ImportGuards::SilentAutoAssignment)
   Contact.prepend(ImportGuards::SilentGravatar)
 end

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -9,6 +9,13 @@
 # Prepended rather than edited into the classes themselves: all three are files the
 # upstream sync rewrites, and a guard clause inside them is a conflict on every merge.
 module ImportGuards
+  # A prepended module publishes whatever it defines, and every callback below except
+  # `fetch_avatar_from_gravatar` is private on the model it guards. Left alone, a guard
+  # would widen the model's public surface as a side effect of narrowing its behaviour --
+  # `conversation.run_auto_assignment` and `message.execute_after_create_commit_callbacks`
+  # callable from anywhere, on a fork whose whole premise is that the diff stays small.
+  # Each guard restates the visibility the method already had; Rails invokes callbacks
+  # through `send`, so private costs nothing.
   # Everything that acts on the world outside this request. An imported message may never
   # reach any of it, at either level of the flag: history that fires an automation, posts
   # an outgoing webhook or notifies an agent is history pretending to be an arrival.
@@ -77,6 +84,8 @@ module ImportGuards
   # agent bot starts its conversations `pending` and overrides the `resolved` an archive
   # importer asked for on purpose.
   module SilentAutoAssignment
+    private
+
     def run_auto_assignment
       return if Import::SilentWrite.archive?
 
@@ -99,16 +108,14 @@ module ImportGuards
   # guard is archive-only. The IP lookup resolves an address an imported contact does not
   # carry at either level, so it is stopped at both.
   #
-  # `Message#reindex_for_search` is the one after-commit side effect deliberately left
-  # alone. It is inert unless advanced search is configured, and guarding it would leave an
-  # archive that exists to be searched silently absent from the index. A deployment that
-  # turns advanced search on wants one bulk reindex after the import, not a job per row.
   module SilentGravatar
     def fetch_avatar_from_gravatar
       return if Import::SilentWrite.archive?
 
       super
     end
+
+    private
 
     def ip_lookup
       return if Import::SilentWrite.on?
@@ -128,6 +135,8 @@ module ImportGuards
   # pending scheduled message in the account: importing one old ticket would hold every
   # follow-up an agent has queued.
   module SilentScheduledMessages
+    private
+
     def hold_pending_scheduled_messages
       return if Import::SilentWrite.archive?
 
@@ -145,6 +154,8 @@ module ImportGuards
   # third party that never agreed to it is a flood when the archive is a decade of mail.
   # A gap sync creating one company should fetch its favicon like any arrival.
   module SilentFavicon
+    private
+
     def fetch_favicon
       return if Import::SilentWrite.archive?
 
@@ -162,6 +173,8 @@ module ImportGuards
   # closed before the feature existed -- and crowds out the live traffic waiting behind it.
   # A gap sync recovering one voice note wants it transcribed like any arrival.
   module SilentTranscription
+    private
+
     def enqueue_audio_transcription
       return if Import::SilentWrite.archive?
 
@@ -169,7 +182,35 @@ module ImportGuards
     end
   end
 
+  # One `Searchkick::ReindexV2Job` per row, enqueued from Message's own `after_commit` on
+  # any installation that has advanced search configured. It reaches neither the dispatcher
+  # guards nor the callbacks below: it is not an event, and it is a separate callback that
+  # `execute_after_create_commit_callbacks` does not carry.
+  #
+  # Stopped so the archive can be indexed properly, not so it can go unindexed -- being
+  # searchable is most of why history is imported at all. `Import::HistorySettlement` hands
+  # each settled batch to the index in one bulk pass instead, which Searchkick splits into
+  # a job per thousand rows rather than a job per row. Half a million jobs is not a slower
+  # import, it is a queue the live traffic is now standing behind: Sidekiq drains in the
+  # order it received, and the reply an agent just sent waits for the archive.
+  #
+  # Both levels rather than archive-only, unlike the other floods here. The batch pass
+  # covers both and is cheaper at both, and `settle` runs outside the flag in one of the
+  # four importers -- a guard that read the level would have to be read back there, where
+  # it is unset, and the archive would be indexed nowhere.
+  module SilentSearchIndex
+    private
+
+    def reindex_for_search
+      return if Import::SilentWrite.on?
+
+      super
+    end
+  end
+
   module SilentMessageCallbacks
+    private
+
     def execute_after_create_commit_callbacks
       return super unless Import::SilentWrite.on?
       return unless Import::SilentWrite.announce?
@@ -186,6 +227,7 @@ Rails.application.config.to_prepare do
   AsyncDispatcher.prepend(ImportGuards::SilentAsyncDispatch)
   Message.prepend(ImportGuards::SilentMessageCallbacks)
   Message.prepend(ImportGuards::SilentScheduledMessages)
+  Message.prepend(ImportGuards::SilentSearchIndex)
   Conversation.prepend(ImportGuards::SilentAutoAssignment)
   Contact.prepend(ImportGuards::SilentGravatar)
   if ChatwootApp.enterprise?

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -1,4 +1,4 @@
-# The three guards that make Whatsapp::Session::SilentWrite mean something.
+# The guards that make Import::SilentWrite mean something.
 #
 # Declared here, and not as autoloaded classes, on purpose: a reloadable module handed to
 # `prepend` is a new object after every reload, so the ancestor chain would grow one copy
@@ -8,7 +8,7 @@
 #
 # Prepended rather than edited into the classes themselves: all three are files the
 # upstream sync rewrites, and a guard clause inside them is a conflict on every merge.
-module WhatsappSessionImportGuards
+module ImportGuards
   # Everything that acts on the world outside this request. An imported message may never
   # reach any of it, at either level of the flag: history that fires an automation, posts
   # an outgoing webhook or notifies an agent is history pretending to be an arrival.
@@ -17,7 +17,7 @@ module WhatsappSessionImportGuards
   # to the importing thread and the job runs on another one, where it would read as unset.
   module SilentAsyncDispatch
     def dispatch(event_name, timestamp, data)
-      return if Whatsapp::Session::SilentWrite.on?
+      return if Import::SilentWrite.on?
 
       super
     end
@@ -34,8 +34,8 @@ module WhatsappSessionImportGuards
   # implements the events it cares about, which is the check Wisper itself makes.
   module SilentSyncDispatch
     def dispatch(event_name, timestamp, data)
-      return super unless Whatsapp::Session::SilentWrite.on?
-      return unless Whatsapp::Session::SilentWrite.announce?
+      return super unless Import::SilentWrite.on?
+      return unless Import::SilentWrite.announce?
 
       event = Events::Base.new(event_name, timestamp, data)
       listener = ActionCableListener.instance
@@ -58,10 +58,36 @@ module WhatsappSessionImportGuards
   # this importer has taken over: the first-reply branch writes `first_reply_created_at` and
   # clears `waiting_since`, and the other branch recomputes `waiting_since` from a message
   # being written oldest first. Both would fight `settle` for the same columns.
+  # Assignment is the one side effect that does not travel through the dispatcher, so
+  # nothing above stops it. A backfilled thread is created resolved, and a status change to
+  # resolved is exactly what wakes the V2 assignment job -- once per conversation, half a
+  # million times over a full import, each one asking the inbox to redistribute capacity it
+  # has no reason to redistribute. The V1 path is worse: it assigns the thread outright, so
+  # a decade of somebody's history lands in a working agent's queue.
+  module SilentAutoAssignment
+    def run_auto_assignment
+      return if Import::SilentWrite.on?
+
+      super
+    end
+  end
+
+  # A contact is created per correspondent, and each one asks Gravatar for a picture.
+  # Ordinary at the rate people write in; half a million outbound HTTP requests when a
+  # mailbox is replayed, which is a queue flood aimed at a third party that never agreed to
+  # it. The avatar is cosmetic and the next live message fills it in.
+  module SilentGravatar
+    def fetch_avatar_from_gravatar
+      return if Import::SilentWrite.on?
+
+      super
+    end
+  end
+
   module SilentMessageCallbacks
     def execute_after_create_commit_callbacks
-      return super unless Whatsapp::Session::SilentWrite.on?
-      return unless Whatsapp::Session::SilentWrite.announce?
+      return super unless Import::SilentWrite.on?
+      return unless Import::SilentWrite.announce?
 
       Rails.configuration.dispatcher.dispatch(
         Events::Types::MESSAGE_CREATED, Time.zone.now, message: self, performed_by: Current.executed_by
@@ -71,7 +97,9 @@ module WhatsappSessionImportGuards
 end
 
 Rails.application.config.to_prepare do
-  SyncDispatcher.prepend(WhatsappSessionImportGuards::SilentSyncDispatch)
-  AsyncDispatcher.prepend(WhatsappSessionImportGuards::SilentAsyncDispatch)
-  Message.prepend(WhatsappSessionImportGuards::SilentMessageCallbacks)
+  SyncDispatcher.prepend(ImportGuards::SilentSyncDispatch)
+  AsyncDispatcher.prepend(ImportGuards::SilentAsyncDispatch)
+  Message.prepend(ImportGuards::SilentMessageCallbacks)
+  Conversation.prepend(ImportGuards::SilentAutoAssignment)
+  Contact.prepend(ImportGuards::SilentGravatar)
 end

--- a/config/initializers/import_guards.rb
+++ b/config/initializers/import_guards.rb
@@ -70,6 +70,18 @@ module ImportGuards
 
       super
     end
+
+    # An inbox with an agent bot starts its conversations `pending`, and the callback that
+    # does it overrides whatever status the creator asked for. An importer asks for
+    # `resolved` on purpose -- a thread born resolved fires no resolution event and files
+    # into no report -- so on an inbox that happens to have a bot the whole archive would
+    # land in the pending queue instead, assigned to the bot, with nothing in the importer
+    # to say why.
+    def determine_conversation_status
+      return if Import::SilentWrite.on?
+
+      super
+    end
   end
 
   # The two things a new contact does on its own, neither of which travels through the

--- a/db/migrate/20260829180000_add_import_cursor_to_channel_email.rb
+++ b/db/migrate/20260829180000_add_import_cursor_to_channel_email.rb
@@ -1,0 +1,10 @@
+class AddImportCursorToChannelEmail < ActiveRecord::Migration[7.1]
+  # A column of its own rather than a key in `provider_config`, which the OAuth refresh
+  # services replace wholesale on every token renewal: a Google or Microsoft inbox renews
+  # long before a multi-day import finishes, so a cursor kept there is deleted mid-run and
+  # the next pass starts the mailbox over. Writing it back would be worse, since the same
+  # blind write can clobber credentials that were just refreshed.
+  def change
+    add_column :channel_email, :import_cursor, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_26_130000) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_29_180000) do
   # These extensions should be enabled to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -618,6 +618,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_26_130000) do
     t.string "provider"
     t.boolean "verified_for_sending", default: false, null: false
     t.string "imap_authentication", default: "plain"
+    t.jsonb "import_cursor", default: {}, null: false
     t.index ["email"], name: "index_channel_email_on_email", unique: true
     t.index ["forward_to_email"], name: "index_channel_email_on_forward_to_email", unique: true
   end

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -129,6 +129,7 @@ RUN apk update && apk add --no-cache \
   git \
   vips \
   ffmpeg \
+  unzip \
   && gem install bundler -v "$BUNDLER_VERSION"
 
 # Restrict libvips to its trusted image loaders when generating variants

--- a/enterprise/app/services/enterprise/import/history_settlement.rb
+++ b/enterprise/app/services/enterprise/import/history_settlement.rb
@@ -1,0 +1,15 @@
+# The company half of the import's contact clock.
+#
+# Live traffic rolls a contact's activity up to its company through Contact's own
+# after_update_commit. The import writes with `update_columns`, which skips every callback
+# on purpose, so the roll-up is asked for here rather than inherited.
+#
+# `record_activity_at!` is the company's own rule and already refuses to move backwards,
+# which is what history needs: a company somebody is talking to today keeps its clock.
+module Enterprise::Import::HistorySettlement
+  private
+
+  def roll_up(contact, at)
+    contact.company&.record_activity_at!(at)
+  end
+end

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -29,7 +29,7 @@ require 'net/imap'
 #   BUDGET_MB          IMAP bytes to spend before stopping (default 2000 of the 2500 allowed)
 #   MAX_LOAD           pause while the host's 1-minute load is above this (default 2.5)
 #   LIMIT              stop after importing this many messages
-#   RESET_CURSOR       1 to forget how far previous passes got and walk from the start.
+#   RESET_CURSOR       true/1 to forget how far previous passes got and walk from the start.
 #                      The run is resumable because it remembers, per folder, the highest
 #                      UID it has already looked at -- the inbox alone cannot say, since
 #                      most of a support mailbox is read and declined rather than written
@@ -53,7 +53,23 @@ module ImapImportOptions
   end
 
   def folders = ENV['FOLDERS'].presence&.split(',')&.map(&:strip)
-  def kinds = (ENV['KINDS'] || 'customer').split(',').map(&:strip)
+
+  # Refused here rather than defaulted, because `KINDS=` is a setting somebody wrote on
+  # purpose and it means nothing: the run would download and classify the whole mailbox,
+  # import none of it, advance the cursor over all of it and report the folder finished.
+  # An empty list is legitimate for `imap:scan`, which builds its own.
+  def kinds
+    given = (ENV['KINDS'] || 'customer').split(',').map(&:strip).compact_blank
+    abort 'ERRO: KINDS esta vazio, nada seria importado' if given.empty?
+
+    given
+  end
+
+  # Cast rather than `present?`: `RESET_CURSOR=0` reads as "off" to whoever typed it and as
+  # "on" to a presence check, and getting it wrong throws away the resume point on every
+  # invocation -- so each pass re-walks and re-downloads the declined mail it had already
+  # got past, which on this mailbox is most of it.
+  def reset_cursor? = ActiveModel::Type::Boolean.new.cast(ENV.fetch('RESET_CURSOR', nil)).present?
 
   # `all`, a date, or nothing at all. Parsed here so a typo stops the run at the first line
   # instead of quietly reading as "none" and finishing without a single attachment.
@@ -205,7 +221,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
       folders: ImapImportOptions.folders, terms: ImapImportOptions.terms,
       attachments: attachments, limit: ImapImportOptions.limit
     )
-    run.cursor.reset if ENV['RESET_CURSOR'].present?
+    run.cursor.reset if ImapImportOptions.reset_cursor?
     puts "Retoma:  #{run.cursor}"
     puts '-' * 70
 

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -198,7 +198,12 @@ module ImapImportOptions
     wanted.each do |uid|
       break if pacer.over_budget?
 
-      kinds[sample_kind(imap, run, uid, pacer)] += 1
+      kind = sample_kind(imap, run, uid, pacer)
+      # A message that did not fit is not a result, and counting it as one would let a
+      # sample cut short by the budget report itself as the sample that was asked for.
+      break if kind.nil?
+
+      kinds[kind] += 1
     end
     [kinds, kinds.values.sum == wanted.length]
   end
@@ -221,7 +226,13 @@ module ImapImportOptions
     Array.new(sample) { |index| uids[(index * step).floor] }
   end
 
+  # `nil` when the message is larger than what is left, which ends the sample. The size is
+  # a round trip of its own here, unlike in the import, and worth it for the same reason
+  # the one-at-a-time fetch above is: a scan pulls whole bodies to classify them, so the
+  # first message it cannot afford is the one that would have crossed the provider's limit.
   def sample_kind(imap, run, uid, pacer)
+    return nil unless room_for_message?(imap, uid, pacer)
+
     raw = imap.uid_fetch(uid, 'BODY.PEEK[]')&.first&.attr&.dig('BODY[]').to_s
     return :vazia if raw.blank?
 
@@ -229,6 +240,13 @@ module ImapImportOptions
     run.send(:classify, Mail.read_from_string(raw))
   rescue StandardError
     :erro
+  end
+
+  # A server that reports no size is sampled as it was: this sharpens the ceiling, it is
+  # not a precondition for having one.
+  def room_for_message?(imap, uid, pacer)
+    size = imap.uid_fetch(uid, 'RFC822.SIZE')&.first&.attr&.dig('RFC822.SIZE').to_i
+    size.zero? || pacer.room_for?(size)
   end
 end
 

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -34,6 +34,9 @@ require 'net/imap'
 #                      UID it has already looked at -- the inbox alone cannot say, since
 #                      most of a support mailbox is read and declined rather than written
 #   SAMPLE             imap:scan only, messages to classify per folder (default 400)
+#   IMAP_DISABLED_OK   true/1 to run against a channel whose IMAP integration is off. Only
+#                      for an archive inbox: it holds credentials on purpose and the live
+#                      fetch job must stay away from the mailbox they open
 module ImapImportOptions
   module_function
 
@@ -41,8 +44,27 @@ module ImapImportOptions
     inbox = Inbox.find_by(id: ENV.fetch('INBOX_ID', nil))
     abort 'ERRO: defina INBOX_ID' if inbox.nil?
     abort "ERRO: inbox #{inbox.id} nao e um canal de e-mail" unless inbox.channel.is_a?(Channel::Email)
+    imap!(inbox)
 
     inbox
+  end
+
+  # `imap_enabled` is the switch that stops Chatwoot from polling a mailbox, and connecting
+  # anyway is spending credentials somebody turned off. Refused by default, the way the task
+  # this replaces refused it: a disabled channel also carries settings nobody has kept
+  # current, so what the run gets instead of a clear line here is a login error.
+  #
+  # Overridable, because an archive inbox is the one configuration where the switch and the
+  # credentials mean different things. It holds real credentials for a mailbox the live
+  # fetch job must never touch -- enabled, `Inboxes::FetchImapEmailsJob` would pull the same
+  # mailbox into the same inbox alongside the import, and the history would arrive twice.
+  # `IMAP_DISABLED_OK=1` is that setup stated out loud rather than assumed by an importer.
+  def imap!(inbox)
+    return if inbox.channel.imap_enabled?
+    return if Import::Options.boolean('IMAP_DISABLED_OK')
+
+    abort "ERRO: IMAP esta desligado no inbox #{inbox.id}. Ligue a integracao, ou passe " \
+          'IMAP_DISABLED_OK=1 se a caixa e so de arquivo e o fetch do Chatwoot nao pode toca-la.'
   end
 
   def terms

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -106,26 +106,38 @@ module ImapImportOptions
     puts "  #{'tempo'.ljust(20)} #{duration(Time.zone.now - started)} (pausado #{duration(pacer.paused_for)})"
   end
 
-  # Classifies a uniform slice of a folder. Uniform rather than the newest N, because the
-  # shape of this mailbox changed over four years and the tail would not describe it.
+  # Classifies a sample of a folder.
   # Charged against the same budget the import spends, and stopped by it. A scan reads whole
   # messages to classify them, so a sample that lands on attachments costs gigabytes -- and
   # the provider lockout a dry run triggers is the same one `BUDGET_MB` exists to avoid,
   # only harder to explain because nothing was written.
+  # One message at a time, and the budget asked before each. A scan reads whole messages to
+  # classify them, so a batch of fifty lands fifty complete bodies -- attachments and all --
+  # before anything can be charged for them, which on this mailbox is the difference between
+  # a margin and a lockout. The sample is a few hundred messages, so the round trips cost
+  # nothing worth the risk.
   def sample_kinds(imap, run, uids, sample, pacer)
     kinds = Hash.new(0)
-    uids.each_slice([uids.length / sample, 1].max).map(&:first).each_slice(50) do |batch|
+    spread(uids, sample).each do |uid|
       break if pacer.over_budget?
 
-      (imap.uid_fetch(batch, 'BODY.PEEK[]') || []).each do |data|
-        raw = data.attr['BODY[]'].to_s
-        pacer.spend(raw.bytesize)
-        kinds[run.send(:classify, Mail.read_from_string(raw))] += 1
-      rescue StandardError
-        kinds[:erro] += 1
-      end
+      kinds[sample_kind(imap, run, uid, pacer)] += 1
     end
     kinds
+  end
+
+  # Spread across the folder rather than the newest N, because the shape of a mailbox
+  # changes over years and its tail does not describe it.
+  def spread(uids, sample) = uids.each_slice([uids.length / sample, 1].max).map(&:first)
+
+  def sample_kind(imap, run, uid, pacer)
+    raw = imap.uid_fetch(uid, 'BODY.PEEK[]')&.first&.attr&.dig('BODY[]').to_s
+    return :vazia if raw.blank?
+
+    pacer.spend(raw.bytesize)
+    run.send(:classify, Mail.read_from_string(raw))
+  rescue StandardError
+    :erro
   end
 
   def header(inbox, extra = {})

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -19,7 +19,10 @@ require 'net/imap'
 # Options, all through the environment:
 #   INBOX_ID           required
 #   FOLDERS            comma separated (default: the all-mail folder plus Spam)
-#   SINCE / UNTIL      IMAP dates, e.g. 01-Jan-2023
+#   SINCE / UNTIL      IMAP dates, e.g. 01-Jan-2023. UNTIL defaults to today, so a run never
+#                      takes mail the live fetch job has not had its turn at -- filed here
+#                      it would be born resolved and silent, and the poller would then skip
+#                      it as already stored
 #   ATTACHMENTS        `all`, or a YYYY-MM-DD to take attachments only on messages newer
 #                      than that date. Unset means none, which is what keeps a first pass
 #                      inside the budget: an attachment is never fetched, not fetched and
@@ -67,12 +70,26 @@ module ImapImportOptions
           'IMAP_DISABLED_OK=1 se a caixa e so de arquivo e o fetch do Chatwoot nao pode toca-la.'
   end
 
+  # A cutoff, and by default today's date, which is the difference between a history import
+  # and a second poller.
+  #
+  # On an inbox whose IMAP is enabled the live fetch job is working the same mailbox, and an
+  # `ALL` search happily selects a message that arrived a minute ago and has not been polled
+  # yet. Filed here it is written under `SilentWrite`, so its conversation is born resolved,
+  # nothing is dispatched and nobody is notified -- and the poller then finds the source id
+  # already stored and skips it. A customer who wrote this morning is filed as history and
+  # never reaches an agent, with no error anywhere.
+  #
+  # `BEFORE` reads the message's arrival date, so today's mail is left to the poller whose
+  # job it is. An operator who means to take it says so with `UNTIL`, which is the ordinary
+  # way to move the line and is now the only way to move it forward.
   def terms
     terms = ['ALL']
     terms = ['SINCE', ENV.fetch('SINCE')] if ENV['SINCE'].present?
-    terms += ['BEFORE', ENV.fetch('UNTIL')] if ENV['UNTIL'].present?
-    terms
+    terms + ['BEFORE', until_date]
   end
+
+  def until_date = ENV['UNTIL'].presence || Date.current.strftime('%d-%b-%Y')
 
   def folders = ENV['FOLDERS'].presence&.split(',')&.map(&:strip)
 
@@ -282,6 +299,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
       inbox,
       Tipos: ImapImportOptions.kinds.join(', '),
       Anexos: attachments.to_s,
+      Ate: "antes de #{ImapImportOptions.until_date}",
       Teto: "#{pacer.budget_mb_left}MB, load maximo #{ENV['MAX_LOAD'] || 2.5}",
       Limite: ImapImportOptions.limit || 'sem limite'
     )

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -99,6 +99,19 @@ module ImapImportOptions
   # Counts are integers and measurements are not: `SAMPLE=0.5` truncates to zero at the call
   # site and the scan classifies nothing while printing a finished projection. See
   # Import::Options for why none of these is read leniently.
+  # A projection built on the folders that fit is not a smaller projection, it is a wrong
+  # one: the folder with the attachments is the one that exhausts the budget, and the one
+  # whose absence the total does not show. So the gap is named rather than left to a reader
+  # of a table that looks complete.
+  def projection(totals, unsampled)
+    puts "\n#{'=' * 70}\nPROJECAO GERAL#{unsampled.any? ? ' (PARCIAL)' : ''}"
+    totals.sort_by { |_, count| -count }.each { |kind, count| puts "  #{kind.to_s.ljust(12)} ~#{count}" }
+    return if unsampled.empty?
+
+    puts "\nORCAMENTO ESGOTADO: nenhuma amostra de #{unsampled.join(', ')}."
+    puts 'A projecao acima nao inclui essas pastas. Rode de novo amanha ou com BUDGET_MB maior.'
+  end
+
   def limit = Import::Options.integer('LIMIT')
   def sample = Import::Options.integer('SAMPLE', default: 400)
 
@@ -215,7 +228,15 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
                                     Teto: "#{pacer.budget_mb_left}MB")
 
     totals = Hash.new(0)
+    unsampled = []
     run.folders(imap).each do |folder|
+      # A scan that ran out of budget in an early folder samples nothing in the later ones,
+      # and a projection built on that is not a smaller projection, it is a wrong one: the
+      # folder with the attachments is exactly the one that exhausts the budget, and exactly
+      # the one whose absence the total does not show. Named here rather than left to the
+      # reader of a table that looks complete.
+      next unsampled << folder if pacer.over_budget?
+
       imap.examine(folder)
       uids = Array(imap.uid_search(ImapImportOptions.terms))
       puts "\n#{folder}: #{uids.length} mensagens"
@@ -231,8 +252,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
     end
     run.close(imap)
 
-    puts "\n#{'=' * 70}\nPROJECAO GERAL"
-    totals.sort_by { |_, v| -v }.each { |kind, count| puts "  #{kind.to_s.ljust(12)} ~#{count}" }
+    ImapImportOptions.projection(totals, unsampled)
   end
 
   desc 'Importa historico de e-mails do IMAP para uma inbox do Chatwoot'

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -99,19 +99,6 @@ module ImapImportOptions
   # Counts are integers and measurements are not: `SAMPLE=0.5` truncates to zero at the call
   # site and the scan classifies nothing while printing a finished projection. See
   # Import::Options for why none of these is read leniently.
-  # A projection built on the folders that fit is not a smaller projection, it is a wrong
-  # one: the folder with the attachments is the one that exhausts the budget, and the one
-  # whose absence the total does not show. So the gap is named rather than left to a reader
-  # of a table that looks complete.
-  def projection(totals, unsampled)
-    puts "\n#{'=' * 70}\nPROJECAO GERAL#{unsampled.any? ? ' (PARCIAL)' : ''}"
-    totals.sort_by { |_, count| -count }.each { |kind, count| puts "  #{kind.to_s.ljust(12)} ~#{count}" }
-    return if unsampled.empty?
-
-    puts "\nORCAMENTO ESGOTADO: nenhuma amostra de #{unsampled.join(', ')}."
-    puts 'A projecao acima nao inclui essas pastas. Rode de novo amanha ou com BUDGET_MB maior.'
-  end
-
   def limit = Import::Options.integer('LIMIT')
   def sample = Import::Options.integer('SAMPLE', default: 400)
 
@@ -170,14 +157,19 @@ module ImapImportOptions
   # before anything can be charged for them, which on this mailbox is the difference between
   # a margin and a lockout. The sample is a few hundred messages, so the round trips cost
   # nothing worth the risk.
+  # Returns the tally and whether it is the tally that was asked for. A sample cut short by
+  # the budget is not a smaller sample, it is a different claim: the projection multiplies
+  # it out over the whole folder either way, and one large first message can end up
+  # describing a mailbox from a single result.
   def sample_kinds(imap, run, uids, sample, pacer)
     kinds = Hash.new(0)
-    spread(uids, sample).each do |uid|
+    wanted = spread(uids, sample)
+    wanted.each do |uid|
       break if pacer.over_budget?
 
       kinds[sample_kind(imap, run, uid, pacer)] += 1
     end
-    kinds
+    [kinds, kinds.values.sum == wanted.length]
   end
 
   # Spread across the folder rather than the newest N, because the shape of a mailbox
@@ -207,11 +199,32 @@ module ImapImportOptions
   rescue StandardError
     :erro
   end
+end
+
+# What the two tasks print. Its own module because a report is not a setting: these read
+# nothing from the environment and decide nothing about the run, and keeping them beside
+# the option readers was what pushed that module past its size.
+module ImapImportReport
+  module_function
 
   def header(inbox, extra = {})
     puts "Inbox:   #{inbox.name} (##{inbox.id})  #{inbox.channel.email}"
     extra.each { |k, v| puts "#{"#{k}:".ljust(9)}#{v}" }
     puts '-' * 70
+  end
+
+  # A projection built on the folders that fit is not a smaller projection, it is a wrong
+  # one: the folder with the attachments is the one that exhausts the budget, and the one
+  # whose absence the total does not show. So the gap is named rather than left to a reader
+  # of a table that looks complete.
+  def projection(totals, unsampled)
+    puts "\n#{'=' * 70}\nPROJECAO GERAL#{unsampled.any? ? ' (PARCIAL)' : ''}"
+    totals.sort_by { |_, count| -count }.each { |kind, count| puts "  #{kind.to_s.ljust(12)} ~#{count}" }
+    return if unsampled.empty?
+
+    puts "\nORCAMENTO ESGOTADO em: #{unsampled.map { |folder, how| "#{folder} (#{how})" }.join(', ')}."
+    puts 'A projecao acima extrapola de menos amostra do que foi pedida, ou de nenhuma.'
+    puts 'Rode de novo amanha ou com BUDGET_MB maior.'
   end
 end
 
@@ -224,8 +237,8 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
     run = Import::Email::Backfill.new(inbox: inbox, kinds: [], pacer: pacer,
                                       folders: ImapImportOptions.folders, terms: ImapImportOptions.terms)
     imap = run.connect
-    ImapImportOptions.header(inbox, Pastas: run.folders(imap).join(', '), Amostra: "#{sample} por pasta",
-                                    Teto: "#{pacer.budget_mb_left}MB")
+    ImapImportReport.header(inbox, Pastas: run.folders(imap).join(', '), Amostra: "#{sample} por pasta",
+                                   Teto: "#{pacer.budget_mb_left}MB")
 
     totals = Hash.new(0)
     unsampled = []
@@ -235,15 +248,18 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
       # folder with the attachments is exactly the one that exhausts the budget, and exactly
       # the one whose absence the total does not show. Named here rather than left to the
       # reader of a table that looks complete.
-      next unsampled << folder if pacer.over_budget?
+      next unsampled << [folder, 'nenhuma amostra'] if pacer.over_budget?
 
       imap.examine(folder)
       uids = Array(imap.uid_search(ImapImportOptions.terms))
       puts "\n#{folder}: #{uids.length} mensagens"
       next if uids.empty?
 
-      kinds = ImapImportOptions.sample_kinds(imap, run, uids, sample, pacer)
+      kinds, whole = ImapImportOptions.sample_kinds(imap, run, uids, sample, pacer)
+      unsampled << [folder, 'amostra parcial'] unless whole
       seen = kinds.values.sum
+      next if seen.zero?
+
       kinds.sort_by { |_, v| -v }.each do |kind, count|
         projected = (uids.length * count / seen.to_f).round
         totals[kind] += projected
@@ -252,7 +268,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
     end
     run.close(imap)
 
-    ImapImportOptions.projection(totals, unsampled)
+    ImapImportReport.projection(totals, unsampled)
   end
 
   desc 'Importa historico de e-mails do IMAP para uma inbox do Chatwoot'
@@ -262,7 +278,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
     started = Time.zone.now
     attachments = ImapImportOptions.attachments
 
-    ImapImportOptions.header(
+    ImapImportReport.header(
       inbox,
       Tipos: ImapImportOptions.kinds.join(', '),
       Anexos: attachments.to_s,

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -84,8 +84,24 @@ module ImapImportOptions
     Import::Email::AttachmentPolicy.build(parsed)
   end
 
-  def limit = ENV['LIMIT'].presence&.to_i
-  def pacer = Import::Email::Pacer.new(budget_mb: ENV['BUDGET_MB'] || 2000, max_load: ENV['MAX_LOAD'] || 2.5)
+  def limit = number('LIMIT', nil)
+  def sample = number('SAMPLE', 400)
+  def pacer = Import::Email::Pacer.new(budget_mb: number('BUDGET_MB', 2000), max_load: number('MAX_LOAD', 2.5))
+
+  # Strict, because `to_f` and `to_i` turn a typo into zero and every one of these settings
+  # fails silently in the expensive direction when it is zero: a zero budget stops before
+  # importing anything, a zero `LIMIT` stops at the first message, and a zero load ceiling
+  # never finds room -- so the run stands still forever against a host that always reports
+  # some load, with no error and nothing on the screen but a pause.
+  def number(key, default)
+    raw = ENV[key].presence
+    return default if raw.nil?
+
+    value = Float(raw, exception: false)
+    abort "ERRO: #{key} deve ser um numero positivo, veio #{raw.inspect}" if value.nil? || !value.positive?
+
+    value
+  end
 
   def duration(seconds)
     seconds = seconds.to_i
@@ -186,7 +202,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
   desc 'Dry run: classifica uma amostra do que imap:import faria, sem escrever nada'
   task scan: :environment do
     inbox = ImapImportOptions.inbox!
-    sample = (ENV['SAMPLE'] || 400).to_i
+    sample = ImapImportOptions.sample.to_i
     pacer = ImapImportOptions.pacer
     run = Import::Email::Backfill.new(inbox: inbox, kinds: [], pacer: pacer,
                                       folders: ImapImportOptions.folders, terms: ImapImportOptions.terms)

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -108,11 +108,19 @@ module ImapImportOptions
 
   # Classifies a uniform slice of a folder. Uniform rather than the newest N, because the
   # shape of this mailbox changed over four years and the tail would not describe it.
-  def sample_kinds(imap, run, uids, sample)
+  # Charged against the same budget the import spends, and stopped by it. A scan reads whole
+  # messages to classify them, so a sample that lands on attachments costs gigabytes -- and
+  # the provider lockout a dry run triggers is the same one `BUDGET_MB` exists to avoid,
+  # only harder to explain because nothing was written.
+  def sample_kinds(imap, run, uids, sample, pacer)
     kinds = Hash.new(0)
     uids.each_slice([uids.length / sample, 1].max).map(&:first).each_slice(50) do |batch|
+      break if pacer.over_budget?
+
       (imap.uid_fetch(batch, 'BODY.PEEK[]') || []).each do |data|
-        kinds[run.send(:classify, Mail.read_from_string(data.attr['BODY[]'].to_s))] += 1
+        raw = data.attr['BODY[]'].to_s
+        pacer.spend(raw.bytesize)
+        kinds[run.send(:classify, Mail.read_from_string(raw))] += 1
       rescue StandardError
         kinds[:erro] += 1
       end
@@ -132,10 +140,12 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
   task scan: :environment do
     inbox = ImapImportOptions.inbox!
     sample = (ENV['SAMPLE'] || 400).to_i
-    run = Import::Email::Backfill.new(inbox: inbox, kinds: [], pacer: ImapImportOptions.pacer,
+    pacer = ImapImportOptions.pacer
+    run = Import::Email::Backfill.new(inbox: inbox, kinds: [], pacer: pacer,
                                       folders: ImapImportOptions.folders, terms: ImapImportOptions.terms)
     imap = run.connect
-    ImapImportOptions.header(inbox, Pastas: run.folders(imap).join(', '), Amostra: "#{sample} por pasta")
+    ImapImportOptions.header(inbox, Pastas: run.folders(imap).join(', '), Amostra: "#{sample} por pasta",
+                                    Teto: "#{pacer.budget_mb_left}MB")
 
     totals = Hash.new(0)
     run.folders(imap).each do |folder|
@@ -144,7 +154,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
       puts "\n#{folder}: #{uids.length} mensagens"
       next if uids.empty?
 
-      kinds = ImapImportOptions.sample_kinds(imap, run, uids, sample)
+      kinds = ImapImportOptions.sample_kinds(imap, run, uids, sample, pacer)
       seen = kinds.values.sum
       kinds.sort_by { |_, v| -v }.each do |kind, count|
         projected = (uids.length * count / seen.to_f).round

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -94,7 +94,8 @@ module ImapImportOptions
 
   def print_progress(stats, pacer, started)
     skipped = stats.sum { |key, value| key.to_s.start_with?('visto_') ? value : 0 } - stats[:importadas]
-    print "\r  #{stats[:importadas]} importadas | #{skipped} puladas | #{pacer.spent_mb}MB | " \
+    enriched = stats[:enriquecidas].positive? ? "#{stats[:enriquecidas]} anexadas | " : ''
+    print "\r  #{stats[:importadas]} importadas | #{enriched}#{skipped} puladas | #{pacer.spent_mb}MB | " \
           "load #{pacer.load_average} | #{duration(Time.zone.now - started)}        "
   end
 

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -1,284 +1,169 @@
 # frozen_string_literal: true
 
 require 'net/imap'
-require 'concurrent'
 
-def connect_imap(channel, folder)
-  imap = Net::IMAP.new(channel.imap_address, port: channel.imap_port, ssl: channel.imap_enable_ssl, open_timeout: 30)
+# Backfills an email inbox from IMAP. The loop lives in Import::Email::Backfill; this is
+# the option parsing and the report around it.
+#
+# Written for a mailbox too big to take in one sitting: hundreds of thousands of messages
+# and hundreds of gigabytes of attachments, behind a provider that allows 2.5 GB of IMAP
+# download a day. So
+# the run is resumable (it re-scans headers and skips what the inbox holds, keyed on
+# Message-ID), paced (against a byte budget and the host's load average) and silent (every
+# write inside Import::SilentWrite: no dashboard push, no automations, no outgoing
+# webhooks, no notifications, so agents working the inbox see nothing appear).
+#
+#   INBOX_ID=1 bundle exec rails imap:scan               # dry run, writes nothing
+#   INBOX_ID=1 LIMIT=200 bundle exec rails imap:import   # first real batch
+#
+# Options, all through the environment:
+#   INBOX_ID           required
+#   FOLDERS            comma separated (default: the all-mail folder plus Spam)
+#   SINCE / UNTIL      IMAP dates, e.g. 01-Jan-2023
+#   ATTACHMENTS_SINCE  YYYY-MM-DD; attachments fetched only on messages newer than this
+#                      (default: none, which is what keeps a first pass inside the budget)
+#   KINDS              comma separated, see Import::Email::Classifier (default: customer)
+#   BUDGET_MB          IMAP bytes to spend before stopping (default 2000 of the 2500 allowed)
+#   MAX_LOAD           pause while the host's 1-minute load is above this (default 2.5)
+#   LIMIT              stop after importing this many messages
+#   SAMPLE             imap:scan only, messages to classify per folder (default 400)
+module ImapImportOptions
+  module_function
 
-  if channel.google?
-    token = Google::RefreshOauthTokenService.new(channel: channel).access_token
-    imap.authenticate('XOAUTH2', channel.imap_login, token)
-  elsif channel.microsoft?
-    token = Microsoft::RefreshOauthTokenService.new(channel: channel).access_token
-    imap.authenticate('XOAUTH2', channel.imap_login, token)
-  else
-    imap.authenticate('PLAIN', channel.imap_login, channel.imap_password)
+  def inbox!
+    inbox = Inbox.find_by(id: ENV.fetch('INBOX_ID', nil))
+    abort 'ERRO: defina INBOX_ID' if inbox.nil?
+    abort "ERRO: inbox #{inbox.id} nao e um canal de e-mail" unless inbox.channel.is_a?(Channel::Email)
+
+    inbox
   end
 
-  imap.select(folder)
-  imap
-end
+  def terms
+    terms = ['ALL']
+    terms = ['SINCE', ENV.fetch('SINCE')] if ENV['SINCE'].present?
+    terms += ['BEFORE', ENV.fetch('UNTIL')] if ENV['UNTIL'].present?
+    terms
+  end
 
-# Logout can raise Net::IMAP::Error when the server has already closed the
-# connection (eg. a transient network blip mid-scan). Mirror the
-# `terminate_imap_connection` pattern used by the IMAP fetch service: log and
-# fall back to a plain disconnect so ensure blocks never fail the whole task.
-def safe_close_imap(imap)
-  return if imap.nil?
+  def folders = ENV['FOLDERS'].presence&.split(',')&.map(&:strip)
+  def kinds = (ENV['KINDS'] || 'customer').split(',').map(&:strip)
+  def attachments_since = (Time.zone.parse(ENV.fetch('ATTACHMENTS_SINCE')) if ENV['ATTACHMENTS_SINCE'].present?)
+  def limit = ENV['LIMIT'].presence&.to_i
+  def pacer = Import::Email::Pacer.new(budget_mb: ENV['BUDGET_MB'] || 2000, max_load: ENV['MAX_LOAD'] || 2.5)
 
-  imap.logout
-rescue Net::IMAP::Error => e
-  warn "  [IMAP] logout failed: #{e.message}; disconnecting"
-  imap.disconnect
-end
+  def duration(seconds)
+    seconds = seconds.to_i
+    return "#{seconds}s" if seconds < 60
+    return "#{seconds / 60}m#{seconds % 60}s" if seconds < 3600
 
-def format_duration(seconds)
-  seconds = seconds.to_i
-  if seconds < 60
-    "#{seconds}s"
-  elsif seconds < 3600
-    "#{seconds / 60}m#{seconds % 60}s"
-  else
     "#{seconds / 3600}h#{(seconds % 3600) / 60}m"
   end
-end
 
-def validate_inbox(inbox_id)
-  inbox = Inbox.find_by(id: inbox_id)
-  abort "ERROR: Inbox #{inbox_id} not found." unless inbox
-
-  channel = inbox.channel
-  abort "ERROR: Inbox #{inbox_id} is not an email channel." unless channel.is_a?(Channel::Email)
-  abort "ERROR: IMAP is not enabled for inbox #{inbox_id}." unless channel.imap_enabled?
-
-  [inbox, channel]
-end
-
-def scan_new_email_uids(imap, channel, uids)
-  new_uids = []
-  skipped = 0
-
-  uids.each_slice(100) do |batch|
-    headers = imap.uid_fetch(batch, 'BODY.PEEK[HEADER.FIELDS (MESSAGE-ID)]')
-    next if headers.blank?
-
-    headers.each do |data|
-      msg_id = Mail.read_from_string(data.attr['BODY[HEADER.FIELDS (MESSAGE-ID)]']).message_id
-      if msg_id.blank? || channel.inbox.messages.exists?(source_id: msg_id)
-        skipped += 1
-      else
-        new_uids << data.attr['UID']
+  # The one-line progress display, and the summary after it. Here rather than inside the
+  # task body so the tasks stay short enough to read in one screen.
+  def printer(pacer, started)
+    lambda do |event, payload|
+      case event
+      when :folder then puts "\n#{payload[:folder]}: #{payload[:total]} candidatas"
+      when :paused then print "\r  [pausa] load #{payload[:load]} acima do teto, aguardando...            "
+      when :error then warn "\n  [ERRO] uid #{payload[:uid]}: #{payload[:error].class} #{payload[:error].message}"
+      when :imported then print_progress(payload[:stats], pacer, started)
       end
     end
-
-    print "\r  Scanning headers... #{new_uids.size} new, #{skipped} skipped (#{new_uids.size + skipped}/#{uids.size})   "
   end
 
-  puts ''
-  [new_uids, skipped]
+  def print_progress(stats, pacer, started)
+    skipped = stats.sum { |key, value| key.to_s.start_with?('visto_') ? value : 0 } - stats[:importadas]
+    print "\r  #{stats[:importadas]} importadas | #{skipped} puladas | #{pacer.spent_mb}MB | " \
+          "load #{pacer.load_average} | #{duration(Time.zone.now - started)}        "
+  end
+
+  def report(run, pacer, started)
+    puts "\n#{'=' * 70}"
+    puts case run.stopped_by
+         when :orcamento then 'Parou no teto de bytes. Rode de novo amanha para continuar.'
+         when :limite then 'Parou no LIMIT. Rode de novo para continuar.'
+         else 'Pastas esgotadas.'
+         end
+    run.stats.sort.each { |key, value| puts "  #{key.to_s.ljust(20)} #{value}" }
+    puts "  #{'baixado'.ljust(20)} #{pacer.spent_mb} MB"
+    puts "  #{'tempo'.ljust(20)} #{duration(Time.zone.now - started)} (pausado #{duration(pacer.paused_for)})"
+  end
+
+  # Classifies a uniform slice of a folder. Uniform rather than the newest N, because the
+  # shape of this mailbox changed over four years and the tail would not describe it.
+  def sample_kinds(imap, run, uids, sample)
+    kinds = Hash.new(0)
+    uids.each_slice([uids.length / sample, 1].max).map(&:first).each_slice(50) do |batch|
+      (imap.uid_fetch(batch, 'BODY.PEEK[]') || []).each do |data|
+        kinds[run.send(:classify, Mail.read_from_string(data.attr['BODY[]'].to_s))] += 1
+      rescue StandardError
+        kinds[:erro] += 1
+      end
+    end
+    kinds
+  end
+
+  def header(inbox, extra = {})
+    puts "Inbox:   #{inbox.name} (##{inbox.id})  #{inbox.channel.email}"
+    extra.each { |k, v| puts "#{"#{k}:".ljust(9)}#{v}" }
+    puts '-' * 70
+  end
 end
 
-def import_single_email(imap, channel, uid)
-  mail_data = imap.uid_fetch(uid, 'RFC822')
-  return false if mail_data.blank?
+namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in one namespace
+  desc 'Dry run: classifica uma amostra do que imap:import faria, sem escrever nada'
+  task scan: :environment do
+    inbox = ImapImportOptions.inbox!
+    sample = (ENV['SAMPLE'] || 400).to_i
+    run = Import::Email::Backfill.new(inbox: inbox, kinds: [], pacer: ImapImportOptions.pacer,
+                                      folders: ImapImportOptions.folders, terms: ImapImportOptions.terms)
+    imap = run.connect
+    ImapImportOptions.header(inbox, Pastas: run.folders(imap).join(', '), Amostra: "#{sample} por pasta")
 
-  mail_str = mail_data[0].attr['RFC822']
-  return false if mail_str.blank?
+    totals = Hash.new(0)
+    run.folders(imap).each do |folder|
+      imap.examine(folder)
+      uids = imap.uid_search(ImapImportOptions.terms)
+      puts "\n#{folder}: #{uids.length} mensagens"
+      next if uids.empty?
 
-  inbound_mail = Mail.read_from_string(mail_str)
-  Imap::ImapMailbox.new.process(inbound_mail, channel)
+      kinds = ImapImportOptions.sample_kinds(imap, run, uids, sample)
+      seen = kinds.values.sum
+      kinds.sort_by { |_, v| -v }.each do |kind, count|
+        projected = (uids.length * count / seen.to_f).round
+        totals[kind] += projected
+        puts "   #{kind.to_s.ljust(10)} #{count}/#{seen} (#{(100.0 * count / seen).round(1)}%)  -> ~#{projected}"
+      end
+    end
+    run.close(imap)
 
-  # Backdate message created_at to the original email date
-  backdate_message(channel, inbound_mail) if inbound_mail.date.present?
-  true
-end
+    puts "\n#{'=' * 70}\nPROJECAO GERAL"
+    totals.sort_by { |_, v| -v }.each { |kind, count| puts "  #{kind.to_s.ljust(12)} ~#{count}" }
+  end
 
-def backdate_message(channel, inbound_mail)
-  message = channel.inbox.messages.find_by(source_id: inbound_mail.message_id)
-  return unless message
+  desc 'Importa historico de e-mails do IMAP para uma inbox do Chatwoot'
+  task import: :environment do
+    inbox = ImapImportOptions.inbox!
+    pacer = ImapImportOptions.pacer
+    started = Time.zone.now
+    attachments = ImapImportOptions.attachments_since
 
-  original_date = inbound_mail.date.to_datetime
-  message.update_columns(created_at: original_date) # rubocop:disable Rails/SkipsModelValidations
-end
-
-# Fixes conversation timestamps after all messages are imported.
-# Must run after import to avoid after_create_commit callbacks overwriting values.
-def backdate_conversations(inbox)
-  puts 'Backdating conversation timestamps...'
-  count = 0
-
-  inbox.conversations.find_each do |conversation|
-    oldest = conversation.messages.minimum(:created_at)
-    newest = conversation.messages.maximum(:created_at)
-    next unless oldest
-
-    conversation.update_columns( # rubocop:disable Rails/SkipsModelValidations
-      created_at: oldest,
-      last_activity_at: newest,
-      agent_last_seen_at: newest,
-      status: :resolved
+    ImapImportOptions.header(
+      inbox,
+      Tipos: ImapImportOptions.kinds.join(', '),
+      Anexos: attachments ? "a partir de #{attachments.to_date}" : 'nenhum',
+      Teto: "#{pacer.budget_mb_left}MB, load maximo #{ENV['MAX_LOAD'] || 2.5}",
+      Limite: ImapImportOptions.limit || 'sem limite'
     )
-    count += 1
-  end
 
-  puts "  Updated #{count} conversations."
-end
+    run = Import::Email::Backfill.new(
+      inbox: inbox, kinds: ImapImportOptions.kinds, pacer: pacer,
+      folders: ImapImportOptions.folders, terms: ImapImportOptions.terms,
+      attachments_since: attachments, limit: ImapImportOptions.limit
+    )
 
-def import_worker(channel, folder, uid_batch, progress) # rubocop:disable Metrics/MethodLength
-  ActiveRecord::Base.connection_pool.with_connection do
-    imap = connect_imap(channel, folder)
-    begin
-      uid_batch.each do |uid|
-        import_single_email(imap, channel, uid)
-
-        progress[:mutex].synchronize do
-          progress[:imported] += 1
-          print_import_progress(progress)
-        end
-      rescue StandardError => e
-        progress[:mutex].synchronize do
-          progress[:errors] += 1
-          print_import_progress(progress)
-        end
-        warn "\n  [ERROR] uid #{uid}: #{e.message}"
-      end
-    ensure
-      safe_close_imap(imap)
-    end
-  end
-rescue StandardError => e
-  warn "\n  [WORKER ERROR] #{e.message}"
-end
-
-def print_import_progress(progress)
-  processed = progress[:imported] + progress[:skipped] + progress[:errors]
-  total = progress[:total]
-  pct = ((processed.to_f / total) * 100).round(1)
-  elapsed = Time.zone.now - progress[:started_at]
-  rate = processed.positive? ? (elapsed / processed) : 0
-  eta = rate.positive? ? ((total - processed) * rate) : 0
-
-  print "\r  [#{pct}%] #{processed}/#{total} | imported: #{progress[:imported]} | " \
-        "skipped: #{progress[:skipped]} | errors: #{progress[:errors]} | " \
-        "elapsed: #{format_duration(elapsed)} | ETA: #{format_duration(eta)}   "
-end
-
-namespace :imap do # rubocop:disable Metrics/BlockLength
-  desc 'Import all historical emails from IMAP into a Chatwoot inbox'
-  task :import, %i[inbox_id days folder workers] => :environment do |_task, args| # rubocop:disable Metrics/BlockLength
-    inbox_id = args[:inbox_id]
-    days = (args[:days] || 7).to_i
-    folder = args[:folder] || 'INBOX'
-    workers = (args[:workers] || 4).to_i
-
-    if inbox_id.blank?
-      puts 'Usage: rails imap:import[<inbox_id>,<days>,<folder>,<workers>]'
-      puts '  days:    how far back to look (default: 7)'
-      puts '  folder:  IMAP folder (default: INBOX)'
-      puts '  workers: parallel connections (default: 4)'
-      puts ''
-      puts 'Tip: set RAILS_MAX_THREADS above worker count to avoid DB pool exhaustion:'
-      puts '  RAILS_MAX_THREADS=10 bundle exec rails imap:import[81,3650,INBOX,8]'
-      next
-    end
-
-    inbox, channel = validate_inbox(inbox_id)
-
-    puts "Inbox:    #{inbox.name} (ID: #{inbox.id})"
-    puts "Email:    #{channel.email}"
-    puts "Server:   #{channel.imap_address}:#{channel.imap_port}"
-    puts "Folder:   #{folder}"
-    puts "Lookback: #{days} days"
-    puts "Workers:  #{workers}"
-    puts '-' * 60
-
-    # Phase 1: scan headers with a single connection to find new emails
-    imap = connect_imap(channel, folder)
-    begin
-      since_date = (Time.zone.today - days).strftime('%d-%b-%Y')
-
-      puts "Searching emails since #{since_date}..."
-      uids = imap.uid_search(['SINCE', since_date])
-      puts "Found #{uids.length} emails in #{folder}."
-
-      new_uids, skipped = scan_new_email_uids(imap, channel, uids)
-    ensure
-      safe_close_imap(imap)
-    end
-
-    if new_uids.empty?
-      puts 'Nothing new to import.'
-      next
-    end
-
-    puts "Importing #{new_uids.size} emails with #{workers} parallel workers..."
-    progress = {
-      imported: 0, skipped: skipped, errors: 0,
-      total: new_uids.size + skipped, mutex: Mutex.new, started_at: Time.zone.now
-    }
-
-    # Phase 2: split work across N threads, each with its own IMAP connection
-    chunks = new_uids.each_slice((new_uids.size.to_f / workers).ceil).to_a
-    threads = chunks.map do |chunk|
-      Thread.new { import_worker(channel, folder, chunk, progress) }
-    end
-    threads.each(&:join)
-
-    # Phase 3: fix conversation timestamps after all callbacks have settled
-    backdate_conversations(inbox)
-
-    elapsed = Time.zone.now - progress[:started_at]
-
-    puts ''
-    puts '=' * 60
-    puts 'Import complete!'
-    puts "  Imported: #{progress[:imported]}"
-    puts "  Skipped:  #{progress[:skipped]} (already present)"
-    puts "  Errors:   #{progress[:errors]}"
-    puts "  Time:     #{format_duration(elapsed)}"
-    puts '=' * 60
-  end
-
-  desc 'Dry-run: count how many emails imap:import would import (no changes)'
-  task :scan, %i[inbox_id days folder] => :environment do |_task, args| # rubocop:disable Metrics/BlockLength
-    inbox_id = args[:inbox_id]
-    days = (args[:days] || 7).to_i
-    folder = args[:folder] || 'INBOX'
-
-    if inbox_id.blank?
-      puts 'Usage: rails imap:scan[<inbox_id>,<days>,<folder>]'
-      puts '  days:   how far back to look (default: 7)'
-      puts '  folder: IMAP folder (default: INBOX)'
-      next
-    end
-
-    inbox, channel = validate_inbox(inbox_id)
-
-    puts "Inbox:    #{inbox.name} (ID: #{inbox.id})"
-    puts "Email:    #{channel.email}"
-    puts "Folder:   #{folder}"
-    puts "Lookback: #{days} days"
-    puts '-' * 60
-
-    imap = connect_imap(channel, folder)
-    begin
-      since_date = (Time.zone.today - days).strftime('%d-%b-%Y')
-
-      puts "Searching emails since #{since_date}..."
-      uids = imap.uid_search(['SINCE', since_date])
-      puts "Found #{uids.length} emails in #{folder}."
-
-      new_uids, skipped = scan_new_email_uids(imap, channel, uids)
-    ensure
-      safe_close_imap(imap)
-    end
-
-    puts ''
-    puts '=' * 60
-    puts 'Scan complete (no changes made).'
-    puts "  Would import: #{new_uids.size}"
-    puts "  Would skip:   #{skipped} (already present)"
-    puts '=' * 60
+    run.perform(&ImapImportOptions.printer(pacer, started))
+    ImapImportOptions.report(run, pacer, started)
   end
 end

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -16,13 +16,20 @@ require 'net/imap'
 #   INBOX_ID=1 bundle exec rails imap:scan               # dry run, writes nothing
 #   INBOX_ID=1 LIMIT=200 bundle exec rails imap:import   # first real batch
 #
+# On an installation with advanced search, run one bulk reindex when the import is done.
+# The rows go to the index a batch at a time, and a batch is in memory until the walk hands
+# it over: a run killed between a commit and that handoff leaves those rows stored and
+# unindexed, and no later pass offers them again -- they are already stored, which is the
+# only question the resume asks. Nothing here can see that gap, so it is closed from
+# outside, once, by the thing that would want a reindex after a bulk import anyway.
+#
 # Options, all through the environment:
 #   INBOX_ID           required
 #   FOLDERS            comma separated (default: the all-mail folder plus Spam)
-#   SINCE / UNTIL      IMAP dates, e.g. 01-Jan-2023. UNTIL defaults to today, so a run never
-#                      takes mail the live fetch job has not had its turn at -- filed here
-#                      it would be born resolved and silent, and the poller would then skip
-#                      it as already stored
+#   SINCE / UNTIL      IMAP dates, e.g. 01-Jan-2023. UNTIL defaults to yesterday, which is
+#                      as far back as the live fetch job reads: a run never touches a day
+#                      that job is also working. Filed here, live mail would be born
+#                      resolved and silent and the poller would then skip it as stored
 #   ATTACHMENTS        `all`, or a YYYY-MM-DD to take attachments only on messages newer
 #                      than that date. Unset means none, which is what keeps a first pass
 #                      inside the budget: an attachment is never fetched, not fetched and
@@ -89,7 +96,14 @@ module ImapImportOptions
     terms + ['BEFORE', until_date]
   end
 
-  def until_date = ENV['UNTIL'].presence || Date.current.strftime('%d-%b-%Y')
+  # `Imap::BaseFetchEmailService#since` searches from `today - interval`, and the job passes
+  # 1 unless told otherwise, so the poller owns yesterday and today. Stopping before
+  # yesterday leaves no day that both would read: two writers on one message can each pass
+  # their own existence check, since nothing here is a lock or a unique index, and the mail
+  # arrives twice in two conversations.
+  POLLER_DAYS = 1
+
+  def until_date = ENV['UNTIL'].presence || (Date.current - POLLER_DAYS).strftime('%d-%b-%Y')
 
   def folders = ENV['FOLDERS'].presence&.split(',')&.map(&:strip)
 

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -20,9 +20,12 @@ require 'net/imap'
 #   INBOX_ID           required
 #   FOLDERS            comma separated (default: the all-mail folder plus Spam)
 #   SINCE / UNTIL      IMAP dates, e.g. 01-Jan-2023
-#   ATTACHMENTS_SINCE  YYYY-MM-DD; attachments fetched only on messages newer than this
-#                      (default: none, which is what keeps a first pass inside the budget)
-#   KINDS              comma separated, see Import::Email::Classifier (default: customer)
+#   ATTACHMENTS        `all`, or a YYYY-MM-DD to take attachments only on messages newer
+#                      than that date. Unset means none, which is what keeps a first pass
+#                      inside the budget: an attachment is never fetched, not fetched and
+#                      dropped, so the bytes are never spent
+#   KINDS              comma separated, see Import::Email::Classifier (default: customer).
+#                      `relay` can be scanned but not imported, see Backfill::UNIMPORTABLE
 #   BUDGET_MB          IMAP bytes to spend before stopping (default 2000 of the 2500 allowed)
 #   MAX_LOAD           pause while the host's 1-minute load is above this (default 2.5)
 #   LIMIT              stop after importing this many messages
@@ -47,7 +50,20 @@ module ImapImportOptions
 
   def folders = ENV['FOLDERS'].presence&.split(',')&.map(&:strip)
   def kinds = (ENV['KINDS'] || 'customer').split(',').map(&:strip)
-  def attachments_since = (Time.zone.parse(ENV.fetch('ATTACHMENTS_SINCE')) if ENV['ATTACHMENTS_SINCE'].present?)
+
+  # `all`, a date, or nothing at all. Parsed here so a typo stops the run at the first line
+  # instead of quietly reading as "none" and finishing without a single attachment.
+  def attachments
+    raw = ENV['ATTACHMENTS'].presence
+    return Import::Email::AttachmentPolicy.build(nil) if raw.nil?
+    return Import::Email::AttachmentPolicy.build(raw) if raw.casecmp('all').zero?
+
+    parsed = Time.zone.parse(raw)
+    raise ArgumentError, "ATTACHMENTS: use `all` or a date (YYYY-MM-DD), got #{raw.inspect}" if parsed.nil?
+
+    Import::Email::AttachmentPolicy.build(parsed)
+  end
+
   def limit = ENV['LIMIT'].presence&.to_i
   def pacer = Import::Email::Pacer.new(budget_mb: ENV['BUDGET_MB'] || 2000, max_load: ENV['MAX_LOAD'] || 2.5)
 
@@ -147,12 +163,12 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
     inbox = ImapImportOptions.inbox!
     pacer = ImapImportOptions.pacer
     started = Time.zone.now
-    attachments = ImapImportOptions.attachments_since
+    attachments = ImapImportOptions.attachments
 
     ImapImportOptions.header(
       inbox,
       Tipos: ImapImportOptions.kinds.join(', '),
-      Anexos: attachments ? "a partir de #{attachments.to_date}" : 'nenhum',
+      Anexos: attachments.to_s,
       Teto: "#{pacer.budget_mb_left}MB, load maximo #{ENV['MAX_LOAD'] || 2.5}",
       Limite: ImapImportOptions.limit || 'sem limite'
     )
@@ -160,7 +176,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
     run = Import::Email::Backfill.new(
       inbox: inbox, kinds: ImapImportOptions.kinds, pacer: pacer,
       folders: ImapImportOptions.folders, terms: ImapImportOptions.terms,
-      attachments_since: attachments, limit: ImapImportOptions.limit
+      attachments: attachments, limit: ImapImportOptions.limit
     )
 
     run.perform(&ImapImportOptions.printer(pacer, started))

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -149,7 +149,21 @@ module ImapImportOptions
 
   # Spread across the folder rather than the newest N, because the shape of a mailbox
   # changes over years and its tail does not describe it.
-  def spread(uids, sample) = uids.each_slice([uids.length / sample, 1].max).map(&:first)
+  # `sample` uids spread evenly across the folder, and never more than `sample`.
+  #
+  # Not `each_slice(length / sample)`: integer division makes that stride 1 for any folder
+  # between `sample + 1` and `2 * sample - 1` messages, so the scan takes every uid in it --
+  # `SAMPLE=400` over 799 messages downloads 799 whole messages, close to double the cap it
+  # was given, against the same byte budget the import is rationing.
+  #
+  # Stepping by a float keeps the count exact. The step is at least 1 whenever the folder is
+  # larger than the sample, so the indices strictly increase and no uid is picked twice.
+  def spread(uids, sample)
+    return uids if uids.length <= sample
+
+    step = uids.length / sample.to_f
+    Array.new(sample) { |index| uids[(index * step).floor] }
+  end
 
   def sample_kind(imap, run, uid, pacer)
     raw = imap.uid_fetch(uid, 'BODY.PEEK[]')&.first&.attr&.dig('BODY[]').to_s
@@ -183,7 +197,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
     totals = Hash.new(0)
     run.folders(imap).each do |folder|
       imap.examine(folder)
-      uids = imap.uid_search(ImapImportOptions.terms)
+      uids = Array(imap.uid_search(ImapImportOptions.terms))
       puts "\n#{folder}: #{uids.length} mensagens"
       next if uids.empty?
 

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -92,18 +92,9 @@ module ImapImportOptions
   # past, which on this mailbox is most of it.
   def reset_cursor? = Import::Options.boolean('RESET_CURSOR')
 
-  # `all`, a date, or nothing at all. Parsed here so a typo stops the run at the first line
-  # instead of quietly reading as "none" and finishing without a single attachment.
-  def attachments
-    raw = ENV['ATTACHMENTS'].presence
-    return Import::Email::AttachmentPolicy.build(nil) if raw.nil?
-    return Import::Email::AttachmentPolicy.build(raw) if raw.casecmp('all').zero?
-
-    parsed = Time.zone.parse(raw)
-    raise ArgumentError, "ATTACHMENTS: use `all` or a date (YYYY-MM-DD), got #{raw.inspect}" if parsed.nil?
-
-    Import::Email::AttachmentPolicy.build(parsed)
-  end
+  # Read strictly, and read in the policy: a typo stops the run at the first line instead of
+  # quietly reading as "none" and finishing without a single attachment.
+  def attachments = Import::Email::AttachmentPolicy.from_setting(ENV['ATTACHMENTS'].presence)
 
   # Counts are integers and measurements are not: `SAMPLE=0.5` truncates to zero at the call
   # site and the scan classifies nothing while printing a finished projection. See

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -65,11 +65,10 @@ module ImapImportOptions
     given
   end
 
-  # Cast rather than `present?`: `RESET_CURSOR=0` reads as "off" to whoever typed it and as
-  # "on" to a presence check, and getting it wrong throws away the resume point on every
-  # invocation -- so each pass re-walks and re-downloads the declined mail it had already
-  # got past, which on this mailbox is most of it.
-  def reset_cursor? = ActiveModel::Type::Boolean.new.cast(ENV.fetch('RESET_CURSOR', nil)).present?
+  # Read strictly rather than cast: getting this wrong throws away the resume point on every
+  # invocation, so each pass re-walks and re-downloads the declined mail it had already got
+  # past, which on this mailbox is most of it.
+  def reset_cursor? = Import::Options.boolean('RESET_CURSOR')
 
   # `all`, a date, or nothing at all. Parsed here so a typo stops the run at the first line
   # instead of quietly reading as "none" and finishing without a single attachment.
@@ -84,23 +83,15 @@ module ImapImportOptions
     Import::Email::AttachmentPolicy.build(parsed)
   end
 
-  def limit = number('LIMIT', nil)
-  def sample = number('SAMPLE', 400)
-  def pacer = Import::Email::Pacer.new(budget_mb: number('BUDGET_MB', 2000), max_load: number('MAX_LOAD', 2.5))
+  # Counts are integers and measurements are not: `SAMPLE=0.5` truncates to zero at the call
+  # site and the scan classifies nothing while printing a finished projection. See
+  # Import::Options for why none of these is read leniently.
+  def limit = Import::Options.integer('LIMIT')
+  def sample = Import::Options.integer('SAMPLE', default: 400)
 
-  # Strict, because `to_f` and `to_i` turn a typo into zero and every one of these settings
-  # fails silently in the expensive direction when it is zero: a zero budget stops before
-  # importing anything, a zero `LIMIT` stops at the first message, and a zero load ceiling
-  # never finds room -- so the run stands still forever against a host that always reports
-  # some load, with no error and nothing on the screen but a pause.
-  def number(key, default)
-    raw = ENV[key].presence
-    return default if raw.nil?
-
-    value = Float(raw, exception: false)
-    abort "ERRO: #{key} deve ser um numero positivo, veio #{raw.inspect}" if value.nil? || !value.positive?
-
-    value
+  def pacer
+    Import::Email::Pacer.new(budget_mb: Import::Options.decimal('BUDGET_MB', default: 2000),
+                             max_load: Import::Options.decimal('MAX_LOAD', default: 2.5))
   end
 
   def duration(seconds)
@@ -202,7 +193,7 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
   desc 'Dry run: classifica uma amostra do que imap:import faria, sem escrever nada'
   task scan: :environment do
     inbox = ImapImportOptions.inbox!
-    sample = ImapImportOptions.sample.to_i
+    sample = ImapImportOptions.sample
     pacer = ImapImportOptions.pacer
     run = Import::Email::Backfill.new(inbox: inbox, kinds: [], pacer: pacer,
                                       folders: ImapImportOptions.folders, terms: ImapImportOptions.terms)

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -198,8 +198,6 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
       Teto: "#{pacer.budget_mb_left}MB, load maximo #{ENV['MAX_LOAD'] || 2.5}",
       Limite: ImapImportOptions.limit || 'sem limite'
     )
-    puts "Retoma:  #{run.cursor}"
-    puts '-' * 70
 
     run = Import::Email::Backfill.new(
       inbox: inbox, kinds: ImapImportOptions.kinds, pacer: pacer,
@@ -207,6 +205,8 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
       attachments: attachments, limit: ImapImportOptions.limit
     )
     run.cursor.reset if ENV['RESET_CURSOR'].present?
+    puts "Retoma:  #{run.cursor}"
+    puts '-' * 70
 
     run.perform(&ImapImportOptions.printer(pacer, started))
     ImapImportOptions.report(run, pacer, started)

--- a/lib/tasks/imap_import.rake
+++ b/lib/tasks/imap_import.rake
@@ -29,6 +29,10 @@ require 'net/imap'
 #   BUDGET_MB          IMAP bytes to spend before stopping (default 2000 of the 2500 allowed)
 #   MAX_LOAD           pause while the host's 1-minute load is above this (default 2.5)
 #   LIMIT              stop after importing this many messages
+#   RESET_CURSOR       1 to forget how far previous passes got and walk from the start.
+#                      The run is resumable because it remembers, per folder, the highest
+#                      UID it has already looked at -- the inbox alone cannot say, since
+#                      most of a support mailbox is read and declined rather than written
 #   SAMPLE             imap:scan only, messages to classify per folder (default 400)
 module ImapImportOptions
   module_function
@@ -194,12 +198,15 @@ namespace :imap do # rubocop:disable Metrics/BlockLength -- two task bodies in o
       Teto: "#{pacer.budget_mb_left}MB, load maximo #{ENV['MAX_LOAD'] || 2.5}",
       Limite: ImapImportOptions.limit || 'sem limite'
     )
+    puts "Retoma:  #{run.cursor}"
+    puts '-' * 70
 
     run = Import::Email::Backfill.new(
       inbox: inbox, kinds: ImapImportOptions.kinds, pacer: pacer,
       folders: ImapImportOptions.folders, terms: ImapImportOptions.terms,
       attachments: attachments, limit: ImapImportOptions.limit
     )
+    run.cursor.reset if ENV['RESET_CURSOR'].present?
 
     run.perform(&ImapImportOptions.printer(pacer, started))
     ImapImportOptions.report(run, pacer, started)

--- a/lib/tasks/octadesk_import.rake
+++ b/lib/tasks/octadesk_import.rake
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Imports an OctaDesk ticket export into an email inbox.
+#
+# The export is the ticketing system's own model: hundreds of thousands of tickets,
+# already threaded and already attributed. It is a better source than the mailbox for
+# everything it covers, and `imap:import` is left to the months that precede it.
+#
+#   INBOX_ID=1 ZIP=/path/ticket.zip LIMIT=200 bundle exec rails octadesk:import
+#   INBOX_ID=1 ZIP=/path/ticket.zip ATTACHMENTS=1 bundle exec rails octadesk:import
+#
+#   INBOX_ID          required
+#   ZIP               required, the *_ticket_ticket_*.zip
+#   ATTACHMENTS       1 to also mirror the attachments off the vendor bucket
+#   LIMIT             stop after this many tickets
+#   FROM_PART         resume from a part name, e.g. part_0007.json
+#   MAX_LOAD          pause while the host's 1-minute load is above this (default 2.5)
+#   FORM_ADDRESS      address the company's website form posts as, so the customer's own
+#                     address is taken out of the ticket body instead
+#   FORM_SENDER_NAME  display name that form posts under, same reason
+module OctadeskImportOptions
+  module_function
+
+  def printer(pacer, started)
+    lambda do |event, payload|
+      case event
+      when :part then puts "\n#{payload[:part]}"
+      when :paused then print "\r  [pausa] load #{payload[:load]} acima do teto...            "
+      when :error then warn "\n  [ERRO] ticket #{payload[:ticket]}: #{payload[:error].class} #{payload[:error].message}"
+      when :ticket then progress(payload[:stats], pacer, started)
+      end
+    end
+  end
+
+  # Printed every twenty-fifth ticket: the write is fast enough that one line per record
+  # would spend real time on terminal output over half a million of them.
+  def progress(stats, pacer, started)
+    return unless (stats[:lidos] % 25).zero?
+
+    print "\r  #{stats[:lidos]} lidos | #{stats[:tickets]} conversas | " \
+          "#{stats[:mensagens]}+#{stats[:respostas]} msgs | #{stats[:anexos]} anexos | " \
+          "load #{pacer.load_average} | #{ImapImportOptions.duration(Time.zone.now - started)}   "
+  end
+
+  def report(run, pacer, started)
+    puts "\n#{'=' * 70}"
+    puts run.stopped_by == :limite ? 'Parou no LIMIT. Rode de novo para continuar.' : 'Export esgotado.'
+    run.stats.sort.each { |key, value| puts "  #{key.to_s.ljust(20)} #{value}" }
+    puts "  #{'tempo'.ljust(20)} #{ImapImportOptions.duration(Time.zone.now - started)} " \
+         "(pausado #{ImapImportOptions.duration(pacer.paused_for)})"
+  end
+end
+
+namespace :octadesk do
+  desc 'Importa o export de tickets do OctaDesk para uma inbox de e-mail'
+  task import: :environment do
+    inbox = Inbox.find_by(id: ENV.fetch('INBOX_ID', nil))
+    abort 'ERRO: defina INBOX_ID' if inbox.nil?
+    zip = ENV.fetch('ZIP', nil)
+    abort 'ERRO: defina ZIP com o caminho do *_ticket_ticket_*.zip' if zip.blank? || !File.exist?(zip)
+
+    pacer = Import::Email::Pacer.new(budget_mb: Float::INFINITY, max_load: ENV['MAX_LOAD'] || 2.5)
+    started = Time.zone.now
+    run = Import::Octadesk::Backfill.new(
+      inbox: inbox, zip_path: zip, pacer: pacer,
+      attachments: ENV['ATTACHMENTS'].present?, limit: ENV['LIMIT'].presence&.to_i,
+      from_part: ENV['FROM_PART'].presence,
+      form_address: ENV['FORM_ADDRESS'].presence, form_sender_name: ENV['FORM_SENDER_NAME'].presence
+    )
+
+    puts "Inbox:   #{inbox.name} (##{inbox.id})  #{inbox.channel.email}"
+    puts "Export:  #{File.basename(zip)}  (#{run.parts.size} partes)"
+    puts "Anexos:  #{ENV['ATTACHMENTS'].present? ? 'sim, espelhando para o S3' : 'nao'}"
+    puts '-' * 70
+
+    run.perform(&OctadeskImportOptions.printer(pacer, started))
+    OctadeskImportOptions.report(run, pacer, started)
+  end
+end

--- a/lib/tasks/octadesk_import.rake
+++ b/lib/tasks/octadesk_import.rake
@@ -26,6 +26,18 @@ module OctadeskImportOptions
   # reads as "off" to whoever typed it and as "on" to a presence check.
   def attachments? = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ATTACHMENTS', nil)).present?
 
+  # Strict for the same reason the IMAP task is: `to_i` turns a typo into zero, and a zero
+  # `LIMIT` stops at the first ticket while looking like a finished run.
+  def limit
+    raw = ENV['LIMIT'].presence
+    return if raw.nil?
+
+    value = Integer(raw, exception: false)
+    abort "ERRO: LIMIT deve ser um inteiro positivo, veio #{raw.inspect}" if value.nil? || !value.positive?
+
+    value
+  end
+
   def printer(pacer, started)
     lambda do |event, payload|
       case event
@@ -68,7 +80,7 @@ namespace :octadesk do
     started = Time.zone.now
     run = Import::Octadesk::Backfill.new(
       inbox: inbox, zip_path: zip, pacer: pacer,
-      attachments: OctadeskImportOptions.attachments?, limit: ENV['LIMIT'].presence&.to_i,
+      attachments: OctadeskImportOptions.attachments?, limit: OctadeskImportOptions.limit,
       from_part: ENV['FROM_PART'].presence,
       form_address: ENV['FORM_ADDRESS'].presence, form_sender_name: ENV['FORM_SENDER_NAME'].presence
     )

--- a/lib/tasks/octadesk_import.rake
+++ b/lib/tasks/octadesk_import.rake
@@ -21,6 +21,10 @@
 module OctadeskImportOptions
   module_function
 
+  # Cast rather than `present?`: mirroring is hundreds of gigabytes, and `ATTACHMENTS=0`
+  # reads as "off" to whoever typed it and as "on" to a presence check.
+  def attachments? = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ATTACHMENTS', nil)).present?
+
   def printer(pacer, started)
     lambda do |event, payload|
       case event
@@ -63,14 +67,14 @@ namespace :octadesk do
     started = Time.zone.now
     run = Import::Octadesk::Backfill.new(
       inbox: inbox, zip_path: zip, pacer: pacer,
-      attachments: ENV['ATTACHMENTS'].present?, limit: ENV['LIMIT'].presence&.to_i,
+      attachments: OctadeskImportOptions.attachments?, limit: ENV['LIMIT'].presence&.to_i,
       from_part: ENV['FROM_PART'].presence,
       form_address: ENV['FORM_ADDRESS'].presence, form_sender_name: ENV['FORM_SENDER_NAME'].presence
     )
 
     puts "Inbox:   #{inbox.name} (##{inbox.id})  #{inbox.channel.email}"
     puts "Export:  #{File.basename(zip)}  (#{run.parts.size} partes)"
-    puts "Anexos:  #{ENV['ATTACHMENTS'].present? ? 'sim, espelhando para o S3' : 'nao'}"
+    puts "Anexos:  #{OctadeskImportOptions.attachments? ? 'sim, espelhando para o S3' : 'nao'}"
     puts '-' * 70
 
     run.perform(&OctadeskImportOptions.printer(pacer, started))

--- a/lib/tasks/octadesk_import.rake
+++ b/lib/tasks/octadesk_import.rake
@@ -12,7 +12,8 @@
 #   INBOX_ID          required
 #   ZIP               required, the *_ticket_ticket_*.zip
 #   ATTACHMENTS       1 to also mirror the attachments off the vendor bucket
-#   LIMIT             stop after this many tickets
+#   LIMIT             stop after this many newly imported tickets, so running again
+#                     continues rather than re-reading the same ones
 #   FROM_PART         resume from a part name, e.g. part_0007.json
 #   MAX_LOAD          pause while the host's 1-minute load is above this (default 2.5)
 #   FORM_ADDRESS      address the company's website form posts as, so the customer's own

--- a/lib/tasks/octadesk_import.rake
+++ b/lib/tasks/octadesk_import.rake
@@ -65,7 +65,8 @@ namespace :octadesk do
     zip = ENV.fetch('ZIP', nil)
     abort 'ERRO: defina ZIP com o caminho do *_ticket_ticket_*.zip' if zip.blank? || !File.exist?(zip)
 
-    pacer = Import::Email::Pacer.new(budget_mb: Float::INFINITY, max_load: ENV['MAX_LOAD'] || 2.5)
+    pacer = Import::Email::Pacer.new(budget_mb: Float::INFINITY,
+                                     max_load: Import::Options.decimal('MAX_LOAD', default: 2.5))
     started = Time.zone.now
     run = Import::Octadesk::Backfill.new(
       inbox: inbox, zip_path: zip, pacer: pacer,

--- a/lib/tasks/octadesk_import.rake
+++ b/lib/tasks/octadesk_import.rake
@@ -22,21 +22,10 @@
 module OctadeskImportOptions
   module_function
 
-  # Cast rather than `present?`: mirroring is hundreds of gigabytes, and `ATTACHMENTS=0`
-  # reads as "off" to whoever typed it and as "on" to a presence check.
-  def attachments? = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ATTACHMENTS', nil)).present?
-
-  # Strict for the same reason the IMAP task is: `to_i` turns a typo into zero, and a zero
-  # `LIMIT` stops at the first ticket while looking like a finished run.
-  def limit
-    raw = ENV['LIMIT'].presence
-    return if raw.nil?
-
-    value = Integer(raw, exception: false)
-    abort "ERRO: LIMIT deve ser um inteiro positivo, veio #{raw.inspect}" if value.nil? || !value.positive?
-
-    value
-  end
+  # Read strictly rather than cast: mirroring is hundreds of gigabytes, and every lenient
+  # reading of this setting errs towards spending them. See Import::Options.
+  def attachments? = Import::Options.boolean('ATTACHMENTS')
+  def limit = Import::Options.integer('LIMIT')
 
   def printer(pacer, started)
     lambda do |event, payload|

--- a/spec/enterprise/services/import/history_settlement_spec.rb
+++ b/spec/enterprise/services/import/history_settlement_spec.rb
@@ -46,6 +46,20 @@ describe Enterprise::Import::HistorySettlement do # rubocop:disable RSpec/SpecFi
     expect(company.reload.last_activity_at).to eq(Time.zone.parse('2026-01-01 09:00'))
   end
 
+  # The clock and the roll-up are two writes with nothing holding them together. A run that
+  # stops between them leaves the contact stamped and the company stale, and the retry
+  # finds a contact already reading the batch's newest date: if that skipped the pair, the
+  # company would never be asked for again.
+  it 'still rolls the company up when the contact clock already reads what it would write' do
+    at = Time.zone.parse('2023-05-01 10:00')
+    row = incoming(at)
+    contact.update_columns(last_activity_at: at) # rubocop:disable Rails/SkipsModelValidations
+    expect(company.reload.last_activity_at).to be_nil
+
+    settler.new.run([row])
+    expect(company.reload.last_activity_at).to eq(at)
+  end
+
   it 'leaves a contact with no company alone rather than raising' do
     contact.update!(company: nil)
     expect { settler.new.run([incoming(Time.zone.parse('2023-05-01 10:00'))]) }.not_to raise_error

--- a/spec/enterprise/services/import/history_settlement_spec.rb
+++ b/spec/enterprise/services/import/history_settlement_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+# The Enterprise half of the contact clock. `update_columns` skips the callback that rolls
+# a contact's activity up to its company, which is deliberate everywhere else -- the import
+# writes clocks without firing the machinery around them -- so the roll-up has to be asked
+# for, and asked for from the tree where Company exists.
+describe Enterprise::Import::HistorySettlement do # rubocop:disable RSpec/SpecFilePathFormat -- the subject is the OSS module this one is prepended into
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:company) { create(:company, account: account, domain: 'empresa.example.com') }
+  let(:contact) { create(:contact, account: account, company: company) }
+  let(:conversation) do
+    contact_inbox = create(:contact_inbox, contact: contact, inbox: inbox)
+    create(:conversation, account: account, inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+  end
+
+  let(:settler) do
+    Class.new do
+      include Import::HistorySettlement
+      attr_reader :opened
+
+      def initialize = @opened = Set.new
+      def announcing(&) = yield
+      def run(rows) = settle(rows, [])
+    end
+  end
+
+  def incoming(at)
+    Import::SilentWrite.wrap do
+      create(:message, account: account, inbox: inbox, conversation: conversation,
+                       message_type: :incoming, sender: contact, created_at: at,
+                       content_attributes: { imported: true })
+    end
+  end
+
+  it 'rolls the imported clock up to the company' do
+    settler.new.run([incoming(Time.zone.parse('2023-05-01 10:00'))])
+    expect(company.reload.last_activity_at).to eq(Time.zone.parse('2023-05-01 10:00'))
+  end
+
+  # A company somebody is talking to today keeps its clock; that is the company's own rule
+  # and history has no business overriding it.
+  it 'never drags a company backwards' do
+    company.update!(last_activity_at: Time.zone.parse('2026-01-01 09:00'))
+    settler.new.run([incoming(Time.zone.parse('2023-05-01 10:00'))])
+    expect(company.reload.last_activity_at).to eq(Time.zone.parse('2026-01-01 09:00'))
+  end
+
+  it 'leaves a contact with no company alone rather than raising' do
+    contact.update!(company: nil)
+    expect { settler.new.run([incoming(Time.zone.parse('2023-05-01 10:00'))]) }.not_to raise_error
+  end
+end

--- a/spec/enterprise/services/import/import_guards_spec.rb
+++ b/spec/enterprise/services/import/import_guards_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+# The Enterprise half of the guards. A Company is created as a side effect of importing a
+# contact with a business address, and its own callback fetches a favicon off the domain --
+# two models away from anything the OSS guards intercept, so neither the dispatcher guards
+# nor the two on Contact ever see it.
+describe 'ImportGuards' do
+  let(:account) { create(:account) }
+
+  it 'fetches a favicon for a company created outside an import, as it always has' do
+    expect { create(:company, account: account, domain: 'empresa.example.com') }
+      .to have_enqueued_job(Avatar::AvatarFromFaviconJob)
+  end
+
+  # One request per company at a third party that never agreed to it, over an archive that
+  # is a decade of mail.
+  it 'fetches none while writing an archive' do
+    expect { Import::SilentWrite.wrap { create(:company, account: account, domain: 'empresa.example.com') } }
+      .not_to have_enqueued_job(Avatar::AvatarFromFaviconJob)
+  end
+
+  it 'fetches one for a gap company, where it is one request like any arrival' do
+    expect { Import::SilentWrite.wrap(announce: true) { create(:company, account: account, domain: 'empresa.example.com') } }
+      .to have_enqueued_job(Avatar::AvatarFromFaviconJob)
+  end
+end

--- a/spec/enterprise/services/import/import_guards_spec.rb
+++ b/spec/enterprise/services/import/import_guards_spec.rb
@@ -23,4 +23,32 @@ describe 'ImportGuards' do
     expect { Import::SilentWrite.wrap(announce: true) { create(:company, account: account, domain: 'empresa.example.com') } }
       .to have_enqueued_job(Avatar::AvatarFromFaviconJob)
   end
+
+  # Transcription spends Captain credits per file. An archive of forwarded voice notes
+  # drains the balance transcribing conversations closed before the feature existed.
+  describe 'an audio attachment' do
+    let(:inbox) { create(:inbox, account: account) }
+    let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+
+    def attach_audio
+      message = create(:message, account: account, inbox: inbox, conversation: conversation)
+      attachment = message.attachments.new(account_id: account.id, file_type: :audio)
+      attachment.file.attach(io: StringIO.new('audio'), filename: 'nota.ogg', content_type: 'audio/ogg')
+      message.save!
+    end
+
+    def audio(**level) = Import::SilentWrite.wrap(**level) { attach_audio }
+
+    it 'is transcribed outside an import, as it always has been' do
+      expect { attach_audio }.to have_enqueued_job(Messages::AudioTranscriptionJob)
+    end
+
+    it 'is not transcribed while writing an archive' do
+      expect { audio }.not_to have_enqueued_job(Messages::AudioTranscriptionJob)
+    end
+
+    it 'is transcribed for a gap row, where it is one file like any arrival' do
+      expect { audio(announce: true) }.to have_enqueued_job(Messages::AudioTranscriptionJob)
+    end
+  end
 end

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -186,8 +186,8 @@ describe 'the import rake tasks' do
   end
 
   describe 'octadesk:import' do
-    let(:dir) { Dir.mktmpdir }
-    let(:zip_path) { File.join(dir, 'export.zip') }
+    # The same trap as the IMAP task: zero against a load average that is never zero means
+    # the run pauses and stands there with nothing on the screen but a pause.
     let(:ticket) do
       { 'Number' => 1, 'RequesterMail' => 'cliente@example.com',
         'DateCreation' => { '$date' => '2023-05-10T12:00:00Z' },
@@ -196,6 +196,10 @@ describe 'the import rake tasks' do
                              'Person' => { 'Type' => 0, 'Name' => 'Cliente' },
                              'DateCreation' => { '$date' => '2023-05-10T12:00:00Z' } }] }
     end
+    let(:zip_path) { File.join(dir, 'export.zip') }
+    let(:dir) { Dir.mktmpdir }
+
+    after { FileUtils.remove_entry(dir) }
 
     before do
       File.write(File.join(dir, 'part_0001.json'), [ticket].to_json)
@@ -203,7 +207,10 @@ describe 'the import rake tasks' do
       ENV['ZIP'] = zip_path
     end
 
-    after { FileUtils.remove_entry(dir) }
+    it 'refuses a MAX_LOAD it cannot read, the same as the IMAP task does' do
+      ENV['MAX_LOAD'] = 'muito'
+      expect { Rake::Task['octadesk:import'].invoke }.to raise_error(ArgumentError, /MAX_LOAD/)
+    end
 
     it 'imports the export and reports what it filed rather than only what it read' do
       expect { Rake::Task['octadesk:import'].invoke }.to output(/tickets\s+1/).to_stdout

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -198,6 +198,16 @@ describe 'the import rake tasks' do
         .to output(/PROJECAO GERAL \(PARCIAL\).*ORCAMENTO ESGOTADO.*Spam/m).to_stdout
     end
 
+    # A sample cut short is not a smaller sample, it is a different claim: the projection
+    # multiplies it out over the whole folder either way, so one large first message can end
+    # up describing a mailbox from a single result.
+    it 'marks a folder whose sample the budget cut short' do
+      allow(imap).to receive(:uid_search).and_return([1, 2, 3])
+      allow(ImapImportOptions).to receive(:sample_kinds).and_return([{ customer: 1 }, false])
+      expect { Rake::Task['imap:scan'].invoke }
+        .to output(/PROJECAO GERAL \(PARCIAL\).*amostra parcial/m).to_stdout
+    end
+
     it 'survives a server that answers the search with something other than an array' do
       esearch = Class.new do
         def initialize(uids) = @uids = uids

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -26,13 +26,37 @@ describe 'the import rake tasks' do
 
   after do
     %w[INBOX_ID ZIP LIMIT ATTACHMENTS KINDS FOLDERS MAX_LOAD BUDGET_MB RESET_CURSOR
-       SAMPLE FROM_PART FORM_ADDRESS FORM_SENDER_NAME IMAP_DISABLED_OK].each { |key| ENV.delete(key) }
+       SAMPLE FROM_PART FORM_ADDRESS FORM_SENDER_NAME IMAP_DISABLED_OK SINCE UNTIL].each { |key| ENV.delete(key) }
   end
 
   # `imap_enabled` is what stops Chatwoot polling a mailbox. A task that connects anyway is
   # spending credentials somebody turned off, and the settings behind a disabled channel are
   # nobody's job to keep current -- which arrives as a login error rather than as a line
   # saying what is wrong.
+  # An `ALL` search on an inbox the live job is also polling selects mail that arrived a
+  # minute ago. Filed here it is written silently, its conversation is born resolved, and the
+  # poller then skips the source id as already stored: a customer who wrote this morning is
+  # filed as history and never reaches an agent, with no error anywhere.
+  describe 'the line between a history import and a second poller' do
+    it 'stops before today unless told otherwise' do
+      expect(ImapImportOptions.terms).to eq(['ALL', 'BEFORE', Date.current.strftime('%d-%b-%Y')])
+    end
+
+    it 'keeps the cutoff beside SINCE rather than replacing it' do
+      ENV['SINCE'] = '01-Jan-2023'
+      expect(ImapImportOptions.terms).to eq(['SINCE', '01-Jan-2023', 'BEFORE', Date.current.strftime('%d-%b-%Y')])
+    end
+
+    it 'moves the line where the operator asks for it' do
+      ENV['UNTIL'] = '01-Jun-2024'
+      expect(ImapImportOptions.terms).to eq(%w[ALL BEFORE 01-Jun-2024])
+    end
+
+    it 'tells the operator where the line is' do
+      expect { Rake::Task['imap:import'].invoke }.to output(/Ate:\s+antes de/).to_stdout
+    end
+  end
+
   describe 'a channel whose IMAP integration is off' do
     let(:channel) { create(:channel_email, account: account) }
 

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -78,6 +78,14 @@ describe 'the import rake tasks' do
       expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /ATTACHMENTS/)
     end
 
+    # `Time.zone.parse` reads this as the year 1, which is a cutoff below every message in
+    # the mailbox: the setting `ATTACHMENTS=all`, arrived at by typo, and the whole provider
+    # budget spent on it.
+    it 'refuses an ambiguous date rather than reading it as some other date' do
+      ENV['ATTACHMENTS'] = '01/02/03'
+      expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /ATTACHMENTS/)
+    end
+
     it 'reports where a previous pass got to' do
       Import::Email::Cursor.new(channel).tap { |cursor| cursor.advance('INBOX', 7, 42) }.flush
       expect { Rake::Task['imap:import'].invoke }.to output(/Retoma:\s+INBOX>42/).to_stdout

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -184,6 +184,20 @@ describe 'the import rake tasks' do
       expect { Rake::Task['imap:scan'].invoke }.to raise_error(ArgumentError, /SAMPLE/)
     end
 
+    # The folder with the attachments is the one that exhausts the budget, and the one whose
+    # absence the total does not show: a projection built on the folders that fit is not a
+    # smaller projection, it is a wrong one.
+    it 'says which folders it never sampled rather than printing a table that looks whole' do
+      allow(imap).to receive(:list).and_return([Struct.new(:name, :attr).new('[Gmail]/Todos', [:All]),
+                                                Struct.new(:name, :attr).new('[Gmail]/Spam', [:Junk])])
+      spent = Import::Email::Pacer.new(budget_mb: 1, max_load: 99)
+      allow(Import::Email::Pacer).to receive(:new).and_return(spent)
+      allow(spent).to receive(:over_budget?).and_return(false, true)
+
+      expect { Rake::Task['imap:scan'].invoke }
+        .to output(/PROJECAO GERAL \(PARCIAL\).*ORCAMENTO ESGOTADO.*Spam/m).to_stdout
+    end
+
     it 'survives a server that answers the search with something other than an array' do
       esearch = Class.new do
         def initialize(uids) = @uids = uids

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -8,7 +8,9 @@ require 'rake'
 # rubocop:disable RSpec/DescribeClass -- the subject is two rake tasks, not a class
 describe 'the import rake tasks' do
   let(:account) { create(:account) }
-  let(:channel) { create(:channel_email, account: account) }
+  # The trait, not the bare factory: the tasks refuse a channel whose IMAP is off, which
+  # is what the bare factory builds.
+  let(:channel) { create(:channel_email, :imap_email, account: account) }
   let(:inbox) { channel.inbox }
   let(:imap) { instance_double(Net::IMAP) }
   let(:folder) { Struct.new(:name, :attr).new('INBOX', [:Hasnochildren]) }
@@ -24,7 +26,32 @@ describe 'the import rake tasks' do
 
   after do
     %w[INBOX_ID ZIP LIMIT ATTACHMENTS KINDS FOLDERS MAX_LOAD BUDGET_MB RESET_CURSOR
-       SAMPLE FROM_PART FORM_ADDRESS FORM_SENDER_NAME].each { |key| ENV.delete(key) }
+       SAMPLE FROM_PART FORM_ADDRESS FORM_SENDER_NAME IMAP_DISABLED_OK].each { |key| ENV.delete(key) }
+  end
+
+  # `imap_enabled` is what stops Chatwoot polling a mailbox. A task that connects anyway is
+  # spending credentials somebody turned off, and the settings behind a disabled channel are
+  # nobody's job to keep current -- which arrives as a login error rather than as a line
+  # saying what is wrong.
+  describe 'a channel whose IMAP integration is off' do
+    let(:channel) { create(:channel_email, account: account) }
+
+    it 'is refused by imap:import' do
+      expect { Rake::Task['imap:import'].invoke }.to raise_error(SystemExit)
+        .and output(/IMAP esta desligado/).to_stderr
+    end
+
+    it 'is refused by imap:scan too, which connects the same way' do
+      expect { Rake::Task['imap:scan'].invoke }.to raise_error(SystemExit)
+        .and output(/IMAP esta desligado/).to_stderr
+    end
+
+    # An archive inbox holds credentials on purpose and the live fetch job must stay away
+    # from the mailbox they open, or the history arrives twice.
+    it 'runs when the archive setup is stated out loud' do
+      ENV['IMAP_DISABLED_OK'] = '1'
+      expect { Rake::Task['imap:import'].invoke }.to output(/Retoma:/).to_stdout
+    end
   end
 
   describe 'imap:import' do

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -63,9 +63,31 @@ describe 'the import rake tasks' do
       expect(channel.reload.import_cursor).to eq({})
     end
 
+    # `RESET_CURSOR=0` reads as "off" to whoever typed it. Honoured as "on" it throws away
+    # the resume point on every invocation, and each pass re-walks the declined mail it had
+    # already got past.
+    it 'keeps the mark when the setting says not to reset' do
+      Import::Email::Cursor.new(channel).tap { |cursor| cursor.advance('INBOX', 7, 42) }.flush
+      ENV['RESET_CURSOR'] = '0'
+      expect { Rake::Task['imap:import'].invoke }.to output(/Retoma:\s+INBOX>42/).to_stdout
+      expect(channel.reload.import_cursor).to be_present
+    end
+
     it 'refuses a kind it cannot file rather than filing it backwards' do
       ENV['KINDS'] = 'customer,sent'
       expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /sent/)
+    end
+
+    it 'refuses a kind the classifier does not answer, rather than importing nothing' do
+      ENV['KINDS'] = 'customers'
+      expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /customers/)
+    end
+
+    # A setting somebody wrote on purpose that means nothing: the run would classify the
+    # whole mailbox, import none of it and report the folder finished.
+    it 'refuses an empty KINDS rather than defaulting around it' do
+      ENV['KINDS'] = ','
+      expect { Rake::Task['imap:import'].invoke }.to raise_error(SystemExit)
     end
   end
 

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -85,13 +85,35 @@ describe 'the import rake tasks' do
     %w[MAX_LOAD BUDGET_MB LIMIT].each do |key|
       it "refuses a #{key} that is not a number" do
         ENV[key] = 'muito'
-        expect { Rake::Task['imap:import'].invoke }.to raise_error(SystemExit)
+        expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /#{key}/)
       end
 
       it "refuses a #{key} of zero, which reads as a setting and means a stopped run" do
         ENV[key] = '0'
-        expect { Rake::Task['imap:import'].invoke }.to raise_error(SystemExit)
+        expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /#{key}/)
       end
+    end
+
+    # A count truncated to zero is worse than a rejected one: `LIMIT=0.5` would stop the run
+    # at the first message while looking like the operator asked for it.
+    it 'refuses a fractional LIMIT rather than truncating it' do
+      ENV['LIMIT'] = '0.5'
+      expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /LIMIT/)
+    end
+
+    # Rails' caster answers anything outside its own false list with true, `no` included, so
+    # a lenient reading throws the resume point away while doing the opposite of what was
+    # typed. `no` is a word an operator means, so it is honoured rather than refused.
+    it 'reads a RESET_CURSOR of no as no' do
+      Import::Email::Cursor.new(channel).tap { |cursor| cursor.advance('INBOX', 7, 42) }.flush
+      ENV['RESET_CURSOR'] = 'no'
+      expect { Rake::Task['imap:import'].invoke }.to output(/Retoma:\s+INBOX>42/).to_stdout
+      expect(channel.reload.import_cursor).to be_present
+    end
+
+    it 'refuses a RESET_CURSOR it cannot read rather than guessing' do
+      ENV['RESET_CURSOR'] = 'talvez'
+      expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /RESET_CURSOR/)
     end
 
     it 'refuses a kind the classifier does not answer, rather than importing nothing' do
@@ -117,7 +139,14 @@ describe 'the import rake tasks' do
     # and no `length`. The scan reads `length` on the line after the search.
     it 'refuses a SAMPLE that is not a number, which would otherwise read as zero' do
       ENV['SAMPLE'] = 'muito'
-      expect { Rake::Task['imap:scan'].invoke }.to raise_error(SystemExit)
+      expect { Rake::Task['imap:scan'].invoke }.to raise_error(ArgumentError, /SAMPLE/)
+    end
+
+    # `SAMPLE=0.5` truncates to zero at the call site and the scan classifies nothing while
+    # printing a finished projection.
+    it 'refuses a fractional SAMPLE rather than truncating it to nothing' do
+      ENV['SAMPLE'] = '0.5'
+      expect { Rake::Task['imap:scan'].invoke }.to raise_error(ArgumentError, /SAMPLE/)
     end
 
     it 'survives a server that answers the search with something other than an array' do

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -78,6 +78,22 @@ describe 'the import rake tasks' do
       expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /sent/)
     end
 
+    # `to_f` turns a typo into zero, and every one of these fails silently in the expensive
+    # direction when it is zero: no budget stops before importing anything, no load ceiling
+    # never finds room, so the run stands still forever against a host that always reports
+    # some load.
+    %w[MAX_LOAD BUDGET_MB LIMIT].each do |key|
+      it "refuses a #{key} that is not a number" do
+        ENV[key] = 'muito'
+        expect { Rake::Task['imap:import'].invoke }.to raise_error(SystemExit)
+      end
+
+      it "refuses a #{key} of zero, which reads as a setting and means a stopped run" do
+        ENV[key] = '0'
+        expect { Rake::Task['imap:import'].invoke }.to raise_error(SystemExit)
+      end
+    end
+
     it 'refuses a kind the classifier does not answer, rather than importing nothing' do
       ENV['KINDS'] = 'customers'
       expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /customers/)
@@ -99,6 +115,11 @@ describe 'the import rake tasks' do
 
     # net-imap 0.6 answers a rev2-capable server with an ESearchResult, which has `to_a`
     # and no `length`. The scan reads `length` on the line after the search.
+    it 'refuses a SAMPLE that is not a number, which would otherwise read as zero' do
+      ENV['SAMPLE'] = 'muito'
+      expect { Rake::Task['imap:scan'].invoke }.to raise_error(SystemExit)
+    end
+
     it 'survives a server that answers the search with something other than an array' do
       esearch = Class.new do
         def initialize(uids) = @uids = uids

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -38,13 +38,17 @@ describe 'the import rake tasks' do
   # poller then skips the source id as already stored: a customer who wrote this morning is
   # filed as history and never reaches an agent, with no error anywhere.
   describe 'the line between a history import and a second poller' do
-    it 'stops before today unless told otherwise' do
-      expect(ImapImportOptions.terms).to eq(['ALL', 'BEFORE', Date.current.strftime('%d-%b-%Y')])
+    # The poller searches from `today - interval` and the job passes 1, so it owns yesterday
+    # and today. Stopping before yesterday leaves no day both would read: nothing here is a
+    # lock or a unique index, so two writers on one message each pass their own existence
+    # check and it arrives twice, in two conversations.
+    it 'stops before the day the poller is already working' do
+      expect(ImapImportOptions.terms).to eq(['ALL', 'BEFORE', 1.day.ago.to_date.strftime('%d-%b-%Y')])
     end
 
     it 'keeps the cutoff beside SINCE rather than replacing it' do
       ENV['SINCE'] = '01-Jan-2023'
-      expect(ImapImportOptions.terms).to eq(['SINCE', '01-Jan-2023', 'BEFORE', Date.current.strftime('%d-%b-%Y')])
+      expect(ImapImportOptions.terms).to eq(['SINCE', '01-Jan-2023', 'BEFORE', 1.day.ago.to_date.strftime('%d-%b-%Y')])
     end
 
     it 'moves the line where the operator asks for it' do

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -249,6 +249,33 @@ describe 'the import rake tasks' do
 
   # The scan downloads each sampled message whole, so the cap is a byte budget and not a
   # preference.
+  # The scan pulls whole bodies to classify them, so the first message it cannot afford is
+  # the one that would have crossed the provider's limit. `over_budget?` only ever answers
+  # for bytes already on the wire.
+  describe 'ImapImportOptions.sample_kind' do
+    let(:tight) { Import::Email::Pacer.new(budget_mb: 1, max_load: 99) }
+    let(:imap) { instance_double(Net::IMAP) }
+
+    it 'refuses a message larger than what is left, without downloading it' do
+      allow(imap).to receive(:uid_fetch).with(7, 'RFC822.SIZE')
+                                        .and_return([Struct.new(:attr).new({ 'RFC822.SIZE' => 5.megabytes })])
+
+      expect(ImapImportOptions.sample_kind(imap, nil, 7, tight)).to be_nil
+      expect(imap).not_to have_received(:uid_fetch).with(7, 'BODY.PEEK[]')
+    end
+
+    # Counting the refusal as a result would let a sample the budget cut short report itself
+    # as the sample that was asked for, and the projection multiplies it out either way.
+    it 'ends the sample there rather than counting it as a result' do
+      allow(ImapImportOptions).to receive(:sample_kind).and_return(:customer, nil, :customer)
+
+      kinds, whole = ImapImportOptions.sample_kinds(imap, nil, [1, 2, 3], 3, tight)
+
+      expect(kinds).to eq({ customer: 1 })
+      expect(whole).to be(false)
+    end
+  end
+
   describe 'ImapImportOptions.spread' do
     it 'takes everything when the folder is smaller than the sample' do
       expect(ImapImportOptions.spread((1..10).to_a, 400).length).to eq(10)

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+require 'rake'
+
+# The tasks are the entry point, and only the services behind them were covered. Two bugs
+# shipped in this call path at once -- reading the run's cursor before the run existed, and
+# handing an already-built policy back to its own builder -- and no service spec could see
+# either. These invoke the tasks the way an operator does.
+# rubocop:disable RSpec/DescribeClass -- the subject is two rake tasks, not a class
+describe 'the import rake tasks' do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, account: account) }
+  let(:inbox) { channel.inbox }
+  let(:imap) { instance_double(Net::IMAP) }
+  let(:folder) { Struct.new(:name, :attr).new('INBOX', [:Hasnochildren]) }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task.tasks.each(&:reenable)
+    ENV['INBOX_ID'] = inbox.id.to_s
+    allow(Net::IMAP).to receive(:new).and_return(imap)
+    allow(imap).to receive_messages(authenticate: nil, list: [folder], examine: nil,
+                                    responses: 7, uid_search: [], logout: nil)
+  end
+
+  after do
+    %w[INBOX_ID ZIP LIMIT ATTACHMENTS KINDS FOLDERS MAX_LOAD BUDGET_MB RESET_CURSOR
+       SAMPLE FROM_PART FORM_ADDRESS FORM_SENDER_NAME].each { |key| ENV.delete(key) }
+  end
+
+  describe 'imap:import' do
+    it 'runs with nothing but the inbox, which is the documented first call' do
+      expect { Rake::Task['imap:import'].invoke }.to output(/Retoma:\s+do inicio/).to_stdout
+    end
+
+    it 'takes no attachments by default, which is what keeps a first pass inside the budget' do
+      expect { Rake::Task['imap:import'].invoke }.to output(/Anexos:\s+nenhum/).to_stdout
+    end
+
+    it 'accepts a cutoff date' do
+      ENV['ATTACHMENTS'] = '2024-01-01'
+      expect { Rake::Task['imap:import'].invoke }.to output(/Anexos:\s+a partir de 2024-01-01/).to_stdout
+    end
+
+    it 'accepts all of them' do
+      ENV['ATTACHMENTS'] = 'all'
+      expect { Rake::Task['imap:import'].invoke }.to output(/Anexos:\s+todos/).to_stdout
+    end
+
+    it 'stops on a setting it cannot read rather than quietly taking none' do
+      ENV['ATTACHMENTS'] = 'quinta-feira'
+      expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /ATTACHMENTS/)
+    end
+
+    it 'reports where a previous pass got to' do
+      Import::Email::Cursor.new(channel).tap { |cursor| cursor.advance('INBOX', 7, 42) }.flush
+      expect { Rake::Task['imap:import'].invoke }.to output(/Retoma:\s+INBOX>42/).to_stdout
+    end
+
+    it 'forgets that mark when asked' do
+      Import::Email::Cursor.new(channel).tap { |cursor| cursor.advance('INBOX', 7, 42) }.flush
+      ENV['RESET_CURSOR'] = '1'
+      expect { Rake::Task['imap:import'].invoke }.to output(/Retoma:\s+do inicio/).to_stdout
+      expect(channel.reload.import_cursor).to eq({})
+    end
+
+    it 'refuses a kind it cannot file rather than filing it backwards' do
+      ENV['KINDS'] = 'customer,sent'
+      expect { Rake::Task['imap:import'].invoke }.to raise_error(ArgumentError, /sent/)
+    end
+  end
+
+  describe 'imap:scan' do
+    it 'reports a projection and writes nothing' do
+      expect { Rake::Task['imap:scan'].invoke }.to output(/PROJECAO GERAL/).to_stdout
+      expect(inbox.messages.count).to eq(0)
+    end
+  end
+
+  describe 'octadesk:import' do
+    let(:dir) { Dir.mktmpdir }
+    let(:zip_path) { File.join(dir, 'export.zip') }
+    let(:ticket) do
+      { 'Number' => 1, 'RequesterMail' => 'cliente@example.com',
+        'DateCreation' => { '$date' => '2023-05-10T12:00:00Z' },
+        'Interactions' => [{ '_id' => { '$binary' => { 'base64' => 'AAAAAAAAAAAAAAAA' } },
+                             'Comments' => [{ 'Content' => 'Mensagem do ticket' }],
+                             'Person' => { 'Type' => 0, 'Name' => 'Cliente' },
+                             'DateCreation' => { '$date' => '2023-05-10T12:00:00Z' } }] }
+    end
+
+    before do
+      File.write(File.join(dir, 'part_0001.json'), [ticket].to_json)
+      system('zip', '-jq', zip_path, File.join(dir, 'part_0001.json'), exception: true)
+      ENV['ZIP'] = zip_path
+    end
+
+    after { FileUtils.remove_entry(dir) }
+
+    it 'imports the export and reports what it filed rather than only what it read' do
+      expect { Rake::Task['octadesk:import'].invoke }.to output(/tickets\s+1/).to_stdout
+      expect(inbox.conversations.count).to eq(1)
+    end
+
+    it 'mirrors no attachments unless asked' do
+      expect { Rake::Task['octadesk:import'].invoke }.to output(/Anexos:\s+nao/).to_stdout
+    end
+
+    # A presence check reads "0" as present, and the difference is hundreds of gigabytes.
+    it 'reads a false value as off' do
+      ENV['ATTACHMENTS'] = '0'
+      expect { Rake::Task['octadesk:import'].invoke }.to output(/Anexos:\s+nao/).to_stdout
+    end
+
+    it 'reads 1 as on' do
+      ENV['ATTACHMENTS'] = '1'
+      expect { Rake::Task['octadesk:import'].invoke }.to output(/Anexos:\s+sim/).to_stdout
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/tasks/import/import_tasks_spec.rb
+++ b/spec/lib/tasks/import/import_tasks_spec.rb
@@ -96,6 +96,43 @@ describe 'the import rake tasks' do
       expect { Rake::Task['imap:scan'].invoke }.to output(/PROJECAO GERAL/).to_stdout
       expect(inbox.messages.count).to eq(0)
     end
+
+    # net-imap 0.6 answers a rev2-capable server with an ESearchResult, which has `to_a`
+    # and no `length`. The scan reads `length` on the line after the search.
+    it 'survives a server that answers the search with something other than an array' do
+      esearch = Class.new do
+        def initialize(uids) = @uids = uids
+        def to_a = @uids
+        def each(&) = @uids.each(&)
+      end
+      allow(imap).to receive(:uid_search).and_return(esearch.new([]))
+      expect { Rake::Task['imap:scan'].invoke }.to output(/PROJECAO GERAL/).to_stdout
+    end
+  end
+
+  # The scan downloads each sampled message whole, so the cap is a byte budget and not a
+  # preference.
+  describe 'ImapImportOptions.spread' do
+    it 'takes everything when the folder is smaller than the sample' do
+      expect(ImapImportOptions.spread((1..10).to_a, 400).length).to eq(10)
+    end
+
+    # Integer division makes the stride 1 for any folder between sample+1 and 2*sample-1,
+    # so `SAMPLE=400` over 799 messages downloaded 799 of them.
+    it 'never takes more than the sample it was given' do
+      expect(ImapImportOptions.spread((1..799).to_a, 400).length).to eq(400)
+    end
+
+    it 'picks no uid twice' do
+      picked = ImapImportOptions.spread((1..799).to_a, 400)
+      expect(picked.uniq.length).to eq(picked.length)
+    end
+
+    it 'spreads them across the folder rather than taking the head' do
+      picked = ImapImportOptions.spread((1..10_000).to_a, 10)
+      expect(picked.first).to eq(1)
+      expect(picked.last).to be > 9000
+    end
   end
 
   describe 'octadesk:import' do

--- a/spec/services/import/email/attachment_policy_spec.rb
+++ b/spec/services/import/email/attachment_policy_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe Import::Email::AttachmentPolicy do
+  describe '.build' do
+    it 'reads a missing value as none, which is the documented default' do
+      expect(described_class.build(nil)).to be_none
+      expect(described_class.build('')).to be_none
+    end
+
+    it 'reads the two spelled-out states' do
+      expect(described_class.build('all')).to be_all
+      expect(described_class.build(:all)).to be_all
+      expect(described_class.build('none')).to be_none
+    end
+
+    it 'reads a time as a cutoff' do
+      policy = described_class.build(Time.zone.parse('2024-01-01'))
+      expect(policy).not_to be_all
+      expect(policy).not_to be_none
+    end
+
+    it 'refuses a value it cannot read rather than falling back' do
+      expect { described_class.build('sim') }.to raise_error(ArgumentError, /must be :none, :all or a time/)
+    end
+  end
+
+  describe '#skip?' do
+    it 'skips everything by default, so a first pass costs no attachment bytes' do
+      policy = described_class.build(nil)
+      expect(policy.skip?(Time.zone.parse('2025-06-01'))).to be(true)
+      expect(policy.skip?(nil)).to be(true)
+    end
+
+    it 'skips nothing when told to take them all' do
+      policy = described_class.build('all')
+      expect(policy.skip?(Time.zone.parse('2020-01-01'))).to be(false)
+      expect(policy.skip?(nil)).to be(false)
+    end
+
+    it 'takes what is newer than the cutoff and leaves what is older' do
+      policy = described_class.build(Time.zone.parse('2024-01-01'))
+      expect(policy.skip?(Time.zone.parse('2023-06-01'))).to be(true)
+      expect(policy.skip?(Time.zone.parse('2025-06-01'))).to be(false)
+    end
+
+    it 'treats an unknown date as out of scope under a cutoff' do
+      expect(described_class.build(Time.zone.parse('2024-01-01')).skip?(nil)).to be(true)
+    end
+  end
+end

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -130,6 +130,27 @@ describe Import::Email::Backfill do
     end
   end
 
+  # net-imap 0.6 answers a rev2-capable server with an ESearchResult rather than an Array.
+  # It carries `each` and `to_a` and none of `length`, `select` or `each_slice`, so the walk
+  # breaks at the progress line, before it can report anything.
+  describe 'a server that answers the search with something other than an array' do
+    let(:run) { described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer) }
+    let(:esearch) do
+      Class.new do
+        def initialize(uids) = @uids = uids
+        def to_a = @uids
+        def each(&) = @uids.each(&)
+      end
+    end
+
+    it 'walks it the same as an array' do
+      imap = instance_double(Net::IMAP, list: [Struct.new(:name, :attr).new('INBOX', [:Hasnochildren])],
+                                        examine: nil, responses: 7, uid_search: esearch.new([10, 11]), logout: nil)
+      allow(run).to receive_messages(connect: imap, unstored: [], close: nil)
+      expect { run.perform }.not_to raise_error
+    end
+  end
+
   # A message that raised is not settled. Marked as read it would be skipped by every later
   # pass, so a timeout or a malformed part would quietly cost a message forever.
   describe 'how far the cursor is allowed to move' do

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -176,6 +176,28 @@ describe Import::Email::Backfill do
     end
   end
 
+  # The importer buffers a settlement at a time and something has to say when a run of them
+  # is a batch. Wired here rather than asserted on the buffer, because what the buffer needs
+  # is that somebody empties it.
+  describe 'emptying what the importer owes the index' do
+    let(:run) { described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer) }
+    let(:importer) { run.send(:instance_variable_get, :@importer) }
+
+    it 'empties it at the batch boundary the walk already has' do
+      imap = instance_double(Net::IMAP, uid_fetch: [])
+      expect(importer).to receive(:flush_search_index).at_least(:once)
+      run.send(:walk, imap, [10, 11])
+    end
+
+    # An interrupted run leaves at most one batch buffered; a run that ends normally must
+    # leave none, or the tail is missing from the index with nothing to say so.
+    it 'empties it when the run ends, whatever ended it' do
+      allow(run).to receive(:connect).and_raise(Net::IMAP::Error)
+      expect(importer).to receive(:flush_search_index)
+      expect { run.perform }.to raise_error(Net::IMAP::Error)
+    end
+  end
+
   # A message that raised is not settled. Marked as read it would be skipped by every later
   # pass, so a timeout or a malformed part would quietly cost a message forever.
   describe 'how far the cursor is allowed to move' do

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -176,6 +176,50 @@ describe Import::Email::Backfill do
     end
   end
 
+  # `BODY.PEEK[]` pulls the encoded attachments along with the words, which is the download
+  # the cutoff exists to refuse. A message that is nothing but attachments has no text part
+  # to name, and falling back to the whole message there fetches every file the policy just
+  # excluded and then discards them -- on exactly the messages where the fallback is the
+  # entire message.
+  describe 'a message under the cutoff whose structure names no text part' do
+    let(:run) { described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer) }
+    let(:leaf) do
+      Struct.new(:media_type, :subtype, :encoding, :param, :disposition, :size, keyword_init: true) # rubocop:disable Lint/StructNewOverride
+    end
+    let(:structure) do
+      Struct.new(:subtype, :parts, keyword_init: true) do
+        def media_type = 'MULTIPART'
+        def encoding = nil
+        def param = nil
+        def disposition = nil
+        def size = 0
+      end.new(subtype: 'MIXED',
+              parts: [leaf.new(media_type: 'IMAGE', subtype: 'PNG', encoding: 'BASE64', param: {},
+                               disposition: Struct.new(:dsp_type, :param).new('ATTACHMENT'), size: 3_000_000)])
+    end
+    let(:header) do
+      "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: fotos\r\n" \
+        "Message-ID: <so-anexo@example.com>\r\nDate: #{Time.zone.parse('2023-05-01 10:00').rfc2822}\r\n"
+    end
+    let(:meta) { Struct.new(:attr).new({ 'BODY[HEADER]' => header, 'BODYSTRUCTURE' => structure }) }
+
+    it 'files it from the header rather than downloading what it will not keep' do
+      imap = instance_double(Net::IMAP)
+      allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE']).and_return([meta])
+
+      expect(run.send(:fetch, imap, 10)).to include('so-anexo@example.com')
+      expect(imap).not_to have_received(:uid_fetch).with(10, 'BODY.PEEK[]')
+    end
+
+    it 'records it as a row still owed its attachments' do
+      imap = instance_double(Net::IMAP)
+      allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE']).and_return([meta])
+
+      run.send(:fetch, imap, 10)
+      expect(run.stats[:sem_anexos]).to eq(1)
+    end
+  end
+
   # The importer buffers a settlement at a time and something has to say when a run of them
   # is a batch. Wired here rather than asserted on the buffer, because what the buffer needs
   # is that somebody empties it.

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -198,13 +198,33 @@ describe Import::Email::Backfill do
     header = "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: com foto\r\n" \
              "Message-ID: <foto@example.com>\r\nDate: #{Time.zone.parse('2023-05-01 10:00').rfc2822}\r\n"
     imap = instance_double(Net::IMAP)
-    allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE'])
-                                      .and_return([Struct.new(:attr).new({ 'BODY[HEADER]' => header, 'BODYSTRUCTURE' => structure })])
+    allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE', 'RFC822.SIZE'])
+                                      .and_return([Struct.new(:attr).new({ 'BODY[HEADER]' => header, 'BODYSTRUCTURE' => structure,
+                                                                           'RFC822.SIZE' => 3_100_000 })])
     allow(imap).to receive(:uid_fetch).with(10, 'BODY.PEEK[1]')
                                       .and_return([Struct.new(:attr).new({ 'BODY[1]' => 'Segue a foto do ingresso que comprei ontem.' })])
 
     expect(run.send(:handle, imap, 10)).to be(true)
     expect(run.stats[:sem_anexos]).to eq(1)
+  end
+
+  # A refused message is not a settled one. Marked as read it would be skipped by every
+  # later pass, so the run that could not afford it is the run that has to leave its mark
+  # below it -- and end there, because ending a pass is what the budget is for.
+  it 'ends the pass below a message it cannot afford, without settling it' do
+    tight = Import::Email::Pacer.new(budget_mb: 1, max_load: 99)
+    run = described_class.new(inbox: inbox, kinds: [:customer], pacer: tight, attachments: :all)
+    run.instance_variable_set(:@progress, ->(*) {})
+    header = "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: gigante\r\n" \
+             "Message-ID: <gigante@example.com>\r\nDate: #{Time.zone.parse('2023-05-01 10:00').rfc2822}\r\n"
+    imap = instance_double(Net::IMAP)
+    allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE', 'RFC822.SIZE'])
+                                      .and_return([Struct.new(:attr).new({ 'BODY[HEADER]' => header, 'BODYSTRUCTURE' => nil,
+                                                                           'RFC822.SIZE' => 5.megabytes })])
+
+    expect(run.send(:handle, imap, 10)).to be(false)
+    expect(run.stopped_by).to eq(:orcamento)
+    expect(imap).not_to have_received(:uid_fetch).with(10, 'BODY.PEEK[]')
   end
 
   # A mark only means anything against the question that produced it, and the question is

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -22,6 +22,18 @@ describe Import::Email::Backfill do
     it 'accepts the ordinary case' do
       expect { described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer) }.not_to raise_error
     end
+
+    # A typo matches nothing, imports nothing, and advances the cursor over the whole
+    # mailbox while the task reports it finished.
+    it 'refuses a kind the classifier does not answer' do
+      expect { described_class.new(inbox: inbox, kinds: %i[customer customers], pacer: pacer) }
+        .to raise_error(ArgumentError, /customers/)
+    end
+
+    # `imap:scan` classifies everything and imports none of it.
+    it 'accepts no kinds at all, which is what a scan asks for' do
+      expect { described_class.new(inbox: inbox, kinds: [], pacer: pacer) }.not_to raise_error
+    end
   end
 
   describe 'choosing folders' do

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+describe Import::Email::Backfill do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, account: account) }
+  let(:inbox) { channel.inbox }
+  let(:pacer) { Import::Email::Pacer.new(budget_mb: Float::INFINITY, max_load: 99) }
+
+  # `sent` and `relay` are recognised so a scan can count them, and refused so a run cannot
+  # file them: both would go through the incoming-only pipeline and come out backwards.
+  describe 'the kinds a run may not take' do
+    it 'refuses the mailbox own outgoing mail' do
+      expect { described_class.new(inbox: inbox, kinds: %i[customer sent], pacer: pacer) }
+        .to raise_error(ArgumentError, /sent/)
+    end
+
+    it 'refuses the ticketing system relay notifications' do
+      expect { described_class.new(inbox: inbox, kinds: [:relay], pacer: pacer) }
+        .to raise_error(ArgumentError, /relay/)
+    end
+
+    it 'accepts the ordinary case' do
+      expect { described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer) }.not_to raise_error
+    end
+  end
+
+  describe 'choosing folders' do
+    let(:run) { described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer) }
+    let(:listed) { Struct.new(:name, :attr) }
+
+    it 'walks the all-mail folder plus spam when the server advertises them' do
+      imap = instance_double(Net::IMAP, list: [listed.new('[Gmail]/Todos', [:All]), listed.new('[Gmail]/Spam', [:Junk])])
+      expect(run.folders(imap)).to eq(['[Gmail]/Todos', '[Gmail]/Spam'])
+    end
+
+    # Without the fallback a perfectly valid channel scans nothing, or scans only spam,
+    # which looks like it worked.
+    it 'falls back to INBOX on a server that advertises no special use' do
+      imap = instance_double(Net::IMAP, list: [listed.new('INBOX', [:Hasnochildren])])
+      expect(run.folders(imap)).to eq(['INBOX'])
+    end
+
+    it 'keeps spam beside INBOX rather than letting it stand in for the mail folder' do
+      imap = instance_double(Net::IMAP, list: [listed.new('Junk', [:Junk])])
+      expect(run.folders(imap)).to eq(%w[INBOX Junk])
+    end
+  end
+
+  # Every pass re-walks the folder and asks what the inbox already holds. One query per
+  # header is a round trip per message for the life of the import.
+  describe 'skipping what the inbox already holds' do
+    let(:run) { described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer) }
+    let(:stored_id) { 'ja-tenho@example.com' }
+    let(:fetched) do
+      [
+        Struct.new(:attr).new({ 'UID' => 10, 'BODY[HEADER.FIELDS (MESSAGE-ID)]' => "Message-ID: <#{stored_id}>\r\n" }),
+        Struct.new(:attr).new({ 'UID' => 11, 'BODY[HEADER.FIELDS (MESSAGE-ID)]' => "Message-ID: <novo@example.com>\r\n" }),
+        Struct.new(:attr).new({ 'UID' => 12, 'BODY[HEADER.FIELDS (MESSAGE-ID)]' => "Subject: sem id\r\n" })
+      ]
+    end
+
+    before do
+      conversation = create(:conversation, account: account, inbox: inbox)
+      create(:message, account: account, inbox: inbox, conversation: conversation, source_id: stored_id)
+    end
+
+    it 'returns only the uids it still has to fetch' do
+      imap = instance_double(Net::IMAP, uid_fetch: fetched)
+      expect(run.send(:unstored, imap, [10, 11, 12])).to eq([11])
+    end
+
+    it 'asks the database once for the whole batch' do
+      imap = instance_double(Net::IMAP, uid_fetch: fetched)
+      queries = 0
+      subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+        queries += 1 if payload[:sql].include?('messages') && payload[:name].to_s.exclude?('SCHEMA')
+      end
+      run.send(:unstored, imap, [10, 11, 12])
+      ActiveSupport::Notifications.unsubscribe(subscription)
+      expect(queries).to eq(1)
+    end
+
+    it 'counts what it skipped and why' do
+      imap = instance_double(Net::IMAP, uid_fetch: fetched)
+      run.send(:unstored, imap, [10, 11, 12])
+      expect(run.stats).to include(ja_importadas: 1, sem_message_id: 1)
+    end
+  end
+end

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -86,4 +86,34 @@ describe Import::Email::Backfill do
       expect(run.stats).to include(ja_importadas: 1, sem_message_id: 1)
     end
   end
+
+  # A message that raised is not settled. Marked as read it would be skipped by every later
+  # pass, so a timeout or a malformed part would quietly cost a message forever.
+  describe 'how far the cursor is allowed to move' do
+    let(:run) { described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer) }
+
+    before do
+      run.instance_variable_set(:@folder, 'INBOX')
+      run.instance_variable_set(:@uidvalidity, 7)
+    end
+
+    it 'marks the whole batch when every message was settled' do
+      allow(run).to receive_messages(unstored: [10, 11, 12], handle: true)
+      run.send(:walk, instance_double(Net::IMAP), [10, 11, 12])
+      expect(channel.reload.import_cursor.dig('INBOX', 'uid')).to eq(12)
+    end
+
+    it 'stops the mark below the first message it could not settle' do
+      allow(run).to receive(:unstored).and_return([10, 11, 12])
+      allow(run).to receive(:handle).and_return(true, false, true)
+      run.send(:walk, instance_double(Net::IMAP), [10, 11, 12])
+      expect(channel.reload.import_cursor.dig('INBOX', 'uid')).to eq(10)
+    end
+
+    it 'writes no mark at all when the first message already failed' do
+      allow(run).to receive_messages(unstored: [10, 11], handle: false)
+      run.send(:walk, instance_double(Net::IMAP), [10, 11])
+      expect(channel.reload.import_cursor).to eq({})
+    end
+  end
 end

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -176,6 +176,37 @@ describe Import::Email::Backfill do
     end
   end
 
+  # The download is a collaborator now, and its own spec builds it by hand with a hash that
+  # is certainly there. What no spec of that class can see is whether the walker handed it
+  # the run's own tallies, so this exercises the wiring on the path the default setting
+  # takes: every message carrying an attachment goes through it.
+  it 'counts a lean fetch into the tallies the run reports' do
+    run = described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer)
+    run.instance_variable_set(:@progress, ->(*) {}) # `perform` sets this; `handle` is called here on its own
+    leaf = Struct.new(:media_type, :subtype, :encoding, :param, :disposition, :size, keyword_init: true) # rubocop:disable Lint/StructNewOverride
+    structure = Struct.new(:subtype, :parts, keyword_init: true) do
+      def media_type = 'MULTIPART'
+      def encoding = nil
+      def param = nil
+      def disposition = nil
+      def size = 0
+    end.new(subtype: 'MIXED',
+            parts: [leaf.new(media_type: 'TEXT', subtype: 'PLAIN', encoding: '7BIT',
+                             param: { 'CHARSET' => 'UTF-8' }, disposition: nil, size: 900),
+                    leaf.new(media_type: 'IMAGE', subtype: 'PNG', encoding: 'BASE64', param: {},
+                             disposition: Struct.new(:dsp_type, :param).new('ATTACHMENT'), size: 3_000_000)])
+    header = "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: com foto\r\n" \
+             "Message-ID: <foto@example.com>\r\nDate: #{Time.zone.parse('2023-05-01 10:00').rfc2822}\r\n"
+    imap = instance_double(Net::IMAP)
+    allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE'])
+                                      .and_return([Struct.new(:attr).new({ 'BODY[HEADER]' => header, 'BODYSTRUCTURE' => structure })])
+    allow(imap).to receive(:uid_fetch).with(10, 'BODY.PEEK[1]')
+                                      .and_return([Struct.new(:attr).new({ 'BODY[1]' => 'Segue a foto do ingresso que comprei ontem.' })])
+
+    expect(run.send(:handle, imap, 10)).to be(true)
+    expect(run.stats[:sem_anexos]).to eq(1)
+  end
+
   # A mark only means anything against the question that produced it, and the question is
   # narrower than the search terms.
   describe 'what invalidates a stored mark' do

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -85,6 +85,27 @@ describe Import::Email::Backfill do
       run.send(:unstored, imap, [10, 11, 12])
       expect(run.stats).to include(ja_importadas: 1, sem_message_id: 1)
     end
+
+    # "Stored" and "nothing left to do" are the same question only under the default. A row
+    # filed without its attachments is stored and incomplete, and skipping it here is what
+    # would put the attachments out of reach of every later pass.
+    describe 'a row a narrower pass filed without its attachments' do
+      before do
+        inbox.messages.find_by(source_id: stored_id)
+             .update!(content_attributes: { imported: true, imported_text_only: true })
+      end
+
+      it 'is still done when the run is not asking for attachments' do
+        imap = instance_double(Net::IMAP, uid_fetch: fetched)
+        expect(run.send(:unstored, imap, [10, 11, 12])).to eq([11])
+      end
+
+      it 'is work again when the run widens the cutoff' do
+        widened = described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer, attachments: :all)
+        imap = instance_double(Net::IMAP, uid_fetch: fetched)
+        expect(widened.send(:unstored, imap, [10, 11, 12])).to eq([10, 11])
+      end
+    end
   end
 
   # A message that raised is not settled. Marked as read it would be skipped by every later

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -158,5 +158,16 @@ describe Import::Email::Backfill do
       run.send(:walk, instance_double(Net::IMAP), [10, 11])
       expect(channel.reload.import_cursor).to eq({})
     end
+
+    # The run carries on past a message it could not settle, and the batches after it are
+    # above the failure. Letting them advance buries the very uid the freeze exists to keep
+    # reachable, and every later pass then starts above it.
+    it 'keeps the mark frozen for the rest of the folder once a batch has failed' do
+      stub_const("#{described_class}::HEADER_BATCH", 2)
+      allow(run).to receive(:unstored) { |_, batch| batch }
+      allow(run).to receive(:handle).and_return(true, false, true, true)
+      run.send(:walk, instance_double(Net::IMAP), [10, 11, 12, 13])
+      expect(channel.reload.import_cursor.dig('INBOX', 'uid')).to eq(10)
+    end
   end
 end

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -107,6 +107,15 @@ describe Import::Email::Backfill do
              .update!(content_attributes: { imported: true, imported_text_only: true })
       end
 
+      def stored_row_dated(at)
+        inbox.messages.find_by(source_id: stored_id).update_column(:created_at, at) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      def from_2024
+        described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer,
+                            attachments: Time.zone.parse('2024-01-01'))
+      end
+
       it 'is still done when the run is not asking for attachments' do
         imap = instance_double(Net::IMAP, uid_fetch: fetched)
         expect(run.send(:unstored, imap, [10, 11, 12])).to eq([11])
@@ -116,6 +125,22 @@ describe Import::Email::Backfill do
         widened = described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer, attachments: :all)
         imap = instance_double(Net::IMAP, uid_fetch: fetched)
         expect(widened.send(:unstored, imap, [10, 11, 12])).to eq([10, 11])
+      end
+
+      # A cutoff is not `all`. An incomplete row below it is not work -- the importer
+      # declines it at `skip_attachments?` -- so re-offering it buys nothing and costs a
+      # full re-fetch of the message, on a run the byte budget is what ends. A decade of a
+      # support mailbox sits below any cutoff worth setting.
+      it 'stays done under a cutoff it sits below' do
+        stored_row_dated(Time.zone.parse('2020-01-01'))
+        imap = instance_double(Net::IMAP, uid_fetch: fetched)
+        expect(from_2024.send(:unstored, imap, [10, 11, 12])).to eq([11])
+      end
+
+      it 'is work again when it sits above the cutoff' do
+        stored_row_dated(Time.zone.parse('2025-06-01'))
+        imap = instance_double(Net::IMAP, uid_fetch: fetched)
+        expect(from_2024.send(:unstored, imap, [10, 11, 12])).to eq([10, 11])
       end
 
       # `unstored` never runs on a uid the cursor filtered out first, so letting the row

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -176,47 +176,44 @@ describe Import::Email::Backfill do
     end
   end
 
-  # `BODY.PEEK[]` pulls the encoded attachments along with the words, which is the download
-  # the cutoff exists to refuse. A message that is nothing but attachments has no text part
-  # to name, and falling back to the whole message there fetches every file the policy just
-  # excluded and then discards them -- on exactly the messages where the fallback is the
-  # entire message.
-  describe 'a message under the cutoff whose structure names no text part' do
-    let(:run) { described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer) }
-    let(:leaf) do
-      Struct.new(:media_type, :subtype, :encoding, :param, :disposition, :size, keyword_init: true) # rubocop:disable Lint/StructNewOverride
-    end
-    let(:structure) do
-      Struct.new(:subtype, :parts, keyword_init: true) do
-        def media_type = 'MULTIPART'
-        def encoding = nil
-        def param = nil
-        def disposition = nil
-        def size = 0
-      end.new(subtype: 'MIXED',
-              parts: [leaf.new(media_type: 'IMAGE', subtype: 'PNG', encoding: 'BASE64', param: {},
-                               disposition: Struct.new(:dsp_type, :param).new('ATTACHMENT'), size: 3_000_000)])
-    end
-    let(:header) do
-      "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: fotos\r\n" \
-        "Message-ID: <so-anexo@example.com>\r\nDate: #{Time.zone.parse('2023-05-01 10:00').rfc2822}\r\n"
-    end
-    let(:meta) { Struct.new(:attr).new({ 'BODY[HEADER]' => header, 'BODYSTRUCTURE' => structure }) }
-
-    it 'files it from the header rather than downloading what it will not keep' do
-      imap = instance_double(Net::IMAP)
-      allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE']).and_return([meta])
-
-      expect(run.send(:fetch, imap, 10)).to include('so-anexo@example.com')
-      expect(imap).not_to have_received(:uid_fetch).with(10, 'BODY.PEEK[]')
+  # A mark only means anything against the question that produced it, and the question is
+  # narrower than the search terms.
+  describe 'what invalidates a stored mark' do
+    def mark(**)
+      run = described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer, **)
+      run.cursor.advance('INBOX', 9, 100)
+      run.cursor.flush
+      run
     end
 
-    it 'records it as a row still owed its attachments' do
-      imap = instance_double(Net::IMAP)
-      allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE']).and_return([meta])
+    def sees_the_mark?(**)
+      run = described_class.new(inbox: inbox.reload, kinds: [:customer], pacer: pacer, **)
+      run.cursor.unseen('INBOX', 9, [10, 200]) == [200]
+    end
 
-      run.send(:fetch, imap, 10)
-      expect(run.stats[:sem_anexos]).to eq(1)
+    # The default cutoff is a date, so it moves every midnight. Counted in the selection, a
+    # run resumed the next day finds every mark stale, starts each folder at UID 0 and
+    # spends the day's provider budget re-walking mail it has already declined -- on a
+    # mailbox that takes weeks, an import that never finishes.
+    it 'survives a cutoff that moved with the calendar' do
+      mark(terms: %w[ALL BEFORE 29-Aug-2026])
+      expect(sees_the_mark?(terms: %w[ALL BEFORE 30-Aug-2026])).to be(true)
+    end
+
+    # Widening SINCE backwards is how older, lower numbered mail becomes eligible under a
+    # mark that would hide it.
+    it 'is invalidated when the run reaches further back' do
+      mark(terms: %w[SINCE 01-Jan-2024])
+      expect(sees_the_mark?(terms: %w[SINCE 01-Jan-2020])).to be(false)
+    end
+
+    # `UIDVALIDITY` is unique inside one mailbox and commonly starts at 1, so a channel
+    # repointed at another account can present a fresh folder whose stamp matches an old
+    # mark, and everything below it is filtered out before the Message-ID check runs.
+    it 'is invalidated when the channel is repointed at another mailbox' do
+      mark
+      channel.update!(imap_login: 'outra@example.com')
+      expect(sees_the_mark?).to be(false)
     end
   end
 

--- a/spec/services/import/email/backfill_spec.rb
+++ b/spec/services/import/email/backfill_spec.rb
@@ -105,6 +105,16 @@ describe Import::Email::Backfill do
         imap = instance_double(Net::IMAP, uid_fetch: fetched)
         expect(widened.send(:unstored, imap, [10, 11, 12])).to eq([10, 11])
       end
+
+      # `unstored` never runs on a uid the cursor filtered out first, so letting the row
+      # through here is worth nothing unless the mark is invalidated too.
+      it 'is reachable at all, because the mark from the narrower pass no longer applies' do
+        narrow = described_class.new(inbox: inbox, kinds: [:customer], pacer: pacer)
+        narrow.cursor.advance('INBOX', 9, 100)
+        narrow.cursor.flush
+        widened = described_class.new(inbox: inbox.reload, kinds: [:customer], pacer: pacer, attachments: :all)
+        expect(widened.cursor.unseen('INBOX', 9, [10, 11])).to eq([10, 11])
+      end
     end
   end
 

--- a/spec/services/import/email/body_spec.rb
+++ b/spec/services/import/email/body_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+# The gap that let a whole round's fix ship as a no-op: the classifier was given a `reply:`
+# and every spec passed one in by hand, so nothing ever asked the presenter for it.
+describe Import::Email::Body do
+  let(:account) { create(:account) }
+  let(:customer) { 'Bom dia, gostaria de cancelar meu pedido feito na semana passada, obrigado.' }
+  let(:receipt) { 'Mensagem automatica: sua solicitacao 123 foi recebida e esta sendo analisada' }
+
+  def body_for(text: nil, html: nil)
+    parts = if html
+              "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=\"b\"\r\n\r\n" \
+                "--b\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n#{text}\r\n" \
+                "--b\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n#{html}\r\n--b--\r\n"
+            else
+              "Content-Type: text/plain; charset=UTF-8\r\n\r\n#{text}"
+            end
+    mail = Mail.read_from_string(
+      "From: cliente@example.com\r\nTo: sac@example.com\r\nSubject: assunto\r\n" \
+      "Message-ID: <b@example.com>\r\nDate: Mon, 1 May 2023 10:00:00 -0300\r\n#{parts}"
+    )
+    described_class.new(MailPresenter.new(mail, account))
+  end
+
+  describe 'a reply that quotes what it answers' do
+    let(:body) { body_for(text: "#{customer}\n\nEm 1 de maio, sac@example.com escreveu:\n> #{receipt}") }
+
+    it 'gives the whole message for :full' do
+      expect(body[:full]).to include(customer).and include(receipt)
+    end
+
+    # `MailPresenter` files the trimmed body under `:quoted` and returns the untrimmed
+    # message for `:reply`. Asking it for `:reply` gets the quote back and undoes the point.
+    it 'gives only the words the sender typed for :reply' do
+      expect(body[:reply]).to include(customer)
+      expect(body[:reply]).not_to include(receipt)
+    end
+  end
+
+  describe 'a message that carries only html' do
+    let(:body) { body_for(text: '', html: "<p>#{customer}</p><blockquote>#{receipt}</blockquote>") }
+
+    it 'falls back to the html with its tags stripped' do
+      expect(body[:full]).to include(customer)
+    end
+  end
+
+  it 'is empty for a message with no body at all rather than raising' do
+    expect(body_for(text: '')[:reply]).to eq('')
+  end
+
+  it 'refuses a reading it does not define' do
+    expect { body_for(text: customer)[:quoted] }.to raise_error(KeyError)
+  end
+end

--- a/spec/services/import/email/classifier_spec.rb
+++ b/spec/services/import/email/classifier_spec.rb
@@ -44,17 +44,34 @@ describe Import::Email::Classifier do
   # Gmail's \All holds the Sent folder, so a fifth of a support mailbox is its own outgoing
   # mail. Read as customer it would invent a contact for the company's own address.
   it 'reads the mailbox own mail as sent' do
-    expect(described_class.new(mail: from_mailbox, text: customer_text, own_address: own).kind).to eq(:sent)
+    expect(described_class.new(mail: from_mailbox, text: customer_text, own_addresses: own).kind).to eq(:sent)
   end
 
   it 'decides sent by the sender before the text, since a reply quotes the mail it answers' do
-    classifier = described_class.new(mail: from_mailbox, own_address: own,
+    classifier = described_class.new(mail: from_mailbox, own_addresses: own,
                                      text: 'Chegou um novo ticket 456 que nao foi atribuido para nenhum agente')
     expect(classifier.kind).to eq(:sent)
   end
 
   it 'reads mail from somebody else as customer even when told the mailbox address' do
-    expect(described_class.new(mail: from_customer, text: customer_text, own_address: own).kind).to eq(:customer)
+    expect(described_class.new(mail: from_customer, text: customer_text, own_addresses: own).kind).to eq(:customer)
+  end
+
+  # A channel has two: the address the inbox publishes and the one it authenticates as.
+  # They differ on legacy Google aliases and on Microsoft UPN setups, and it is the login
+  # that owns the Sent copies -- read as customer they would be filed as things customers
+  # wrote, on a fifth of the mailbox.
+  it 'reads mail from the login as sent, even when it is not the published address' do
+    alias_mail = Mail.read_from_string("From: sac.antigo@example.com\r\nTo: cliente@example.com\r\n" \
+                                       "Subject: Re: assunto\r\nMessage-ID: <a@example.com>\r\n\r\nCorpo")
+    classifier = described_class.new(mail: alias_mail, text: customer_text,
+                                     own_addresses: [own, 'sac.antigo@example.com'])
+    expect(classifier.kind).to eq(:sent)
+  end
+
+  it 'ignores a blank second address rather than matching everything' do
+    expect(described_class.new(mail: from_customer, text: customer_text, own_addresses: [own, nil]).kind)
+      .to eq(:customer)
   end
 
   it 'never answers sent when the caller does not say what the mailbox is' do

--- a/spec/services/import/email/classifier_spec.rb
+++ b/spec/services/import/email/classifier_spec.rb
@@ -37,8 +37,17 @@ describe Import::Email::Classifier do
     expect([alert.kind, relay.kind, csat.kind]).to eq(%i[alert relay csat])
   end
 
-  it 'reads a body with nothing in it as empty' do
-    expect(described_class.new(mail: from_customer, text: 'ok').kind).to eq(:empty)
+  # The test is for a blank message rather than a short one, and it is taken over the
+  # subject and the body together: `from_customer` carries a subject, so `ok` under it is a
+  # customer answering a thread and not a message saying nothing.
+  it 'reads a message with nothing on either line as empty' do
+    blank = Mail.read_from_string("From: cliente@example.com\r\nTo: #{own}\r\nSubject: \r\n" \
+                                  "Message-ID: <y@example.com>\r\nDate: Mon, 1 May 2023 10:00:00 -0300\r\n\r\n")
+    expect(described_class.new(mail: blank, text: '').kind).to eq(:empty)
+  end
+
+  it 'keeps a short answer under a subject of its own' do
+    expect(described_class.new(mail: from_customer, text: 'ok').kind).to eq(:customer)
   end
 
   # Gmail's \All holds the Sent folder, so a fifth of a support mailbox is its own outgoing
@@ -168,6 +177,44 @@ describe Import::Email::Classifier do
     it 'falls back to the whole body when nothing survives the trim' do
       receipt = 'Mensagem automatica: sua solicitacao 123 foi recebida'
       expect(described_class.new(mail: from_customer, text: receipt, reply: '').kind).to eq(:receipt)
+    end
+  end
+
+  # A support mailbox is written from phones, and a phone puts the whole request on the
+  # subject line and leaves the body to its own signature. Judged on the body alone the
+  # message reads as empty, `skip?` drops it, and the cursor moves past a customer's
+  # question with no error anywhere.
+  describe 'a request that lives on the subject line' do
+    def kind_of(subject, body)
+      mail = Mail.new(from: 'cliente@example.com', to: 'sac@example.com', subject: subject, body: body)
+      described_class.new(mail: mail, text: body, own_addresses: ['sac@example.com']).kind
+    end
+
+    it 'reads the subject as part of what the message says' do
+      expect(kind_of('Como faco para entrar com pessoas menores de idade', 'Enviado do meu iPhone')).to eq(:customer)
+    end
+
+    it 'still calls a message with nothing on either line empty' do
+      expect(kind_of('Re:', '')).to eq(:empty)
+    end
+
+    # The side to err on, and it is a choice rather than an oversight: a signature with no
+    # subject over it comes in as a thin row. An archive pays for that once. It pays for a
+    # dropped request forever, and silently, because `skip?` moves the cursor past it.
+    it 'lets a bare signature through rather than risk the request beside it' do
+      expect(kind_of('', 'Enviado do meu iPhone')).to eq(:customer)
+    end
+
+    # `Re: Fwd:` is nine characters that would rescue a message saying nothing.
+    it 'does not count the reply prefixes as content' do
+      expect(kind_of('Re: Fwd: Enc: ok', '')).to eq(:empty)
+    end
+
+    # Every kind above the emptiness test is decided by who sent the message or by a
+    # template's fixed phrases, and both live in the body.
+    it 'leaves a message the sender already settled alone' do
+      mail = Mail.new(from: 'sac@example.com', to: 'cliente@example.com', subject: 'Uma pergunta bem comprida do cliente', body: '')
+      expect(described_class.new(mail: mail, text: '', own_addresses: ['sac@example.com']).kind).to eq(:sent)
     end
   end
 end

--- a/spec/services/import/email/classifier_spec.rb
+++ b/spec/services/import/email/classifier_spec.rb
@@ -85,6 +85,14 @@ describe Import::Email::Classifier do
     expect(described_class.new(mail: routed, text: customer_text, own_addresses: own).kind).to eq(:sent)
   end
 
+  # A form that lists its own routing address beside the customer is still delegating, and
+  # one owned address in the list would be enough to have the message refused.
+  it 'reads a mixed Reply-To as delegated rather than as our own' do
+    mixed = Mail.read_from_string("From: #{own}\r\nReply-To: #{own}, cliente@example.com\r\n" \
+                                  "To: #{own}\r\nSubject: contato\r\nMessage-ID: <m@example.com>\r\n\r\nCorpo")
+    expect(described_class.new(mail: mixed, text: customer_text, own_addresses: own).kind).to eq(:customer)
+  end
+
   it 'ignores a blank second address rather than matching everything' do
     expect(described_class.new(mail: from_customer, text: customer_text, own_addresses: [own, nil]).kind)
       .to eq(:customer)

--- a/spec/services/import/email/classifier_spec.rb
+++ b/spec/services/import/email/classifier_spec.rb
@@ -69,6 +69,22 @@ describe Import::Email::Classifier do
     expect(classifier.kind).to eq(:sent)
   end
 
+  # The website form posts as the company and points Reply-To at the customer, so `From` is
+  # ours and the message is inbound. Read as sent it is refused outright and the cursor
+  # moves past it -- every message the form ever generated, gone.
+  it 'reads mail sent on somebody else behalf as customer, whatever the From says' do
+    form = Mail.read_from_string("From: #{own}\r\nReply-To: cliente@example.com\r\nTo: #{own}\r\n" \
+                                 "Subject: contato pelo site\r\nMessage-ID: <f@example.com>\r\n\r\nCorpo")
+    expect(described_class.new(mail: form, text: customer_text, own_addresses: own).kind).to eq(:customer)
+  end
+
+  # A Reply-To that is also ours is an ordinary outgoing mail carrying a routing header.
+  it 'still reads our own reply as sent when the Reply-To is also ours' do
+    routed = Mail.read_from_string("From: #{own}\r\nReply-To: #{own}\r\nTo: cliente@example.com\r\n" \
+                                   "Subject: Re: assunto\r\nMessage-ID: <r@example.com>\r\n\r\nCorpo")
+    expect(described_class.new(mail: routed, text: customer_text, own_addresses: own).kind).to eq(:sent)
+  end
+
   it 'ignores a blank second address rather than matching everything' do
     expect(described_class.new(mail: from_customer, text: customer_text, own_addresses: [own, nil]).kind)
       .to eq(:customer)

--- a/spec/services/import/email/classifier_spec.rb
+++ b/spec/services/import/email/classifier_spec.rb
@@ -85,6 +85,31 @@ describe Import::Email::Classifier do
     expect(described_class.new(mail: routed, text: customer_text, own_addresses: own).kind).to eq(:sent)
   end
 
+  # A list or a forwarder puts our own address in `From` and the customer in
+  # `X-Original-Sender`, with no `Reply-To` at all. `MailPresenter#original_sender` reads
+  # that header ahead of `From`, so the importer would file the message as inbound from the
+  # customer -- but only if the classifier lets it through, and read on `From` alone the
+  # whole class answers `:sent`, which a run refuses outright.
+  it 'reads X-Original-Sender the way the presenter does when there is no Reply-To' do
+    forwarded = Mail.read_from_string("From: #{own}\r\nX-Original-Sender: Cliente <cliente@example.com>\r\n" \
+                                      "To: #{own}\r\nSubject: pergunta\r\nMessage-ID: <x@example.com>\r\n\r\nCorpo")
+    expect(described_class.new(mail: forwarded, text: customer_text, own_addresses: own).kind).to eq(:customer)
+  end
+
+  # `Reply-To` comes first in that order, so it decides on its own and the other header is
+  # not consulted -- the same precedence the presenter applies.
+  it 'lets our own Reply-To settle it even when X-Original-Sender points elsewhere' do
+    routed = Mail.read_from_string("From: #{own}\r\nReply-To: #{own}\r\nX-Original-Sender: cliente@example.com\r\n" \
+                                   "To: cliente@example.com\r\nSubject: Re: assunto\r\nMessage-ID: <y@example.com>\r\n\r\nCorpo")
+    expect(described_class.new(mail: routed, text: customer_text, own_addresses: own).kind).to eq(:sent)
+  end
+
+  it 'reads our own outgoing mail as sent when it carries neither header' do
+    plain = Mail.read_from_string("From: #{own}\r\nTo: cliente@example.com\r\n" \
+                                  "Subject: Re: assunto\r\nMessage-ID: <z@example.com>\r\n\r\nCorpo")
+    expect(described_class.new(mail: plain, text: customer_text, own_addresses: own).kind).to eq(:sent)
+  end
+
   # A form that lists its own routing address beside the customer is still delegating, and
   # one owned address in the list would be enough to have the message refused.
   it 'reads a mixed Reply-To as delegated rather than as our own' do

--- a/spec/services/import/email/classifier_spec.rb
+++ b/spec/services/import/email/classifier_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe Import::Email::Classifier do
+  let(:own) { 'sac@example.com' }
+  let(:from_customer) do
+    Mail.read_from_string("From: cliente@example.com\r\nTo: #{own}\r\nSubject: Assunto #12345\r\n" \
+                          "Message-ID: <x@example.com>\r\nDate: Mon, 1 May 2023 10:00:00 -0300\r\n\r\nCorpo")
+  end
+  let(:from_mailbox) do
+    Mail.read_from_string("From: #{own}\r\nTo: cliente@example.com\r\nSubject: Re: Assunto #12345\r\n" \
+                          "Message-ID: <y@example.com>\r\nDate: Mon, 1 May 2023 10:00:00 -0300\r\n\r\nCorpo")
+  end
+  let(:customer_text) { 'Bom dia, gostaria de cancelar meu pedido feito na semana passada, obrigado.' }
+
+  # The same sentence arrives spelled three ways on a mailbox this old, and the folding is
+  # what makes one pattern match all of them.
+  ['solicitação 123 foi recebida', 'solicita&ccedil;&atilde;o 123 foi recebida',
+   'solicitac&#807;a&#771;o 123 foi recebida'].each do |spelling|
+    it "recognises a receipt spelled #{spelling[0, 26]}" do
+      classifier = described_class.new(mail: from_customer, text: "Mensagem automatica: sua #{spelling} e esta sendo analisada")
+      expect(classifier.kind).to eq(:receipt)
+    end
+  end
+
+  it 'survives text that lies about its encoding rather than dropping the message' do
+    expect { described_class.fold("caf\xE9 sem acento valido") }.not_to raise_error
+  end
+
+  it 'reads ordinary mail from a person as customer' do
+    expect(described_class.new(mail: from_customer, text: customer_text).kind).to eq(:customer)
+  end
+
+  it 'separates the shapes the ticketing system writes' do
+    alert = described_class.new(mail: from_customer, text: 'Chegou um novo ticket 456 que nao foi atribuido para nenhum agente')
+    relay = described_class.new(mail: from_customer, text: 'Por favor acesse o octadesk e verifique essa solicitacao')
+    csat = described_class.new(mail: from_customer, text: 'Responda nossa pesquisa de satisfacao sobre o atendimento de hoje')
+    expect([alert.kind, relay.kind, csat.kind]).to eq(%i[alert relay csat])
+  end
+
+  it 'reads a body with nothing in it as empty' do
+    expect(described_class.new(mail: from_customer, text: 'ok').kind).to eq(:empty)
+  end
+
+  # Gmail's \All holds the Sent folder, so a fifth of a support mailbox is its own outgoing
+  # mail. Read as customer it would invent a contact for the company's own address.
+  it 'reads the mailbox own mail as sent' do
+    expect(described_class.new(mail: from_mailbox, text: customer_text, own_address: own).kind).to eq(:sent)
+  end
+
+  it 'decides sent by the sender before the text, since a reply quotes the mail it answers' do
+    classifier = described_class.new(mail: from_mailbox, own_address: own,
+                                     text: 'Chegou um novo ticket 456 que nao foi atribuido para nenhum agente')
+    expect(classifier.kind).to eq(:sent)
+  end
+
+  it 'reads mail from somebody else as customer even when told the mailbox address' do
+    expect(described_class.new(mail: from_customer, text: customer_text, own_address: own).kind).to eq(:customer)
+  end
+
+  it 'never answers sent when the caller does not say what the mailbox is' do
+    expect(described_class.new(mail: from_mailbox, text: customer_text).kind).to eq(:customer)
+  end
+
+  it 'reads the ticket number off the end of the subject' do
+    expect(described_class.new(mail: from_customer, text: 'corpo').ticket).to eq('12345')
+  end
+
+  it 'falls back to the ticket number in the body' do
+    plain = Mail.read_from_string("From: c@example.com\r\nTo: #{own}\r\nSubject: sem numero\r\n" \
+                                  "Message-ID: <z@example.com>\r\n\r\nCorpo")
+    expect(described_class.new(mail: plain, text: 'sobre o ticket 987 que abri ontem').ticket).to eq('987')
+  end
+end

--- a/spec/services/import/email/classifier_spec.rb
+++ b/spec/services/import/email/classifier_spec.rb
@@ -70,4 +70,38 @@ describe Import::Email::Classifier do
                                   "Message-ID: <z@example.com>\r\n\r\nCorpo")
     expect(described_class.new(mail: plain, text: 'sobre o ticket 987 que abri ontem').ticket).to eq('987')
   end
+
+  # A customer answering machine mail quotes it. Read whole, the body carries the
+  # template's phrases and the reply is filed as the machine mail it answers -- which under
+  # the default `KINDS=customer` drops the customer's words and moves the cursor past them.
+  describe 'a customer answering machine mail' do
+    let(:quoted_receipt) do
+      "#{customer_text}\n\nEm 1 de maio, sac@example.com escreveu:\n" \
+        '> Mensagem automatica: sua solicitacao 123 foi recebida e esta sendo analisada por nossa equipe'
+    end
+
+    it 'is the customer, not the receipt underneath the reply' do
+      classifier = described_class.new(mail: from_customer, text: quoted_receipt, reply: customer_text)
+      expect(classifier.kind).to eq(:customer)
+    end
+
+    it 'still reads the ticket number out of the part that was quoted' do
+      body = "#{customer_text}\n\n> sobre o ticket 987 que abri ontem"
+      plain = Mail.read_from_string("From: c@example.com\r\nTo: #{own}\r\nSubject: sem numero\r\n" \
+                                    "Message-ID: <w@example.com>\r\n\r\nCorpo")
+      expect(described_class.new(mail: plain, text: body, reply: customer_text).ticket).to eq('987')
+    end
+
+    # A receipt's own fixed text is the unquoted top of it, so trimming changes nothing.
+    it 'leaves the machine mail itself classified as before' do
+      receipt = 'Mensagem automatica: sua solicitacao 123 foi recebida'
+      classifier = described_class.new(mail: from_customer, text: "#{receipt}\n\n> #{customer_text}", reply: receipt)
+      expect(classifier.kind).to eq(:receipt)
+    end
+
+    it 'falls back to the whole body when nothing survives the trim' do
+      receipt = 'Mensagem automatica: sua solicitacao 123 foi recebida'
+      expect(described_class.new(mail: from_customer, text: receipt, reply: '').kind).to eq(:receipt)
+    end
+  end
 end

--- a/spec/services/import/email/cursor_spec.rb
+++ b/spec/services/import/email/cursor_spec.rb
@@ -91,6 +91,16 @@ describe Import::Email::Cursor do
       expect(widened.unseen(folder, 5, [10, 20, 30])).to eq([10, 20, 30])
     end
 
+    # The policy changes nothing about which messages are imported and everything about
+    # which are finished. Left out of the key, the mark from the narrow pass filters out
+    # every uid before the enrichment path is ever asked about them.
+    it 'starts the folder over when the attachment policy widens' do
+      cursor.advance(folder, 5, 100)
+      cursor.flush
+      widened = described_class.new(channel.reload, selection: [%w[SINCE 01-Jan-2024], [:customer], 'all'])
+      expect(widened.unseen(folder, 5, [10, 20, 30])).to eq([10, 20, 30])
+    end
+
     it 'resumes when the same selection comes back, whatever order the kinds arrived in' do
       cursor.advance(folder, 5, 100)
       cursor.flush

--- a/spec/services/import/email/cursor_spec.rb
+++ b/spec/services/import/email/cursor_spec.rb
@@ -54,10 +54,20 @@ describe Import::Email::Cursor do
     expect(described_class.new(channel.reload).unseen(folder, 5, [1, 2])).to eq([1, 2])
   end
 
-  it 'leaves the rest of the provider config alone' do
-    channel.update!(provider_config: { 'keep' => 'me' })
+  # The OAuth refresh services replace `provider_config` wholesale on every token renewal,
+  # and an access token expires long before a multi-day import finishes. A cursor kept
+  # there is deleted mid-run, and the run starts the mailbox over.
+  it 'survives an OAuth token refresh, which replaces the provider config wholesale' do
     cursor.advance(folder, 5, 10)
     cursor.flush
-    expect(channel.reload.provider_config['keep']).to eq('me')
+    channel.update!(provider_config: { access_token: 'novo', refresh_token: 'novo', expires_on: 1.hour.from_now.to_s })
+    expect(described_class.new(channel.reload).unseen(folder, 5, [9, 10, 11])).to eq([11])
+  end
+
+  it 'does not write over the credentials while saving its own mark' do
+    channel.update!(provider_config: { access_token: 'guardado' })
+    cursor.advance(folder, 5, 10)
+    cursor.flush
+    expect(channel.reload.provider_config['access_token']).to eq('guardado')
   end
 end

--- a/spec/services/import/email/cursor_spec.rb
+++ b/spec/services/import/email/cursor_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+# What the inbox cannot answer: how far a pass looked, as opposed to what it wrote. Most
+# of a support mailbox is read and declined, and without this every pass re-downloads the
+# declined mail, pays the same bytes and stops in the same place.
+describe Import::Email::Cursor do
+  let(:channel) { create(:channel_email) }
+  let(:cursor) { described_class.new(channel) }
+  let(:folder) { '[Gmail]/Todos os e-mails' }
+
+  it 'takes every uid before anything has been marked' do
+    expect(cursor.unseen(folder, 5, [1, 2, 3])).to eq([1, 2, 3])
+  end
+
+  it 'takes only what is above the mark once a pass has saved one' do
+    cursor.advance(folder, 5, 2)
+    cursor.flush
+    expect(described_class.new(channel.reload).unseen(folder, 5, [1, 2, 3, 4])).to eq([3, 4])
+  end
+
+  it 'keeps a mark per folder, since spam is walked separately' do
+    cursor.advance(folder, 5, 10)
+    cursor.advance('[Gmail]/Spam', 7, 3)
+    cursor.flush
+    resumed = described_class.new(channel.reload)
+    expect(resumed.unseen(folder, 5, [9, 10, 11])).to eq([11])
+    expect(resumed.unseen('[Gmail]/Spam', 7, [3, 4])).to eq([4])
+  end
+
+  # A provider that renumbers a folder invalidates its own cursor. Trusting it would skip
+  # into the middle of a folder whose uids now mean something else.
+  it 'starts the folder over when the provider has renumbered it' do
+    cursor.advance(folder, 5, 100)
+    cursor.flush
+    expect(described_class.new(channel.reload).unseen(folder, 6, [1, 2, 3])).to eq([1, 2, 3])
+  end
+
+  it 'never moves backwards, so a batch that stopped early cannot undo an earlier pass' do
+    cursor.advance(folder, 5, 10)
+    cursor.advance(folder, 5, 4)
+    cursor.flush
+    expect(described_class.new(channel.reload).unseen(folder, 5, [5, 10, 11])).to eq([11])
+  end
+
+  it 'writes nothing until it is flushed, so a run pays one update per batch' do
+    cursor.advance(folder, 5, 10)
+    expect(described_class.new(channel.reload).unseen(folder, 5, [1, 2])).to eq([1, 2])
+  end
+
+  it 'forgets everything when asked, so an operator can walk the mailbox again' do
+    cursor.advance(folder, 5, 10)
+    cursor.flush
+    described_class.new(channel.reload).reset
+    expect(described_class.new(channel.reload).unseen(folder, 5, [1, 2])).to eq([1, 2])
+  end
+
+  it 'leaves the rest of the provider config alone' do
+    channel.update!(provider_config: { 'keep' => 'me' })
+    cursor.advance(folder, 5, 10)
+    cursor.flush
+    expect(channel.reload.provider_config['keep']).to eq('me')
+  end
+end

--- a/spec/services/import/email/cursor_spec.rb
+++ b/spec/services/import/email/cursor_spec.rb
@@ -70,4 +70,32 @@ describe Import::Email::Cursor do
     cursor.flush
     expect(channel.reload.provider_config['access_token']).to eq('guardado')
   end
+
+  # UIDs rise with arrival, so widening the window asks for LOWER uids -- every one of them
+  # below the mark a narrower pass left behind. Honoured, that mark reports the folder
+  # exhausted while the older mail is still sitting there unread.
+  describe 'when the selection changes' do
+    let(:cursor) { described_class.new(channel, selection: [%w[SINCE 01-Jan-2024], [:customer]]) }
+
+    it 'starts the folder over when the search widens to older mail' do
+      cursor.advance(folder, 5, 100)
+      cursor.flush
+      widened = described_class.new(channel.reload, selection: [['ALL'], [:customer]])
+      expect(widened.unseen(folder, 5, [10, 20, 30])).to eq([10, 20, 30])
+    end
+
+    it 'starts the folder over when the kinds widen, since declined mail was walked past' do
+      cursor.advance(folder, 5, 100)
+      cursor.flush
+      widened = described_class.new(channel.reload, selection: [%w[SINCE 01-Jan-2024], [:customer, :receipt]])
+      expect(widened.unseen(folder, 5, [10, 20, 30])).to eq([10, 20, 30])
+    end
+
+    it 'resumes when the same selection comes back, whatever order the kinds arrived in' do
+      cursor.advance(folder, 5, 100)
+      cursor.flush
+      same = described_class.new(channel.reload, selection: [%w[SINCE 01-Jan-2024], [:customer]])
+      expect(same.unseen(folder, 5, [99, 100, 101])).to eq([101])
+    end
+  end
 end

--- a/spec/services/import/email/download_spec.rb
+++ b/spec/services/import/email/download_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe Import::Email::Download do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, account: account) }
+  let(:pacer) { Import::Email::Pacer.new(budget_mb: Float::INFINITY, max_load: 99) }
+  let(:stats) { Hash.new(0) }
+  let(:leaf) do
+    Struct.new(:media_type, :subtype, :encoding, :param, :disposition, :size, keyword_init: true) # rubocop:disable Lint/StructNewOverride
+  end
+  let(:structure) do
+    Struct.new(:subtype, :parts, keyword_init: true) do
+      def media_type = 'MULTIPART'
+      def encoding = nil
+      def param = nil
+      def disposition = nil
+      def size = 0
+    end.new(subtype: 'MIXED',
+            parts: [leaf.new(media_type: 'IMAGE', subtype: 'PNG', encoding: 'BASE64', param: {},
+                             disposition: Struct.new(:dsp_type, :param).new('ATTACHMENT'), size: 3_000_000)])
+  end
+  let(:header) do
+    "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: fotos\r\n" \
+      "Message-ID: <so-anexo@example.com>\r\nDate: #{Time.zone.parse('2023-05-01 10:00').rfc2822}\r\n"
+  end
+  let(:meta) { Struct.new(:attr).new({ 'BODY[HEADER]' => header, 'BODYSTRUCTURE' => structure }) }
+  let(:imap) { instance_double(Net::IMAP) }
+
+  before do
+    allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE']).and_return([meta])
+  end
+
+  def download(attachments)
+    described_class.new(pacer: pacer, attachments: Import::Email::AttachmentPolicy.build(attachments), stats: stats)
+  end
+
+  # `BODY.PEEK[]` pulls the encoded attachments along with the words, which is the download
+  # the cutoff exists to refuse. A message that is nothing but attachments has no text part
+  # to name, and falling back to the whole message there fetches every file the policy just
+  # excluded and then discards them -- on exactly the messages where the fallback is the
+  # entire message.
+  describe 'a message under the cutoff whose structure names no text part' do
+    it 'builds it from the header rather than downloading what it will not keep' do
+      expect(download(nil).perform(imap, 10)).to include('so-anexo@example.com')
+      expect(imap).not_to have_received(:uid_fetch).with(10, 'BODY.PEEK[]')
+    end
+
+    it 'reports it as a row still owed its attachments' do
+      run = download(nil)
+      run.perform(imap, 10)
+      expect(run).to be_lean
+      expect(stats[:sem_anexos]).to eq(1)
+    end
+  end
+
+  # Nothing to save on a message whose attachments the run is taking anyway: both fetches
+  # cost the same bytes and one of them costs an extra round trip.
+  it 'takes the whole message when the policy wants the attachments' do
+    allow(imap).to receive(:uid_fetch).with(10, 'BODY.PEEK[]')
+                                      .and_return([Struct.new(:attr).new({ 'BODY[]' => "#{header}\r\ncorpo" })])
+    run = download(:all)
+
+    expect(run.perform(imap, 10)).to include('corpo')
+    expect(run).not_to be_lean
+  end
+end

--- a/spec/services/import/email/download_spec.rb
+++ b/spec/services/import/email/download_spec.rb
@@ -23,11 +23,13 @@ describe Import::Email::Download do
     "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: fotos\r\n" \
       "Message-ID: <so-anexo@example.com>\r\nDate: #{Time.zone.parse('2023-05-01 10:00').rfc2822}\r\n"
   end
-  let(:meta) { Struct.new(:attr).new({ 'BODY[HEADER]' => header, 'BODYSTRUCTURE' => structure }) }
+  let(:meta) do
+    Struct.new(:attr).new({ 'BODY[HEADER]' => header, 'BODYSTRUCTURE' => structure, 'RFC822.SIZE' => 3_100_000 })
+  end
   let(:imap) { instance_double(Net::IMAP) }
 
   before do
-    allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE']).and_return([meta])
+    allow(imap).to receive(:uid_fetch).with(10, ['BODY.PEEK[HEADER]', 'BODYSTRUCTURE', 'RFC822.SIZE']).and_return([meta])
   end
 
   def download(attachments)
@@ -62,5 +64,18 @@ describe Import::Email::Download do
 
     expect(run.perform(imap, 10)).to include('corpo')
     expect(run).not_to be_lean
+    expect(run).not_to be_declined
+  end
+
+  # The ceiling sits under a provider limit whose answer to an overdraft is locking IMAP
+  # for the whole account, live fetch included. Noticing after the transfer is a ceiling
+  # plus one message, and the message that crosses it is the one carrying the attachments.
+  it 'refuses a message larger than what is left of the budget' do
+    tight = Import::Email::Pacer.new(budget_mb: 1, max_load: 99)
+    run = described_class.new(pacer: tight, attachments: Import::Email::AttachmentPolicy.build(:all), stats: stats)
+
+    expect(run.perform(imap, 10)).to be_nil
+    expect(run).to be_declined
+    expect(imap).not_to have_received(:uid_fetch).with(10, 'BODY.PEEK[]')
   end
 end

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -77,6 +77,24 @@ describe Import::Email::HistoryImporter do
     end
   end
 
+  # One instance files every mail of the run, and the mailbox it subclasses keeps the row it
+  # wrote in `@message`. `create_message` returns early on a source id it already holds
+  # without clearing that, so a mail the live poller files between the check and the write
+  # would otherwise hand its attachments and its date to the previous mail's row -- and a
+  # batch of two hundred takes minutes, with the inbox polled throughout.
+  it 'does not hand a mail its predecessor row when the poller got there first' do
+    first = mail(date: Time.zone.parse('2023-05-01 10:00'), message_id: 'um@example.com')
+    importer.import(first, channel)
+    written = inbox.messages.find_by(source_id: 'um@example.com')
+
+    second = mail(date: Time.zone.parse('2024-09-09 09:00'), message_id: 'dois@example.com')
+    allow(importer).to receive(:stored).and_return(nil)
+    allow_any_instance_of(Conversation).to receive_message_chain(:messages, :find_by).and_return(written) # rubocop:disable RSpec/AnyInstance,RSpec/MessageChain
+    importer.import(second, channel)
+
+    expect(written.reload.created_at).to eq(Time.zone.parse('2023-05-01 10:00'))
+  end
+
   it 'files the message at the date it was sent, not at the date it was imported' do
     importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel)
     expect(inbox.messages.first.created_at).to eq(Time.zone.parse('2023-05-01 10:00'))

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -186,6 +186,24 @@ describe Import::Email::HistoryImporter do
       expect(message.content_attributes['imported_text_only']).to be(true)
     end
 
+    # `text_only` returns nil when the structure names no text part worth taking, and the
+    # backfill then fetches the whole message. The attachments are in hand and dropped
+    # here, so this is the one path where the row's own writer is the one withholding.
+    it 'marks the row when the whole message was fetched and the attachments dropped here' do
+      described_class.new.import(with_attachment, channel)
+      expect(inbox.messages.last.content_attributes['imported_text_only']).to be(true)
+    end
+
+    it 'marks nothing when the message carries no attachments to withhold' do
+      plain = Mail.read_from_string(
+        "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: sem anexo\r\n" \
+        "Message-ID: <simples@example.com>\r\nDate: Mon, 1 May 2023 10:00:00 -0300\r\n\r\n" \
+        'Corpo com texto suficiente para o pipeline aceitar sem reclamar.'
+      )
+      described_class.new.import(plain, channel)
+      expect(inbox.messages.where(Import::TEXT_ONLY_SQL).count).to eq(0)
+    end
+
     it 'does not touch a row that was already complete' do
       described_class.new(attachments: :all).import(with_attachment, channel)
       again = described_class.new(attachments: :all)

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -103,6 +103,31 @@ describe Import::Email::HistoryImporter do
     end
   end
 
+  # Live traffic keeps this in `Message#update_contact_activity`, inside the after-create
+  # callbacks the import suppresses wholesale. Left null, a contact with a decade of mail
+  # sorts below one who has never written.
+  describe 'when the contact last said anything' do
+    it 'stamps it from the mail rather than from the clock' do
+      importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel)
+      expect(inbox.contacts.last.last_activity_at).to eq(Time.zone.parse('2023-05-01 10:00'))
+    end
+
+    it 'keeps the newest of the thread, whatever order the mail arrives in' do
+      importer.import(mail(date: Time.zone.parse('2023-06-10 10:00'), message_id: root_id), channel)
+      importer.import(mail(date: Time.zone.parse('2023-01-05 08:00'), reply_to_root: true), channel)
+      expect(inbox.contacts.last.last_activity_at).to eq(Time.zone.parse('2023-06-10 10:00'))
+    end
+
+    # A contact somebody is talking to now has a real clock, and history must not move it.
+    it 'never drags a live contact backwards' do
+      importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel)
+      contact = inbox.contacts.last
+      contact.update!(last_activity_at: Time.zone.parse('2026-01-01 09:00'))
+      described_class.new.import(mail(date: Time.zone.parse('2023-07-01 10:00'), reply_to_root: true), channel)
+      expect(contact.reload.last_activity_at).to eq(Time.zone.parse('2026-01-01 09:00'))
+    end
+  end
+
   describe 'attachments' do
     let(:with_attachment) do
       Mail.read_from_string(

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -57,9 +57,13 @@ describe Import::Email::HistoryImporter do
     # silence and give nothing back.
     it 'owes the index the row a later pass enriched, not only the ones it created' do
       allow(importer).to receive_messages(skip_attachments?: false, incomplete?: true, fill_attachments: nil)
-      stored = create(:message, account: account, inbox: inbox,
-                                conversation: create(:conversation, account: account, inbox: inbox),
-                                content_attributes: { imported: true, imported_text_only: true })
+      # Written the way the earlier pass wrote it, which is what silences the per-row
+      # callback: outside the wrap this fixture would exercise that callback instead.
+      stored = Import::SilentWrite.wrap(indexing: true) do
+        create(:message, account: account, inbox: inbox,
+                         conversation: create(:conversation, account: account, inbox: inbox),
+                         content_attributes: { imported: true, imported_text_only: true })
+      end
       importer.send(:enrich, mail(date: Time.zone.parse('2023-05-01 10:00')), channel, stored)
       importer.flush_search_index
 

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -17,6 +17,35 @@ describe Import::Email::HistoryImporter do
     )
   end
 
+  # The buffer exists for exactly this path, and every spec of the buffer itself exercises a
+  # stand-in: left at the default this importer would send one bulk job per mail, which is
+  # the flood the per-row guard was put in to stop wearing a different job class, and not
+  # one of those specs would notice.
+  describe 'what it owes the search index' do
+    let(:relation) { double('Message relation') } # rubocop:disable RSpec/VerifiedDoubles
+    let(:asked) { [] }
+
+    before do
+      allow(relation).to receive(:reindex)
+      allow(ChatwootApp).to receive(:advanced_search_allowed?).and_return(true)
+      allow(Message).to receive(:where) do |args|
+        asked << args[:id]
+        relation
+      end
+    end
+
+    it 'holds the mail back rather than asking per message' do
+      2.times { importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel) }
+      expect(asked).to be_empty
+    end
+
+    it 'hands over everything it held when the walk empties it' do
+      2.times { importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel) }
+      importer.flush_search_index
+      expect(asked).to eq([inbox.messages.pluck(:id)])
+    end
+  end
+
   it 'files the message at the date it was sent, not at the date it was imported' do
     importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel)
     expect(inbox.messages.first.created_at).to eq(Time.zone.parse('2023-05-01 10:00'))

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -39,6 +39,18 @@ describe Import::Email::HistoryImporter do
       expect(asked).to be_empty
     end
 
+    # The buffer only makes sense if the per-row callback is off while it writes, and the
+    # guard reads this rather than the level. Left unset, every row would be indexed twice.
+    it 'takes the index on itself while it writes, which is what silences the callback' do
+      seen = nil
+      allow(importer).to receive(:settle_thread).and_wrap_original do |original|
+        seen = Import::SilentWrite.indexing?
+        original.call
+      end
+      importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel)
+      expect(seen).to be(true)
+    end
+
     it 'hands over everything it held when the walk empties it' do
       2.times { importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel) }
       importer.flush_search_index

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -131,4 +131,66 @@ describe Import::Email::HistoryImporter do
       expect(inbox.messages.last.attachments).to be_empty
     end
   end
+
+  # A first pass files a mailbox text-only to stay inside the provider budget; a later one
+  # widens the cutoff. Without an enrichment path the second pass finds the Message-ID
+  # stored, calls it done, and the attachments stay in a mailbox nobody reads again.
+  describe 'widening the cutoff over mail already filed' do
+    let(:with_attachment) do
+      Mail.read_from_string(
+        "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: com anexo\r\n" \
+        "Message-ID: <anexo@example.com>\r\nDate: Mon, 1 May 2023 10:00:00 -0300\r\nMIME-Version: 1.0\r\n" \
+        "Content-Type: multipart/mixed; boundary=\"limite\"\r\n\r\n" \
+        "--limite\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n" \
+        "Corpo com texto suficiente para o pipeline aceitar sem reclamar.\r\n" \
+        "--limite\r\nContent-Type: text/plain; charset=UTF-8\r\n" \
+        "Content-Disposition: attachment; filename=\"nota.txt\"\r\n\r\nconteudo do anexo\r\n--limite--\r\n"
+      )
+    end
+
+    def file_text_only
+      described_class.new.import(with_attachment, channel, text_only: true)
+      inbox.messages.last
+    end
+
+    it 'says on the row that its attachments were left behind' do
+      expect(file_text_only.content_attributes['imported_text_only']).to be(true)
+      expect(inbox.messages.where(Import::TEXT_ONLY_SQL).count).to eq(1)
+    end
+
+    it 'says nothing when the pass fetched the whole message' do
+      described_class.new(attachments: :all).import(with_attachment, channel)
+      expect(inbox.messages.where(Import::TEXT_ONLY_SQL).count).to eq(0)
+    end
+
+    it 'fetches the attachments onto the row a narrower pass already filed' do
+      message = file_text_only
+      widened = described_class.new(attachments: :all)
+      expect { widened.import(with_attachment, channel) }.not_to change(inbox.messages, :count)
+      expect(message.reload.attachments.count).to eq(1)
+      expect(widened.outcome_kind).to eq(:enriquecidas)
+    end
+
+    it 'clears the flag, so a third pass has nothing left to do' do
+      file_text_only
+      described_class.new(attachments: :all).import(with_attachment, channel)
+      third = described_class.new(attachments: :all)
+      expect { third.import(with_attachment, channel) }.not_to change(Attachment, :count)
+      expect(third.outcome_kind).to eq(:inalteradas)
+    end
+
+    it 'leaves it alone when the widened cutoff still excludes the message' do
+      message = file_text_only
+      described_class.new(attachments: Time.zone.parse('2024-01-01')).import(with_attachment, channel)
+      expect(message.reload.attachments).to be_empty
+      expect(message.content_attributes['imported_text_only']).to be(true)
+    end
+
+    it 'does not touch a row that was already complete' do
+      described_class.new(attachments: :all).import(with_attachment, channel)
+      again = described_class.new(attachments: :all)
+      expect { again.import(with_attachment, channel) }.not_to change(Attachment, :count)
+      expect(again.outcome_kind).to eq(:inalteradas)
+    end
+  end
 end

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -51,6 +51,21 @@ describe Import::Email::HistoryImporter do
       expect(seen).to be(true)
     end
 
+    # A later pass that fills in the attachments changes what the row is, and
+    # `Messages::SearchDataPresenter` reads them. The flag silences the callback the update
+    # would fire and this path settles nothing, so without asking by hand the flag would buy
+    # silence and give nothing back.
+    it 'owes the index the row a later pass enriched, not only the ones it created' do
+      allow(importer).to receive_messages(skip_attachments?: false, incomplete?: true, fill_attachments: nil)
+      stored = create(:message, account: account, inbox: inbox,
+                                conversation: create(:conversation, account: account, inbox: inbox),
+                                content_attributes: { imported: true, imported_text_only: true })
+      importer.send(:enrich, mail(date: Time.zone.parse('2023-05-01 10:00')), channel, stored)
+      importer.flush_search_index
+
+      expect(asked).to eq([[stored.id]])
+    end
+
     it 'hands over everything it held when the walk empties it' do
       2.times { importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel) }
       importer.flush_search_index

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -128,6 +128,36 @@ describe Import::Email::HistoryImporter do
     end
   end
 
+  # A form posts as the company and names the customer in `Reply-To`. `MailPresenter`
+  # takes the first address there is, so a form that lists its own routing address first
+  # files the thread under the company -- and the dedupe is by Message-ID, so no later pass
+  # revisits it.
+  describe 'mail sent on somebody else behalf' do
+    def delegated(reply_to)
+      Mail.read_from_string(
+        "From: #{channel.email}\r\nReply-To: #{reply_to}\r\nTo: #{channel.email}\r\n" \
+        "Subject: contato pelo site\r\nMessage-ID: <#{SecureRandom.hex(6)}@example.com>\r\n" \
+        "Date: Mon, 1 May 2023 10:00:00 -0300\r\n\r\n" \
+        'Uma mensagem com corpo suficiente para o pipeline aceitar sem reclamar de nada.'
+      )
+    end
+
+    it 'files it under the customer when the routing header names us first' do
+      importer.import(delegated("#{channel.email}, cliente@example.com"), channel)
+      expect(inbox.conversations.last.contact.email).to eq('cliente@example.com')
+    end
+
+    it 'files it under the customer when the routing header names only them' do
+      importer.import(delegated('cliente@example.com'), channel)
+      expect(inbox.conversations.last.contact.email).to eq('cliente@example.com')
+    end
+
+    it 'leaves an ordinary reply of ours alone' do
+      importer.import(delegated(channel.email), channel)
+      expect(inbox.conversations.last.contact.email).to eq(channel.email)
+    end
+  end
+
   describe 'attachments' do
     let(:with_attachment) do
       Mail.read_from_string(

--- a/spec/services/import/email/history_importer_spec.rb
+++ b/spec/services/import/email/history_importer_spec.rb
@@ -1,0 +1,134 @@
+require 'rails_helper'
+
+describe Import::Email::HistoryImporter do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, account: account) }
+  let(:inbox) { channel.inbox }
+  let(:importer) { described_class.new }
+  let(:root_id) { 'raiz@example.com' }
+
+  def mail(date:, message_id: "#{SecureRandom.hex(6)}@example.com", reply_to_root: false, headers: '')
+    thread = reply_to_root ? "In-Reply-To: <#{root_id}>\r\nReferences: <#{root_id}>\r\n" : ''
+    stamp = date ? "Date: #{date.rfc2822}\r\n" : ''
+    Mail.read_from_string(
+      "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: Assunto do thread\r\n" \
+      "Message-ID: <#{message_id}>\r\n#{stamp}#{thread}#{headers}\r\n" \
+      'Uma mensagem com corpo suficiente para o pipeline aceitar sem reclamar de nada.'
+    )
+  end
+
+  it 'files the message at the date it was sent, not at the date it was imported' do
+    importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel)
+    expect(inbox.messages.first.created_at).to eq(Time.zone.parse('2023-05-01 10:00'))
+  end
+
+  # Born resolved rather than transitioned into it: a transition fires a resolution event
+  # and files the thread into today's figures.
+  it 'opens the conversation already resolved and dated to the mail' do
+    importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel)
+    conversation = inbox.conversations.last
+    expect(conversation.status).to eq('resolved')
+    expect(conversation.created_at).to eq(Time.zone.parse('2023-05-01 10:00'))
+  end
+
+  it 'resolves the conversation even when the mail carries no usable date' do
+    importer.import(mail(date: nil, headers: "Received: from a by b; Tue, 14 Mar 2023 10:22:31 -0300\r\n"), channel)
+    conversation = inbox.conversations.last
+    expect(conversation.status).to eq('resolved')
+    expect(conversation.created_at).to eq(Time.zone.parse('2023-03-14 13:22:31 UTC'))
+  end
+
+  it 'marks what it wrote as imported, so reports can exclude it' do
+    importer.import(mail(date: Time.zone.parse('2023-05-01 10:00')), channel)
+    expect(inbox.messages.where(Import::IMPORTED_SQL).count).to eq(1)
+  end
+
+  # The live pipeline dedupes inside the thread it just picked, which is right for an
+  # arrival and wrong for a replay: a mail whose References no longer resolve opens a fresh
+  # conversation and the check then runs against a thread that is empty by construction.
+  it 'writes nothing twice when the same mail comes round again' do
+    message = mail(date: Time.zone.parse('2023-05-01 10:00'))
+    importer.import(message, channel)
+    expect { described_class.new.import(message, channel) }.not_to change(inbox.messages, :count)
+  end
+
+  describe 'a thread whose mail arrives out of order' do
+    before do
+      # IMAP hands out UIDs in arrival order, so the newest can be scanned first.
+      importer.import(mail(date: Time.zone.parse('2023-06-10 10:00'), message_id: root_id), channel)
+      importer.import(mail(date: Time.zone.parse('2023-01-05 08:00'), reply_to_root: true), channel)
+      importer.import(mail(date: Time.zone.parse('2023-03-20 14:00'), reply_to_root: true), channel)
+    end
+
+    it 'keeps the thread together' do
+      expect(inbox.conversations.count).to eq(1)
+      expect(inbox.messages.count).to eq(3)
+    end
+
+    it 'sorts on the newest message rather than the last one scanned' do
+      expect(inbox.conversations.last.last_activity_at).to eq(Time.zone.parse('2023-06-10 10:00'))
+    end
+
+    it 'dates the conversation from its oldest message rather than the one that opened it' do
+      expect(inbox.conversations.last.created_at).to eq(Time.zone.parse('2023-01-05 08:00'))
+    end
+  end
+
+  describe 'a mail that threads into a conversation somebody is working' do
+    let(:contact_inbox) do
+      ContactInboxWithContactBuilder.new(source_id: 'cliente@example.com', inbox: inbox,
+                                         contact_attributes: { name: 'C', email: 'cliente@example.com' }).perform
+    end
+    let(:live) do
+      conversation = Conversation.create!(account_id: account.id, inbox_id: inbox.id, status: :open,
+                                          contact_id: contact_inbox.contact_id, contact_inbox_id: contact_inbox.id)
+      create(:message, account: account, inbox: inbox, conversation: conversation, message_type: :incoming,
+                       content: 'pergunta', source_id: root_id, created_at: 2.days.ago)
+      create(:message, account: account, inbox: inbox, conversation: conversation, message_type: :outgoing,
+                       content: 'ja respondemos', created_at: 1.day.ago)
+      conversation.reload
+    end
+
+    it 'does not move the waiting clock back to the archive, which would file it as unattended' do
+      live.update_columns(waiting_since: nil) # rubocop:disable Rails/SkipsModelValidations -- the state an answered thread is in
+      expect do
+        importer.import(mail(date: Time.zone.parse('2023-05-15 09:00'), reply_to_root: true), channel)
+      end.not_to(change { live.reload.waiting_since })
+    end
+
+    it 'leaves the creation date of a live thread alone' do
+      expect do
+        importer.import(mail(date: Time.zone.parse('2020-01-01 08:00'), reply_to_root: true), channel)
+      end.not_to(change { live.reload.created_at })
+    end
+  end
+
+  describe 'attachments' do
+    let(:with_attachment) do
+      Mail.read_from_string(
+        "From: cliente@example.com\r\nTo: #{channel.email}\r\nSubject: com anexo\r\n" \
+        "Message-ID: <anexo@example.com>\r\nDate: Mon, 1 May 2023 10:00:00 -0300\r\nMIME-Version: 1.0\r\n" \
+        "Content-Type: multipart/mixed; boundary=\"limite\"\r\n\r\n" \
+        "--limite\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n" \
+        "Corpo com texto suficiente para o pipeline aceitar sem reclamar.\r\n" \
+        "--limite\r\nContent-Type: text/plain; charset=UTF-8\r\n" \
+        "Content-Disposition: attachment; filename=\"nota.txt\"\r\n\r\nconteudo do anexo\r\n--limite--\r\n"
+      )
+    end
+
+    it 'takes none by default, which is what keeps a first pass inside the byte budget' do
+      described_class.new.import(with_attachment, channel)
+      expect(inbox.messages.last.attachments).to be_empty
+    end
+
+    it 'takes them when the caller asks for all of them' do
+      described_class.new(attachments: :all).import(with_attachment, channel)
+      expect(inbox.messages.last.attachments).to be_present
+    end
+
+    it 'leaves behind what is older than the cutoff' do
+      described_class.new(attachments: Time.zone.parse('2024-01-01')).import(with_attachment, channel)
+      expect(inbox.messages.last.attachments).to be_empty
+    end
+  end
+end

--- a/spec/services/import/email/pacer_spec.rb
+++ b/spec/services/import/email/pacer_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Import::Email::Pacer do
+  # The budget stops a run and the load only pauses it: one is a daily allowance that does
+  # not come back, the other is a machine that will be free again in a minute.
+  it 'stops the run once the byte budget is spent' do
+    pacer = described_class.new(budget_mb: 1, max_load: 99)
+    expect(pacer).not_to be_over_budget
+    pacer.spend(2.megabytes)
+    expect(pacer).to be_over_budget
+  end
+
+  it 'reports what is left of the allowance' do
+    pacer = described_class.new(budget_mb: 10, max_load: 99)
+    pacer.spend(4.megabytes)
+    expect(pacer.spent_mb).to be_within(0.1).of(4)
+    expect(pacer.budget_mb_left).to be_within(0.1).of(6)
+  end
+
+  it 'does not pause a machine that is idle' do
+    pacer = described_class.new(budget_mb: 10, max_load: 99)
+    paused = false
+    pacer.wait_for_room { paused = true }
+    expect(paused).to be(false)
+    expect(pacer.paused_for).to eq(0)
+  end
+end

--- a/spec/services/import/email/pacer_spec.rb
+++ b/spec/services/import/email/pacer_spec.rb
@@ -17,6 +17,15 @@ describe Import::Email::Pacer do
     expect(pacer.budget_mb_left).to be_within(0.1).of(6)
   end
 
+  # Asked before a fetch, because the bytes that would break the ceiling are the ones that
+  # have not been spent yet.
+  it 'answers whether a transfer still fits under the ceiling' do
+    pacer = described_class.new(budget_mb: 10, max_load: 99)
+    pacer.spend(9.megabytes)
+    expect(pacer.room_for?(1.megabyte)).to be(true)
+    expect(pacer.room_for?(2.megabytes)).to be(false)
+  end
+
   it 'does not pause a machine that is idle' do
     pacer = described_class.new(budget_mb: 10, max_load: 99)
     paused = false

--- a/spec/services/import/email/text_only_spec.rb
+++ b/spec/services/import/email/text_only_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+describe Import::Email::TextOnly do
+  # Doubles rather than a live connection: what matters is the shape Net::IMAP returns for
+  # BODYSTRUCTURE, and these carry the same readers the walk uses.
+  # `size` is the reader Net::IMAP uses for a part's octets, so the double has to carry it.
+  let(:leaf) do
+    Struct.new(:media_type, :subtype, :encoding, :param, :disposition, :size, keyword_init: true) # rubocop:disable Lint/StructNewOverride
+  end
+  let(:multi) do
+    Struct.new(:subtype, :parts, keyword_init: true) do
+      def media_type = 'MULTIPART'
+      def encoding = nil
+      def param = nil
+      def disposition = nil
+      def size = 0
+    end
+  end
+  let(:disposition) { Struct.new(:dsp_type) }
+
+  def text(subtype = 'PLAIN', size: 900, dsp: nil)
+    leaf.new(media_type: 'TEXT', subtype: subtype, encoding: '7BIT',
+             param: { 'CHARSET' => 'UTF-8' }, disposition: dsp, size: size)
+  end
+
+  def binary
+    leaf.new(media_type: 'IMAGE', subtype: 'PNG', encoding: 'BASE64',
+             param: {}, disposition: disposition.new('ATTACHMENT'), size: 3_000_000)
+  end
+
+  describe '#attachments?' do
+    it 'is false for a message that is only text, where a second fetch would save nothing' do
+      expect(described_class.new(text)).not_to be_attachments
+      expect(described_class.new(multi.new(subtype: 'ALTERNATIVE', parts: [text, text('HTML')]))).not_to be_attachments
+    end
+
+    it 'is true when a part is not text' do
+      expect(described_class.new(multi.new(subtype: 'MIXED', parts: [text, binary]))).to be_attachments
+    end
+
+    it 'counts text offered as a file, which weighs the same as any other attachment' do
+      csv = text('CSV', size: 9000, dsp: disposition.new('ATTACHMENT'))
+      expect(described_class.new(multi.new(subtype: 'MIXED', parts: [text, csv]))).to be_attachments
+    end
+  end
+
+  describe '#part' do
+    it 'numbers a single-part body as section 1' do
+      expect(described_class.new(text).part).to include(section: '1', type: 'text/plain')
+    end
+
+    it 'addresses a nested part the way BODY[n.m] does' do
+      inner = multi.new(subtype: 'ALTERNATIVE', parts: [text, text('HTML', size: 3000)])
+      structure = multi.new(subtype: 'MIXED', parts: [inner, binary])
+      expect(described_class.new(structure).part[:section]).to eq('1.1')
+    end
+
+    it 'prefers plain when it says anything' do
+      structure = multi.new(subtype: 'MIXED', parts: [text(size: 900), text('HTML', size: 9000), binary])
+      expect(described_class.new(structure).part).to include(section: '1', type: 'text/plain')
+    end
+
+    # An HTML-only message still carries a plain alternative, and it is routinely an empty
+    # stub. Preferring plain by subtype alone files those messages with no body at all.
+    it 'passes over an empty plain stub for the HTML that carries the words' do
+      structure = multi.new(subtype: 'MIXED', parts: [text(size: 2), text('HTML', size: 4000), binary])
+      expect(described_class.new(structure).part).to include(section: '2', type: 'text/html')
+    end
+
+    # The floor decides the preference and nothing else: applied to the result it would
+    # send "See attached" back to the whole message, attachment included.
+    it 'takes a very short body rather than giving up on the message' do
+      structure = multi.new(subtype: 'MIXED', parts: [text(size: 12), binary])
+      expect(described_class.new(structure).part).to include(section: '1')
+    end
+
+    it 'is nil when the structure names no text at all, so the caller takes the whole message' do
+      expect(described_class.new(multi.new(subtype: 'MIXED', parts: [binary, binary])).part).to be_nil
+    end
+  end
+
+  describe '#rebuild' do
+    let(:header) do
+      "Return-Path: <a@example.com>\r\nFrom: A <a@example.com>\r\nTo: b@example.com\r\n" \
+        "Subject: Assunto\r\nMessage-ID: <keep-me@example.com>\r\nReferences: <parent@example.com>\r\n" \
+        "Date: Mon, 1 May 2023 10:00:00 -0300\r\nMIME-Version: 1.0\r\n" \
+        "Content-Type: multipart/mixed; boundary=\"xyz\"\r\nContent-Transfer-Encoding: 7bit\r\n"
+    end
+    let(:rebuilt) do
+      lean = described_class.new(multi.new(subtype: 'MIXED', parts: [text, binary]))
+      Mail.read_from_string(lean.rebuild(header, 'Corpo de teste'))
+    end
+
+    it 'keeps the identity and threading headers the dedupe and the thread lookup read' do
+      expect(rebuilt.message_id).to eq('keep-me@example.com')
+      expect(rebuilt.references).to eq('parent@example.com')
+      expect(rebuilt.subject).to eq('Assunto')
+      expect(rebuilt.date).to eq(DateTime.parse('Mon, 1 May 2023 10:00:00 -0300'))
+    end
+
+    it 'announces the part that is standing in for the body, so the mail parses as single-part' do
+      expect(rebuilt).not_to be_multipart
+      expect(rebuilt.content_type).to eq('text/plain; charset=UTF-8')
+      expect(rebuilt.body.decoded.strip).to eq('Corpo de teste')
+    end
+
+    it 'drops the multipart boundary it is no longer describing' do
+      expect(rebuilt.header.to_s).not_to include('boundary')
+    end
+  end
+end

--- a/spec/services/import/email/text_only_spec.rb
+++ b/spec/services/import/email/text_only_spec.rb
@@ -16,7 +16,7 @@ describe Import::Email::TextOnly do
       def size = 0
     end
   end
-  let(:disposition) { Struct.new(:dsp_type) }
+  let(:disposition) { Struct.new(:dsp_type, :param) }
 
   def text(subtype = 'PLAIN', size: 900, dsp: nil)
     leaf.new(media_type: 'TEXT', subtype: subtype, encoding: '7BIT',
@@ -41,6 +41,25 @@ describe Import::Email::TextOnly do
     it 'counts text offered as a file, which weighs the same as any other attachment' do
       csv = text('CSV', size: 9000, dsp: disposition.new('ATTACHMENT'))
       expect(described_class.new(multi.new(subtype: 'MIXED', parts: [text, csv]))).to be_attachments
+    end
+
+    # Legacy mail names a file without ever saying `attachment`. Read on the disposition
+    # alone the message looks free of attachments, so the whole of it is downloaded --
+    # which is the byte the cutoff exists to refuse.
+    it 'counts a text part named by its content type, with no disposition at all' do
+      csv = leaf.new(media_type: 'TEXT', subtype: 'CSV', encoding: '7BIT',
+                     param: { 'CHARSET' => 'UTF-8', 'NAME' => 'nota.csv' }, disposition: nil, size: 900_000)
+      expect(described_class.new(multi.new(subtype: 'MIXED', parts: [text, csv]))).to be_attachments
+    end
+
+    it 'counts a text part offered inline under a filename' do
+      csv = text('CSV', size: 900_000, dsp: disposition.new('INLINE', { 'FILENAME' => 'nota.csv' }))
+      expect(described_class.new(multi.new(subtype: 'MIXED', parts: [text, csv]))).to be_attachments
+    end
+
+    it 'leaves an ordinary inline body alone' do
+      body = text(dsp: disposition.new('INLINE', {}))
+      expect(described_class.new(multi.new(subtype: 'ALTERNATIVE', parts: [body, text('HTML')]))).not_to be_attachments
     end
   end
 

--- a/spec/services/import/email/timestamp_spec.rb
+++ b/spec/services/import/email/timestamp_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe Import::Email::Timestamp do
+  def mail_with(headers)
+    Mail.read_from_string(
+      "From: a@example.com\r\nTo: b@example.com\r\nMessage-ID: <x@example.com>\r\n#{headers}\r\nCorpo"
+    )
+  end
+
+  it 'reads the Date header when it parses' do
+    mail = mail_with("Date: Mon, 1 May 2023 10:00:00 -0300\r\n")
+    expect(described_class.of(mail)).to eq(Time.zone.parse('2023-05-01 13:00:00 UTC'))
+  end
+
+  it 'falls back to the oldest Received line when there is no Date' do
+    mail = mail_with("Received: from a by b; Tue, 14 Mar 2023 10:22:31 -0300\r\n")
+    expect(described_class.of(mail)).to eq(Time.zone.parse('2023-03-14 13:22:31 UTC'))
+  end
+
+  it 'falls back when Date is text rather than a date' do
+    mail = mail_with("Received: from a by b; Tue, 14 Mar 2023 10:22:31 -0300\r\nDate: nao e uma data\r\n")
+    expect(described_class.of(mail)).to eq(Time.zone.parse('2023-03-14 13:22:31 UTC'))
+  end
+
+  it 'falls back when Date parses into an impossible time, which raises from the reader' do
+    mail = mail_with("Received: from a by b; Tue, 14 Mar 2023 10:22:31 -0300\r\nDate: 32 Xxx 2023 99:99:99\r\n")
+    expect(described_class.of(mail)).to eq(Time.zone.parse('2023-03-14 13:22:31 UTC'))
+  end
+
+  it 'answers nil when the mail says nothing usable, rather than answering now' do
+    expect(described_class.of(mail_with(''))).to be_nil
+  end
+end

--- a/spec/services/import/history_settlement_spec.rb
+++ b/spec/services/import/history_settlement_spec.rb
@@ -62,6 +62,35 @@ describe Import::HistorySettlement do
     expect(ana.reload.last_activity_at).to eq(Time.zone.parse('2026-01-01 09:00'))
   end
 
+  # Being searchable is most of why an archive is imported. The per-row callback is stopped
+  # in the guards precisely so the batch can go over in one pass, so the pass has to exist.
+  describe 'handing the batch to the search index' do
+    let(:ana) { create(:contact, account: account, name: 'Ana') }
+    let(:rows) do
+      [incoming(ana, Time.zone.parse('2023-05-01 10:00')),
+       incoming(ana, Time.zone.parse('2023-05-02 10:00'))]
+    end
+
+    it 'asks for one bulk pass over the whole batch, not one job per row' do
+      # `reindex` reaches a relation through ActiveRecord's delegation to the class, so a
+      # verifying double refuses it: the method is not defined on Relation.
+      relation = double('Message relation') # rubocop:disable RSpec/VerifiedDoubles
+      written = rows
+      allow(ChatwootApp).to receive(:advanced_search_allowed?).and_return(true)
+      allow(Message).to receive(:where).with(id: written.map(&:id)).and_return(relation)
+      expect(relation).to receive(:reindex).with(mode: :async)
+      settler.new.run(written)
+    end
+
+    # `reindex` is not defined at all unless `searchkick` was declared, which is itself
+    # conditional on the same test.
+    it 'leaves the index alone where advanced search is not configured' do
+      allow(ChatwootApp).to receive(:advanced_search_allowed?).and_return(false)
+      expect(Message).not_to receive(:where)
+      settler.new.run(rows)
+    end
+  end
+
   # The resume path reads the thread back off the database, where `sender` on every row is
   # a query. Read off `sender_id` the batch costs one.
   it 'asks for the contacts once for the whole batch' do

--- a/spec/services/import/history_settlement_spec.rb
+++ b/spec/services/import/history_settlement_spec.rb
@@ -12,6 +12,8 @@ describe Import::HistorySettlement do
     create(:conversation, account: account, inbox: inbox, contact: group, contact_inbox: contact_inbox)
   end
 
+  # A backfill's shape: it names a batch size, which is how it says it has taken the search
+  # index on itself. An importer that has not is covered separately below.
   let(:settler) do
     Class.new do
       include Import::HistorySettlement
@@ -21,6 +23,7 @@ describe Import::HistorySettlement do
       def announcing(&) = yield
       def run(rows) = settle(rows, [])
       def run_contacts(conversation, rows) = stamp_contact(conversation, rows)
+      def search_index_batch = 1
     end
   end
 
@@ -161,6 +164,24 @@ describe Import::HistorySettlement do
 
         expect(calls).to eq([[row.id]])
       end
+    end
+
+    # An importer handed a webhook's worth of rows and thrown away keeps Message's own
+    # per-row callback, which the guard leaves alone for it. Indexing here as well would be
+    # the same rows twice, and buffering here would lose the ones a batch committed before
+    # it raised: they never reach a settlement, and the retry filters them out as stored.
+    it 'leaves it to the callback for an importer that has not taken it on' do
+      passive = Class.new do
+        include Import::HistorySettlement
+        attr_reader :opened
+
+        def initialize = @opened = Set.new
+        def announcing(&) = yield
+        def run(rows) = settle(rows, [])
+      end
+      allow(ChatwootApp).to receive(:advanced_search_allowed?).and_return(true)
+      expect(Message).not_to receive(:where)
+      passive.new.run(rows)
     end
 
     # `reindex` is not defined at all unless `searchkick` was declared, which is itself

--- a/spec/services/import/history_settlement_spec.rb
+++ b/spec/services/import/history_settlement_spec.rb
@@ -101,6 +101,68 @@ describe Import::HistorySettlement do
       expect(indexed).to be(true)
     end
 
+    # Searchkick splits rows within one `reindex` call and not across calls, so a job per
+    # settlement is a job per message wherever a settlement is one message -- which is the
+    # IMAP path, and which is the flood the guard was put in to stop.
+    describe 'an importer that outlives its settlements' do
+      let(:buffering) do
+        Class.new do
+          include Import::HistorySettlement
+          attr_reader :opened
+
+          def initialize = @opened = Set.new
+          def announcing(&) = yield
+          def run(rows) = settle(rows, [])
+          def search_index_batch = 3
+        end
+      end
+
+      let(:ana) { create(:contact, account: account, name: 'Ana') }
+
+      def watch
+        relation = double('Message relation') # rubocop:disable RSpec/VerifiedDoubles
+        allow(relation).to receive(:reindex)
+        allow(ChatwootApp).to receive(:advanced_search_allowed?).and_return(true)
+        calls = []
+        allow(Message).to receive(:where) do |args|
+          calls << args[:id]
+          relation
+        end
+        calls
+      end
+
+      it 'sends one pass for the batch instead of one per settlement' do
+        calls = watch
+        importer = buffering.new
+        written = Array.new(3) { |i| incoming(ana, Time.zone.parse('2023-05-01 10:00') + i.days) }
+        written.each { |row| importer.run([row]) }
+
+        expect(calls).to eq([written.map(&:id)])
+      end
+
+      it 'sends what is still owed when the run says it is over' do
+        calls = watch
+        importer = buffering.new
+        written = Array.new(2) { |i| incoming(ana, Time.zone.parse('2023-05-01 10:00') + i.days) }
+        written.each { |row| importer.run([row]) }
+        expect(calls).to be_empty
+
+        importer.flush_search_index
+        expect(calls).to eq([written.map(&:id)])
+      end
+
+      # A resumed OctaDesk ticket settles from the whole conversation, so the same row is
+      # offered again by the next settlement in the same batch.
+      it 'asks for a row once however many settlements named it' do
+        calls = watch
+        importer = buffering.new
+        row = incoming(ana, Time.zone.parse('2023-05-01 10:00'))
+        3.times { importer.run([row]) }
+
+        expect(calls).to eq([[row.id]])
+      end
+    end
+
     # `reindex` is not defined at all unless `searchkick` was declared, which is itself
     # conditional on the same test.
     it 'leaves the index alone where advanced search is not configured' do

--- a/spec/services/import/history_settlement_spec.rb
+++ b/spec/services/import/history_settlement_spec.rb
@@ -82,6 +82,25 @@ describe Import::HistorySettlement do
       settler.new.run(written)
     end
 
+    # The IMAP importer settles inside the transaction that writes the row. Enqueued there,
+    # a worker is free to run the job before the row exists, find nothing, and leave it out
+    # of the index for good -- the per-row callback that would have caught it later is the
+    # one this replaced.
+    it 'waits for the transaction the importer settles inside to commit' do
+      relation = double('Message relation') # rubocop:disable RSpec/VerifiedDoubles
+      written = rows
+      indexed = false
+      allow(ChatwootApp).to receive(:advanced_search_allowed?).and_return(true)
+      allow(Message).to receive(:where).with(id: written.map(&:id)).and_return(relation)
+      allow(relation).to receive(:reindex) { indexed = true }
+
+      ActiveRecord::Base.transaction do
+        settler.new.run(written)
+        expect(indexed).to be(false)
+      end
+      expect(indexed).to be(true)
+    end
+
     # `reindex` is not defined at all unless `searchkick` was declared, which is itself
     # conditional on the same test.
     it 'leaves the index alone where advanced search is not configured' do

--- a/spec/services/import/history_settlement_spec.rb
+++ b/spec/services/import/history_settlement_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+# The shared settlement, exercised through a stand-in includer rather than through one of
+# the importers: what is worth pinning is the rule, and each importer hands it the same
+# thing -- a conversation and the rows written into it.
+describe Import::HistorySettlement do
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:group) { create(:contact, account: account, name: 'Grupo') }
+  let(:conversation) do
+    contact_inbox = create(:contact_inbox, contact: group, inbox: inbox)
+    create(:conversation, account: account, inbox: inbox, contact: group, contact_inbox: contact_inbox)
+  end
+
+  let(:settler) do
+    Class.new do
+      include Import::HistorySettlement
+      attr_reader :opened
+
+      def initialize = @opened = Set.new
+      def announcing(&) = yield
+      def run(rows) = settle(rows, [])
+      def run_contacts(conversation, rows) = stamp_contact(conversation, rows)
+    end
+  end
+
+  # Written the way an importer writes, because the live `update_contact_activity` would
+  # otherwise stamp every sender with `DateTime.now` and hide whatever the settlement did.
+  def incoming(sender, at)
+    Import::SilentWrite.wrap do
+      create(:message, account: account, inbox: inbox, conversation: conversation,
+                       message_type: :incoming, sender: sender, created_at: at,
+                       content_attributes: { imported: true })
+    end
+  end
+
+  # On a group the conversation's contact is the group and each row was written by a
+  # participant. Stamping the conversation's contact gives the group a clock it never
+  # earned and leaves every participant at null.
+  describe 'when the conversation is a group and the rows are its participants' do
+    let(:ana) { create(:contact, account: account, name: 'Ana') }
+    let(:bruno) { create(:contact, account: account, name: 'Bruno') }
+
+    it 'stamps each participant from what that participant wrote' do
+      rows = [incoming(ana, Time.zone.parse('2023-05-01 10:00')),
+              incoming(bruno, Time.zone.parse('2023-06-10 09:00')),
+              incoming(ana, Time.zone.parse('2023-03-01 08:00'))]
+      settler.new.run(rows)
+      expect(ana.reload.last_activity_at).to eq(Time.zone.parse('2023-05-01 10:00'))
+      expect(bruno.reload.last_activity_at).to eq(Time.zone.parse('2023-06-10 09:00'))
+    end
+
+    it 'leaves the group itself alone, since the group never wrote anything' do
+      settler.new.run([incoming(ana, Time.zone.parse('2023-05-01 10:00'))])
+      expect(group.reload.last_activity_at).to be_nil
+    end
+  end
+
+  it 'never drags a contact backwards, whoever wrote the row' do
+    ana = create(:contact, account: account, last_activity_at: Time.zone.parse('2026-01-01 09:00'))
+    settler.new.run([incoming(ana, Time.zone.parse('2023-05-01 10:00'))])
+    expect(ana.reload.last_activity_at).to eq(Time.zone.parse('2026-01-01 09:00'))
+  end
+
+  # The resume path reads the thread back off the database, where `sender` on every row is
+  # a query. Read off `sender_id` the batch costs one.
+  it 'asks for the contacts once for the whole batch' do
+    rows = Array.new(6) { |i| incoming(create(:contact, account: account), Time.zone.parse('2023-05-01 10:00') + i.days) }
+    reloaded = conversation.messages.reload.to_a
+    queries = 0
+    subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+      queries += 1 if payload[:sql].start_with?('SELECT') && payload[:sql].include?('"contacts"')
+    end
+    settler.new.run_contacts(conversation, reloaded)
+    ActiveSupport::Notifications.unsubscribe(subscription)
+    expect(rows.length).to eq(6)
+    expect(queries).to eq(1)
+  end
+end

--- a/spec/services/import/history_settlement_spec.rb
+++ b/spec/services/import/history_settlement_spec.rb
@@ -174,6 +174,27 @@ describe Import::HistorySettlement do
         expect(relation).to have_received(:reindex).twice
       end
 
+      # The threshold flush fires inside the mail importer's transaction, carrying ids from
+      # hundreds of messages that committed long before it. Rails discards an after_commit
+      # callback when the transaction rolls back, so clearing the backlog up front would
+      # lose every one of them -- their per-row callback was suppressed and every later pass
+      # skips them as already stored.
+      it 'keeps what a rolled back transaction never handed over' do
+        written = Array.new(2) { |i| incoming(ana, Time.zone.parse('2023-05-01 10:00') + i.days) }
+        calls = watch
+        importer = buffering.new
+        written.each { |row| importer.run([row]) }
+
+        ActiveRecord::Base.transaction do
+          importer.flush_search_index
+          raise ActiveRecord::Rollback
+        end
+        expect(calls).to be_empty
+
+        importer.flush_search_index
+        expect(calls).to eq([written.map(&:id)])
+      end
+
       # A resumed OctaDesk ticket settles from the whole conversation, so the same row is
       # offered again by the next settlement in the same batch.
       it 'asks for a row once however many settlements named it' do

--- a/spec/services/import/history_settlement_spec.rb
+++ b/spec/services/import/history_settlement_spec.rb
@@ -122,6 +122,9 @@ describe Import::HistorySettlement do
 
       let(:ana) { create(:contact, account: account, name: 'Ana') }
 
+      # Turned on only once the rows exist. An importer that has not taken the index on
+      # itself keeps Message's own per-row callback, which is the point of the guard now, so
+      # writing the fixtures under the stub would be exercising that callback instead.
       def watch
         relation = double('Message relation') # rubocop:disable RSpec/VerifiedDoubles
         allow(relation).to receive(:reindex)
@@ -135,18 +138,18 @@ describe Import::HistorySettlement do
       end
 
       it 'sends one pass for the batch instead of one per settlement' do
+        written = Array.new(3) { |i| incoming(ana, Time.zone.parse('2023-05-01 10:00') + i.days) }
         calls = watch
         importer = buffering.new
-        written = Array.new(3) { |i| incoming(ana, Time.zone.parse('2023-05-01 10:00') + i.days) }
         written.each { |row| importer.run([row]) }
 
         expect(calls).to eq([written.map(&:id)])
       end
 
       it 'sends what is still owed when the run says it is over' do
+        written = Array.new(2) { |i| incoming(ana, Time.zone.parse('2023-05-01 10:00') + i.days) }
         calls = watch
         importer = buffering.new
-        written = Array.new(2) { |i| incoming(ana, Time.zone.parse('2023-05-01 10:00') + i.days) }
         written.each { |row| importer.run([row]) }
         expect(calls).to be_empty
 
@@ -157,9 +160,9 @@ describe Import::HistorySettlement do
       # A resumed OctaDesk ticket settles from the whole conversation, so the same row is
       # offered again by the next settlement in the same batch.
       it 'asks for a row once however many settlements named it' do
+        row = incoming(ana, Time.zone.parse('2023-05-01 10:00'))
         calls = watch
         importer = buffering.new
-        row = incoming(ana, Time.zone.parse('2023-05-01 10:00'))
         3.times { importer.run([row]) }
 
         expect(calls).to eq([[row.id]])
@@ -179,9 +182,10 @@ describe Import::HistorySettlement do
         def announcing(&) = yield
         def run(rows) = settle(rows, [])
       end
+      written = rows
       allow(ChatwootApp).to receive(:advanced_search_allowed?).and_return(true)
       expect(Message).not_to receive(:where)
-      passive.new.run(rows)
+      passive.new.run(written)
     end
 
     # `reindex` is not defined at all unless `searchkick` was declared, which is itself

--- a/spec/services/import/history_settlement_spec.rb
+++ b/spec/services/import/history_settlement_spec.rb
@@ -157,6 +157,23 @@ describe Import::HistorySettlement do
         expect(calls).to eq([written.map(&:id)])
       end
 
+      # The rows are committed and the next pass skips them as already stored, so a batch
+      # dropped on a failed handoff is a batch nothing ever indexes again.
+      it 'keeps what it could not hand over' do
+        written = Array.new(2) { |i| incoming(ana, Time.zone.parse('2023-05-01 10:00') + i.days) }
+        relation = double('Message relation') # rubocop:disable RSpec/VerifiedDoubles
+        allow(ChatwootApp).to receive(:advanced_search_allowed?).and_return(true)
+        allow(Message).to receive(:where).and_return(relation)
+        allow(relation).to receive(:reindex).and_raise(Redis::CannotConnectError)
+        importer = buffering.new
+        written.each { |row| importer.run([row]) }
+
+        expect { importer.flush_search_index }.to raise_error(Redis::CannotConnectError)
+        allow(relation).to receive(:reindex)
+        importer.flush_search_index
+        expect(relation).to have_received(:reindex).twice
+      end
+
       # A resumed OctaDesk ticket settles from the whole conversation, so the same row is
       # offered again by the next settlement in the same batch.
       it 'asks for a row once however many settlements named it' do

--- a/spec/services/import/import_guards_spec.rb
+++ b/spec/services/import/import_guards_spec.rb
@@ -52,6 +52,47 @@ describe 'ImportGuards' do
     end
   end
 
+  # `create_activity` does not act, it enqueues: the job creates a real Message on a Sidekiq
+  # thread, where the flag is gone and every callback runs live -- the dispatcher, the bot,
+  # the index, and `last_activity_at` moved to the time of the import. A thread from 2021
+  # would arrive at the top of the inbox wearing today's date and a line nobody wrote.
+  describe 'the activity line a conversation writes about itself' do
+    # Reached at all only because these examples name an actor. Nothing in the import does:
+    # `create_label_change` returns unless something named one, and a rake task leaves
+    # `Current` empty. That is ambient state the import does not control -- the same importer
+    # driven from a request carries the operator in `Current.user` -- so the guard is written
+    # against the callback rather than against the one call that reaches it today.
+    let(:operator) { create(:user, account: account) }
+
+    before { Current.user = operator }
+
+    after { Current.reset }
+
+    it 'is enqueued outside an import, as it always has been' do
+      conversation = new_conversation
+      expect { conversation.add_labels(['suporte']) }.to have_enqueued_job(Conversations::ActivityMessageJob)
+    end
+
+    # Both levels, unlike the guards around it: the job runs where no level reaches, so an
+    # announcing run would hand the event to every listener a second after the sync
+    # dispatcher let exactly one of them through.
+    it 'is not enqueued at either level of the flag' do
+      archived = new_conversation
+      announced = new_conversation
+
+      expect { Import::SilentWrite.wrap { archived.add_labels(['suporte']) } }
+        .not_to have_enqueued_job(Conversations::ActivityMessageJob)
+      expect { Import::SilentWrite.wrap(announce: true) { announced.add_labels(['suporte']) } }
+        .not_to have_enqueued_job(Conversations::ActivityMessageJob)
+    end
+
+    it 'still writes the labels it was asked for' do
+      conversation = new_conversation
+      Import::SilentWrite.wrap { conversation.add_labels(%w[suporte reembolso]) }
+      expect(conversation.reload.label_list).to match_array(%w[suporte reembolso])
+    end
+  end
+
   # Not exercised through Message: `should_index?` is false unless advanced search is
   # configured at boot, so a create-a-message test would pass with the guard deleted. What
   # is checkable without a cluster is that the guard is on the method Message actually

--- a/spec/services/import/import_guards_spec.rb
+++ b/spec/services/import/import_guards_spec.rb
@@ -52,6 +52,48 @@ describe 'ImportGuards' do
     end
   end
 
+  # Not exercised through Message: `should_index?` is false unless advanced search is
+  # configured at boot, so a create-a-message test would pass with the guard deleted. What
+  # is checkable without a cluster is that the guard is on the method Message actually
+  # defines, and that it reads both levels.
+  describe 'the per-row search index job' do
+    it 'is prepended over the callback Message defines' do
+      expect(Message.private_method_defined?(:reindex_for_search)).to be(true)
+      expect(Message.ancestors.index(ImportGuards::SilentSearchIndex))
+        .to be < Message.ancestors.index(Message)
+    end
+
+    it 'stops the per-row reindex at both levels, where the batch pass takes over' do
+      indexed = Class.new { def reindex_for_search = :indexed }
+      indexed.prepend(ImportGuards::SilentSearchIndex)
+      row = indexed.new
+
+      expect(row.send(:reindex_for_search)).to eq(:indexed)
+      expect(Import::SilentWrite.wrap { row.send(:reindex_for_search) }).to be_nil
+      expect(Import::SilentWrite.wrap(announce: true) { row.send(:reindex_for_search) }).to be_nil
+    end
+  end
+
+  # A prepended module publishes what it defines, so a guard that forgot to restate the
+  # visibility would widen the model's public surface as a side effect of narrowing its
+  # behaviour. Read off the models rather than off the modules, because it is the model's
+  # surface that is the claim.
+  describe 'the public surface of the guarded models' do
+    it 'leaves every guarded callback as private as it was' do
+      surface = {
+        Message => %i[execute_after_create_commit_callbacks hold_pending_scheduled_messages reindex_for_search],
+        Conversation => %i[run_auto_assignment set_active_bot_conversation],
+        Contact => %i[ip_lookup]
+      }
+      leaked = surface.flat_map { |klass, names| names.reject { |name| klass.private_method_defined?(name) } }
+      expect(leaked).to be_empty
+    end
+
+    it 'leaves the one that was already public alone' do
+      expect(Contact.public_method_defined?(:fetch_avatar_from_gravatar)).to be(true)
+    end
+  end
+
   describe 'the jobs a new contact would start on its own' do
     it 'skips the Gravatar fetch for an archive, where one request per contact is a flood' do
       expect do

--- a/spec/services/import/import_guards_spec.rb
+++ b/spec/services/import/import_guards_spec.rb
@@ -70,6 +70,46 @@ describe 'ImportGuards' do
     end
   end
 
+  # `hold_on_reply` means "if the customer writes back first, do not send this". A row that
+  # is incoming, public and not a reaction is the whole trigger, and an imported row passes
+  # that test the same way a live one does.
+  describe 'a scheduled message waiting on the customer to reply' do
+    let(:conversation) { new_conversation }
+    let(:scheduled) do
+      create(:scheduled_message, account: account, inbox: inbox, conversation: conversation,
+                                 scheduled_at: 2.days.from_now, hold_on_reply: true, status: :pending)
+    end
+
+    def import(created_at, **level)
+      Import::SilentWrite.wrap(**level) do
+        create(:message, account: account, inbox: inbox, conversation: conversation,
+                         message_type: :incoming, content: 'historia', created_at: created_at)
+      end
+    end
+
+    it 'holds it when a live reply arrives, which is what the flag is for' do
+      scheduled
+      create(:message, account: account, inbox: inbox, conversation: conversation,
+                       message_type: :incoming, content: 'oi')
+      expect(scheduled.reload.status).to eq('held')
+    end
+
+    # The archive row is years old, so `scheduled_at > created_at` is true of every pending
+    # scheduled message in the account: one imported ticket would hold the lot.
+    it 'leaves it alone while writing an archive' do
+      scheduled
+      import(3.years.ago)
+      expect(scheduled.reload.status).to eq('pending')
+    end
+
+    # A gap row is a reply that did arrive, just late. Holding is the right answer there.
+    it 'holds it for a gap row, which is a real reply we learned about late' do
+      scheduled
+      import(1.minute.ago, announce: true)
+      expect(scheduled.reload.status).to eq('held')
+    end
+  end
+
   describe 'the fan-out around a written message' do
     it 'reaches nothing at either level' do
       conversation = Import::SilentWrite.wrap { new_conversation }

--- a/spec/services/import/import_guards_spec.rb
+++ b/spec/services/import/import_guards_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+# The guards live in an initializer and are prepended at boot; what is worth covering is
+# which level each one reads, because getting that wrong is silent in both directions.
+describe 'ImportGuards' do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, account: account) }
+  let(:inbox) { channel.inbox }
+  let(:contact_inbox) do
+    ContactInboxWithContactBuilder.new(source_id: 'quem@example.com', inbox: inbox,
+                                       contact_attributes: { name: 'Quem', email: 'quem@example.com' }).perform
+  end
+
+  def new_conversation
+    Conversation.create!(account_id: account.id, inbox_id: inbox.id,
+                         contact_id: contact_inbox.contact_id, contact_inbox_id: contact_inbox.id)
+  end
+
+  context 'when the inbox has an active agent bot' do
+    before do
+      bot = create(:agent_bot, account: account)
+      create(:agent_bot_inbox, inbox: inbox, agent_bot: bot, status: :active)
+      inbox.reload
+    end
+
+    it 'starts a conversation pending outside an import, as it always has' do
+      expect(new_conversation.status).to eq('pending')
+    end
+
+    # An archive thread is created resolved on purpose: born in that state it fires no
+    # resolution event and lands in no report. The bot override would undo that for the
+    # whole archive at once.
+    it 'leaves the status alone while writing an archive' do
+      conversation = Import::SilentWrite.wrap { new_conversation }
+      expect(conversation.status).to eq('open')
+      expect(conversation.assignee_agent_bot_id).to be_nil
+    end
+
+    # A gap thread is live work recovered a minute late, and has to be routed like any
+    # other arrival or nobody works it until they reload.
+    it 'routes a gap thread the way an arrival would be' do
+      conversation = Import::SilentWrite.wrap(announce: true) { new_conversation }
+      expect(conversation.status).to eq('pending')
+      expect(conversation.assignee_agent_bot_id).to be_present
+    end
+
+    it 'still resolves a blocked contact at either level, which is not the import to undo' do
+      contact_inbox.contact.update!(blocked: true)
+      archived = Import::SilentWrite.wrap { new_conversation }
+      announced = Import::SilentWrite.wrap(announce: true) { new_conversation }
+      expect([archived.status, announced.status]).to eq(%w[resolved resolved])
+    end
+  end
+
+  describe 'the jobs a new contact would start on its own' do
+    it 'skips the Gravatar fetch for an archive, where one request per contact is a flood' do
+      expect do
+        Import::SilentWrite.wrap do
+          create(:contact, account: account, email: "arquivo-#{SecureRandom.hex(4)}@example.com")
+        end
+      end.not_to have_enqueued_job(Avatar::AvatarFromGravatarJob)
+    end
+
+    it 'fetches it for a gap contact, where it is one request like any arrival' do
+      expect do
+        Import::SilentWrite.wrap(announce: true) do
+          create(:contact, account: account, email: "gap-#{SecureRandom.hex(4)}@example.com")
+        end
+      end.to have_enqueued_job(Avatar::AvatarFromGravatarJob)
+    end
+  end
+
+  describe 'the fan-out around a written message' do
+    it 'reaches nothing at either level' do
+      conversation = Import::SilentWrite.wrap { new_conversation }
+      expect do
+        Import::SilentWrite.wrap do
+          create(:message, account: account, inbox: inbox, conversation: conversation,
+                           message_type: :incoming, content: 'historia')
+        end
+      end.not_to have_enqueued_job(EventDispatcherJob)
+    end
+  end
+end

--- a/spec/services/import/import_guards_spec.rb
+++ b/spec/services/import/import_guards_spec.rb
@@ -63,14 +63,20 @@ describe 'ImportGuards' do
         .to be < Message.ancestors.index(Message)
     end
 
-    it 'stops the per-row reindex at both levels, where the batch pass takes over' do
+    # Not the level: the question is who indexes, not how loud the write is. A writer that
+    # has not taken it on keeps the callback, and needs it -- a batch of its that raised
+    # after some rows committed never reaches a settlement, and the retry filters those rows
+    # out as already stored, so this is the only thing that would ever index them.
+    it 'stops the per-row reindex only for a writer that indexes its own rows' do
       indexed = Class.new { def reindex_for_search = :indexed }
       indexed.prepend(ImportGuards::SilentSearchIndex)
       row = indexed.new
 
       expect(row.send(:reindex_for_search)).to eq(:indexed)
-      expect(Import::SilentWrite.wrap { row.send(:reindex_for_search) }).to be_nil
-      expect(Import::SilentWrite.wrap(announce: true) { row.send(:reindex_for_search) }).to be_nil
+      expect(Import::SilentWrite.wrap { row.send(:reindex_for_search) }).to eq(:indexed)
+      expect(Import::SilentWrite.wrap(announce: true) { row.send(:reindex_for_search) }).to eq(:indexed)
+      expect(Import::SilentWrite.wrap(indexing: true) { row.send(:reindex_for_search) }).to be_nil
+      expect(Import::SilentWrite.wrap(announce: true, indexing: true) { row.send(:reindex_for_search) }).to be_nil
     end
   end
 

--- a/spec/services/import/octadesk/attachment_fetcher_spec.rb
+++ b/spec/services/import/octadesk/attachment_fetcher_spec.rb
@@ -26,6 +26,14 @@ describe Import::Octadesk::AttachmentFetcher do
     expect(message.reload.attachments.first.file.filename.to_s).to eq('foto.png')
   end
 
+  # The filename cannot tell two objects apart, and a second pass has to. The source URL is
+  # the only key that is one-to-one with the object in the vendor's bucket.
+  it 'stamps where it came from, which is what a second pass keys on' do
+    stub_request(:get, url).to_return(status: 200, body: 'conteudo', headers: { 'content-type' => 'image/png' })
+    described_class.new(message: message, url: url, name: 'foto.png').perform
+    expect(message.reload.attachments.first.file.blob.metadata['import_source']).to eq(url)
+  end
+
   it 'answers nil when the object is gone, so the caller does not count it as mirrored' do
     stub_request(:get, url).to_return(status: 404)
     expect(described_class.new(message: message, url: url, name: 'foto.png').perform).to be_nil

--- a/spec/services/import/octadesk/attachment_fetcher_spec.rb
+++ b/spec/services/import/octadesk/attachment_fetcher_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe Import::Octadesk::AttachmentFetcher do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, account: account) }
+  let(:inbox) { channel.inbox }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox) }
+  let(:message) { create(:message, account: account, inbox: inbox, conversation: conversation) }
+  let(:url) { 'https://storage.googleapis.com/tenant/foto.png' }
+
+  # The URL comes out of a data file, so it is input. Without the check an edited export
+  # could point the fetcher at an internal address.
+  it 'fetches from the vendor bucket and nowhere else' do
+    fetcher = described_class.new(message: message, url: 'https://interno.example.com/x.png', name: 'x.png')
+    expect(fetcher.perform).to be_nil
+    expect(message.attachments).to be_empty
+  end
+
+  it 'refuses anything that is not https' do
+    expect(described_class.new(message: message, url: 'http://storage.googleapis.com/x.png', name: nil).perform).to be_nil
+  end
+
+  it 'stores what it downloads and says so' do
+    stub_request(:get, url).to_return(status: 200, body: 'conteudo', headers: { 'content-type' => 'image/png' })
+    expect(described_class.new(message: message, url: url, name: 'foto.png').perform).to be_present
+    expect(message.reload.attachments.first.file.filename.to_s).to eq('foto.png')
+  end
+
+  it 'answers nil when the object is gone, so the caller does not count it as mirrored' do
+    stub_request(:get, url).to_return(status: 404)
+    expect(described_class.new(message: message, url: url, name: 'foto.png').perform).to be_nil
+    expect(message.reload.attachments).to be_empty
+  end
+
+  # Reading the response whole and measuring afterwards would have the oversized object in
+  # memory before the check could run, which is the failure the cap exists for.
+  it 'abandons an object larger than the cap' do
+    stub_request(:get, url).to_return(status: 200, body: 'x' * (described_class::MAX_BYTES + 1),
+                                      headers: { 'content-type' => 'image/png' })
+    expect(described_class.new(message: message, url: url, name: 'foto.png').perform).to be_nil
+  end
+
+  describe '.filename_for' do
+    it 'prefers the name the export gave' do
+      expect(described_class.filename_for(url, 'nota fiscal.pdf')).to eq('nota fiscal.pdf')
+    end
+
+    it 'falls back to the last segment of the url' do
+      expect(described_class.filename_for(url, nil)).to eq('foto.png')
+    end
+
+    it 'keeps a name from becoming a path' do
+      expect(described_class.filename_for(url, 'a/b.png')).to eq('a_b.png')
+    end
+  end
+
+  # A bucket that answers application/octet-stream is answering about every file the same
+  # way, and taken at its word it files images, audio and video as :file, which is the one
+  # thing the dashboard will not preview.
+  describe 'the file type' do
+    {
+      ['image/jpeg', 'foto.jpg'] => 'image',
+      ['application/octet-stream', 'foto.jpg'] => 'image',
+      ['application/octet-stream', 'audio.mp3'] => 'audio',
+      ['', 'video.mp4'] => 'video',
+      ['application/octet-stream', 'doc.pdf'] => 'file',
+      ['application/octet-stream', 'sem-extensao'] => 'file'
+    }.each do |(content_type, name), expected|
+      it "is #{expected} for #{name} declared as #{content_type.presence || 'nothing'}" do
+        stub_request(:get, "https://storage.googleapis.com/tenant/#{name}")
+          .to_return(status: 200, body: 'x', headers: { 'content-type' => content_type })
+        described_class.new(message: message, url: "https://storage.googleapis.com/tenant/#{name}", name: name).perform
+        expect(message.reload.attachments.last.file_type).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/services/import/octadesk/backfill_spec.rb
+++ b/spec/services/import/octadesk/backfill_spec.rb
@@ -25,6 +25,17 @@ describe Import::Octadesk::Backfill do
 
   after { FileUtils.remove_entry(dir) }
 
+  # A ticket is a real batch, but a job per ticket is still tens of thousands of them over
+  # an export, so the importer buffers and this has to empty it -- including when a run ends
+  # because something raised, or the tail is missing from the index with nothing to say so.
+  it 'empties what the importer owes the index when the run ends' do
+    run = described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer)
+    importer = run.send(:instance_variable_get, :@importer)
+    allow(run).to receive(:parts).and_raise(ArgumentError)
+    expect(importer).to receive(:flush_search_index)
+    expect { run.perform }.to raise_error(ArgumentError)
+  end
+
   it 'walks every part and files what it finds' do
     run = described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer).perform
     expect(inbox.conversations.count).to eq(6)

--- a/spec/services/import/octadesk/backfill_spec.rb
+++ b/spec/services/import/octadesk/backfill_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+describe Import::Octadesk::Backfill do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, account: account) }
+  let(:inbox) { channel.inbox }
+  let(:pacer) { Import::Email::Pacer.new(budget_mb: Float::INFINITY, max_load: 99) }
+  let(:dir) { Dir.mktmpdir }
+  let(:zip_path) { File.join(dir, 'export.zip') }
+
+  def ticket(number)
+    { 'Number' => number, 'RequesterMail' => "cliente#{number}@example.com",
+      'DateCreation' => { '$date' => '2023-05-10T12:00:00Z' },
+      'Interactions' => [{ '_id' => { '$binary' => { 'base64' => format('%016d', number) } },
+                           'Comments' => [{ 'Content' => "Mensagem do ticket #{number}" }],
+                           'Person' => { 'Type' => 0, 'Name' => 'Cliente' },
+                           'DateCreation' => { '$date' => '2023-05-10T12:00:00Z' } }] }
+  end
+
+  before do
+    File.write(File.join(dir, 'part_0001.json'), (1..3).map { |n| ticket(n) }.to_json)
+    File.write(File.join(dir, 'part_0002.json'), (4..6).map { |n| ticket(n) }.to_json)
+    system('zip', '-jq', zip_path, File.join(dir, 'part_0001.json'), File.join(dir, 'part_0002.json'), exception: true)
+  end
+
+  after { FileUtils.remove_entry(dir) }
+
+  it 'walks every part and files what it finds' do
+    run = described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer).perform
+    expect(inbox.conversations.count).to eq(6)
+    expect(run.stats[:lidos]).to eq(6)
+  end
+
+  it 'reports what the importer filed, not only what the walker read' do
+    run = described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer).perform
+    expect(run.stats).to include(lidos: 6, tickets: 6, mensagens: 6)
+  end
+
+  # A limit on reads cannot advance: the next run re-reads the same already-imported
+  # tickets, writes nothing, and stops before reaching anything new.
+  describe 'LIMIT' do
+    it 'stops after that many newly imported tickets' do
+      described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer, limit: 2).perform
+      expect(inbox.conversations.count).to eq(2)
+    end
+
+    it 'continues where the previous run stopped when it is run again' do
+      described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer, limit: 2).perform
+      described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer, limit: 2).perform
+      expect(inbox.conversations.count).to eq(4)
+    end
+
+    it 'reports that it stopped on the limit rather than on the end of the export' do
+      run = described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer, limit: 2).perform
+      expect(run.stopped_by).to eq(:limite)
+    end
+  end
+
+  describe 'FROM_PART' do
+    it 'skips the parts before the one it names' do
+      run = described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer, from_part: 'part_0002.json').perform
+      expect(inbox.conversations.count).to eq(3)
+      expect(run.stats[:lidos]).to eq(3)
+    end
+
+    # Left to drop_while, a typo starts at whatever sorts after it, skips everything
+    # between, and reports the export exhausted.
+    it 'refuses a name that is not a member of the archive' do
+      expect { described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer, from_part: 'part_0007z.json').parts }
+        .to raise_error(ArgumentError, /is not a member of this export/)
+    end
+  end
+
+  it 'reports a ticket it could not read without stopping the run' do
+    File.write(File.join(dir, 'part_0003.json'), [{ 'Number' => 7 }].to_json)
+    system('zip', '-jq', zip_path, File.join(dir, 'part_0003.json'), exception: true)
+    run = described_class.new(inbox: inbox, zip_path: zip_path, pacer: pacer).perform
+    expect(run.stats[:lidos]).to eq(7)
+    expect(inbox.conversations.count).to eq(6)
+  end
+end

--- a/spec/services/import/octadesk/stream_spec.rb
+++ b/spec/services/import/octadesk/stream_spec.rb
@@ -40,6 +40,24 @@ describe Import::Octadesk::Stream do
     expect(yielded).to eq([{ 'Number' => 2 }])
   end
 
+  # A member that lists but will not extract leaves stdout empty, which Oj accepts as a
+  # well-formed nothing -- so the part reports zero tickets and the run moves on with every
+  # number on the screen looking right.
+  it 'raises rather than reporting an unextractable member as an empty one' do
+    expect { described_class.new(zip_path).each_object('nao-esta-no-zip.json') { |_| nil } }
+      .to raise_error(RuntimeError, /cannot read nao-esta-no-zip.json/)
+  end
+
+  # Stopping early closes the pipe and unzip dies of SIGPIPE, which is the caller getting
+  # what it asked for rather than a failure.
+  it 'does not mistake a caller that stopped early for a broken member' do
+    expect do
+      described_class.new(zip_path).each_object('part_0002.json') do |_| # rubocop:disable Lint/UnreachableLoop -- that is the point
+        raise StopIteration
+      end
+    end.not_to raise_error
+  end
+
   describe 'the shapes Mongo extended JSON wraps its scalars in' do
     it 'reads an id from either spelling' do
       expect(described_class.oid({ '$binary' => { 'base64' => 'QUJD' } })).to eq('QUJD')

--- a/spec/services/import/octadesk/stream_spec.rb
+++ b/spec/services/import/octadesk/stream_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe Import::Octadesk::Stream do
+  let(:dir) { Dir.mktmpdir }
+  let(:zip_path) { File.join(dir, 'export.zip') }
+
+  before do
+    File.write(File.join(dir, 'part_0002.json'), '[{"Number":2},{"Number":3}]')
+    File.write(File.join(dir, 'part_0001.json'), '[{"Number":1}]')
+    File.write(File.join(dir, 'leiame.txt'), 'nao e uma parte')
+    system('zip', '-jq', zip_path, File.join(dir, 'part_0001.json'), File.join(dir, 'part_0002.json'),
+           File.join(dir, 'leiame.txt'), exception: true)
+  end
+
+  after { FileUtils.remove_entry(dir) }
+
+  it 'lists the json members in order and ignores everything else' do
+    expect(described_class.new(zip_path).parts).to eq(%w[part_0001.json part_0002.json])
+  end
+
+  # An empty list walks nothing and prints "export exhausted", so a broken archive and a
+  # finished import would be indistinguishable.
+  it 'raises rather than reporting an unreadable archive as an empty one' do
+    expect { described_class.new(File.join(dir, 'nao-existe.zip')).parts }
+      .to raise_error(RuntimeError, /cannot read the archive/)
+  end
+
+  it 'yields one top-level object at a time, so a gigabyte part never lands whole' do
+    yielded = []
+    described_class.new(zip_path).each_object('part_0002.json') { |object| yielded << object }
+    expect(yielded).to eq([{ 'Number' => 2 }, { 'Number' => 3 }])
+  end
+
+  it 'lets the caller stop reading part way, which is what a LIMIT does' do
+    yielded = []
+    described_class.new(zip_path).each_object('part_0002.json') do |object| # rubocop:disable Lint/UnreachableLoop -- that is the point
+      yielded << object
+      raise StopIteration
+    end
+    expect(yielded).to eq([{ 'Number' => 2 }])
+  end
+
+  describe 'the shapes Mongo extended JSON wraps its scalars in' do
+    it 'reads an id from either spelling' do
+      expect(described_class.oid({ '$binary' => { 'base64' => 'QUJD' } })).to eq('QUJD')
+      expect(described_class.oid({ '$oid' => 'abc123' })).to eq('abc123')
+      expect(described_class.oid('já é uma string')).to eq('já é uma string')
+    end
+
+    it 'reads a date, and answers nil for anything that is not one' do
+      expect(described_class.time({ '$date' => '2023-05-10T12:00:00Z' })).to eq(Time.zone.parse('2023-05-10T12:00:00Z'))
+      expect(described_class.time(nil)).to be_nil
+      expect(described_class.time({})).to be_nil
+    end
+  end
+
+  # The keys are captured before the stack is popped; getting that backwards attaches every
+  # nested object to the wrong parent.
+  it 'keeps nested objects and arrays under the keys they belong to' do
+    File.write(File.join(dir, 'part_0003.json'),
+               '[{"Number":9,"Person":{"Type":1,"Name":"A"},"Comments":[{"Content":"x"},{"Content":"y"}]}]')
+    system('zip', '-jq', zip_path, File.join(dir, 'part_0003.json'), exception: true)
+    yielded = []
+    described_class.new(zip_path).each_object('part_0003.json') { |object| yielded << object }
+    expect(yielded).to eq([{ 'Number' => 9, 'Person' => { 'Type' => 1, 'Name' => 'A' },
+                             'Comments' => [{ 'Content' => 'x' }, { 'Content' => 'y' }] }])
+  end
+end

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -299,6 +299,25 @@ describe Import::Octadesk::TicketImporter do
     expect(a_request(:get, urls.last)).not_to have_been_made
   end
 
+  # A blank entry or a URL listed twice among the first fifteen would spend a slot, and the
+  # real file at position sixteen is then never attempted -- not on this pass and not on any
+  # later one, because every pass reads the same list the same way. The message ends up
+  # holding fewer than the permitted number and still missing a file.
+  it 'spends the cap on candidates rather than on blanks and repeats' do
+    real = Array.new(15) { |i| "https://storage.googleapis.com/t/#{i}/f.png" }
+    real.each { |url| stub_request(:get, url).to_return(status: 200, body: url, headers: { 'content-type' => 'image/png' }) }
+    listed = [{ 'Url' => '', 'Name' => 'vazio' },
+              { 'Url' => real.first, 'Name' => 'f.png' }] + real.map { |url| { 'Url' => url, 'Name' => 'f.png' } }
+    mixed = ticket.merge('Number' => 4332,
+                         'Interactions' => [ticket['Interactions'].first.merge('Attachments' => listed)])
+
+    run = described_class.new(inbox: inbox, attachments: true)
+    run.import(mixed)
+    expect(inbox.messages.find_by(message_type: :incoming).attachments.count).to eq(15)
+    expect(run.stats[:anexos_acima_do_teto]).to eq(0)
+    expect(a_request(:get, real.last)).to have_been_made.once
+  end
+
   # Like the mail importer, this one batches its own reindexes, so the per-row callback has
   # to be off while it writes or every row is indexed twice. The guard reads this flag
   # rather than the level.

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -221,5 +221,14 @@ describe Import::Octadesk::TicketImporter do
       described_class.new(inbox: inbox, form_address: 'contato@empresa.example.com').import(orphan)
       expect(inbox.conversations.find_by(identifier: 'octadesk:4329').contact.email).to eq('maria@example.com')
     end
+
+    # Either configured value identifies the form on its own. Keyed on the address alone, a
+    # deployment that knows only the display name takes the company address at face value
+    # and merges every form ticket into one contact.
+    it 'recognises the form by the name it posts under, with no address configured' do
+      named = form_ticket.merge('Number' => 4330, 'RequesterName' => 'Formulario do Site')
+      described_class.new(inbox: inbox, form_sender_name: 'Formulario do Site').import(named)
+      expect(inbox.conversations.find_by(identifier: 'octadesk:4330').contact.email).to eq('maria@example.com')
+    end
   end
 end

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -213,12 +213,49 @@ describe Import::Octadesk::TicketImporter do
       expect(message.reload.attachments.count).to eq(2)
     end
 
+    # An interaction listing the same URL twice is the vendor's business, not ours. Read
+    # only from the snapshot taken before the loop, the second copy is another download of a
+    # file just stored -- on a run whose cost is the downloads.
+    it 'fetches a url listed twice in the same interaction once' do
+      repeated = ticket.merge(
+        'Number' => 4328,
+        'Interactions' => [ticket['Interactions'].first.merge(
+          'Attachments' => Array.new(2) { { 'Url' => 'https://storage.googleapis.com/tenant/a/foto.png', 'Name' => 'foto.png' } }
+        )]
+      )
+      described_class.new(inbox: inbox, attachments: true).import(repeated)
+      expect(inbox.messages.find_by(message_type: :incoming).attachments.count).to eq(1)
+      expect(a_request(:get, 'https://storage.googleapis.com/tenant/a/foto.png')).to have_been_made.once
+    end
+
     it 'does not fetch one twice when both are already stored' do
       stub_request(:get, 'https://storage.googleapis.com/tenant/b/foto.png')
         .to_return(status: 200, body: 'segundo', headers: { 'content-type' => 'image/png' })
       described_class.new(inbox: inbox, attachments: true).import(with_attachments)
       described_class.new(inbox: inbox, attachments: true).import(with_attachments)
       expect(inbox.messages.find_by(message_type: :incoming).attachments.count).to eq(2)
+    end
+  end
+
+  # `Message` validates content at 150,000 and the mail path never reaches it, because
+  # `MailboxSanitizer` truncates first. Left whole here, `create!` raises and the ticket is
+  # abandoned where it stands: the interactions before it stay committed, so every retry
+  # files nothing new, hits the same comment and gives up again.
+  describe 'a comment longer than a message may be' do
+    let(:enormous) do
+      ticket.merge('Number' => 4329,
+                   'Interactions' => [ticket['Interactions'].first.merge('Comments' => [{ 'Content' => 'a' * 160_000 }]),
+                                      ticket['Interactions'].last])
+    end
+
+    it 'files it truncated rather than losing the rest of the ticket' do
+      expect { described_class.new(inbox: inbox).import(enormous) }.not_to raise_error
+      expect(inbox.messages.where(message_type: :incoming).first.content.length).to eq(150_000)
+    end
+
+    it 'still files the interactions after it' do
+      described_class.new(inbox: inbox).import(enormous)
+      expect(inbox.messages.where(message_type: :outgoing).count).to eq(1)
     end
   end
 

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -113,6 +113,45 @@ describe Import::Octadesk::TicketImporter do
       expect(conversation.reload.last_activity_at).to eq(conversation.messages.maximum(:created_at))
     end
 
+    # A run that stops between the insert and the metadata leaves a thread with no labels and
+    # a resolution stamped at the moment of the import, and the next pass finds it, returns
+    # it and writes nothing.
+    it 'reapplies the labels a stopped run never got to' do
+      tagged = ticket.merge('Number' => 4331, 'Tags' => [{ 'Name' => 'cancelamento' }, 'urgente'])
+      importer.import(tagged)
+      conversation = inbox.conversations.find_by(identifier: 'octadesk:4331')
+      conversation.update!(label_list: [])
+
+      described_class.new(inbox: inbox).import(tagged)
+      expect(conversation.reload.label_list).to contain_exactly('cancelamento', 'urgente')
+    end
+
+    it 'restamps a resolution a stopped run never got to' do
+      importer.import(ticket)
+      conversation = inbox.conversations.last
+      conversation.update_columns(status_changed_at: Time.current) # rubocop:disable Rails/SkipsModelValidations -- the state an interrupted run leaves
+
+      described_class.new(inbox: inbox).import(ticket)
+      expect(conversation.reload.status_changed_at).to eq(Time.zone.parse('2023-05-11T09:00:00Z'))
+    end
+
+    # A pass over an archive that is already right should cost a read and no label writes:
+    # reapplying every label on every resume is a write per ticket over the whole export.
+    it 'does not rewrite the labels that are already there' do
+      tagged = ticket.merge('Number' => 4332, 'Tags' => [{ 'Name' => 'cancelamento' }])
+      importer.import(tagged)
+      conversation = inbox.conversations.find_by(identifier: 'octadesk:4332')
+
+      writes = 0
+      subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+        writes += 1 if payload[:sql].start_with?('INSERT', 'UPDATE') && payload[:sql].include?('taggings')
+      end
+      described_class.new(inbox: inbox).import(tagged)
+      ActiveSupport::Notifications.unsubscribe(subscription)
+      expect(conversation.reload.label_list).to eq(['cancelamento'])
+      expect(writes).to eq(0)
+    end
+
     # The third interruption point, and the one a "did I write anything" test gets wrong:
     # the comments landed and the activity rows did not. The next pass writes a batch that
     # is real but partial, and settling from it alone drags the thread back to whichever

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -237,6 +237,20 @@ describe Import::Octadesk::TicketImporter do
     end
   end
 
+  # Like the mail importer, this one batches its own reindexes, so the per-row callback has
+  # to be off while it writes or every row is indexed twice. The guard reads this flag
+  # rather than the level.
+  it 'takes the search index on itself while it writes' do
+    seen = nil
+    importer = described_class.new(inbox: inbox)
+    allow(importer).to receive(:settle_ticket).and_wrap_original do |original, *args|
+      seen = Import::SilentWrite.indexing?
+      original.call(*args)
+    end
+    importer.import(ticket)
+    expect(seen).to be(true)
+  end
+
   # `Message` validates content at 150,000 and the mail path never reaches it, because
   # `MailboxSanitizer` truncates first. Left whole here, `create!` raises and the ticket is
   # abandoned where it stands: the interactions before it stay committed, so every retry

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -279,6 +279,26 @@ describe Import::Octadesk::TicketImporter do
     end
   end
 
+  # `Message` refuses more than fifteen and the mail pipeline trims to that before it
+  # attaches anything. Past the sixteenth the bytes are spent on a download that produces a
+  # message the dashboard will not render.
+  it 'stops at the attachment cap rather than downloading past it' do
+    urls = Array.new(18) { |i| "https://storage.googleapis.com/t/#{i}/f.png" }
+    urls.each do |url|
+      stub_request(:get, url).to_return(status: 200, body: url, headers: { 'content-type' => 'image/png' })
+    end
+    many = ticket.merge('Number' => 4331,
+                        'Interactions' => [ticket['Interactions'].first.merge(
+                          'Attachments' => urls.map { |url| { 'Url' => url, 'Name' => 'f.png' } }
+                        )])
+
+    run = described_class.new(inbox: inbox, attachments: true)
+    run.import(many)
+    expect(inbox.messages.find_by(message_type: :incoming).attachments.count).to eq(Message::NUMBER_OF_PERMITTED_ATTACHMENTS)
+    expect(run.stats[:anexos_acima_do_teto]).to eq(3)
+    expect(a_request(:get, urls.last)).not_to have_been_made
+  end
+
   # Like the mail importer, this one batches its own reindexes, so the per-row callback has
   # to be off while it writes or every row is indexed twice. The guard reads this flag
   # rather than the level.

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -205,5 +205,21 @@ describe Import::Octadesk::TicketImporter do
       importer.import(form_ticket)
       expect(inbox.conversations.find_by(identifier: 'octadesk:4325').contact.email).to eq('contato@empresa.example.com')
     end
+
+    # An `Email:` line in a comment is as likely to be somebody the customer is writing
+    # about -- a colleague, a supplier, the address on an invoice -- as the customer.
+    # Filing the thread under that person is worse than filing it under nobody.
+    it 'does not take an address out of the body when no form is configured' do
+      orphan = form_ticket.merge('Number' => 4328, 'RequesterMail' => nil)
+      importer.import(orphan)
+      expect(inbox.conversations.find_by(identifier: 'octadesk:4328')).to be_nil
+      expect(importer.stats[:sem_contato]).to eq(1)
+    end
+
+    it 'takes it when the caller did configure a form' do
+      orphan = form_ticket.merge('Number' => 4329, 'RequesterMail' => nil)
+      described_class.new(inbox: inbox, form_address: 'contato@empresa.example.com').import(orphan)
+      expect(inbox.conversations.find_by(identifier: 'octadesk:4329').contact.email).to eq('maria@example.com')
+    end
   end
 end

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -1,0 +1,140 @@
+require 'rails_helper'
+
+describe Import::Octadesk::TicketImporter do
+  let(:account) { create(:account) }
+  let(:channel) { create(:channel_email, account: account) }
+  let(:inbox) { channel.inbox }
+  let(:importer) { described_class.new(inbox: inbox) }
+  let(:opened_at) { '2023-05-10T12:00:00Z' }
+
+  let(:ticket) do
+    {
+      'Number' => 4321, 'RequesterMail' => 'cliente@example.com', 'RequesterName' => 'Cliente Um',
+      'DateCreation' => { '$date' => opened_at }, 'DoneDate' => { '$date' => '2023-05-11T09:00:00Z' },
+      'Interactions' => [
+        { '_id' => { '$binary' => { 'base64' => 'AAAAAAAAAAAAAAAA' } },
+          'Comments' => [{ 'Content' => 'Bom dia, preciso cancelar meu pedido.' }],
+          'Person' => { 'Type' => 0, 'Name' => 'Cliente Um' },
+          'DateCreation' => { '$date' => opened_at } },
+        { '_id' => { '$binary' => { 'base64' => 'AAAAAAAAAAAAAAAB' } },
+          'Comments' => [{ 'Content' => 'Boa tarde, ja cancelamos para voce.' }],
+          'Person' => { 'Type' => 1, 'Name' => 'Atendente Dois' },
+          'DateCreation' => { '$date' => '2023-05-10T15:00:00Z' } }
+      ]
+    }
+  end
+
+  it 'files the ticket as one resolved conversation dated to when it opened' do
+    importer.import(ticket)
+    conversation = inbox.conversations.last
+    expect(conversation.status).to eq('resolved')
+    expect(conversation.created_at).to eq(Time.zone.parse(opened_at))
+    expect(conversation.status_changed_at).to eq(Time.zone.parse('2023-05-11T09:00:00Z'))
+  end
+
+  it 'reads direction off the export rather than guessing it from headers' do
+    importer.import(ticket)
+    expect(inbox.messages.reorder(:created_at).pluck(:message_type)).to eq(%w[incoming outgoing])
+  end
+
+  # An outgoing message with no sender and no sender_name renders as the bot, which would
+  # attribute every agent reply in the archive to one.
+  it 'names the agent who wrote an outgoing message' do
+    importer.import(ticket)
+    outgoing = inbox.messages.find_by(message_type: :outgoing)
+    expect(outgoing.additional_attributes['sender_name']).to eq('Atendente Dois')
+  end
+
+  it 'keys the conversation on an indexed column so the lookup does not scan the inbox' do
+    importer.import(ticket)
+    expect(inbox.conversations.last.identifier).to eq('octadesk:4321')
+    expect(inbox.conversations.last.custom_attributes['octadesk']).to eq('4321')
+  end
+
+  it 'writes nothing twice when the ticket comes round again' do
+    importer.import(ticket)
+    expect { described_class.new(inbox: inbox).import(ticket) }.not_to change(inbox.messages, :count)
+  end
+
+  describe 'a ticket whose whole history is status changes' do
+    let(:activity_only) do
+      ticket.merge(
+        'Number' => 4322,
+        'Interactions' => [
+          { '_id' => { '$binary' => { 'base64' => 'AAAAAAAAAAAAAAAC' } }, 'Comments' => [],
+            'PropertiesChanges' => { 'Status' => 'Resolvido' },
+            'Person' => { 'Type' => 1, 'Name' => 'Atendente Dois' },
+            'DateCreation' => { '$date' => '2023-05-10T13:00:00Z' } }
+        ]
+      )
+    end
+
+    it 'is still history and still becomes a conversation' do
+      importer.import(activity_only)
+      conversation = inbox.conversations.find_by(identifier: 'octadesk:4322')
+      expect(conversation).to be_present
+      expect(conversation.messages.pluck(:message_type)).to eq(['activity'])
+      expect(conversation.messages.first.content).to eq('Status: Resolvido (por Atendente Dois)')
+    end
+
+    it 'is empty only when nothing at all would be written' do
+      importer.import(ticket.merge('Number' => 4323, 'Interactions' => []))
+      expect(inbox.conversations.find_by(identifier: 'octadesk:4323')).to be_nil
+      expect(importer.stats[:sem_conteudo]).to eq(1)
+    end
+
+    # "Gatilho executado: notificar o solicitante" is machinery, not an event.
+    it 'is empty when the only interactions are triggers' do
+      trigger = activity_only['Interactions'].first.merge('Person' => { 'Type' => 3 })
+      importer.import(activity_only.merge('Number' => 4324, 'Interactions' => [trigger]))
+      expect(inbox.conversations.find_by(identifier: 'octadesk:4324')).to be_nil
+    end
+  end
+
+  describe 'resuming a run that stopped between the write and the settlement' do
+    it 'repairs stamps the next pass would otherwise never touch, because it writes nothing' do
+      importer.import(ticket)
+      conversation = inbox.conversations.last
+      settled = conversation.last_activity_at
+      conversation.update_columns(last_activity_at: Time.current, waiting_since: Time.current) # rubocop:disable Rails/SkipsModelValidations -- the state an interrupted run leaves behind
+
+      described_class.new(inbox: inbox).import(ticket)
+      expect(conversation.reload.last_activity_at).to eq(settled)
+      expect(conversation.waiting_since).to be_nil
+    end
+
+    it 'backdates a conversation created before its first message was written' do
+      importer.import(ticket)
+      conversation = inbox.conversations.last
+      conversation.messages.destroy_all
+      conversation.update_columns(last_activity_at: Time.current) # rubocop:disable Rails/SkipsModelValidations -- ditto
+
+      described_class.new(inbox: inbox).import(ticket)
+      expect(conversation.reload.last_activity_at).to eq(conversation.messages.maximum(:created_at))
+    end
+  end
+
+  describe 'the website form, which posts as the company' do
+    let(:form_ticket) do
+      ticket.merge(
+        'Number' => 4325, 'RequesterMail' => 'contato@empresa.example.com', 'RequesterName' => 'Empresa',
+        'Interactions' => [ticket['Interactions'].first.merge(
+          'Comments' => [{ 'Content' => "Nome: Maria Souza\nEmail: maria@example.com\nMensagem: quero cancelar" }]
+        )]
+      )
+    end
+
+    it 'takes the customer out of the body when the ticket names the company' do
+      described_class.new(inbox: inbox, form_address: 'contato@empresa.example.com',
+                          form_sender_name: 'Empresa').import(form_ticket)
+      contact = inbox.conversations.find_by(identifier: 'octadesk:4325').contact
+      expect(contact.email).to eq('maria@example.com')
+      expect(contact.name).to eq('Maria Souza')
+    end
+
+    it 'takes the ticket at its word when the caller says nothing about a form' do
+      importer.import(form_ticket)
+      expect(inbox.conversations.find_by(identifier: 'octadesk:4325').contact.email).to eq('contato@empresa.example.com')
+    end
+  end
+end

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -112,6 +112,75 @@ describe Import::Octadesk::TicketImporter do
       described_class.new(inbox: inbox).import(ticket)
       expect(conversation.reload.last_activity_at).to eq(conversation.messages.maximum(:created_at))
     end
+
+    # The third interruption point, and the one a "did I write anything" test gets wrong:
+    # the comments landed and the activity rows did not. The next pass writes a batch that
+    # is real but partial, and settling from it alone drags the thread back to whichever
+    # row happened to be missing.
+    it 'settles from the whole thread when the pass only wrote the rows that were missing' do
+      partial = ticket.merge(
+        'Number' => 4326,
+        'Interactions' => ticket['Interactions'] + [
+          { '_id' => { '$binary' => { 'base64' => 'AAAAAAAAAAAAAAAD' } }, 'Comments' => [],
+            'PropertiesChanges' => { 'Status' => 'Resolvido' },
+            'Person' => { 'Type' => 1, 'Name' => 'Atendente Dois' },
+            'DateCreation' => { '$date' => '2023-05-10T13:00:00Z' } }
+        ]
+      )
+      importer.import(partial)
+      conversation = inbox.conversations.find_by(identifier: 'octadesk:4326')
+      newest = conversation.messages.maximum(:created_at)
+      conversation.messages.where(message_type: :activity).destroy_all
+      conversation.update_columns(last_activity_at: Time.current) # rubocop:disable Rails/SkipsModelValidations -- ditto
+
+      described_class.new(inbox: inbox).import(partial)
+      expect(conversation.reload.last_activity_at).to eq(newest)
+    end
+  end
+
+  # The vendor's bucket stops existing when the subscription does, so an attachment a run
+  # failed to fetch has to still be owed on the next pass. Which means the test for "already
+  # stored" has to be exact.
+  describe 'attachments a pass could not finish' do
+    let(:with_attachments) do
+      ticket.merge(
+        'Number' => 4327,
+        'Interactions' => [ticket['Interactions'].first.merge(
+          'Attachments' => [
+            { 'Url' => 'https://storage.googleapis.com/tenant/a/foto.png', 'Name' => 'foto.png' },
+            { 'Url' => 'https://storage.googleapis.com/tenant/b/foto.png', 'Name' => 'foto.png' }
+          ]
+        )]
+      )
+    end
+
+    before do
+      stub_request(:get, 'https://storage.googleapis.com/tenant/a/foto.png')
+        .to_return(status: 200, body: 'primeiro', headers: { 'content-type' => 'image/png' })
+    end
+
+    # Two different files under one name is ordinary: a customer sends a photo, an agent
+    # sends another, and the vendor names both after the camera. Keyed on the filename, the
+    # one that got through calls the one that did not done, and it is never fetched again.
+    it 'still owes the copy that failed, even under a name that is already stored' do
+      stub_request(:get, 'https://storage.googleapis.com/tenant/b/foto.png').to_return(status: 500)
+      described_class.new(inbox: inbox, attachments: true).import(with_attachments)
+      message = inbox.messages.find_by(message_type: :incoming)
+      expect(message.attachments.count).to eq(1)
+
+      stub_request(:get, 'https://storage.googleapis.com/tenant/b/foto.png')
+        .to_return(status: 200, body: 'segundo', headers: { 'content-type' => 'image/png' })
+      described_class.new(inbox: inbox, attachments: true).import(with_attachments)
+      expect(message.reload.attachments.count).to eq(2)
+    end
+
+    it 'does not fetch one twice when both are already stored' do
+      stub_request(:get, 'https://storage.googleapis.com/tenant/b/foto.png')
+        .to_return(status: 200, body: 'segundo', headers: { 'content-type' => 'image/png' })
+      described_class.new(inbox: inbox, attachments: true).import(with_attachments)
+      described_class.new(inbox: inbox, attachments: true).import(with_attachments)
+      expect(inbox.messages.find_by(message_type: :incoming).attachments.count).to eq(2)
+    end
   end
 
   describe 'the website form, which posts as the company' do

--- a/spec/services/import/octadesk/ticket_importer_spec.rb
+++ b/spec/services/import/octadesk/ticket_importer_spec.rb
@@ -237,6 +237,48 @@ describe Import::Octadesk::TicketImporter do
     end
   end
 
+  # A reply that is only a photo is an ordinary thing for a customer to send. Read as "no
+  # comment" the interaction is a status change at best and nothing at all at worst, and it
+  # takes the attachment with it -- to a bucket that stops existing when the subscription
+  # does, which makes that loss permanent rather than late.
+  describe 'an interaction that is only an attachment' do
+    let(:only_a_file) do
+      ticket.merge('Number' => 4330,
+                   'Interactions' => [ticket['Interactions'].first.merge(
+                     'Comments' => [], 'Attachments' => [{ 'Url' => 'https://storage.googleapis.com/t/a/foto.png', 'Name' => 'foto.png' }]
+                   )])
+    end
+
+    before do
+      stub_request(:get, 'https://storage.googleapis.com/t/a/foto.png')
+        .to_return(status: 200, body: 'foto', headers: { 'content-type' => 'image/png' })
+    end
+
+    it 'files it as a message rather than dropping the whole interaction' do
+      described_class.new(inbox: inbox, attachments: true).import(only_a_file)
+      message = inbox.messages.find_by(message_type: :incoming)
+      expect(message).to be_present
+      expect(message.attachments.count).to eq(1)
+    end
+
+    # The row carries the sender, the date and its place in the thread whether or not this
+    # pass is fetching files, and the pass that does finds it by interaction id.
+    it 'files the row even on a pass that is not fetching attachments' do
+      described_class.new(inbox: inbox).import(only_a_file)
+      expect(inbox.messages.where(message_type: :incoming).count).to eq(1)
+
+      described_class.new(inbox: inbox, attachments: true).import(only_a_file)
+      expect(inbox.messages.find_by(message_type: :incoming).attachments.count).to eq(1)
+    end
+
+    it 'does not also write it as an activity line' do
+      described_class.new(inbox: inbox).import(
+        only_a_file.merge('Interactions' => [only_a_file['Interactions'].first.merge('PropertiesChanges' => { 'Status' => 'Resolvido' })])
+      )
+      expect(inbox.messages.where(message_type: :activity).count).to eq(0)
+    end
+  end
+
   # Like the mail importer, this one batches its own reindexes, so the per-row callback has
   # to be off while it writes or every row is indexed twice. The guard reads this flag
   # rather than the level.

--- a/spec/services/import/options_spec.rb
+++ b/spec/services/import/options_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+# Every lenient reading of one of these fails in the expensive direction, so the words are
+# listed rather than inferred.
+describe Import::Options do
+  after { %w[FLAG COUNT MEASURE].each { |key| ENV.delete(key) } }
+
+  describe '.boolean' do
+    it 'takes the default when nothing was set' do
+      expect(described_class.boolean('FLAG')).to be(false)
+      expect(described_class.boolean('FLAG', default: true)).to be(true)
+    end
+
+    %w[1 true YES on sim].each do |word|
+      it "reads #{word} as true" do
+        ENV['FLAG'] = word
+        expect(described_class.boolean('FLAG')).to be(true)
+      end
+    end
+
+    # `ActiveModel::Type::Boolean` answers every one of these with true, because none is in
+    # its own false list. Under that reading `ATTACHMENTS=no` mirrors hundreds of gigabytes.
+    %w[0 false NO off nao].each do |word|
+      it "reads #{word} as false, where the Rails caster reads it as true" do
+        ENV['FLAG'] = word
+        expect(described_class.boolean('FLAG')).to be(false)
+        expect(ActiveModel::Type::Boolean.new.cast(word).present?).to be(true) if %w[no nao].include?(word.downcase)
+      end
+    end
+
+    it 'refuses a word it cannot read rather than guessing which way it went' do
+      ENV['FLAG'] = 'flase'
+      expect { described_class.boolean('FLAG') }.to raise_error(ArgumentError, /FLAG/)
+    end
+  end
+
+  describe '.integer' do
+    it 'takes a count' do
+      ENV['COUNT'] = '400'
+      expect(described_class.integer('COUNT')).to eq(400)
+    end
+
+    # `SAMPLE=0.5` truncates to zero at the call site and the scan classifies nothing while
+    # printing a finished projection.
+    it 'refuses a fraction rather than truncating it' do
+      ENV['COUNT'] = '0.5'
+      expect { described_class.integer('COUNT') }.to raise_error(ArgumentError, /COUNT/)
+    end
+
+    it 'refuses zero, which every setting that takes one reads as an instruction' do
+      ENV['COUNT'] = '0'
+      expect { described_class.integer('COUNT') }.to raise_error(ArgumentError, /COUNT/)
+    end
+
+    it 'refuses a word' do
+      ENV['COUNT'] = 'muito'
+      expect { described_class.integer('COUNT') }.to raise_error(ArgumentError, /COUNT/)
+    end
+  end
+
+  describe '.decimal' do
+    it 'takes a fraction, since a load average is one' do
+      ENV['MEASURE'] = '2.5'
+      expect(described_class.decimal('MEASURE')).to eq(2.5)
+    end
+
+    # A zero load ceiling never finds room against a load average that is never zero, so the
+    # run pauses and stands there with nothing on the screen but a pause.
+    it 'refuses zero' do
+      ENV['MEASURE'] = '0'
+      expect { described_class.decimal('MEASURE') }.to raise_error(ArgumentError, /MEASURE/)
+    end
+
+    it 'refuses a word' do
+      ENV['MEASURE'] = 'alto'
+      expect { described_class.decimal('MEASURE') }.to raise_error(ArgumentError, /MEASURE/)
+    end
+  end
+end

--- a/spec/services/import/silent_write_spec.rb
+++ b/spec/services/import/silent_write_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe Import::SilentWrite do
+  it 'is off outside a wrap, which is the ordinary path and must go through untouched' do
+    expect(described_class).not_to be_on
+    expect(described_class).not_to be_archive
+    expect(described_class).not_to be_announce
+  end
+
+  it 'writes an archive by default' do
+    described_class.wrap do
+      expect(described_class).to be_on
+      expect(described_class).to be_archive
+      expect(described_class).not_to be_announce
+    end
+  end
+
+  it 'raises the level for the stretch somebody is watching' do
+    described_class.wrap(announce: true) do
+      expect(described_class).to be_on
+      expect(described_class).not_to be_archive
+      expect(described_class).to be_announce
+    end
+  end
+
+  # The gap half of a run raises the level inside the enclosing archive wrap and has to
+  # hand the archive level back on the way out.
+  it 'restores the enclosing level rather than clearing it' do
+    described_class.wrap do
+      described_class.wrap(announce: true) { expect(described_class).to be_announce }
+      expect(described_class).to be_archive
+    end
+    expect(described_class).not_to be_on
+  end
+
+  it 'clears the flag when the block raises' do
+    expect { described_class.wrap { raise 'boom' } }.to raise_error('boom')
+    expect(described_class).not_to be_on
+  end
+end


### PR DESCRIPTION
Files years of support history into a Chatwoot inbox without the people working that inbox seeing any of it appear.

## The problem

The existing `imap:import` task creates every message at insertion time and patches the dates afterwards. While it runs, five-year-old email surfaces in the live dashboard, on top of the conversations agents are actually working, and each row sets off the ordinary arrival machinery on its way in: automations, outgoing webhooks, agent notifications, auto-replies to a message answered in 2023, a Gravatar fetch per contact, an auto-assignment per conversation.

## The refactor

`Whatsapp::Session::SilentWrite` and its settlement service already solved this for the WhatsApp history sync, but neither has anything to do with WhatsApp: one suppresses the fan-out around a write, the other stamps a conversation's activity columns after a backdated batch. They move to `Import::SilentWrite` and `Import::HistorySettlement`, and the initializer to `config/initializers/import_guards.rb`.

Two guards are new and were found by counting the jobs a 300-ticket run queued:

- `SilentAutoAssignment` — a conversation created `resolved` wakes the assignment job. 299 jobs per 300 tickets; at full scale it would round-robin the whole archive onto working agents.
- `SilentGravatar` — one outbound HTTP request per contact created, ~282 per 300 tickets. A queue flood aimed at a third party.

Guards are prepended rather than edited into the classes, since all of them are files the upstream sync rewrites.

## The importers

`imap:import` walks the all-mail and spam folders, resumable by Message-ID, paced against a daily byte budget and the host's load average. `Import::Email::Classifier` separates a ticketing system's own receipts, alerts and relays from what a person wrote, so a run can take the customer mail and leave the machinery. Folding to unaccented ASCII before matching, because the same sentence arrives as `solicitação`, as `solicita&ccedil;&atilde;o` and as `solicitac&#807;a&#771;o` — a base letter plus a combining mark, encoded as numeric entities, which is why a `solicita..o` pattern silently stops matching.

`octadesk:import` streams the vendor's JSON export straight out of the zip with an `Oj::Saj` handler that emits one top-level object at a time, so a multi-gigabyte part never lands on disk or in memory whole. The export carries direction, authorship and threading already, so nothing is guessed from headers. Optionally mirrors attachments off the vendor bucket into Active Storage, which is the only chance to keep them.

Both write backdated at insert, never patched afterwards, and mark each row `content_attributes.imported`. Conversations are born `resolved` rather than transitioned into it, so they fire no resolution event and never land in today's reports.

Idempotent on both paths: IMAP dedupes inbox-wide on Message-ID, the export on ticket number and interaction id. Re-running costs lookups and writes nothing twice.

## Deployment-specific values are inputs

The website-form heuristic (a form that posts as the company with the customer named in the body) takes `FORM_ADDRESS` and `FORM_SENDER_NAME` from the environment. With neither set it never fires and every ticket is taken at its stated requester.

## Testing

- `bundle exec rspec` — 11418 examples, 11 failures, all of which also fail on `origin/main` in this environment (mailer sender, frontend URL, installation config); zero regressions.
- `bundle exec rubocop` — clean.
- End to end against a real export: 400 tickets at 25/s, producing 1213 messages (565 incoming, 541 outgoing, 107 activity). All resolved, none assigned, no `waiting_since`, none dated today, zero jobs, webhooks or events queued, and a re-run wrote nothing.
- End to end over IMAP with 70 real messages: 67 imported, correct contact names, and a re-run wrote nothing.
- Attachments: 66 fetched and stored with correct content types; S3 round-trip verified against the production service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/441)
<!-- Reviewable:end -->
