### PR TITLE
fix(email): read the html part that carries the message, not the first one

### DIFF
--- a/app/presenters/html_part_chooser.rb
+++ b/app/presenters/html_part_chooser.rb
@@ -44,13 +44,46 @@ class HtmlPartChooser
   # leaf under it is attached content. Reading the disposition as well is what makes the
   # walk stop at the top of that subtree rather than one level inside it.
   def body_parts(part = @mail, found = [])
-    part.parts.each do |child|
+    body_children(part).each do |child|
       next if attached?(child)
 
       found << child
       body_parts(child, found) if child.multipart?
     end
     found
+  end
+
+  # Which children of a container are the message. Under `multipart/alternative` and
+  # `multipart/mixed` all of them are. Under `multipart/related` only one is: the rest are
+  # resources the body points at by `Content-ID`, an image almost always, but a `text/html`
+  # fragment reads to a flat walk exactly like a candidate and is not one. RFC 2387 names
+  # that one in `start`, and means the first child when it says nothing.
+  #
+  # The gem gets this right by accident -- its answer is the first `text/html` in order, and
+  # the root comes first -- so looking past an empty body without this would be a new way to
+  # be wrong, not a fix.
+  def body_children(part)
+    children = part.parts
+    return children unless part.mime_type == 'multipart/related'
+
+    [root_of(part, children)].compact
+  end
+
+  def root_of(part, children)
+    named = part.content_type_parameters.to_h['start'].to_s
+    return children.first if named.blank?
+
+    children.find { |child| cid(child) == unbracket(named) } || children.first
+  end
+
+  def cid(part)
+    unbracket(part.content_id.to_s)
+  rescue StandardError
+    ''
+  end
+
+  def unbracket(value)
+    value.strip.delete_prefix('<').delete_suffix('>')
   end
 
   def attached?(part)

--- a/app/presenters/html_part_chooser.rb
+++ b/app/presenters/html_part_chooser.rb
@@ -1,0 +1,69 @@
+# Which `text/html` part of a message carries what the sender wrote.
+#
+# Its own class because it is a policy with a cost, not a step. `Mail::Message#html_part`
+# answers with the first `text/html` it meets in a depth-first walk, which is right almost
+# always and silently wrong on a shape iOS Mail produces: a `multipart/alternative` whose
+# one child is a `multipart/mixed`, holding a stub of a hundred-odd bytes, then the
+# attachment, then the part the customer actually wrote. The stub renders to nothing, so
+# the message reaches the agent as an empty bubble under a subject -- no error, no
+# attachment missing, just no words.
+class HtmlPartChooser
+  def self.for(mail) = new(mail).perform
+
+  def initialize(mail)
+    @mail = mail
+  end
+
+  # The gem's answer stands unless there is a choice to make and its answer says nothing,
+  # so every message whose first part is the real one keeps the part it has today. That
+  # restraint is the point: taking the largest outright would prefer a quoted forward over
+  # the short reply written above it, which is a worse failure than the one being fixed and
+  # a far more common shape.
+  #
+  # The two cheap tests come before the expensive one on purpose. This sits on every inbound
+  # email and answering it costs a full parse, so the parse is reached only by a message
+  # that actually carries rival parts.
+  def perform
+    chosen = @mail.html_part
+    rivals = body_parts.select { |part| part.mime_type == 'text/html' }
+    return chosen if chosen.nil? || rivals.length < 2 || rendered(chosen).present?
+
+    rivals.max_by { |part| rendered(part).length } || chosen
+  end
+
+  private
+
+  # The parts of the message itself, which is not every part it carries. An attached
+  # document has parts of its own, and a `text/html` inside one reads, to a flat walk,
+  # exactly like a candidate. It is not one, and preferring it because it is longer than the
+  # reply above it is precisely the failure this class exists to avoid.
+  #
+  # `attachment?` alone does not answer where to stop: it is a question about a file, a
+  # disposition plus a name, and the container holding an attached document has no name. A
+  # `multipart/related` carrying `Content-Disposition: attachment` answers false while every
+  # leaf under it is attached content. Reading the disposition as well is what makes the
+  # walk stop at the top of that subtree rather than one level inside it.
+  def body_parts(part = @mail, found = [])
+    part.parts.each do |child|
+      next if attached?(child)
+
+      found << child
+      body_parts(child, found) if child.multipart?
+    end
+    found
+  end
+
+  def attached?(part)
+    part.attachment? || part.content_disposition.to_s.strip.downcase.start_with?('attachment')
+  rescue StandardError
+    false
+  end
+
+  # What a part is worth to a reader, which is the same question the caller asks of it a
+  # moment later. A part that is only markup answers with nothing.
+  def rendered(part)
+    ::HtmlParser.parse_reply(part.body.decoded.to_s).to_s
+  rescue StandardError
+    ''
+  end
+end

