### PR TITLE
feat(whatsapp): fetch a file WhatsApp dropped instead of flagging the bubble

### DIFF
--- a/app/jobs/whatsapp/session/media_fetch_job.rb
+++ b/app/jobs/whatsapp/session/media_fetch_job.rb
@@ -50,9 +50,15 @@ class Whatsapp::Session::MediaFetchJob < ApplicationJob
   # The second half is the one that survives being in the family: a connector blob and a
   # Uazapi message id mean nothing to anyone but the provider that issued them, and the
   # conversion has already disconnected the one that did.
+  #
+  # It only has anything to say about a ref that exists. A fetch for a message whose file
+  # never came carries none, and asks the provider by message id alone -- which is the
+  # same thing the refresh behind a lapsed ref does, and is answered the same way when the
+  # provider does not know the message.
   def conversion_refusal(channel, media)
     return "inbox ##{channel.inbox.id} left the session layer" unless channel.session_provider?
-    return "ref was issued by a provider other than #{channel.provider}" unless media.ref&.served_by?(channel.provider)
+    return if media.ref.nil?
+    return "ref was issued by a provider other than #{channel.provider}" unless media.ref.served_by?(channel.provider)
 
     nil
   end

--- a/app/services/whatsapp/session/inbound/dispatcher.rb
+++ b/app/services/whatsapp/session/inbound/dispatcher.rb
@@ -44,6 +44,7 @@ class Whatsapp::Session::Inbound::Dispatcher
   IGNORED = %w[
     pairing.passkey_request pairing.passkey_confirmation contact.identity_changed
     call.offer call.terminate
+    session.offline_sync_preview session.offline_sync_completed
   ].freeze
 
   attr_reader :channel, :event, :instance

--- a/app/services/whatsapp/session/inbound/handlers/media_download_failed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/media_download_failed.rb
@@ -1,17 +1,49 @@
-# The provider could not decrypt or download the media of a message it already
-# delivered. The message stays, flagged so the agent knows the attachment is gone
-# rather than still loading.
+# The provider could not hand over the media of a message it already delivered.
+#
+# Usually that is the end of it and the message is flagged, so the agent knows the
+# attachment is gone rather than still loading. The exception is a file WhatsApp has
+# dropped off its CDN while the sender's phone may still hold it: the provider says so on
+# the event, and the answer is to ask for the bytes rather than to give up on them.
 class Whatsapp::Session::Inbound::Handlers::MediaDownloadFailed < Whatsapp::Session::Inbound::Handlers::Base
   def perform
     message = find_message(payload.message_id)
     return :ignored if message.nil?
     return :ignored if message.attachments.any?
 
+    return ask_again(message) if worth_asking_for?(message)
+
     # `is_unsupported` lives in the content_attributes JSON, so writing it off the
     # instance loaded before a revoke landed would rewrite the whole hash and undelete
     # the message.
     message.update_under_lock!(is_unsupported: true)
     Rails.logger.warn("[WHATSAPP SESSION] media download failed for #{payload.message_id}: #{payload.reason}")
+    :handled
+  end
+
+  private
+
+  # Both halves are the provider's answer and neither is enough alone: the flag says the
+  # bytes may still be reachable, and the descriptor the writer kept is what a fetch
+  # needs to attach them once they arrive. A message that carries no descriptor was never
+  # published as one waiting for its file, so there is nothing here to ask for.
+  def worth_asking_for?(message)
+    payload.recoverable && message.content_attributes['pending_media'].present?
+  end
+
+  # Nothing is flagged. The bubble stays as it is while the fetch runs, and the job marks
+  # it unsupported itself if the provider turns out not to reach the bytes either, which
+  # is the same end this method is standing in front of.
+  #
+  # The chat is the one the event carried, for the same reason MediaFetchJob takes it
+  # from the message event: a chat rebuilt from the contact addresses the fetch to a chat
+  # the message does not live in.
+  def ask_again(message)
+    Whatsapp::Session::MediaFetchJob.perform_later(
+      message, message.content_attributes['pending_media'], payload.chat&.to_h
+    )
+    Rails.logger.info(
+      "[WHATSAPP SESSION] media for #{payload.message_id} is #{payload.reason}, asking #{channel.provider} again"
+    )
     :handled
   end
 end

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -18,12 +18,14 @@ class Whatsapp::Session::Inbound::MessageWriter
     @imported = imported
   end
 
