### PR TITLE
feat(reports): show how the period splits across agents, inboxes and teams

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -110,3 +110,12 @@ app/controllers/api/v1/widget/redirect_tokens_controller.rb: Snapshot the origin
 # carries it, and until a message exists there is no episode for a consumer to act on. Making
 # creation bot-visible changes the agent-bot contract for every inbox in the account.
 app/controllers/api/v1/widget/redirect_tokens_controller.rb: Notify the agent bot on the first message-less redirect  # PR#418
+# PR#448: the rule is real and this is not what it is about. AGENTS.md bans inline styles
+# so that appearance lives in Tailwind, and every colour, radius, height and state here is
+# a utility class. What `:style` carries is one data-driven length, which no utility can
+# express: a bar is 25.9% wide because an agent holds 25.9% of the period. The repo already
+# does exactly this wherever a proportion is drawn — BillingMeter.vue, ImportProgress.vue,
+# KnowledgeCard.vue, PollDisplay.vue — and the alternatives are worse: snapping to w-1/12
+# steps lies about the number, and an SVG rect moves fill and radius out of Tailwind to
+# avoid a single width.
+app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryDistribution.vue: Render distribution widths without inline styles  # PR#448

--- a/app/javascript/dashboard/components-next/message/bubbles/Audio.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Audio.vue
@@ -3,16 +3,25 @@ import { computed } from 'vue';
 import BaseBubble from './Base.vue';
 import AudioChip from 'next/message/chips/Audio.vue';
 import { useMessageContext } from '../provider.js';
+import { MESSAGE_VARIANTS } from '../constants';
 
-const { attachments } = useMessageContext();
+const { attachments, variant } = useMessageContext();
 
 const attachment = computed(() => {
   return attachments.value[0];
 });
+
+// The audio chip carries its own card, so the bubble behind it is normally
+// invisible. A private note is the exception: the amber background is what
+// marks it as internal, so it has to stay.
+const isPrivate = computed(() => variant.value === MESSAGE_VARIANTS.PRIVATE);
 </script>
 
 <template>
-  <BaseBubble class="bg-transparent" data-bubble-name="audio">
+  <BaseBubble
+    :class="isPrivate ? 'p-2' : 'bg-transparent'"
+    data-bubble-name="audio"
+  >
     <AudioChip
       :attachment="attachment"
       class="p-2 text-n-slate-12 skip-context-menu"