--- a/app/presenters/html_part_chooser.rb
+++ b/app/presenters/html_part_chooser.rb
@@ -61,8 +61,16 @@ class HtmlPartChooser
 
   # What a part is worth to a reader, which is the same question the caller asks of it a
   # moment later. A part that is only markup answers with nothing.
+  #
+  # `decoded` and not `body.decoded`, because they are different questions and only the
+  # first is the one being asked. `body.decoded` undoes the transfer encoding and stops,
+  # handing back bytes tagged binary; `decoded` goes on to transcode the charset the part
+  # declares, which is what the presenter renders a moment later. On any charset a byte
+  # wide the two agree, so the gap only opens on UTF-16 and its family -- where the raw
+  # bytes parse to nothing at all, a part that says something scores zero, and a one-word
+  # rival wins on length.
   def rendered(part)
-    ::HtmlParser.parse_reply(part.body.decoded.to_s).to_s
+    ::HtmlParser.parse_reply(part.decoded.to_s).to_s
   rescue StandardError
     ''
   end

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -11,6 +11,27 @@ class MailPresenter < SimpleDelegator
     encode_to_unicode(@mail.subject)
   end
 
+  # Which `text/html` part carries the message, when there is more than one.
+  #
+  # The mail gem answers with the first it meets in a depth-first walk, which is right
+  # almost always and silently wrong on a shape iOS Mail produces: a `multipart/alternative`
+  # whose one child is a `multipart/mixed`, holding a stub of a hundred-odd bytes, then the
+  # attachment, then the `text/html` the customer actually wrote. The stub renders to
+  # nothing, so the message reaches the agent as an empty bubble under a subject -- no
+  # error, no attachment missing, just no words.
+  #
+  # Only consulted when the gem's own answer renders to nothing, so every message whose
+  # first part is the real one keeps the part it has today. That restraint is the point:
+  # taking the largest outright would prefer a quoted forward over the short reply written
+  # above it, which is a worse failure than the one being fixed and a far more common shape.
+  def html_part
+    chosen = @mail.html_part
+    return chosen if chosen.nil? || rendered(chosen).present?
+
+    candidates = @mail.all_parts.select { |part| part.mime_type == 'text/html' && !part.attachment? }
+    candidates.max_by { |part| rendered(part).length } || chosen
+  end
+
   # encode decoded mail text_part or html_part if mail is multipart email
   # encode decoded mail raw bodyt if mail is not multipart email but the body content is text/html
   def mail_content(mail_part)
@@ -205,6 +226,14 @@ class MailPresenter < SimpleDelegator
     return str if current_encoding == 'UTF-8'
 
     str.encode(current_encoding, 'UTF-8', invalid: :replace, undef: :replace, replace: '?')
+  rescue StandardError
+    ''
+  end
+
+  # What a part is worth to a reader, which is the same question the caller asks of it a
+  # moment later. A part that is only markup answers zero.
+  def rendered(part)
+    ::HtmlParser.parse_reply(part.body.decoded.to_s).to_s
   rescue StandardError
     ''
   end

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -11,25 +11,12 @@ class MailPresenter < SimpleDelegator
     encode_to_unicode(@mail.subject)
   end
 
-  # Which `text/html` part carries the message, when there is more than one.
-  #
-  # The mail gem answers with the first it meets in a depth-first walk, which is right
-  # almost always and silently wrong on a shape iOS Mail produces: a `multipart/alternative`
-  # whose one child is a `multipart/mixed`, holding a stub of a hundred-odd bytes, then the
-  # attachment, then the `text/html` the customer actually wrote. The stub renders to
-  # nothing, so the message reaches the agent as an empty bubble under a subject -- no
-  # error, no attachment missing, just no words.
-  #
-  # Only consulted when the gem's own answer renders to nothing, so every message whose
-  # first part is the real one keeps the part it has today. That restraint is the point:
-  # taking the largest outright would prefer a quoted forward over the short reply written
-  # above it, which is a worse failure than the one being fixed and a far more common shape.
+  # See HtmlPartChooser: the gem's own answer is the first `text/html` in a depth-first
+  # walk, which on one shape iOS Mail produces is a stub that renders to nothing.
   def html_part
-    chosen = @mail.html_part
-    return chosen if chosen.nil? || rendered(chosen).present?
+    return @html_part if defined?(@html_part)
 
-    candidates = @mail.all_parts.select { |part| part.mime_type == 'text/html' && !part.attachment? }
-    candidates.max_by { |part| rendered(part).length } || chosen
+    @html_part = HtmlPartChooser.for(@mail)
   end
 
   # encode decoded mail text_part or html_part if mail is multipart email