-  # The media an inbound message carries, whichever shape holds it, or nil.
+  # The media an inbound message carries, whichever shape holds it, or nil. Says nothing
+  # about whether its bytes are reachable: a media message published with no `ref` is one
+  # whose file did not come with it, and `media.download_failed` is what explains that.
   def self.media_in(inbound)
     content = inbound.content
     media = content if content&.wire_type == 'media'
     media ||= content.media if content&.wire_type == 'rich'
-    media if media.present? && media.ref.present?
+    media.presence
   end
 
   # Queues the fetch for a message that is already stored.
@@ -35,7 +37,12 @@ class Whatsapp::Session::Inbound::MessageWriter
   # stands down when the bytes are already attached or the fetch has given up.
   def self.fetch_media_for(message, inbound)
     media = media_in(inbound)
-    return if media.nil? || message.attachments.any? || message.content_attributes['is_unsupported']
+    # A media message with no reference has no bytes to collect yet, and asking for them
+    # here would ask on behalf of every file that is gone for good as well. The failure
+    # that follows this message is what knows the difference, and Handlers::
+    # MediaDownloadFailed queues the fetch for the one file worth asking about.
+    return if media.nil? || media.ref.blank?
+    return if message.attachments.any? || message.content_attributes['is_unsupported']
 
     Whatsapp::Session::MediaFetchJob.perform_later(message, media.to_h, inbound.chat&.to_h)
   end
@@ -104,12 +111,33 @@ class Whatsapp::Session::Inbound::MessageWriter
       in_reply_to_external_id: inbound.quoted_id.presence,
       referral: inbound.referral.presence,
       is_unsupported: (true if unsupported?),
+      pending_media: pending_media,
       # Not the same statement as `external_created_at`, which every session message
       # carries: this one says the row was filed after the fact, which is what a report
       # excluding backfilled traffic, or a bubble explaining an old date, has to read.
       imported: (true if imported),
       rich: (content.to_content_attribute if content_type == 'rich')
     }.compact
+  end
+
+  # What the file was, for a media message whose bytes did not come with it.
+  #
+  # The provider says on the `media.download_failed` that follows whether they can still
+  # be fetched, and by then this row is the only place the file's own description
+  # survives: the event that carried it does not come again, and there is no attachment
+  # to read it off. Without it a recoverable file could be asked for and then not
+  # attached, because nothing would know what kind of attachment to build.
+  #
+  # Only what a later fetch reads. The caption is already this message's content and the
+  # preview is a data URI worth kilobytes, so neither is copied into a column nothing
+  # renders from.
+  def pending_media
+    media = self.class.media_in(inbound)
+    return if media.nil? || media.ref.present?
+
+    Whatsapp::Session::Model::Content::Media.new(
+      kind: media.kind, mime: media.mime, filename: media.filename, voice_note: media.voice_note
+    ).to_h
   end
 
   # A rich card with no text and no media header renders as an empty bubble, which is

--- a/app/services/whatsapp/session/model/events.rb
+++ b/app/services/whatsapp/session/model/events.rb
@@ -66,9 +66,23 @@ module Whatsapp::Session::Model::Events
     wire_type 'pairing.passkey_request'
   end
 
-  class PairingPasskeyConfirmation < Data.define(:code)
+  class PairingPasskeyConfirmation < Data.define(:request_id, :code)
     include Serializable
     wire_type 'pairing.passkey_confirmation'
