### PR TITLE
feat(conversations): let agents record a voice note on a private note

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Audio.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Audio.vue
@@ -3,16 +3,25 @@ import { computed } from 'vue';
 import BaseBubble from './Base.vue';
 import AudioChip from 'next/message/chips/Audio.vue';
 import { useMessageContext } from '../provider.js';
+import { MESSAGE_VARIANTS } from '../constants';
 
-const { attachments } = useMessageContext();
+const { attachments, variant } = useMessageContext();
 
 const attachment = computed(() => {
   return attachments.value[0];
 });
+
+// The audio chip carries its own card, so the bubble behind it is normally
+// invisible. A private note is the exception: the amber background is what
+// marks it as internal, so it has to stay.
+const isPrivate = computed(() => variant.value === MESSAGE_VARIANTS.PRIVATE);
 </script>
 
 <template>
-  <BaseBubble class="bg-transparent" data-bubble-name="audio">
+  <BaseBubble
+    :class="isPrivate ? 'p-2' : 'bg-transparent'"
+    data-bubble-name="audio"
+  >
     <AudioChip
       :attachment="attachment"
       class="p-2 text-n-slate-12 skip-context-menu"

--- a/app/javascript/dashboard/components-next/message/bubbles/specs/Audio.spec.js
+++ b/app/javascript/dashboard/components-next/message/bubbles/specs/Audio.spec.js
@@ -1,0 +1,55 @@
+import { defineComponent, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import AudioBubble from '../Audio.vue';
+import { provideMessageContext } from '../../provider.js';
+import { MESSAGE_VARIANTS, ORIENTATION } from '../../constants';
+
+const mountAudio = variant => {
+  const TestHost = defineComponent({
+    components: { AudioBubble },
+    setup() {
+      provideMessageContext({
+        attachments: ref([{ fileType: 'audio', dataUrl: 'audio.mp3' }]),
+        variant: ref(variant),
+        orientation: ref(ORIENTATION.RIGHT),
+        contentAttributes: ref({}),
+        additionalAttributes: ref({}),
+        shouldGroupWithNext: ref(false),
+        inReplyTo: ref(null),
+        id: ref(1),
+        sender: ref({}),
+        senderType: ref('user'),
+      });
+    },
+    template: '<AudioBubble />',
+  });
+
+  return mount(TestHost, {
+    global: {
+      stubs: {
+        AudioChip: true,
+        MessageMeta: true,
+        ReferralCard: true,
+        CaptainGenerationDetails: true,
+      },
+      mocks: { $t: key => key },
+    },
+  });
+};
+
+describe('Audio bubble', () => {
+  it('keeps the private note amber, which is what marks it as internal', () => {
+    const bubble = mountAudio(MESSAGE_VARIANTS.PRIVATE).find('div');
+
+    expect(bubble.classes()).toContain('bg-n-solid-amber');
+    // Tailwind emits .bg-transparent after every .bg-n-* utility at the same
+    // specificity, so letting it through would silently win over the amber.
+    expect(bubble.classes()).not.toContain('bg-transparent');
+  });
+
+  it('lets the chip stand on its own everywhere else', () => {
+    const bubble = mountAudio(MESSAGE_VARIANTS.AGENT).find('div');
+
+    expect(bubble.classes()).toContain('bg-transparent');
+  });
+});

--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.spec.js
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.spec.js
@@ -1,0 +1,76 @@
+import { shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import ReplyBottomPanel from './ReplyBottomPanel.vue';
+
+const buildStore = ({ voiceRecorderEnabled = true } = {}) =>
+  createStore({
+    getters: {
+      getCurrentAccountId: () => 1,
+      getUISettings: () => ({}),
+      'accounts/isFeatureEnabledonAccount': () => () => voiceRecorderEnabled,
+      'integrations/getUIFlags': () => ({ isFetching: false }),
+    },
+  });
+
+const mountWith = ({ voiceRecorderEnabled, ...props } = {}) =>
+  shallowMount(ReplyBottomPanel, {
+    props: {
+      conversationId: 1,
+      portalSlug: 'handbook',
+      showAudioRecorder: true,
+      ...props,
+    },
+    global: {
+      plugins: [buildStore({ voiceRecorderEnabled })],
+      mocks: { $t: key => key },
+    },
+  });
+
+describe('ReplyBottomPanel', () => {
+  describe.each([
+    ['Line', { channel_type: 'Channel::Line' }],
+    ['TikTok', { channel_type: 'Channel::Tiktok' }],
+  ])('%s', (_name, inbox) => {
+    it('hides the voice recorder on a reply, which the channel cannot carry', () => {
+      const wrapper = mountWith({ inbox });
+
+      expect(wrapper.vm.showAudioRecorderButton).toBe(false);
+    });
+
+    it('offers the voice recorder on a private note, which stays internal', () => {
+      const wrapper = mountWith({ inbox, isOnPrivateNote: true });
+
+      expect(wrapper.vm.showAudioRecorderButton).toBe(true);
+    });
+  });
+
+  it('hides the voice recorder while the editor is disabled', () => {
+    const wrapper = mountWith({
+      inbox: { channel_type: 'Channel::WebWidget' },
+      isOnPrivateNote: true,
+      isEditorDisabled: true,
+    });
+
+    expect(wrapper.vm.showAudioRecorderButton).toBe(false);
+  });
+
+  it('stays behind the account feature flag, note or not', () => {
+    const wrapper = mountWith({
+      inbox: { channel_type: 'Channel::WebWidget' },
+      isOnPrivateNote: true,
+      voiceRecorderEnabled: false,
+    });
+
+    expect(wrapper.vm.showAudioRecorderButton).toBe(false);
+  });
+
+  it('offers the play/stop control while a note is being recorded', () => {
+    const wrapper = mountWith({
+      inbox: { channel_type: 'Channel::Line' },
+      isOnPrivateNote: true,
+      isRecordingAudio: true,
+    });
+
+    expect(wrapper.vm.showAudioPlayStopButton).toBe(true);
+  });
+});

--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -199,7 +199,12 @@ export default {
     },
     showAudioRecorderButton() {
       if (this.isEditorDisabled) return false;
-      if (this.isALineChannel || this.isATiktokChannel) {
+      // These channels can't carry a voice message, but a private note isn't
+      // going anywhere near them.
+      if (
+        (this.isALineChannel || this.isATiktokChannel) &&
+        !this.isOnPrivateNote
+      ) {
         return false;
       }
       // Disable audio recorder for safari browser as recording is not supported

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -705,6 +705,18 @@ export default {
         mode: updatedReplyType,
       });
       this.switchDraftContext(this.conversationIdByRoute, updatedReplyType);
+      // The composer can leave note mode without the agent touching anything: a
+      // bot releases the pending conversation it owned, the messaging window
+      // reopens, an Instagram restriction lifts. Whatever is staged was produced
+      // under the old privacy but would be sent under the new one, so a voice
+      // note recorded for the team could reach the contact. The draft survives
+      // because switchDraftContext keeps one per mode; attachments and a cited
+      // private note have no such split, so they go.
+      if (this.isRecordingAudio) this.onTypingOff();
+      this.resetRecorderAndClearAttachments();
+      if (this.inReplyTo?.private && !this.isOnPrivateNote) {
+        this.resetReplyToMessage();
+      }
     },
   },
 

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -1276,14 +1276,15 @@ export default {
 
       // Added a new key isVoiceMessage to the file to identify recorded audio
       // Because to filter and show only non recorded audio and other attachments
-      const autoRecordedFile = {
-        ...file,
-        isVoiceMessage: true,
-      };
       // Stamped with what the composer was when the mic was armed — the agent
       // spoke and the audio was converted since, and either could have outlasted
       // the mode the recording was meant for.
-      return file && this.stageFile(autoRecordedFile, this.recordingGeneration);
+      const autoRecordedFile = {
+        ...file,
+        isVoiceMessage: true,
+        composerGeneration: this.recordingGeneration,
+      };
+      return file && this.stageFile(autoRecordedFile);
     },
     onRecordError() {
       this.toggleAudioRecorder();
@@ -1308,8 +1309,16 @@ export default {
     // the composer can move to a public reply — or to another conversation —
     // before the file ever arrives, and attachFile would then stage it under a
     // privacy the agent never chose.
-    stageFile(file, generation = this.composerGeneration) {
-      if (file) file.composerGeneration = generation;
+    stageFile(file) {
+      if (!file) return;
+
+      // Never a positional second argument here: this is wired straight to the
+      // uploader's `input-file`, which emits (newFile, oldFile) and re-emits on
+      // every progress update. A recorder capture arrives already stamped, from
+      // when the mic was armed.
+      if (file.composerGeneration === undefined) {
+        file.composerGeneration = this.composerGeneration;
+      }
       this.onFileUpload(file);
     },
     attachFile({ blob, file }) {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -465,7 +465,9 @@ export default {
       return this.attachedFiles.some(file => file.isVoiceMessage);
     },
     showAudioRecorder() {
-      return !this.isOnPrivateNote && this.showFileUpload;
+      // A private note never reaches the channel, so the channel's upload
+      // support doesn't gate it — same rule the attach button already follows.
+      return this.showFileUpload || this.isOnPrivateNote;
     },
     showAudioRecorderEditor() {
       return this.showAudioRecorder && this.isRecordingAudio;
@@ -518,6 +520,13 @@ export default {
       return `draft-${this.conversationIdByRoute}-${this.effectiveReplyMode}`;
     },
     audioRecordFormat() {
+      // Notes stay inside Chatwoot, so the channel's preferred container is
+      // irrelevant. MP3 is the one format every browser and both mobile apps
+      // play, and it keeps long notes under the 25 MB transcription ceiling
+      // that uncompressed WAV would blow past in ~5 minutes.
+      if (this.isOnPrivateNote) {
+        return AUDIO_FORMATS.MP3;
+      }
       if (this.isAWhatsAppCloudChannel) {
         return AUDIO_FORMATS.OGG;
       }

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -1210,6 +1210,10 @@ export default {
       this.copilot.execute(action, data);
     },
     clearMessage() {
+      // Sending consumes the composer as much as switching mode does: a capture
+      // still uploading belongs to the message that just left, and would
+      // otherwise land in the empty composer and ride along with the next one.
+      this.composerGeneration += 1;
       this.message = '';
       this.clearCopilotAcceptedMessage();
       this.attachedFiles = [];

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -145,6 +145,9 @@ export default {
       // stamps it on the way in, so an upload that lands afterwards can tell that
       // it outlived what the agent was composing under.
       composerGeneration: 0,
+      // The recorder's capture starts when the mic is armed, not when the file
+      // shows up: talking and then converting to MP3 both happen in between.
+      recordingGeneration: 0,
       isRecordingAudio: false,
       recordingAudioState: '',
       recordingAudioDurationText: '',
@@ -1229,6 +1232,7 @@ export default {
         this.resetAudioRecorderInput();
         this.onTypingOff();
       } else {
+        this.recordingGeneration = this.composerGeneration;
         this.onRecording();
       }
     },
@@ -1276,7 +1280,10 @@ export default {
         ...file,
         isVoiceMessage: true,
       };
-      return file && this.stageFile(autoRecordedFile);
+      // Stamped with what the composer was when the mic was armed — the agent
+      // spoke and the audio was converted since, and either could have outlasted
+      // the mode the recording was meant for.
+      return file && this.stageFile(autoRecordedFile, this.recordingGeneration);
     },
     onRecordError() {
       this.toggleAudioRecorder();
@@ -1301,8 +1308,8 @@ export default {
     // the composer can move to a public reply — or to another conversation —
     // before the file ever arrives, and attachFile would then stage it under a
     // privacy the agent never chose.
-    stageFile(file) {
-      if (file) file.composerGeneration = this.composerGeneration;
+    stageFile(file, generation = this.composerGeneration) {
+      if (file) file.composerGeneration = generation;
       this.onFileUpload(file);
     },
     attachFile({ blob, file }) {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -141,6 +141,10 @@ export default {
       isFocused: false,
       showEmojiPicker: false,
       attachedFiles: [],
+      // Bumped whenever the composer's privacy or conversation changes. A capture
+      // stamps it on the way in, so an upload that lands afterwards can tell that
+      // it outlived what the agent was composing under.
+      composerGeneration: 0,
       isRecordingAudio: false,
       recordingAudioState: '',
       recordingAudioDurationText: '',
@@ -671,6 +675,7 @@ export default {
     },
     conversationIdByRoute(conversationId, oldConversationId) {
       if (conversationId !== oldConversationId) {
+        this.composerGeneration += 1;
         this.switchDraftContext(conversationId, this.effectiveReplyMode);
         this.resetRecorderAndClearAttachments();
       }
@@ -712,6 +717,7 @@ export default {
       // note recorded for the team could reach the contact. The draft survives
       // because switchDraftContext keeps one per mode; attachments and a cited
       // private note have no such split, so they go.
+      this.composerGeneration += 1;
       if (this.isRecordingAudio) this.onTypingOff();
       this.resetRecorderAndClearAttachments();
       if (this.inReplyTo?.private && !this.isOnPrivateNote) {
@@ -981,7 +987,7 @@ export default {
         })
         .forEach(file => {
           const { name, type, size } = file;
-          this.onFileUpload({ name, type, size, file });
+          this.stageFile({ name, type, size, file });
         });
     },
     toggleUserMention(currentMentionState) {
@@ -1270,7 +1276,7 @@ export default {
         ...file,
         isVoiceMessage: true,
       };
-      return file && this.onFileUpload(autoRecordedFile);
+      return file && this.stageFile(autoRecordedFile);
     },
     onRecordError() {
       this.toggleAudioRecorder();
@@ -1290,7 +1296,20 @@ export default {
         isPrivate,
       });
     },
+    // Every capture goes through here: the recorder, the clip button, drag and
+    // drop, and paste. MP3 conversion and the upload that follows are async, so
+    // the composer can move to a public reply — or to another conversation —
+    // before the file ever arrives, and attachFile would then stage it under a
+    // privacy the agent never chose.
+    stageFile(file) {
+      if (file) file.composerGeneration = this.composerGeneration;
+      this.onFileUpload(file);
+    },
     attachFile({ blob, file }) {
+      const generation = file?.composerGeneration;
+      // Checked here so a stale recording can't clear a newer one below.
+      if (generation !== this.composerGeneration) return;
+
       if (file?.isVoiceMessage) {
         this.removeRecordedAudio();
       }
@@ -1300,6 +1319,11 @@ export default {
       const reader = new FileReader();
       reader.readAsDataURL(file.file);
       reader.onloadend = () => {
+        // Reading the file is async as well, so the mode can change between the
+        // two. The push is the only moment that decides what gets sent, so it is
+        // where the capture has to still be current.
+        if (generation !== this.composerGeneration) return;
+
         this.attachedFiles.push({
           currentChatId: this.currentChat.id,
           resource: blob || file,
@@ -1693,7 +1717,7 @@ export default {
         :is-send-disabled="isReplyButtonDisabled"
         :is-note="isPrivate"
         :is-editor-disabled="isEditorDisabled"
-        :on-file-upload="onFileUpload"
+        :on-file-upload="stageFile"
         :on-send="onSendReply"
         :conversation-type="conversationType"
         :recording-audio-duration-text="recordingAudioDurationText"

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -600,6 +600,27 @@ describe('ReplyBox', () => {
     expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
   });
 
+  it('stages a file the uploader hands over with its (newFile, oldFile) pair', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+
+    // vue-upload-component emits input-file with two arguments and re-emits on
+    // every progress update. stageFile is wired straight to it, so a second
+    // positional parameter there would silently read oldFile.
+    const newFile = { name: 'doc.pdf', file: new Blob(['pdf']) };
+    const oldFile = {
+      name: 'doc.pdf',
+      file: new Blob(['pdf']),
+      progress: '0.00',
+    };
+    wrapper.vm.stageFile(newFile, oldFile);
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(wrapper.vm.attachedFiles).toHaveLength(1);
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -482,6 +482,59 @@ describe('ReplyBox', () => {
     expect(payload.isVoiceMessage).toBe(true);
   });
 
+  it('drops a note recording when the bot hands the conversation back', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+    expect(wrapper.vm.isOnPrivateNote).toBe(true);
+
+    wrapper.vm.attachedFiles = [
+      { isVoiceMessage: true, resource: { file: new Blob(['audio']) } },
+    ];
+    wrapper.vm.isRecordingAudio = true;
+
+    // The bot releases the conversation: nobody switched the composer, but it is
+    // no longer on a note, and the recording was made for the team.
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+
+    expect(wrapper.vm.isOnPrivateNote).toBe(false);
+    expect(wrapper.vm.attachedFiles).toEqual([]);
+    expect(wrapper.vm.isRecordingAudio).toBe(false);
+  });
+
+  it('drops a cited private note when the composer stops being internal', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+    wrapper.vm.inReplyTo = { id: 99, private: true };
+
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+
+    // Left in place, the note's id would ride along in the outbound message's
+    // in_reply_to and its preview would be quoted to the contact.
+    expect(wrapper.vm.inReplyTo).toEqual({});
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -535,6 +535,39 @@ describe('ReplyBox', () => {
     expect(wrapper.vm.inReplyTo).toEqual({});
   });
 
+  it('drops an upload that lands after the composer stopped being internal', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+
+    // The agent stops the recorder: MP3 conversion and the upload start here,
+    // and attachFile only runs once they finish.
+    const recorded = { isVoiceMessage: true, file: new Blob(['audio']) };
+    wrapper.vm.stageFile(recorded);
+
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+
+    // Staged after the switch, so this one is legitimate. Waiting for it is what
+    // makes the recording's absence a result rather than a race: both go through
+    // the same async FileReader, and this one was queued second.
+    const current = { name: 'current.png', file: new Blob(['image']) };
+    wrapper.vm.stageFile(current);
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(wrapper.vm.attachedFiles).toHaveLength(1);
+    expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -568,6 +568,35 @@ describe('ReplyBox', () => {
     expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
   });
 
+  it('drops a recording whose conversion outlived the note it was made on', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+
+    // Mic armed on a note. Talking and the MP3 conversion that follows both
+    // happen before onFinishRecorder ever runs.
+    wrapper.vm.toggleAudioRecorder();
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+    wrapper.vm.onFinishRecorder({ name: 'nota.mp3', file: new Blob(['audio']) });
+
+    const current = { name: 'current.png', file: new Blob(['image']) };
+    wrapper.vm.stageFile(current);
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(wrapper.vm.attachedFiles).toHaveLength(1);
+    expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -621,6 +621,25 @@ describe('ReplyBox', () => {
     expect(wrapper.vm.attachedFiles).toHaveLength(1);
   });
 
+  it('drops a capture still uploading when the message it belonged to is sent', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+
+    const recorded = { isVoiceMessage: true, file: new Blob(['audio']) };
+    wrapper.vm.stageFile(recorded);
+    // The agent sends the typed note without waiting for the upload.
+    wrapper.vm.clearMessage();
+
+    const current = { name: 'current.png', file: new Blob(['image']) };
+    wrapper.vm.stageFile(current);
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(wrapper.vm.attachedFiles).toHaveLength(1);
+    expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -89,6 +89,14 @@ const buildStore = ({
     },
   });
 
+// Every mount subscribes to the global reply-to bus in mounted(). Left alive,
+// they all answer an emit from whichever test fires one, and each one reaches
+// for an editor method the stub doesn't have.
+const mounted = [];
+afterEach(() => {
+  while (mounted.length) mounted.pop().unmount();
+});
+
 const mountWith = ({
   inbox,
   chat,
@@ -111,9 +119,21 @@ const mountWith = ({
       mocks: { $t: key => key },
       // The bottom panel sits inside a <Transition>, which shallowMount stubs
       // without rendering its children.
-      stubs: { transition: false },
+      stubs: {
+        transition: false,
+        // Same name and props the auto-stub would carry, so findComponent and
+        // props() keep working, plus the one method the composer calls on the
+        // editor ref after a reply-to reset.
+        WootMessageEditor: {
+          name: 'WootMessageEditor',
+          props: ['editorId', 'modelValue', 'isPrivate', 'placeholder'],
+          template: '<div />',
+          methods: { focusEditorInputField: () => {} },
+        },
+      },
     },
   });
+  mounted.push(wrapper);
   return { wrapper, store };
 };
 

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -587,7 +587,10 @@ describe('ReplyBox', () => {
       meta: { sender: { id: 2 } },
     });
     await nextTick();
-    wrapper.vm.onFinishRecorder({ name: 'nota.mp3', file: new Blob(['audio']) });
+    wrapper.vm.onFinishRecorder({
+      name: 'nota.mp3',
+      file: new Blob(['audio']),
+    });
 
     const current = { name: 'current.png', file: new Blob(['image']) };
     wrapper.vm.stageFile(current);

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import { REPLY_EDITOR_MODES } from 'dashboard/components/widgets/WootWriter/constants';
+import { AUDIO_FORMATS } from 'shared/constants/messages';
 import { nextTick } from 'vue';
 import { createStore } from 'vuex';
 import ReplyBox from '../ReplyBox.vue';
@@ -212,6 +213,19 @@ describe('ReplyBox', () => {
         REPLY_EDITOR_MODES.NOTE
       );
       expect(topPanel(wrapper).isEditorDisabled).toBe(false);
+    });
+
+    it('offers the voice recorder once the agent switches to a note', async () => {
+      const { wrapper } = mountWith({ inbox });
+      wrapper
+        .findComponent({ name: 'ReplyTopPanel' })
+        .vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+      await nextTick();
+
+      expect(bottomPanel(wrapper).showAudioRecorder).toBe(true);
+      // A note never leaves Chatwoot, so it records in the one container every
+      // browser and both mobile apps play, whatever the channel accepts.
+      expect(wrapper.vm.audioRecordFormat).toBe(AUDIO_FORMATS.MP3);
     });
 
     it('opens in reply mode for every other conversation', () => {
@@ -430,5 +444,66 @@ describe('ReplyBox', () => {
         REPLY_EDITOR_MODES.NOTE
       );
     });
+  });
+
+  it('unlocks the recorder on a note in an inbox that takes no uploads', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Tiktok' },
+      chat: {
+        additional_attributes: { tiktok_capabilities: { image_send: false } },
+      },
+    });
+
+    expect(wrapper.vm.showAudioRecorder).toBe(false);
+
+    wrapper
+      .findComponent({ name: 'ReplyTopPanel' })
+      .vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+    await nextTick();
+
+    expect(wrapper.vm.showAudioRecorder).toBe(true);
+  });
+
+  it('sends a recorded note as a private voice message', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    wrapper
+      .findComponent({ name: 'ReplyTopPanel' })
+      .vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+    await nextTick();
+    wrapper.vm.attachedFiles = [
+      { isVoiceMessage: true, resource: { file: new Blob(['audio']) } },
+    ];
+
+    const payload = wrapper.vm.getMessagePayload('');
+
+    expect(payload.private).toBe(true);
+    expect(payload.isVoiceMessage).toBe(true);
+  });
+
+  describe('recording format in reply mode', () => {
+    it.each([
+      [
+        'WhatsApp Cloud',
+        { channel_type: 'Channel::Whatsapp', provider: 'whatsapp_cloud' },
+        AUDIO_FORMATS.OGG,
+      ],
+      [
+        'Twilio WhatsApp',
+        { channel_type: 'Channel::TwilioSms', medium: 'whatsapp' },
+        AUDIO_FORMATS.MP3,
+      ],
+      ['Telegram', { channel_type: 'Channel::Telegram' }, AUDIO_FORMATS.MP3],
+      ['API', { channel_type: 'Channel::Api' }, AUDIO_FORMATS.MP3],
+      ['Web widget', { channel_type: 'Channel::WebWidget' }, AUDIO_FORMATS.WAV],
+    ])(
+      'keeps %s on the container the channel accepts',
+      (_name, inbox, format) => {
+        const { wrapper } = mountWith({ inbox });
+
+        expect(wrapper.vm.audioRecordFormat).toBe(format);
+      }
+    );
   });
 });

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -260,6 +260,24 @@ describe Messages::MessageBuilder do
       end
     end
 
+    context 'when the voice message is a private note' do
+      let(:params) do
+        ActionController::Parameters.new({
+                                           attachments: [Rack::Test::UploadedFile.new('spec/assets/sample.ogg', 'audio/ogg')],
+                                           is_voice_message: true,
+                                           private: true
+                                         })
+      end
+
+      it 'attaches the recording to the note like any other message' do
+        message = message_builder
+
+        expect(message).to be_private
+        expect(message.attachments.first.file_type).to eq 'audio'
+        expect(message.attachments.first.meta).to include('is_voice_message' => true)
+      end
+    end
+
     context 'when is_voice_message is not provided' do
       let(:params) do
         ActionController::Parameters.new({

--- a/spec/enterprise/models/attachment_spec.rb
+++ b/spec/enterprise/models/attachment_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Attachment do
+  let(:conversation) { create(:conversation) }
+
+  it 'transcribes a voice note recorded on a private message' do
+    message = create(:message, message_type: :outgoing, private: true,
+                               conversation: conversation, account: conversation.account)
+
+    expect do
+      message.attachments.create!(
+        account_id: message.account_id,
+        file_type: :audio,
+        file: fixture_file_upload('public/audio/widget/ding.mp3')
+      )
+    end.to have_enqueued_job(Messages::AudioTranscriptionJob)
+  end
+end

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -72,6 +72,22 @@ describe Whatsapp::SendOnWhatsappService do
         expect(message.reload.source_id).to eq('123456789')
       end
 
+      it 'keeps a private note off the channel, attachment and all' do
+        create(:message, message_type: :incoming, content: 'test',
+                         conversation: conversation, account: conversation.account)
+        message = create(:message, message_type: :outgoing, private: true, content: 'heads up',
+                                   conversation: conversation, account: conversation.account)
+        message.attachments.create!(
+          account_id: message.account_id,
+          file_type: :audio,
+          file: fixture_file_upload('public/audio/widget/ding.mp3')
+        )
+
+        described_class.new(message: message).perform
+
+        expect(a_request(:post, 'https://waba.360dialog.io/v1/messages')).not_to have_been_made
+      end
+
       it 'fails a free-form message without contacting the provider when outside the 24 hour limit' do
         create(:message, message_type: :incoming, content: 'test', created_at: 25.hours.ago,
                          conversation: conversation, account: conversation.account)


### PR DESCRIPTION
Agents can now record a voice note straight into a private note. Until now the microphone was hidden the moment the composer switched to note mode, so an internal recado had to be typed — or recorded elsewhere and attached as a file.

A note never reaches the contact, so the inbox's channel no longer has a say over it: the recorder follows the same rule the attach button already followed, and shows up in every inbox, including the ones (LINE, TikTok) whose wire format rejects voice messages.

## How to test

1. Open any conversation and switch the composer to **Private note** — the microphone sits next to the paperclip.
2. Record a few seconds and send. The note shows up amber, with the lock icon and the same player used by regular audio messages.
3. Confirm on the contact's side (WhatsApp, widget) that nothing arrived.
4. Repeat on a LINE or TikTok inbox: the mic is there in note mode, and gone again in reply mode.
5. With Captain and the account's `audio_transcriptions` toggle on, the transcription appears under the player on its own, without a refresh.

## What changed

- `ReplyBox.vue` — the recorder gate went from `!isOnPrivateNote && showFileUpload` to `showFileUpload || isOnPrivateNote`, and a note records MP3 whatever the channel accepts. MP3 is what plays on iOS and Android, and what keeps a long note under the 25 MB transcription ceiling; WAV, the previous default, crosses it at roughly five minutes.
- `ReplyBottomPanel.vue` — the LINE/TikTok exclusion now applies to replies only.
- `bubbles/Audio.vue` — the bubble no longer paints private notes transparent. Tailwind emits `.bg-transparent` after every `.bg-n-*` utility at the same specificity, so the class the bubble passed to let the chip's own card show through was silently overriding the amber variant background, leaving a voice note indistinguishable from a public audio message.

No backend change: the builder already attaches audio to private messages, `Base::SendOnChannelService` already cuts every private message before the channel, and the enterprise transcription job already fires on any audio attachment. Specs were added to hold each of those in place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/446)
<!-- Reviewable:end -->