@@ -226,14 +213,6 @@ class MailPresenter < SimpleDelegator
     return str if current_encoding == 'UTF-8'
 
     str.encode(current_encoding, 'UTF-8', invalid: :replace, undef: :replace, replace: '?')
-  rescue StandardError
-    ''
-  end
-
-  # What a part is worth to a reader, which is the same question the caller asks of it a
-  # moment later. A part that is only markup answers zero.
-  def rendered(part)
-    ::HtmlParser.parse_reply(part.body.decoded.to_s).to_s
   rescue StandardError
     ''
   end

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -299,5 +299,43 @@ RSpec.describe MailPresenter do
       presenter = described_class.new(nested(stub_html, '<html><body><br></body></html>'))
       expect(presenter.html_content).to eq({})
     end
+
+    # An attached document has parts of its own, and `attachment?` does not answer where the
+    # message stops: it is a question about a file, and the container holding an attached
+    # document has no filename, so it answers false while everything under it is attached.
+    it 'does not take the body out of an attached document' do
+      mail = nested(stub_html, '<html><body>Segue em anexo.</body></html>')
+      attached = Mail::Part.new
+      attached.content_type = 'multipart/related'
+      attached.content_disposition = 'attachment'
+      inner = Mail::Part.new
+      inner.content_type = 'text/html; charset=utf-8'
+      inner.body = "<html><body>#{'Texto de uma nota fiscal encaminhada. ' * 40}</body></html>"
+      attached.add_part(inner)
+      mail.parts.first.add_part(attached)
+
+      expect(described_class.new(mail).html_content[:full]).to include('Segue em anexo.')
+    end
+
+    # This sits on every inbound email and `html_content` asks for it twice, so the parse
+    # has to be reached only by a message that actually carries rival parts.
+    it 'does not parse anything to answer a message with one html part' do
+      mail = Mail.new(from: 'cliente@example.com', to: 'sac@example.com', subject: 'Oi')
+      mail.content_type = 'multipart/alternative'
+      text = Mail::Part.new
+      text.content_type = 'text/plain; charset=utf-8'
+      text.body = 'Bom dia'
+      html = Mail::Part.new
+      html.content_type = 'text/html; charset=utf-8'
+      html.body = '<html><body>Bom dia</body></html>'
+      [text, html].each { |part| mail.add_part(part) }
+
+      presenter = described_class.new(mail)
+      allow(HtmlParser).to receive(:parse_reply).and_call_original
+      presenter.html_part
+      presenter.html_part
+
+      expect(HtmlParser).not_to have_received(:parse_reply)
+    end
   end
 end

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -335,6 +335,25 @@ RSpec.describe MailPresenter do
       expect(presenter.html_content[:full]).to include('Preciso do reembolso')
     end
 
+    # A `multipart/related` carries one body and a set of resources it points at by
+    # `Content-ID`. A `text/html` resource is not a candidate, however long it is, and the
+    # gem only avoids it by accident of ordering: it answers with the first part it meets,
+    # and the root comes first.
+    it 'does not take the body from a resource the body points at' do
+      raw = +"From: cliente@example.com\r\nTo: sac@example.com\r\nSubject: Pedido\r\n"
+      raw << "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=\"A\"\r\n\r\n"
+      raw << "--A\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n\r\n"
+      raw << "--A\r\nContent-Type: multipart/related; boundary=\"R\"; start=\"<raiz@ex>\"\r\n\r\n"
+      raw << "--R\r\nContent-Type: text/html; charset=utf-8\r\nContent-ID: <raiz@ex>\r\n\r\n"
+      raw << "<html><body><br></body></html>\r\n"
+      raw << "--R\r\nContent-Type: text/html; charset=utf-8\r\nContent-ID: <recurso@ex>\r\n\r\n"
+      raw << "<html><body>#{'Rodape institucional da empresa. ' * 20}</body></html>\r\n--R--\r\n--A--\r\n"
+
+      chosen = HtmlPartChooser.for(Mail.read_from_string(raw))
+
+      expect(chosen.content_id).to eq('<raiz@ex>')
+    end
+
     # This sits on every inbound email and `html_content` asks for it twice, so the parse
     # has to be reached only by a message that actually carries rival parts.
     it 'does not parse anything to answer a message with one html part' do

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -259,4 +259,45 @@ RSpec.describe MailPresenter do
       end
     end
   end