+  end
+
+  # What the session missed while it was down, counted by the server before it replays
+  # any of it, so a reader can say how much is coming instead of watching a queue move.
+  # The messages themselves arrive afterwards as ordinary `message.received`.
+  class SessionOfflineSyncPreview < Data.define(:messages, :receipts, :notifications, :app_data_changes, :total)
+    include Serializable
+    wire_type 'session.offline_sync_preview'
+  end
+
+  # The replay is over: what has not arrived by now is not coming.
+  class SessionOfflineSyncCompleted < Data.define(:count)
+    include Serializable
+    wire_type 'session.offline_sync_completed'
   end
 
   class MessageReceived < Data.define(:message)
@@ -113,10 +127,19 @@ module Whatsapp::Session::Model::Events
     end
   end
 
-  class MediaDownloadFailed < Data.define(:chat, :message_id, :reason)
+  class MediaDownloadFailed < Data.define(:chat, :message_id, :reason, :recoverable)
     include Serializable
     wire_type 'media.download_failed'
     coerce chat: Address
+    # Whether the file may still be somewhere the provider can reach: WhatsApp drops a
+    # file off its CDN long before the sender's phone forgets it, and asking for it again
+    # is what recovers a message that sat in a backlog. Everything else here is the file
+    # being gone.
+    #
+    # False is what a provider that predates the field says by saying nothing, and it is
+    # the half that changes nothing: the bubble is flagged and nobody comes back for the
+    # bytes, which is what this event has always meant.
+    defaults recoverable: false
   end
 
   class CommandFailed < Data.define(:command_id, :command_type, :message_id, :error)