--- a/app/javascript/dashboard/components-next/message/bubbles/specs/Audio.spec.js
+++ b/app/javascript/dashboard/components-next/message/bubbles/specs/Audio.spec.js
@@ -1,0 +1,55 @@
+import { defineComponent, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import AudioBubble from '../Audio.vue';
+import { provideMessageContext } from '../../provider.js';
+import { MESSAGE_VARIANTS, ORIENTATION } from '../../constants';
+
+const mountAudio = variant => {
+  const TestHost = defineComponent({
+    components: { AudioBubble },
+    setup() {
+      provideMessageContext({
+        attachments: ref([{ fileType: 'audio', dataUrl: 'audio.mp3' }]),
+        variant: ref(variant),
+        orientation: ref(ORIENTATION.RIGHT),
+        contentAttributes: ref({}),
+        additionalAttributes: ref({}),
+        shouldGroupWithNext: ref(false),
+        inReplyTo: ref(null),
+        id: ref(1),
+        sender: ref({}),
+        senderType: ref('user'),
+      });
+    },
+    template: '<AudioBubble />',
+  });
+
+  return mount(TestHost, {
+    global: {
+      stubs: {
+        AudioChip: true,
+        MessageMeta: true,
+        ReferralCard: true,
+        CaptainGenerationDetails: true,
+      },
+      mocks: { $t: key => key },
+    },
+  });
+};
+
+describe('Audio bubble', () => {
+  it('keeps the private note amber, which is what marks it as internal', () => {
+    const bubble = mountAudio(MESSAGE_VARIANTS.PRIVATE).find('div');
+
+    expect(bubble.classes()).toContain('bg-n-solid-amber');
+    // Tailwind emits .bg-transparent after every .bg-n-* utility at the same
+    // specificity, so letting it through would silently win over the amber.
+    expect(bubble.classes()).not.toContain('bg-transparent');
+  });
+
+  it('lets the chip stand on its own everywhere else', () => {
+    const bubble = mountAudio(MESSAGE_VARIANTS.AGENT).find('div');
+
+    expect(bubble.classes()).toContain('bg-transparent');
+  });
+});

--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.spec.js
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.spec.js
@@ -1,0 +1,76 @@
+import { shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import ReplyBottomPanel from './ReplyBottomPanel.vue';
+
+const buildStore = ({ voiceRecorderEnabled = true } = {}) =>
+  createStore({
+    getters: {
+      getCurrentAccountId: () => 1,
+      getUISettings: () => ({}),
+      'accounts/isFeatureEnabledonAccount': () => () => voiceRecorderEnabled,
+      'integrations/getUIFlags': () => ({ isFetching: false }),
+    },
+  });
+
+const mountWith = ({ voiceRecorderEnabled, ...props } = {}) =>
+  shallowMount(ReplyBottomPanel, {
+    props: {
+      conversationId: 1,
+      portalSlug: 'handbook',
+      showAudioRecorder: true,
+      ...props,
+    },
+    global: {
+      plugins: [buildStore({ voiceRecorderEnabled })],
+      mocks: { $t: key => key },
+    },
+  });
+
+describe('ReplyBottomPanel', () => {
+  describe.each([
+    ['Line', { channel_type: 'Channel::Line' }],
+    ['TikTok', { channel_type: 'Channel::Tiktok' }],
+  ])('%s', (_name, inbox) => {
+    it('hides the voice recorder on a reply, which the channel cannot carry', () => {
+      const wrapper = mountWith({ inbox });
+
+      expect(wrapper.vm.showAudioRecorderButton).toBe(false);
+    });
+
+    it('offers the voice recorder on a private note, which stays internal', () => {
+      const wrapper = mountWith({ inbox, isOnPrivateNote: true });
+
+      expect(wrapper.vm.showAudioRecorderButton).toBe(true);
+    });
+  });
+
+  it('hides the voice recorder while the editor is disabled', () => {
+    const wrapper = mountWith({
+      inbox: { channel_type: 'Channel::WebWidget' },
+      isOnPrivateNote: true,
+      isEditorDisabled: true,
+    });
+
+    expect(wrapper.vm.showAudioRecorderButton).toBe(false);
+  });
+
+  it('stays behind the account feature flag, note or not', () => {
+    const wrapper = mountWith({
+      inbox: { channel_type: 'Channel::WebWidget' },
+      isOnPrivateNote: true,
+      voiceRecorderEnabled: false,
+    });
+
+    expect(wrapper.vm.showAudioRecorderButton).toBe(false);
+  });
+
+  it('offers the play/stop control while a note is being recorded', () => {
+    const wrapper = mountWith({
+      inbox: { channel_type: 'Channel::Line' },
+      isOnPrivateNote: true,
+      isRecordingAudio: true,
+    });
+
+    expect(wrapper.vm.showAudioPlayStopButton).toBe(true);
+  });
+});

--- a/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
+++ b/app/javascript/dashboard/components/widgets/WootWriter/ReplyBottomPanel.vue
@@ -199,7 +199,12 @@ export default {
     },
     showAudioRecorderButton() {
       if (this.isEditorDisabled) return false;
-      if (this.isALineChannel || this.isATiktokChannel) {
+      // These channels can't carry a voice message, but a private note isn't
+      // going anywhere near them.
+      if (
+        (this.isALineChannel || this.isATiktokChannel) &&
+        !this.isOnPrivateNote
+      ) {
         return false;
       }
       // Disable audio recorder for safari browser as recording is not supported

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -705,6 +705,18 @@ export default {
         mode: updatedReplyType,
       });
       this.switchDraftContext(this.conversationIdByRoute, updatedReplyType);
+      // The composer can leave note mode without the agent touching anything: a
+      // bot releases the pending conversation it owned, the messaging window
+      // reopens, an Instagram restriction lifts. Whatever is staged was produced
+      // under the old privacy but would be sent under the new one, so a voice
+      // note recorded for the team could reach the contact. The draft survives
+      // because switchDraftContext keeps one per mode; attachments and a cited
+      // private note have no such split, so they go.
+      if (this.isRecordingAudio) this.onTypingOff();
+      this.resetRecorderAndClearAttachments();
+      if (this.inReplyTo?.private && !this.isOnPrivateNote) {
+        this.resetReplyToMessage();
+      }
     },
   },
 

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -1276,14 +1276,15 @@ export default {
 
       // Added a new key isVoiceMessage to the file to identify recorded audio
       // Because to filter and show only non recorded audio and other attachments
-      const autoRecordedFile = {
-        ...file,
-        isVoiceMessage: true,
-      };
       // Stamped with what the composer was when the mic was armed — the agent
       // spoke and the audio was converted since, and either could have outlasted
       // the mode the recording was meant for.
-      return file && this.stageFile(autoRecordedFile, this.recordingGeneration);
+      const autoRecordedFile = {
+        ...file,
+        isVoiceMessage: true,
+        composerGeneration: this.recordingGeneration,
+      };
+      return file && this.stageFile(autoRecordedFile);
     },
     onRecordError() {
       this.toggleAudioRecorder();
@@ -1308,8 +1309,16 @@ export default {
     // the composer can move to a public reply — or to another conversation —
     // before the file ever arrives, and attachFile would then stage it under a
     // privacy the agent never chose.
-    stageFile(file, generation = this.composerGeneration) {
-      if (file) file.composerGeneration = generation;
+    stageFile(file) {
+      if (!file) return;
+
+      // Never a positional second argument here: this is wired straight to the
+      // uploader's `input-file`, which emits (newFile, oldFile) and re-emits on
+      // every progress update. A recorder capture arrives already stamped, from
+      // when the mic was armed.
+      if (file.composerGeneration === undefined) {
+        file.composerGeneration = this.composerGeneration;
+      }
       this.onFileUpload(file);
     },
     attachFile({ blob, file }) {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -465,7 +465,9 @@ export default {
       return this.attachedFiles.some(file => file.isVoiceMessage);
     },
     showAudioRecorder() {
-      return !this.isOnPrivateNote && this.showFileUpload;
+      // A private note never reaches the channel, so the channel's upload
+      // support doesn't gate it — same rule the attach button already follows.
+      return this.showFileUpload || this.isOnPrivateNote;
     },
     showAudioRecorderEditor() {
       return this.showAudioRecorder && this.isRecordingAudio;
@@ -518,6 +520,13 @@ export default {
       return `draft-${this.conversationIdByRoute}-${this.effectiveReplyMode}`;
     },
     audioRecordFormat() {
+      // Notes stay inside Chatwoot, so the channel's preferred container is
+      // irrelevant. MP3 is the one format every browser and both mobile apps
+      // play, and it keeps long notes under the 25 MB transcription ceiling
+      // that uncompressed WAV would blow past in ~5 minutes.
+      if (this.isOnPrivateNote) {
+        return AUDIO_FORMATS.MP3;
+      }
       if (this.isAWhatsAppCloudChannel) {
         return AUDIO_FORMATS.OGG;
       }

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -1210,6 +1210,10 @@ export default {
       this.copilot.execute(action, data);
     },
     clearMessage() {
+      // Sending consumes the composer as much as switching mode does: a capture
+      // still uploading belongs to the message that just left, and would
+      // otherwise land in the empty composer and ride along with the next one.
+      this.composerGeneration += 1;
       this.message = '';
       this.clearCopilotAcceptedMessage();
       this.attachedFiles = [];

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -145,6 +145,9 @@ export default {
       // stamps it on the way in, so an upload that lands afterwards can tell that
       // it outlived what the agent was composing under.
       composerGeneration: 0,
+      // The recorder's capture starts when the mic is armed, not when the file
+      // shows up: talking and then converting to MP3 both happen in between.
+      recordingGeneration: 0,
       isRecordingAudio: false,
       recordingAudioState: '',
       recordingAudioDurationText: '',
@@ -1229,6 +1232,7 @@ export default {
         this.resetAudioRecorderInput();
         this.onTypingOff();
       } else {
+        this.recordingGeneration = this.composerGeneration;
         this.onRecording();
       }
     },
@@ -1276,7 +1280,10 @@ export default {
         ...file,
         isVoiceMessage: true,
       };
-      return file && this.stageFile(autoRecordedFile);
+      // Stamped with what the composer was when the mic was armed — the agent
+      // spoke and the audio was converted since, and either could have outlasted
+      // the mode the recording was meant for.
+      return file && this.stageFile(autoRecordedFile, this.recordingGeneration);
     },
     onRecordError() {
       this.toggleAudioRecorder();
@@ -1301,8 +1308,8 @@ export default {
     // the composer can move to a public reply — or to another conversation —
     // before the file ever arrives, and attachFile would then stage it under a
     // privacy the agent never chose.
-    stageFile(file) {
-      if (file) file.composerGeneration = this.composerGeneration;
+    stageFile(file, generation = this.composerGeneration) {
+      if (file) file.composerGeneration = generation;
       this.onFileUpload(file);
     },
     attachFile({ blob, file }) {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -141,6 +141,10 @@ export default {
       isFocused: false,
       showEmojiPicker: false,
       attachedFiles: [],
+      // Bumped whenever the composer's privacy or conversation changes. A capture
+      // stamps it on the way in, so an upload that lands afterwards can tell that
+      // it outlived what the agent was composing under.
+      composerGeneration: 0,
       isRecordingAudio: false,
       recordingAudioState: '',
       recordingAudioDurationText: '',
@@ -671,6 +675,7 @@ export default {
     },
     conversationIdByRoute(conversationId, oldConversationId) {
       if (conversationId !== oldConversationId) {
+        this.composerGeneration += 1;
         this.switchDraftContext(conversationId, this.effectiveReplyMode);
         this.resetRecorderAndClearAttachments();
       }
@@ -712,6 +717,7 @@ export default {
       // note recorded for the team could reach the contact. The draft survives
       // because switchDraftContext keeps one per mode; attachments and a cited
       // private note have no such split, so they go.
+      this.composerGeneration += 1;
       if (this.isRecordingAudio) this.onTypingOff();
       this.resetRecorderAndClearAttachments();
       if (this.inReplyTo?.private && !this.isOnPrivateNote) {
@@ -981,7 +987,7 @@ export default {
         })
         .forEach(file => {
           const { name, type, size } = file;
-          this.onFileUpload({ name, type, size, file });
+          this.stageFile({ name, type, size, file });
         });
     },
     toggleUserMention(currentMentionState) {
@@ -1270,7 +1276,7 @@ export default {
         ...file,
         isVoiceMessage: true,
       };
-      return file && this.onFileUpload(autoRecordedFile);
+      return file && this.stageFile(autoRecordedFile);
     },
     onRecordError() {
       this.toggleAudioRecorder();
@@ -1290,7 +1296,20 @@ export default {
         isPrivate,
       });
     },
+    // Every capture goes through here: the recorder, the clip button, drag and
+    // drop, and paste. MP3 conversion and the upload that follows are async, so
+    // the composer can move to a public reply — or to another conversation —
+    // before the file ever arrives, and attachFile would then stage it under a
+    // privacy the agent never chose.
+    stageFile(file) {
+      if (file) file.composerGeneration = this.composerGeneration;
+      this.onFileUpload(file);
+    },
     attachFile({ blob, file }) {
+      const generation = file?.composerGeneration;
+      // Checked here so a stale recording can't clear a newer one below.
+      if (generation !== this.composerGeneration) return;
+
       if (file?.isVoiceMessage) {
         this.removeRecordedAudio();
       }
@@ -1300,6 +1319,11 @@ export default {
       const reader = new FileReader();
       reader.readAsDataURL(file.file);
       reader.onloadend = () => {
+        // Reading the file is async as well, so the mode can change between the
+        // two. The push is the only moment that decides what gets sent, so it is
+        // where the capture has to still be current.
+        if (generation !== this.composerGeneration) return;
+
         this.attachedFiles.push({
           currentChatId: this.currentChat.id,
           resource: blob || file,
@@ -1693,7 +1717,7 @@ export default {
         :is-send-disabled="isReplyButtonDisabled"
         :is-note="isPrivate"
         :is-editor-disabled="isEditorDisabled"
-        :on-file-upload="onFileUpload"
+        :on-file-upload="stageFile"
         :on-send="onSendReply"
         :conversation-type="conversationType"
         :recording-audio-duration-text="recordingAudioDurationText"

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -600,6 +600,27 @@ describe('ReplyBox', () => {
     expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
   });
 
+  it('stages a file the uploader hands over with its (newFile, oldFile) pair', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+
+    // vue-upload-component emits input-file with two arguments and re-emits on
+    // every progress update. stageFile is wired straight to it, so a second
+    // positional parameter there would silently read oldFile.
+    const newFile = { name: 'doc.pdf', file: new Blob(['pdf']) };
+    const oldFile = {
+      name: 'doc.pdf',
+      file: new Blob(['pdf']),
+      progress: '0.00',
+    };
+    wrapper.vm.stageFile(newFile, oldFile);
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(wrapper.vm.attachedFiles).toHaveLength(1);
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -482,6 +482,59 @@ describe('ReplyBox', () => {
     expect(payload.isVoiceMessage).toBe(true);
   });
 
+  it('drops a note recording when the bot hands the conversation back', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+    expect(wrapper.vm.isOnPrivateNote).toBe(true);
+
+    wrapper.vm.attachedFiles = [
+      { isVoiceMessage: true, resource: { file: new Blob(['audio']) } },
+    ];
+    wrapper.vm.isRecordingAudio = true;
+
+    // The bot releases the conversation: nobody switched the composer, but it is
+    // no longer on a note, and the recording was made for the team.
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+
+    expect(wrapper.vm.isOnPrivateNote).toBe(false);
+    expect(wrapper.vm.attachedFiles).toEqual([]);
+    expect(wrapper.vm.isRecordingAudio).toBe(false);
+  });
+
+  it('drops a cited private note when the composer stops being internal', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+    wrapper.vm.inReplyTo = { id: 99, private: true };
+
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+
+    // Left in place, the note's id would ride along in the outbound message's
+    // in_reply_to and its preview would be quoted to the contact.
+    expect(wrapper.vm.inReplyTo).toEqual({});
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -535,6 +535,39 @@ describe('ReplyBox', () => {
     expect(wrapper.vm.inReplyTo).toEqual({});
   });
 
+  it('drops an upload that lands after the composer stopped being internal', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+
+    // The agent stops the recorder: MP3 conversion and the upload start here,
+    // and attachFile only runs once they finish.
+    const recorded = { isVoiceMessage: true, file: new Blob(['audio']) };
+    wrapper.vm.stageFile(recorded);
+
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+
+    // Staged after the switch, so this one is legitimate. Waiting for it is what
+    // makes the recording's absence a result rather than a race: both go through
+    // the same async FileReader, and this one was queued second.
+    const current = { name: 'current.png', file: new Blob(['image']) };
+    wrapper.vm.stageFile(current);
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(wrapper.vm.attachedFiles).toHaveLength(1);
+    expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -568,6 +568,35 @@ describe('ReplyBox', () => {
     expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
   });
 
+  it('drops a recording whose conversion outlived the note it was made on', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+
+    // Mic armed on a note. Talking and the MP3 conversion that follows both
+    // happen before onFinishRecorder ever runs.
+    wrapper.vm.toggleAudioRecorder();
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+    wrapper.vm.onFinishRecorder({ name: 'nota.mp3', file: new Blob(['audio']) });
+
+    const current = { name: 'current.png', file: new Blob(['image']) };
+    wrapper.vm.stageFile(current);
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(wrapper.vm.attachedFiles).toHaveLength(1);
+    expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -621,6 +621,25 @@ describe('ReplyBox', () => {
     expect(wrapper.vm.attachedFiles).toHaveLength(1);
   });
 
+  it('drops a capture still uploading when the message it belonged to is sent', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+
+    const recorded = { isVoiceMessage: true, file: new Blob(['audio']) };
+    wrapper.vm.stageFile(recorded);
+    // The agent sends the typed note without waiting for the upload.
+    wrapper.vm.clearMessage();
+
+    const current = { name: 'current.png', file: new Blob(['image']) };
+    wrapper.vm.stageFile(current);
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(wrapper.vm.attachedFiles).toHaveLength(1);
+    expect(wrapper.vm.attachedFiles[0].isVoiceMessage).toBe(false);
+  });
+
   describe('recording format in reply mode', () => {
     it.each([
       [

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -89,6 +89,14 @@ const buildStore = ({
     },
   });
 
+// Every mount subscribes to the global reply-to bus in mounted(). Left alive,
+// they all answer an emit from whichever test fires one, and each one reaches
+// for an editor method the stub doesn't have.
+const mounted = [];
+afterEach(() => {
+  while (mounted.length) mounted.pop().unmount();
+});
+
 const mountWith = ({
   inbox,
   chat,
@@ -111,9 +119,21 @@ const mountWith = ({
       mocks: { $t: key => key },
       // The bottom panel sits inside a <Transition>, which shallowMount stubs
       // without rendering its children.
-      stubs: { transition: false },
+      stubs: {
+        transition: false,
+        // Same name and props the auto-stub would carry, so findComponent and
+        // props() keep working, plus the one method the composer calls on the
+        // editor ref after a reply-to reset.
+        WootMessageEditor: {
+          name: 'WootMessageEditor',
+          props: ['editorId', 'modelValue', 'isPrivate', 'placeholder'],
+          template: '<div />',
+          methods: { focusEditorInputField: () => {} },
+        },
+      },
     },
   });
+  mounted.push(wrapper);
   return { wrapper, store };
 };
 

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -587,7 +587,10 @@ describe('ReplyBox', () => {
       meta: { sender: { id: 2 } },
     });
     await nextTick();
-    wrapper.vm.onFinishRecorder({ name: 'nota.mp3', file: new Blob(['audio']) });
+    wrapper.vm.onFinishRecorder({
+      name: 'nota.mp3',
+      file: new Blob(['audio']),
+    });
 
     const current = { name: 'current.png', file: new Blob(['image']) };
     wrapper.vm.stageFile(current);

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import { REPLY_EDITOR_MODES } from 'dashboard/components/widgets/WootWriter/constants';
+import { AUDIO_FORMATS } from 'shared/constants/messages';
 import { nextTick } from 'vue';
 import { createStore } from 'vuex';
 import ReplyBox from '../ReplyBox.vue';
@@ -212,6 +213,19 @@ describe('ReplyBox', () => {
         REPLY_EDITOR_MODES.NOTE
       );
       expect(topPanel(wrapper).isEditorDisabled).toBe(false);
+    });
+
+    it('offers the voice recorder once the agent switches to a note', async () => {
+      const { wrapper } = mountWith({ inbox });
+      wrapper
+        .findComponent({ name: 'ReplyTopPanel' })
+        .vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+      await nextTick();
+
+      expect(bottomPanel(wrapper).showAudioRecorder).toBe(true);
+      // A note never leaves Chatwoot, so it records in the one container every
+      // browser and both mobile apps play, whatever the channel accepts.
+      expect(wrapper.vm.audioRecordFormat).toBe(AUDIO_FORMATS.MP3);
     });
 
     it('opens in reply mode for every other conversation', () => {
@@ -430,5 +444,66 @@ describe('ReplyBox', () => {
         REPLY_EDITOR_MODES.NOTE
       );
     });
+  });
+
+  it('unlocks the recorder on a note in an inbox that takes no uploads', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Tiktok' },
+      chat: {
+        additional_attributes: { tiktok_capabilities: { image_send: false } },
+      },
+    });
+
+    expect(wrapper.vm.showAudioRecorder).toBe(false);
+
+    wrapper
+      .findComponent({ name: 'ReplyTopPanel' })
+      .vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+    await nextTick();
+
+    expect(wrapper.vm.showAudioRecorder).toBe(true);
+  });
+
+  it('sends a recorded note as a private voice message', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    wrapper
+      .findComponent({ name: 'ReplyTopPanel' })
+      .vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+    await nextTick();
+    wrapper.vm.attachedFiles = [
+      { isVoiceMessage: true, resource: { file: new Blob(['audio']) } },
+    ];
+
+    const payload = wrapper.vm.getMessagePayload('');
+
+    expect(payload.private).toBe(true);
+    expect(payload.isVoiceMessage).toBe(true);
+  });
+
+  describe('recording format in reply mode', () => {
+    it.each([
+      [
+        'WhatsApp Cloud',
+        { channel_type: 'Channel::Whatsapp', provider: 'whatsapp_cloud' },
+        AUDIO_FORMATS.OGG,
+      ],
+      [
+        'Twilio WhatsApp',
+        { channel_type: 'Channel::TwilioSms', medium: 'whatsapp' },
+        AUDIO_FORMATS.MP3,
+      ],
+      ['Telegram', { channel_type: 'Channel::Telegram' }, AUDIO_FORMATS.MP3],
+      ['API', { channel_type: 'Channel::Api' }, AUDIO_FORMATS.MP3],
+      ['Web widget', { channel_type: 'Channel::WebWidget' }, AUDIO_FORMATS.WAV],
+    ])(
+      'keeps %s on the container the channel accepts',
+      (_name, inbox, format) => {
+        const { wrapper } = mountWith({ inbox });
+
+        expect(wrapper.vm.audioRecordFormat).toBe(format);
+      }
+    );
   });
 });

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/report.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/report.json
@@ -16,7 +16,8 @@
         "RESOLUTIONS": "Resolved"
       },
       "OTHERS": "Others ({count})",
-      "ASSIGNED_ONLY": "Counts only conversations that have an assignee."
+      "ASSIGNED_ONLY": "Counts only conversations that have an assignee.",
+      "EMPTY_METRIC": "Not enough data to compare on this metric."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/report.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/report.json
@@ -4,6 +4,19 @@
       "ALL_INBOXES": "All inboxes",
       "ALL_AGENTS": "All agents",
       "NO_RESULTS": "No activity for this filter in the selected period."
+    },
+    "DISTRIBUTION": {
+      "TITLE": {
+        "AGENT": "Distribution by agent",
+        "INBOX": "Distribution by inbox",
+        "TEAM": "Distribution by team"
+      },
+      "METRIC": {
+        "CONVERSATIONS": "Conversations",
+        "RESOLUTIONS": "Resolved"
+      },
+      "OTHERS": "Others ({count})",
+      "ASSIGNED_ONLY": "Counts only conversations that have an assignee."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/report.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/report.json
@@ -16,7 +16,8 @@
         "RESOLUTIONS": "Resueltas"
       },
       "OTHERS": "Otros ({count})",
-      "ASSIGNED_ONLY": "Solo cuenta las conversaciones con responsable asignado."
+      "ASSIGNED_ONLY": "Solo cuenta las conversaciones con responsable asignado.",
+      "EMPTY_METRIC": "No hay datos suficientes para comparar en esta métrica."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/report.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/report.json
@@ -4,6 +4,19 @@
       "ALL_INBOXES": "Todas las bandejas de entrada",
       "ALL_AGENTS": "Todos los agentes",
       "NO_RESULTS": "Sin actividad para este filtro en el período seleccionado."
+    },
+    "DISTRIBUTION": {
+      "TITLE": {
+        "AGENT": "Distribución por agente",
+        "INBOX": "Distribución por bandeja de entrada",
+        "TEAM": "Distribución por equipo"
+      },
+      "METRIC": {
+        "CONVERSATIONS": "Conversaciones",
+        "RESOLUTIONS": "Resueltas"
+      },
+      "OTHERS": "Otros ({count})",
+      "ASSIGNED_ONLY": "Solo cuenta las conversaciones con responsable asignado."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/report.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/report.json
@@ -4,6 +4,19 @@
       "ALL_INBOXES": "Todas as caixas de entrada",
       "ALL_AGENTS": "Todos os agentes",
       "NO_RESULTS": "Nenhuma atividade para este filtro no período selecionado."
+    },
+    "DISTRIBUTION": {
+      "TITLE": {
+        "AGENT": "Distribuição por agente",
+        "INBOX": "Distribuição por caixa de entrada",
+        "TEAM": "Distribuição por time"
+      },
+      "METRIC": {
+        "CONVERSATIONS": "Conversas",
+        "RESOLUTIONS": "Resolvidas"
+      },
+      "OTHERS": "Outros ({count})",
+      "ASSIGNED_ONLY": "Conta apenas conversas com responsável atribuído."
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/report.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/report.json
@@ -16,7 +16,8 @@
         "RESOLUTIONS": "Resolvidas"
       },
       "OTHERS": "Outros ({count})",
-      "ASSIGNED_ONLY": "Conta apenas conversas com responsável atribuído."
+      "ASSIGNED_ONLY": "Conta apenas conversas com responsável atribuído.",
+      "EMPTY_METRIC": "Sem dados suficientes para comparar nesta métrica."
     }
   }
 }

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryDistribution.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryDistribution.vue
@@ -52,16 +52,17 @@ const onTabChange = tab => {
   activeMetricIndex.value = tab.index;
 };
 
-const rankedRows = computed(() =>
+const rankBy = metricKey =>
   props.rows
     .map(row => ({
       id: row.id,
       name: row.name,
-      value: Number(row[activeMetric.value.key]) || 0,
+      value: Number(row[metricKey]) || 0,
     }))
     .filter(row => row.value > 0)
-    .sort((a, b) => b.value - a.value)
-);
+    .sort((a, b) => b.value - a.value);
+
+const rankedRows = computed(() => rankBy(activeMetric.value.key));
 
 const total = computed(() =>
   rankedRows.value.reduce((sum, row) => sum + row.value, 0)
@@ -120,7 +121,14 @@ const formatShare = value =>
 
 // One row is not a distribution: a single full-width bar says nothing the table
 // does not already say.
-const hasData = computed(() => rankedRows.value.length > 1);
+const hasMetricData = computed(() => rankedRows.value.length > 1);
+
+// Visibility follows every metric, not the selected one. Tying it to the
+// selection means picking a metric with no activity takes the tabs down with the
+// card, and nothing is left to switch back with.
+const hasData = computed(() =>
+  METRICS.some(metric => rankBy(metric.key).length > 1)
+);
 
 // Agents and teams only account for conversations that carry an assignee, so the
 // total here is not the account's conversation count and should not claim to be.
@@ -163,6 +171,13 @@ const openRow = segment => {
       <div class="w-5/12 h-5 rounded bg-n-slate-3 animate-pulse" />
     </div>
 
+    <p
+      v-else-if="!hasMetricData"
+      class="py-8 mb-0 text-sm text-center text-n-slate-11"
+    >
+      {{ $t('REPORT.DISTRIBUTION.EMPTY_METRIC') }}
+    </p>
+
     <template v-else>
       <div class="flex items-baseline gap-2 mt-4">
         <span class="text-2xl font-semibold tabular-nums text-n-slate-12">
@@ -178,7 +193,7 @@ const openRow = segment => {
           <component
             :is="segment.linked ? 'button' : 'div'"
             :type="segment.linked ? 'button' : undefined"
-            class="grid items-center w-full grid-cols-[minmax(5rem,11rem)_minmax(0,1fr)_3rem_3.25rem] gap-4 px-2 py-1.5 -mx-2 text-left rounded-lg"
+            class="grid items-center w-full grid-cols-[minmax(0,1fr)_3rem_3.25rem] sm:grid-cols-[minmax(5rem,11rem)_minmax(0,1fr)_3rem_3.25rem] gap-4 px-2 py-1.5 -mx-2 text-left rounded-lg"
             :class="segment.linked ? 'hover:bg-n-alpha-1' : 'cursor-default'"
             @click="openRow(segment)"
           >
@@ -188,7 +203,9 @@ const openRow = segment => {
             >
               {{ segment.name }}
             </span>
-            <span class="h-2 overflow-hidden rounded-full bg-n-alpha-1">
+            <span
+              class="hidden h-2 overflow-hidden rounded-full sm:block bg-n-alpha-1"
+            >
               <!-- data-driven width, the one thing a utility class cannot carry -->
               <span
                 class="block h-2 rounded-full"

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryDistribution.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryDistribution.vue
@@ -1,0 +1,212 @@
+<script setup>
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import TabBar from 'dashboard/components-next/tabbar/TabBar.vue';
+
+const props = defineProps({
+  // 'agent' | 'inbox' | 'team'. Labels are left out on purpose: a conversation
+  // carries several of them, so the shares would add up past the total.
+  type: {
+    type: String,
+    required: true,
+  },
+  // [{ id, name, conversationsCount, resolvedConversationsCount }] with the raw
+  // numbers, already narrowed by whatever filter the table is showing.
+  rows: {
+    type: Array,
+    default: () => [],
+  },
+  isLoading: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const router = useRouter();
+const { t, locale } = useI18n();
+
+// Past this the card stops being a summary and starts competing with the table
+// below it, so the rest is aggregated into a single row.
+const MAX_ROWS = 10;
+
+const METRICS = [
+  {
+    key: 'conversationsCount',
+    labelKey: 'REPORT.DISTRIBUTION.METRIC.CONVERSATIONS',
+  },
+  {
+    key: 'resolvedConversationsCount',
+    labelKey: 'REPORT.DISTRIBUTION.METRIC.RESOLUTIONS',
+  },
+];
+
+const activeMetricIndex = ref(0);
+const activeMetric = computed(() => METRICS[activeMetricIndex.value]);
+
+const tabs = computed(() =>
+  METRICS.map((metric, index) => ({ index, label: t(metric.labelKey) }))
+);
+
+const onTabChange = tab => {
+  activeMetricIndex.value = tab.index;
+};
+
+const rankedRows = computed(() =>
+  props.rows
+    .map(row => ({
+      id: row.id,
+      name: row.name,
+      value: Number(row[activeMetric.value.key]) || 0,
+    }))
+    .filter(row => row.value > 0)
+    .sort((a, b) => b.value - a.value)
+);
+
+const total = computed(() =>
+  rankedRows.value.reduce((sum, row) => sum + row.value, 0)
+);
+
+const segments = computed(() => {
+  const head = rankedRows.value.slice(0, MAX_ROWS);
+  const tail = rankedRows.value.slice(MAX_ROWS);
+  const tailValue = tail.reduce((sum, row) => sum + row.value, 0);
+
+  // The aggregated tail can outgrow the biggest single row, so it takes part in
+  // the scale instead of running past the end of the track.
+  const max = Math.max(head[0]?.value ?? 0, tailValue);
+  const barWidth = value =>
+    max ? `${Math.max((value / max) * 100, 2)}%` : '0%';
+
+  const rows = head.map(row => ({
+    ...row,
+    linked: true,
+    barClass: 'bg-n-blue-9',
+    width: barWidth(row.value),
+  }));
+
+  if (!tail.length) return rows;
+
+  // The tail is one row, not a footnote: the reader still wants to know how much
+  // of the total sits outside the top of the list.
+  return [
+    ...rows,
+    {
+      id: 'tail',
+      name: t('REPORT.DISTRIBUTION.OTHERS', { count: tail.length }),
+      value: tailValue,
+      linked: false,
+      barClass: 'bg-n-slate-8',
+      width: barWidth(tailValue),
+    },
+  ];
+});
+
+// vue-i18n carries locales as pt_BR, Intl wants pt-BR.
+const bcp47Locale = computed(() => locale.value.replace(/_/g, '-'));
+
+const formatCount = value => value.toLocaleString(bcp47Locale.value);
+
+const percentageFormatter = computed(
+  () =>
+    new Intl.NumberFormat(bcp47Locale.value, {
+      style: 'percent',
+      maximumFractionDigits: 1,
+    })
+);
+
+const formatShare = value =>
+  total.value ? percentageFormatter.value.format(value / total.value) : '';
+
+// One row is not a distribution: a single full-width bar says nothing the table
+// does not already say.
+const hasData = computed(() => rankedRows.value.length > 1);
+
+// Agents and teams only account for conversations that carry an assignee, so the
+// total here is not the account's conversation count and should not claim to be.
+const showsAssignedOnly = computed(() => props.type !== 'inbox');
+
+const openRow = segment => {
+  if (!segment.linked) return;
+  router.push({
+    name: `${props.type}_reports_show`,
+    params: { id: segment.id },
+  });
+};
+</script>
+
+<template>
+  <div
+    v-if="isLoading || hasData"
+    class="px-6 py-5 mt-5 shadow outline-1 outline outline-n-container rounded-xl bg-n-solid-2"
+  >
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <h3 class="mb-0 text-sm font-medium text-n-slate-12">
+          {{ $t(`REPORT.DISTRIBUTION.TITLE.${type.toUpperCase()}`) }}
+        </h3>
+        <p v-if="showsAssignedOnly" class="mt-1 mb-0 text-xs text-n-slate-10">
+          {{ $t('REPORT.DISTRIBUTION.ASSIGNED_ONLY') }}
+        </p>
+      </div>
+      <TabBar
+        :tabs="tabs"
+        :initial-active-tab="activeMetricIndex"
+        @tab-changed="onTabChange"
+      />
+    </div>
+
+    <div v-if="isLoading" class="flex flex-col gap-3 mt-6">
+      <div class="w-11/12 h-5 rounded bg-n-slate-3 animate-pulse" />
+      <div class="w-9/12 h-5 rounded bg-n-slate-3 animate-pulse" />
+      <div class="w-7/12 h-5 rounded bg-n-slate-3 animate-pulse" />
+      <div class="w-5/12 h-5 rounded bg-n-slate-3 animate-pulse" />
+    </div>
+
+    <template v-else>
+      <div class="flex items-baseline gap-2 mt-4">
+        <span class="text-2xl font-semibold tabular-nums text-n-slate-12">
+          {{ formatCount(total) }}
+        </span>
+        <span class="text-sm text-n-slate-10">
+          {{ $t(activeMetric.labelKey).toLowerCase() }}
+        </span>
+      </div>
+
+      <ul class="flex flex-col gap-0.5 mt-3 mb-0 list-none">
+        <li v-for="segment in segments" :key="segment.id">
+          <component
+            :is="segment.linked ? 'button' : 'div'"
+            :type="segment.linked ? 'button' : undefined"
+            class="grid items-center w-full grid-cols-[minmax(5rem,11rem)_minmax(0,1fr)_3rem_3.25rem] gap-4 px-2 py-1.5 -mx-2 text-left rounded-lg"
+            :class="segment.linked ? 'hover:bg-n-alpha-1' : 'cursor-default'"
+            @click="openRow(segment)"
+          >
+            <span
+              class="text-sm truncate"
+              :class="segment.linked ? 'text-n-slate-12' : 'text-n-slate-10'"
+            >
+              {{ segment.name }}
+            </span>
+            <span class="h-2 overflow-hidden rounded-full bg-n-alpha-1">
+              <!-- data-driven width, the one thing a utility class cannot carry -->
+              <span
+                class="block h-2 rounded-full"
+                :class="segment.barClass"
+                :style="{ width: segment.width }"
+              />
+            </span>
+            <span class="text-sm text-right tabular-nums text-n-slate-11">
+              {{ formatCount(segment.value) }}
+            </span>
+            <span
+              class="text-sm font-medium text-right tabular-nums text-n-slate-12"
+            >
+              {{ formatShare(segment.value) }}
+            </span>
+          </component>
+        </li>
+      </ul>
+    </template>
+  </div>
+</template>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
@@ -1,5 +1,6 @@
 <script setup>
 import OverviewReportFilters from './OverviewReportFilters.vue';
+import SummaryDistribution from './SummaryDistribution.vue';
 import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
 import { formatTime } from '@chatwoot/utils';
 import { useStore, useMapGetter } from 'dashboard/composables/store';
@@ -148,6 +149,27 @@ const tableData = computed(() =>
   })
 );
 
+// The chart reads the same rows as the table, but needs the numbers unformatted.
+// Labels are left out: a conversation carries several of them, so the shares
+// would add up past the total.
+const distributionType = computed(() =>
+  ['agent', 'inbox', 'team'].includes(props.type) ? props.type : ''
+);
+
+const distributionRows = computed(() =>
+  visibleRowItems.value.map(row => {
+    const { conversationsCount, resolvedConversationsCount } = getMetrics(
+      row.id
+    );
+    return {
+      id: row.id,
+      name: row.name ?? row.title,
+      conversationsCount: conversationsCount ?? 0,
+      resolvedConversationsCount: resolvedConversationsCount ?? 0,
+    };
+  })
+);
+
 // Names the downloaded file, so the same report filtered two ways lands in two
 // files instead of overwriting itself.
 const crossFilterName = computed(() => {
@@ -249,6 +271,12 @@ defineExpose({ downloadReports });
     :disabled="isLoading"
     :cross-filter-type="crossFilterType"
     @filter-change="onFilterChange"
+  />
+  <SummaryDistribution
+    v-if="distributionType"
+    :type="distributionType"
+    :rows="distributionRows"
+    :is-loading="isLoading"
   />
   <div
     class="relative flex-1 overflow-auto px-2 py-2 mt-5 shadow outline-1 outline outline-n-container rounded-xl bg-n-solid-2"

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryDistribution.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryDistribution.spec.js
@@ -1,0 +1,142 @@
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import SummaryDistribution from '../SummaryDistribution.vue';
+
+const push = vi.fn();
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+}));
+
+const buildI18n = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: {
+      en: {
+        REPORT: {
+          DISTRIBUTION: {
+            TITLE: {
+              AGENT: 'Distribution by agent',
+              INBOX: 'Distribution by inbox',
+            },
+            METRIC: { CONVERSATIONS: 'Conversations', RESOLUTIONS: 'Resolved' },
+            OTHERS: 'Others ({count})',
+            ASSIGNED_ONLY: 'Counts only conversations that have an assignee.',
+          },
+        },
+      },
+    },
+  });
+
+const buildRows = (count, value) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    name: `Agent ${index + 1}`,
+    conversationsCount: value ?? count - index,
+    resolvedConversationsCount: 1,
+  }));
+
+const mountComponent = (props = {}) =>
+  mount(SummaryDistribution, {
+    props: { type: 'agent', rows: buildRows(3), ...props },
+    global: {
+      plugins: [buildI18n()],
+      stubs: { TabBar: true },
+    },
+  });
+
+// Name, count and share; the second cell is the bar track and carries no text.
+const rowsOf = wrapper =>
+  wrapper.findAll('li').map(row => {
+    const [name, , count, share] = [...row.element.firstElementChild.children];
+    return [name, count, share].map(cell => cell.textContent.trim()).join(' ');
+  });
+
+const barWidthsOf = wrapper =>
+  wrapper
+    .findAll('li span[style]')
+    .map(bar => Number.parseFloat(bar.attributes('style').match(/[\d.]+/)[0]));
+
+describe('SummaryDistribution.vue', () => {
+  beforeEach(() => push.mockClear());
+
+  it('ranks rows by the active metric and shows each share of the total', () => {
+    const wrapper = mountComponent({
+      rows: [
+        { id: 1, name: 'Alice', conversationsCount: 20 },
+        { id: 2, name: 'Bob', conversationsCount: 60 },
+        { id: 3, name: 'Carol', conversationsCount: 20 },
+      ],
+    });
+
+    expect(rowsOf(wrapper)).toEqual([
+      'Bob 60 60%',
+      'Alice 20 20%',
+      'Carol 20 20%',
+    ]);
+  });
+
+  it('leaves out rows the period has nothing for', () => {
+    const wrapper = mountComponent({
+      rows: [
+        { id: 1, name: 'Alice', conversationsCount: 5 },
+        { id: 2, name: 'Bob', conversationsCount: 0 },
+        { id: 3, name: 'Carol', conversationsCount: undefined },
+        { id: 4, name: 'Dave', conversationsCount: 5 },
+      ],
+    });
+
+    expect(rowsOf(wrapper)).toEqual(['Alice 5 50%', 'Dave 5 50%']);
+  });
+
+  it('aggregates everything past the tenth row into a single tail row', () => {
+    const wrapper = mountComponent({ rows: buildRows(13) });
+    const rows = rowsOf(wrapper);
+
+    // 13 down to 4 stay named, 3 + 2 + 1 land in the tail.
+    expect(rows).toHaveLength(11);
+    expect(rows.at(-1)).toBe('Others (3) 6 6.6%');
+  });
+
+  it('keeps the tail bar inside the track when it outgrows the biggest row', () => {
+    // Twelve rows of ten: the two-row tail is worth twice the biggest one.
+    const widths = barWidthsOf(mountComponent({ rows: buildRows(12, 10) }));
+
+    expect(widths.at(-1)).toBe(100);
+    expect(Math.max(...widths.slice(0, -1))).toBe(50);
+  });
+
+  it('renders nothing until there are two rows to compare', () => {
+    const wrapper = mountComponent({
+      rows: [{ id: 1, name: 'Alice', conversationsCount: 9 }],
+    });
+
+    expect(wrapper.find('h3').exists()).toBe(false);
+  });
+
+  it('opens the report of the row that was clicked', async () => {
+    const wrapper = mountComponent();
+    await wrapper.findAll('li button')[0].trigger('click');
+
+    expect(push).toHaveBeenCalledWith({
+      name: 'agent_reports_show',
+      params: { id: 1 },
+    });
+  });
+
+  it('does not link the aggregated tail anywhere', () => {
+    const wrapper = mountComponent({ rows: buildRows(13) });
+
+    expect(wrapper.findAll('li button')).toHaveLength(10);
+  });
+
+  it('warns that the total leaves unassigned conversations out, except on inboxes', () => {
+    const assignedOnly = 'Counts only conversations that have an assignee.';
+
+    expect(mountComponent().text()).toContain(assignedOnly);
+    expect(mountComponent({ type: 'inbox' }).text()).not.toContain(
+      assignedOnly
+    );
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryDistribution.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryDistribution.spec.js
@@ -22,6 +22,7 @@ const buildI18n = () =>
             },
             METRIC: { CONVERSATIONS: 'Conversations', RESOLUTIONS: 'Resolved' },
             OTHERS: 'Others ({count})',
+            EMPTY_METRIC: 'Not enough data to compare on this metric.',
             ASSIGNED_ONLY: 'Counts only conversations that have an assignee.',
           },
         },
@@ -113,6 +114,36 @@ describe('SummaryDistribution.vue', () => {
     });
 
     expect(wrapper.find('h3').exists()).toBe(false);
+  });
+
+  it('keeps the card up for a metric with no activity, so the tabs survive', () => {
+    // Two agents took conversations, neither resolved one.
+    const wrapper = mountComponent({
+      rows: [
+        {
+          id: 1,
+          name: 'Alice',
+          conversationsCount: 5,
+          resolvedConversationsCount: 0,
+        },
+        {
+          id: 2,
+          name: 'Bob',
+          conversationsCount: 3,
+          resolvedConversationsCount: 0,
+        },
+      ],
+    });
+    // Switch to the empty metric the way the tab bar does.
+    wrapper
+      .findComponent({ name: 'TabBar' })
+      .vm.$emit('tabChanged', { index: 1 });
+
+    return wrapper.vm.$nextTick().then(() => {
+      expect(wrapper.find('h3').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Not enough data to compare');
+      expect(wrapper.findAll('li')).toHaveLength(0);
+    });
   });
 
   it('opens the report of the row that was clicked', async () => {

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -260,6 +260,24 @@ describe Messages::MessageBuilder do
       end
     end
 
+    context 'when the voice message is a private note' do
+      let(:params) do
+        ActionController::Parameters.new({
+                                           attachments: [Rack::Test::UploadedFile.new('spec/assets/sample.ogg', 'audio/ogg')],
+                                           is_voice_message: true,
+                                           private: true
+                                         })
+      end
+
+      it 'attaches the recording to the note like any other message' do
+        message = message_builder
+
+        expect(message).to be_private
+        expect(message.attachments.first.file_type).to eq 'audio'
+        expect(message.attachments.first.meta).to include('is_voice_message' => true)
+      end
+    end
+
     context 'when is_voice_message is not provided' do
       let(:params) do
         ActionController::Parameters.new({

--- a/spec/enterprise/models/attachment_spec.rb
+++ b/spec/enterprise/models/attachment_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Attachment do
+  let(:conversation) { create(:conversation) }
+
+  it 'transcribes a voice note recorded on a private message' do
+    message = create(:message, message_type: :outgoing, private: true,
+                               conversation: conversation, account: conversation.account)
+
+    expect do
+      message.attachments.create!(
+        account_id: message.account_id,
+        file_type: :audio,
+        file: fixture_file_upload('public/audio/widget/ding.mp3')
+      )
+    end.to have_enqueued_job(Messages::AudioTranscriptionJob)
+  end
+end

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -72,6 +72,22 @@ describe Whatsapp::SendOnWhatsappService do
         expect(message.reload.source_id).to eq('123456789')
       end
 
+      it 'keeps a private note off the channel, attachment and all' do
+        create(:message, message_type: :incoming, content: 'test',
+                         conversation: conversation, account: conversation.account)
+        message = create(:message, message_type: :outgoing, private: true, content: 'heads up',
+                                   conversation: conversation, account: conversation.account)
+        message.attachments.create!(
+          account_id: message.account_id,
+          file_type: :audio,
+          file: fixture_file_upload('public/audio/widget/ding.mp3')
+        )
+
+        described_class.new(message: message).perform
+
+        expect(a_request(:post, 'https://waba.360dialog.io/v1/messages')).not_to have_been_made
+      end
+
       it 'fails a free-form message without contacting the provider when outside the 24 hour limit' do
         create(:message, message_type: :incoming, content: 'test', created_at: 25.hours.ago,
                          conversation: conversation, account: conversation.account)


### PR DESCRIPTION
Os relatórios de Agentes, Caixa de Entrada e Time mostram seis colunas de números absolutos, sem ordenação e sem total. Dá para ver quantas conversas cada agente teve, mas não quem carrega a operação: o percentual de cada um fica por conta de quem lê.

Agora, acima da tabela, aparece um card de distribuição: o total do período em destaque, uma linha por agente ordenada por volume, com barra proporcional, contagem e percentual do total. Clicar na linha abre o relatório daquele agente. Um seletor alterna entre conversas e resolvidas.

Tudo vem do payload que a tela já carrega: nenhuma consulta nova, nenhuma migration.

## How to test

1. Relatórios > Agentes, num período com movimento.
2. O card deve listar os agentes do maior para o menor, com contagem e percentual, e o total no topo.
3. Alterne para **Resolvidas**: a ordem muda, porque `conversations_count` conta pelo responsável atual e `resolutions_count` pelo responsável no momento da resolução.
4. Aplique o filtro de caixa de entrada: o card acompanha a tabela.
5. Clique numa linha: abre o relatório daquele agente.
6. Repita em Caixa de Entrada (o aviso de "conversas com responsável atribuído" não aparece lá, porque toda conversa tem caixa) e em Time.
7. Numa conta com mais de dez agentes, a décima primeira linha é "Outros (N)" em cinza, com o volume agregado.
8. Etiquetas continua sem o card.

## What changed

- `SummaryDistribution.vue` (novo) monta o ranking a partir das linhas que a tabela já recebe, agrega a cauda além da décima linha e navega para o relatório da linha clicada.
- `SummaryReports.vue` passa as mesmas linhas com os números crus, filtradas pelo mesmo filtro cruzado da tabela.
- Chaves novas em `REPORT.DISTRIBUTION` (en, pt_BR, es).

### Barras, e não rosca

A referência que motivou o pedido é uma rosca. Ela foi construída primeiro, com o `DonutChart` do `@chatwoot/viz`, e descartada com o resultado na tela: o design system tem quatro matizes que passam nos testes de daltonismo (blue, teal, violet, ruby), já que amber reprova por luminosidade e iris fica indistinguível de violet. Numa conta de teste com sete agentes, a rosca de quatro fatias mandava 31% do volume para "Outros". Barras ordenadas não têm esse teto e comparam melhor valores próximos, que é onde uma rosca falha (na referência original, três agentes com 43, 43 e 42 são fatias indistinguíveis).

### Duas ressalvas registradas na UI

- **Etiquetas ficam de fora**: uma conversa carrega várias, então as fatias somariam mais que o total.
- **O total conta apenas conversas com responsável atribuído** em Agentes e Time, e o card diz isso, porque o número não bate com o da tela de Conversas.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/448)
<!-- Reviewable:end -->