+
+  # iOS Mail composes a `multipart/alternative` whose one child is a `multipart/mixed`: a
+  # stub that renders to nothing, then the attachment, then the part the customer wrote.
+  # The mail gem answers `html_part` with the first `text/html` it meets, so the message
+  # reached the agent as an empty bubble under a subject.
+  describe 'a message whose first html part is a stub' do
+    def nested(first_html, second_html)
+      inner = Mail::Part.new
+      inner.content_type = 'multipart/mixed'
+      [first_html, second_html].each do |html|
+        part = Mail::Part.new
+        part.content_type = 'text/html; charset=utf-8'
+        part.body = html
+        inner.add_part(part)
+      end
+      mail = Mail.new(from: 'cliente@example.com', to: 'sac@example.com', subject: 'Pedido')
+      mail.content_type = 'multipart/alternative'
+      mail.add_part(inner)
+      mail
+    end
+
+    let(:stub_html) { '<html><body dir="auto"><br></body></html>' }
+    let(:real_html) { '<html><body>Bom dia, preciso cancelar o pedido e receber o estorno.</body></html>' }
+
+    it 'reads the part that carries the message instead of the stub above it' do
+      presenter = described_class.new(nested(stub_html, real_html))
+      expect(presenter.html_content[:full]).to include('preciso cancelar o pedido')
+    end
+
+    # The restraint is the point. Taking the largest outright would prefer a quoted forward
+    # over the short reply written above it, which is a worse failure and a commoner shape.
+    it 'leaves a first part that says something alone, however short' do
+      presenter = described_class.new(nested('<html><body>Ok, obrigado.</body></html>', real_html))
+      expect(presenter.html_content[:full]).to include('Ok, obrigado.')
+    end
+
+    it 'still answers nothing when no part says anything' do
+      presenter = described_class.new(nested(stub_html, '<html><body><br></body></html>'))
+      expect(presenter.html_content).to eq({})
+    end
+  end
 end

--- a/spec/presenters/mail_presenter_spec.rb
+++ b/spec/presenters/mail_presenter_spec.rb
@@ -317,6 +317,24 @@ RSpec.describe MailPresenter do
       expect(described_class.new(mail).html_content[:full]).to include('Segue em anexo.')
     end
 
+    # Scoring a part means rendering it, and rendering it means decoding it the way the
+    # reader will. `body.decoded` stops at the transfer encoding and hands back bytes
+    # tagged binary, which on UTF-16 parse to nothing: the part that says something scores
+    # zero and loses to a one-word rival.
+    it 'reads a part in a charset a byte does not fit' do
+      written = '<html><body>Preciso do reembolso, o evento foi cancelado.</body></html>'
+      payload = [written.encode('UTF-16LE').force_encoding('BINARY')].pack('m0')
+      raw = +"From: cliente@example.com\r\nTo: sac@example.com\r\nSubject: Reembolso\r\n"
+      raw << "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=\"B\"\r\n\r\n"
+      raw << "--B\r\nContent-Type: text/html; charset=UTF-16LE\r\n"
+      raw << "Content-Transfer-Encoding: base64\r\n\r\n#{payload}\r\n"
+      raw << "--B\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<html><body>ok</body></html>\r\n--B--\r\n"
+
+      presenter = described_class.new(Mail.read_from_string(raw))
+
+      expect(presenter.html_content[:full]).to include('Preciso do reembolso')
+    end
+
     # This sits on every inbound email and `html_content` asks for it twice, so the parse
     # has to be reached only by a message that actually carries rival parts.
     it 'does not parse anything to answer a message with one html part' do


### PR DESCRIPTION
A customer writes from an iPhone, attaches something, and the agent opens the thread to an empty bubble under a subject. No error, no attachment missing, just no words.

iOS Mail composes a `multipart/alternative` whose one child is a `multipart/mixed`, holding a stub of a hundred-odd bytes, then the attachment, then the `text/html` the customer actually wrote. `Mail::Message#html_part` is `find_first_mime_type('text/html')`, so it answers with the stub, and the stub renders to nothing.

This is not only an import concern. `ImapMailbox`, `ReplyMailbox` and the conversation finder strategies all read the body through `MailPresenter`, so it is every inbound email path.

**The fix looks past the gem's answer only when that answer renders to nothing.** Every message whose first part is the real one keeps the part it has today, and the restraint is the point: taking the largest part outright would prefer a quoted forward over the short reply written above it, which is a worse failure than the one being fixed and a far more common shape.

Found while replaying a real support mailbox rather than fixtures, which is also the only way to size it. It is rare, on the order of one message in a thousand, but the whole body is lost each time and nothing anywhere says so. Verified against the real message that produced it: extraction went from nothing to the full body, and two neighbouring messages whose html is genuinely empty stayed empty.

Three examples cover it, including the one that would fail if the fallback were made greedy. `spec/presenters`, `spec/mailboxes`, `spec/services/imap` and `spec/services/mailbox` are green apart from `reply_mailbox_spec.rb:389`, which fails on `main` too and is environment-driven.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/444)
<!-- Reviewable:end -->