@@ -241,7 +264,8 @@ module Whatsapp::Session::Model::Events
 
   CLASSES = [
     SessionState, SessionLoggedOut, SessionStreamReplaced, SessionTemporaryBan, SessionClientOutdated,
-    SessionConnectFailure, PairingQr, PairingCode, PairingSuccess, PairingError, PairingPasskeyRequest,
+    SessionConnectFailure, SessionOfflineSyncPreview, SessionOfflineSyncCompleted,
+    PairingQr, PairingCode, PairingSuccess, PairingError, PairingPasskeyRequest,
     PairingPasskeyConfirmation, MessageReceived, MessageReceipt, MessageEdited, MessageRevoked, MessageReaction,
     MediaDownloadFailed, CommandFailed, ChatPresence, PresenceUpdate, ContactPictureChanged, ContactIdentityChanged,
     GroupJoined, GroupUpdated, GroupPictureChanged, GroupActivity, AccountReachoutTimelock, AccountNewChatCap,

--- a/spec/fixtures/whatsapp/session/contract/CONTRACT_REF
+++ b/spec/fixtures/whatsapp/session/contract/CONTRACT_REF
@@ -1,3 +1,3 @@
 repo=fazer-ai/whatsapp-connector
-ref=150342c451fd25bc8e548aa5ad1a8f474a153af0
+ref=eb6e6fd0977b938f8a0ce10ff545599b19a5d30b
 checksum=0aade52f1731b47dc6c9989664b530134e29a764d8bfabd5cc38a3c50c8b9b8d

--- a/spec/fixtures/whatsapp/session/contract/CONTRACT_REF
+++ b/spec/fixtures/whatsapp/session/contract/CONTRACT_REF
@@ -1,3 +1,3 @@
 repo=fazer-ai/whatsapp-connector
-ref=2c8da96
-checksum=b38049377a2f9295a7ca3c6f2bfb8e9e89fbb5124ff5bc0dbade36b7badaf56d
+ref=150342c451fd25bc8e548aa5ad1a8f474a153af0
+checksum=0aade52f1731b47dc6c9989664b530134e29a764d8bfabd5cc38a3c50c8b9b8d

--- a/spec/fixtures/whatsapp/session/contract/fixtures/events/command_failed_provider_unavailable.json
+++ b/spec/fixtures/whatsapp/session/contract/fixtures/events/command_failed_provider_unavailable.json
@@ -1,0 +1,20 @@
+{
+  "v": 1,
+  "id": "01920000-0000-7000-8000-000000000044",
+  "type": "command.failed",
+  "sid": "9f1c0f4e-6a2b-4c8e-9d1a-2b3c4d5e6f70",
+  "epoch": 7,
+  "seq": 44,
+  "ts": 1755440000456,
+  "inst": "connector-a1b2c3",
+  "payload": {
+    "command_id": "cmd_000013",
+    "command_type": "message.send",
+    "message_id": "3EB0A1B2C3D4E5F60751",
+    "error": {
+      "code": "provider_unavailable",
+      "message": "could not fetch the file to send from http://rails:3000: connection refused",
+      "retryable": true
+    }
+  }
+}

--- a/spec/fixtures/whatsapp/session/contract/fixtures/events/media_download_failed_recoverable.json
+++ b/spec/fixtures/whatsapp/session/contract/fixtures/events/media_download_failed_recoverable.json
@@ -1,11 +1,11 @@
 {
   "v": 1,
-  "id": "01920000-0000-7000-8000-000000000044",
+  "id": "01920000-0000-7000-8000-000000000045",
   "type": "media.download_failed",
   "sid": "9f1c0f4e-6a2b-4c8e-9d1a-2b3c4d5e6f70",
   "epoch": 7,
-  "seq": 44,
-  "ts": 1755440000123,
+  "seq": 45,
+  "ts": 1755440000456,
   "inst": "connector-a1b2c3",
   "payload": {
     "chat": {
@@ -13,7 +13,7 @@
       "id": "5541999990000"
     },
     "message_id": "3EB0A1B2C3D4E5F60720",
-    "reason": "media_key_expired",
-    "recoverable": false
+    "reason": "media_off_cdn",
+    "recoverable": true
   }
 }

--- a/spec/fixtures/whatsapp/session/contract/fixtures/events/message_received_unavailable.json
+++ b/spec/fixtures/whatsapp/session/contract/fixtures/events/message_received_unavailable.json
@@ -1,0 +1,30 @@
+{
+  "v": 1,
+  "id": "01920000-0000-7000-8000-000000000011",
+  "type": "message.received",
+  "sid": "9f1c0f4e-6a2b-4c8e-9d1a-2b3c4d5e6f70",
+  "epoch": 7,
+  "seq": 11,
+  "ts": 1755440000123,
+  "inst": "connector-a1b2c3",
+  "payload": {
+    "message": {
+      "id": "3EB0A1B2C3D4E5F60728",
+      "chat": {
+        "kind": "phone",
+        "id": "5541999990000"
+      },
+      "sender": {
+        "phone": "5541999990000",
+        "lid": "182736451928374",
+        "push_name": "Ana Souza"
+      },
+      "from_me": false,
+      "timestamp": 1755440000123,
+      "content": {
+        "type": "unsupported",
+        "reason": "unavailable"
+      }
+    }
+  }
+}

--- a/spec/fixtures/whatsapp/session/contract/fixtures/events/pairing_passkey_confirmation.json
+++ b/spec/fixtures/whatsapp/session/contract/fixtures/events/pairing_passkey_confirmation.json
@@ -8,6 +8,7 @@
   "ts": 1755440000123,
   "inst": "connector-a1b2c3",
   "payload": {
+    "request_id": "pk_01j9y0",
     "code": "4821"
   }
 }

--- a/spec/fixtures/whatsapp/session/contract/fixtures/events/session_offline_sync_completed.json
+++ b/spec/fixtures/whatsapp/session/contract/fixtures/events/session_offline_sync_completed.json
@@ -1,0 +1,13 @@
+{
+  "v": 1,
+  "id": "01920000-0000-7000-8000-00000000002b",
+  "type": "session.offline_sync_completed",
+  "sid": "9f1c0f4e-6a2b-4c8e-9d1a-2b3c4d5e6f70",
+  "epoch": 8,
+  "seq": 51,
+  "ts": 1755440507400,
+  "inst": "connector-a1b2c3",
+  "payload": {
+    "count": 47
+  }
+}

--- a/spec/fixtures/whatsapp/session/contract/fixtures/events/session_offline_sync_preview.json
+++ b/spec/fixtures/whatsapp/session/contract/fixtures/events/session_offline_sync_preview.json
@@ -1,0 +1,17 @@
+{
+  "v": 1,
+  "id": "01920000-0000-7000-8000-00000000002a",
+  "type": "session.offline_sync_preview",
+  "sid": "9f1c0f4e-6a2b-4c8e-9d1a-2b3c4d5e6f70",
+  "epoch": 8,
+  "seq": 2,
+  "ts": 1755440500000,
+  "inst": "connector-a1b2c3",
+  "payload": {
+    "messages": 14,
+    "receipts": 31,
+    "notifications": 2,
+    "app_data_changes": 0,
+    "total": 47
+  }
+}

--- a/spec/fixtures/whatsapp/session/contract/schema/protocol.schema.json
+++ b/spec/fixtures/whatsapp/session/contract/schema/protocol.schema.json
@@ -206,7 +206,7 @@
       "type": "object",
       "properties": {
         "type": { "const": "unsupported" },
-        "reason": { "enum": ["unknown_type", "undecryptable", "protocol", "empty"] }
+        "reason": { "enum": ["unknown_type", "undecryptable", "unavailable", "protocol", "empty"] }
       },
       "required": ["type", "reason"],
       "additionalProperties": true
@@ -282,7 +282,7 @@
         "invalid_payload", "unsupported", "session_not_found", "not_connected", "not_paired",
         "owned_elsewhere", "quarantined", "client_outdated", "rate_limited", "expired", "timeout",
         "media_too_large", "media_unavailable", "recipient_not_on_whatsapp", "group_participant_not_allowed",
-        "wa_error", "internal"
+        "wa_error", "provider_unavailable", "internal"
       ]
     },
 
@@ -358,6 +358,8 @@
             { "properties": { "type": { "const": "session.temporary_ban" }, "payload": { "$ref": "#/definitions/event_session_temporary_ban" } }, "required": ["type"] },
             { "properties": { "type": { "const": "session.client_outdated" }, "payload": { "type": "object" } }, "required": ["type"] },
             { "properties": { "type": { "const": "session.connect_failure" }, "payload": { "$ref": "#/definitions/event_session_connect_failure" } }, "required": ["type"] },
+            { "properties": { "type": { "const": "session.offline_sync_preview" }, "payload": { "$ref": "#/definitions/event_session_offline_sync_preview" } }, "required": ["type"] },
+            { "properties": { "type": { "const": "session.offline_sync_completed" }, "payload": { "$ref": "#/definitions/event_session_offline_sync_completed" } }, "required": ["type"] },
             { "properties": { "type": { "const": "pairing.qr" }, "payload": { "$ref": "#/definitions/event_pairing_qr" } }, "required": ["type"] },
             { "properties": { "type": { "const": "pairing.code" }, "payload": { "$ref": "#/definitions/event_pairing_code" } }, "required": ["type"] },
             { "properties": { "type": { "const": "pairing.success" }, "payload": { "$ref": "#/definitions/event_pairing_success" } }, "required": ["type"] },
@@ -401,6 +403,28 @@
         "ban": { "oneOf": [{ "$ref": "#/definitions/ban" }, { "type": "null" }] }
       },
       "required": ["state"],
+      "additionalProperties": true
+    },
+    "event_session_offline_sync_preview": {
+      "description": "The server is about to replay what this session missed while it was down. Counts are the server's own, sent before the events themselves, so a reader can say how much is coming instead of watching the queue move on its own. The messages arrive afterwards as ordinary message.received.",
+      "type": "object",
+      "properties": {
+        "messages": { "type": "integer", "minimum": 0 },
+        "receipts": { "type": "integer", "minimum": 0 },
+        "notifications": { "type": "integer", "minimum": 0 },
+        "app_data_changes": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["total"],
+      "additionalProperties": true
+    },
+    "event_session_offline_sync_completed": {
+      "description": "The replay is over. What did not arrive by now is not coming, so this is where a reader stops waiting.",
+      "type": "object",
+      "properties": {
+        "count": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["count"],
       "additionalProperties": true
     },
     "event_session_logged_out": {
@@ -473,7 +497,10 @@
     },
     "event_pairing_passkey_confirmation": {
       "type": "object",
-      "properties": { "code": { "type": "string" } },
+      "properties": {
+        "request_id": { "type": "string" },
+        "code": { "type": "string" }
+      },
       "required": ["code"],
       "additionalProperties": true
     },
@@ -540,7 +567,8 @@
       "properties": {
         "chat": { "$ref": "#/definitions/address" },
         "message_id": { "$ref": "#/definitions/message_id" },
-        "reason": { "type": "string" }
+        "reason": { "type": "string" },
+        "recoverable": { "type": "boolean" }
       },
       "required": ["message_id", "reason"],
       "additionalProperties": true

--- a/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
+++ b/spec/jobs/whatsapp/session/media_fetch_job_spec.rb
@@ -69,6 +69,31 @@ RSpec.describe Whatsapp::Session::MediaFetchJob do
     expect(message.reload.attachments.first).to have_attributes(file_type: 'image')
   end
 
+  # A file whose bytes never came with the message has no ref to carry, and the provider
+  # is asked by message id alone. Refusing it for having no ref -- which is what reading
+  # `ref&.served_by?` as false did -- is refusing exactly the fetch this exists for.
+  context 'when the message never had a reference to its file' do
+    let(:media) { model::Content::Media.new(kind: 'image', mime: 'image/jpeg', filename: 'foto.jpg') }
+
+    it 'asks the provider by message id and attaches what comes back' do
+      described_class.perform_now(message, media.to_h)
+
+      expect(backend.commands.last).to have_attributes(message_id: '3EB0AAAA0001', ref: nil)
+      expect(message.reload.attachments.first).to have_attributes(file_type: 'image')
+    end
+
+    # The inbox left the session layer while this sat in the queue, which the first half
+    # of the refusal still catches: no ref does not mean no guard.
+    it 'still gives up when the inbox has left the session layer' do
+      channel.update_columns(provider: 'whatsapp_cloud') # rubocop:disable Rails/SkipsModelValidations
+
+      described_class.perform_now(message, media.to_h)
+
+      expect(message.reload.content_attributes['is_unsupported']).to be(true)
+      expect(backend.commands).to be_empty
+    end
+  end
+
   # A native inbox whose config is broken is a deployment bug, not media that is gone:
   # marking the bubble unsupported would hide it.
   it 'lets a genuine misconfiguration fail loudly' do

--- a/spec/services/whatsapp/session/inbound/handlers/media_download_failed_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/media_download_failed_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Inbound::Handlers::MediaDownloadFailed do
+  subject(:dispatch) { Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event) }
+
+  let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+  let(:inbox) { channel.inbox }
+  let(:backend) { Whatsapp::Session::Backends::Fake.new(channel) }
+
+  let(:model) { Whatsapp::Session::Model }
+  let(:chat) { model::Address.phone('5541999990000') }
+  let(:conversation) { create(:conversation, inbox: inbox, account: channel.account) }
+  let(:pending_media) do
+    model::Content::Media.new(kind: 'image', mime: 'image/jpeg', filename: 'foto.jpg').to_h
+  end
+  let(:message) do
+    create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                     source_id: '3EB0AAAA0001', content_attributes: { 'pending_media' => pending_media })
+  end
+  let(:failure) do
+    model::Events::MediaDownloadFailed.new(
+      chat: chat, message_id: message.source_id, reason: reason, recoverable: recoverable
+    )
+  end
+  let(:event) { model::Event.build(failure, epoch: 1, seq: 1) }
+
+  before { allow(channel).to receive(:provider_service).and_return(backend) }
+
+  context 'when the file is gone for good' do
+    let(:reason) { 'media_key_expired' }
+    let(:recoverable) { false }
+
+    it 'flags the bubble so the agent stops waiting for it' do
+      expect(dispatch).to eq(:handled)
+
+      expect(message.reload.content_attributes['is_unsupported']).to be(true)
+    end
+
+    it 'asks nobody for the bytes' do
+      expect { dispatch }.not_to have_enqueued_job(Whatsapp::Session::MediaFetchJob)
+    end
+  end
+
+  context "when WhatsApp dropped the file and the sender's phone may still have it" do
+    let(:reason) { 'media_off_cdn' }
+    let(:recoverable) { true }
+
+    # The whole point of the flag: the bubble is not flagged, so the fetch that follows
+    # can still put the attachment in it. Flagging first is what used to make the
+    # recovery unreachable, since MediaFetchJob stands down on `is_unsupported`.
+    it 'asks for the bytes instead of giving up on them' do
+      expect { dispatch }.to have_enqueued_job(Whatsapp::Session::MediaFetchJob)
+        .with(message, pending_media, chat.to_h)
+
+      expect(message.reload.content_attributes['is_unsupported']).to be_nil
+    end
+
+    # A message published before the writer kept a descriptor, or one that never carried
+    # media at all. There is nothing to rebuild an attachment from, so asking would fetch
+    # bytes nothing could attach.
+    it 'gives up when nothing was kept to fetch with' do
+      message.update!(content_attributes: {})
+
+      expect { dispatch }.not_to have_enqueued_job(Whatsapp::Session::MediaFetchJob)
+      expect(message.reload.content_attributes['is_unsupported']).to be(true)
+    end
+
+    # The bytes arrived by another route while this event was in flight. Flagging the
+    # bubble now would say the attachment is missing next to the attachment.
+    it 'does nothing for a message that already has its file' do
+      message.attachments.create!(account_id: message.account_id, file_type: :image)
+
+      expect(dispatch).to eq(:ignored)
+      expect(message.reload.content_attributes['is_unsupported']).to be_nil
+    end
+  end
+end

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
 
       message = inbox.messages.find_by(source_id: '3EB0AAAA0001')
       expect(message.content).to eq('olha isso')
+      expect(message.content_attributes).not_to have_key('pending_media')
       expect(Whatsapp::Session::MediaFetchJob).to have_been_enqueued
         .with(message, hash_including('kind' => 'image'), hash_including('kind' => 'phone'))
     end
@@ -173,6 +174,29 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
 
       expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)).to eq(:duplicate)
 
+      expect(Whatsapp::Session::MediaFetchJob).not_to have_been_enqueued
+    end
+  end
+
+  # The file did not come with the message. Nothing is queued here, because at this point
+  # nothing knows whether the bytes are reachable at all -- `media.download_failed` is
+  # what says so, and it arrives next. What this has to leave behind is the file's own
+  # description, which lives on the event and nowhere else once it has gone by.
+  context 'with media whose bytes did not come with it' do
+    let(:content) do
+      model::Content::Media.new(
+        kind: 'audio', mime: 'audio/ogg', caption: 'ouve isso', voice_note: true,
+        thumbnail: "data:image/jpeg;base64,#{'A' * 128}"
+      )
+    end
+
+    it 'keeps what the file was, and asks nobody for it yet' do
+      expect(dispatch).to eq(:handled)
+
+      message = inbox.messages.find_by(source_id: '3EB0AAAA0001')
+      expect(message.content_attributes['pending_media']).to eq(
+        'type' => 'media', 'kind' => 'audio', 'mime' => 'audio/ogg', 'voice_note' => true
+      )
       expect(Whatsapp::Session::MediaFetchJob).not_to have_been_enqueued
     end
   end


### PR DESCRIPTION
The Chatwoot half of fazer-ai/whatsapp-connector#18. Pairs with fazer-ai/whatsapp-connector#78, which is what puts `recoverable` on the wire.

## What was broken

`media.download_failed` was final on every reason: `Handlers::MediaDownloadFailed` wrote `is_unsupported: true`, and `MessageWriter.fetch_media_for` then refused to queue another fetch for that message. That is right for a file that is gone, and wrong for the one case the connector can recover. WhatsApp drops a file off its CDN long before the sender's phone forgets it, and asking the phone to upload it again is what saves a message that sat in a backlog: a session that was down, an account resumed after a while.

The connector now says which of the two it is. Three gates on this side had to move before its answer could reach anything.

## The commits

**1. Re-vendor the contract and catch the models up.** The vendored copy had drifted in three ways nothing here was reading, because a model that does not exist is an event the dispatcher drops as unknown rather than a failure anybody sees:

- `media.download_failed` gained `recoverable`, which the next commit acts on.
- `pairing.passkey_confirmation` gained `request_id`, which is how the passkey flow ties an answer to its request. Both passkey events stay in `IGNORED`: that wall is answered by the browser extension, not here. The member is carried so the round trip is faithful and the correlation exists when something does read it.
- `session.offline_sync_preview` and `session.offline_sync_completed` had no model at all. Added to the catalog and to `IGNORED`, which is the list that exists so a dropped type is a decision on the record rather than silence.

Reviewable on its own; nothing in it changes behaviour.

**2. The change itself.**

- `fetch_media_for` stops treating "has a ref" as part of what media *is*. It still queues nothing without one, for a better reason: at that point nothing knows whether the bytes are reachable, and asking on behalf of every permanently failed file would spend a round trip per failure and, on an instance with no media root, three retries and a dead job per message.
- `MessageWriter` keeps the file's own description on the row when the bytes did not come with the message (`content_attributes['pending_media']`). It is on the event and nowhere else once that has gone by, and there is no attachment to read it off: without it a recoverable file could be fetched and then not attached, because nothing would know what kind of attachment to build. Only what a fetch reads, so the caption (already the message's content) and the thumbnail (a data URI worth kilobytes) are not copied.
- `Handlers::MediaDownloadFailed` queues the fetch when the provider says the bytes may still be reachable and the row says what they were. Nothing is flagged in that case: `MediaFetchJob` marks the message unsupported itself if the provider turns out not to reach them either, which is the same end.
- `MediaFetchJob` stops refusing a fetch with no ref. The guard is about a ref naming a provider the inbox has left; with none there is nothing to misattribute, and the message id alone is what the refresh behind a lapsed ref already asks with. The inbox having left the session layer still refuses.

## Tests

New: a spec for `MediaDownloadFailed`, which had none at all. It covers both verdicts, a recoverable failure on a message with nothing kept to fetch with, and one whose bytes arrived by another route while the event was in flight.

Extended: `message_received_spec` for the descriptor being kept (and not kept when the ref works), `media_fetch_job_spec` for a ref-less fetch and for the family guard still holding without one.

Four reversion proofs against the committed baseline, each failing exactly the test that covers it: dropping the handler's retry branch, dropping the descriptor, restoring `ref&.served_by?`, and letting `fetch_media_for` queue without a ref.

`spec/services/whatsapp spec/jobs/whatsapp spec/lib/whatsapp spec/models/channel/whatsapp_spec.rb`: 1736 examples, 0 failures. RuboCop clean.

## Before merging

`CONTRACT_REF` points at `150342c` on the connector's PR branch. It has to be re-vendored against the squashed commit on the connector's `main` once #78 lands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/442)
<!-- Reviewable:end -->
