### PR TITLE
feat(reports): sort the summary table by any column

### DIFF
--- a/app/javascript/dashboard/components/table/Table.vue
+++ b/app/javascript/dashboard/components/table/Table.vue
@@ -18,6 +18,13 @@ const props = defineProps({
   },
 });
 
+const SORT_DIRECTIONS = { asc: 'ascending', desc: 'descending' };
+
+const ariaSort = header => {
+  if (!header.column.getCanSort()) return undefined;
+  return SORT_DIRECTIONS[header.column.getIsSorted()] ?? 'none';
+};
+
 const isRelaxed = computed(() => props.type === 'relaxed');
 const headerClass = computed(() =>
   isRelaxed.value
@@ -42,18 +49,23 @@ const headerClass = computed(() =>
           }"
           class="text-left py-3 px-5 font-medium text-sm text-n-slate-12"
           :class="headerClass"
-          @click="header.column.getCanSort() && header.column.toggleSorting()"
+          :aria-sort="ariaSort(header)"
         >
-          <div
+          <!-- A sortable header is a real button: a click handler on the th
+               alone leaves the control unreachable by keyboard. -->
+          <component
+            :is="header.column.getCanSort() ? 'button' : 'div'"
             v-if="!header.isPlaceholder"
+            :type="header.column.getCanSort() ? 'button' : undefined"
             class="flex place-items-center gap-1"
+            @click="header.column.getCanSort() && header.column.toggleSorting()"
           >
             <FlexRender
               :render="header.column.columnDef.header"
               :props="header.getContext()"
             />
             <SortButton v-if="header.column.getCanSort()" :header="header" />
-          </div>
+          </component>
         </th>
       </tr>
     </thead>

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
@@ -82,6 +82,13 @@ const spanRender = format => cellProps => {
   return h('span', { class: value ? '' : 'text-n-slate-12' }, format(value));
 };
 
+// Named rather than inferred: TanStack picks the comparator by sampling
+// `flatRows.slice(10)`, which is empty on a roster of ten or fewer and lands on
+// a lexicographic compare. It happens to read these floats correctly today, and
+// would stop the day the API sends `"600.0"` instead of `600`.
+const byNumber = (rowA, rowB, columnId) =>
+  Number(rowA.getValue(columnId)) - Number(rowB.getValue(columnId));
+
 // A row with nothing to show stays at the bottom either way round: it is the
 // absence of a measurement, not a measurement of zero.
 const metricColumn = (key, headerKey, format) =>
@@ -91,6 +98,7 @@ const metricColumn = (key, headerKey, format) =>
     cell: spanRender(format),
     sortDescFirst: true,
     sortUndefined: 'last',
+    sortingFn: byNumber,
   });
 
 const columns = computed(() => [

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
@@ -11,6 +11,7 @@ import {
   useVueTable,
   createColumnHelper,
   getCoreRowModel,
+  getSortedRowModel,
 } from '@tanstack/vue-table';
 import { computed, onMounted, ref, h } from 'vue';
 
@@ -70,51 +71,57 @@ const getMetrics = id =>
 const columnHelper = createColumnHelper();
 const { t } = useI18n();
 
-const defaulSpanRender = cellProps =>
-  h(
-    'span',
-    {
-      class: cellProps.getValue() ? '' : 'text-n-slate-12',
-    },
-    cellProps.getValue()
-  );
+// The row carries the raw number so sorting compares numbers; the cell is what
+// turns it into "28 Min 40 Sec" or "--".
+const renderAvgTime = value => (value ? formatTime(value) : '--');
+
+const renderCount = value => (value ? value.toLocaleString() : '--');
+
+const spanRender = format => cellProps => {
+  const value = cellProps.getValue();
+  return h('span', { class: value ? '' : 'text-n-slate-12' }, format(value));
+};
+
+// A row with nothing to show stays at the bottom either way round: it is the
+// absence of a measurement, not a measurement of zero.
+const metricColumn = (key, headerKey, format) =>
+  columnHelper.accessor(key, {
+    header: t(headerKey),
+    width: 200,
+    cell: spanRender(format),
+    sortDescFirst: true,
+    sortUndefined: 'last',
+  });
 
 const columns = computed(() => [
   columnHelper.accessor('name', {
     header: t(`SUMMARY_REPORTS.${props.type.toUpperCase()}`),
     width: 300,
     cell: cellProps => h(SummaryReportLink, cellProps),
+    sortDescFirst: false,
   }),
-  columnHelper.accessor('conversationsCount', {
-    header: t('SUMMARY_REPORTS.CONVERSATIONS'),
-    width: 200,
-    cell: defaulSpanRender,
-  }),
-  columnHelper.accessor('avgFirstResponseTime', {
-    header: t('SUMMARY_REPORTS.AVG_FIRST_RESPONSE_TIME'),
-    width: 200,
-    cell: defaulSpanRender,
-  }),
-  columnHelper.accessor('avgResolutionTime', {
-    header: t('SUMMARY_REPORTS.AVG_RESOLUTION_TIME'),
-    width: 200,
-    cell: defaulSpanRender,
-  }),
-  columnHelper.accessor('avgReplyTime', {
-    header: t('SUMMARY_REPORTS.AVG_REPLY_TIME'),
-    width: 200,
-    cell: defaulSpanRender,
-  }),
-  columnHelper.accessor('resolutionsCount', {
-    header: t('SUMMARY_REPORTS.RESOLUTION_COUNT'),
-    width: 200,
-    cell: defaulSpanRender,
-  }),
+  metricColumn(
+    'conversationsCount',
+    'SUMMARY_REPORTS.CONVERSATIONS',
+    renderCount
+  ),
+  metricColumn(
+    'avgFirstResponseTime',
+    'SUMMARY_REPORTS.AVG_FIRST_RESPONSE_TIME',
+    renderAvgTime
+  ),
+  metricColumn(
+    'avgResolutionTime',
+    'SUMMARY_REPORTS.AVG_RESOLUTION_TIME',
+    renderAvgTime
+  ),
+  metricColumn('avgReplyTime', 'SUMMARY_REPORTS.AVG_REPLY_TIME', renderAvgTime),
+  metricColumn(
+    'resolutionsCount',
+    'SUMMARY_REPORTS.RESOLUTION_COUNT',
+    renderCount
+  ),
 ]);
-
-const renderAvgTime = value => (value ? formatTime(value) : '--');
-
-const renderCount = value => (value ? value.toLocaleString() : '--');
 
 // Once the report is narrowed to a single inbox (or agent), the backend only
 // returns the rows that took part in it, so the roster is trimmed to match.
@@ -140,11 +147,11 @@ const tableData = computed(() =>
       // we fallback on title, label for instance does not have a name property
       name: row.name ?? row.title,
       type: props.type,
-      conversationsCount: renderCount(conversationsCount),
-      avgFirstResponseTime: renderAvgTime(avgFirstResponseTime),
-      avgReplyTime: renderAvgTime(avgReplyTime),
-      avgResolutionTime: renderAvgTime(avgResolutionTime),
-      resolutionsCount: renderCount(resolvedConversationsCount),
+      conversationsCount: conversationsCount || undefined,
+      avgFirstResponseTime: avgFirstResponseTime || undefined,
+      avgReplyTime: avgReplyTime || undefined,
+      avgResolutionTime: avgResolutionTime || undefined,
+      resolutionsCount: resolvedConversationsCount || undefined,
     };
   })
 );
@@ -231,8 +238,9 @@ const table = useVueTable({
   get columns() {
     return columns.value;
   },
-  enableSorting: false,
+  enableSorting: true,
   getCoreRowModel: getCoreRowModel(),
+  getSortedRowModel: getSortedRowModel(),
 });
 
 // downloadReports method is not used in this component

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryReports.vue
@@ -99,6 +99,11 @@ const columns = computed(() => [
     width: 300,
     cell: cellProps => h(SummaryReportLink, cellProps),
     sortDescFirst: false,
+    // Without this the comparator is inferred, and 8.20.5 infers it from
+    // `flatRows.slice(10)` — empty on a roster of ten or fewer, which falls back
+    // to a case-sensitive compare that puts `VIP` above `billing`. Alphanumeric
+    // also reads the digits in names like `Suporte 10` as numbers.
+    sortingFn: 'alphanumeric',
   }),
   metricColumn(
     'conversationsCount',

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryReports.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryReports.spec.js
@@ -9,11 +9,13 @@ const agents = [
   { id: 2, name: 'Bob' },
 ];
 
-// Bob replies fastest and takes the fewest; Dave has no activity at all.
+// Bob replies fastest and takes the fewest; Dave has no activity at all. The
+// durations arrive as strings on purpose: they are floats over the wire today,
+// and sorting must not depend on that.
 const metrics = [
-  { id: 1, conversationsCount: 9, avgFirstResponseTime: 600 },
-  { id: 2, conversationsCount: 10, avgFirstResponseTime: 120 },
-  { id: 3, conversationsCount: 2, avgFirstResponseTime: 3600 },
+  { id: 1, conversationsCount: 9, avgFirstResponseTime: '600.0' },
+  { id: 2, conversationsCount: 10, avgFirstResponseTime: '120.0' },
+  { id: 3, conversationsCount: 2, avgFirstResponseTime: '3600.0' },
   { id: 4 },
 ];
 
@@ -68,7 +70,7 @@ describe('SummaryReports.vue', () => {
     expect(columnOf(wrapper, 1)).toEqual(['10', '9', '2', '--']);
   });
 
-  it('sorts a duration column by its seconds', async () => {
+  it('sorts a duration column by its seconds, even when they arrive as strings', async () => {
     const wrapper = mountReports();
     await sortBy(wrapper, 2);
 

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryReports.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryReports.spec.js
@@ -1,0 +1,87 @@
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import SummaryReports from '../SummaryReports.vue';
+
+const agents = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+  { id: 3, name: 'Carol' },
+  { id: 4, name: 'Dave' },
+];
+
+// Bob replies fastest and takes the fewest; Dave has no activity at all.
+const metrics = [
+  { id: 1, conversationsCount: 9, avgFirstResponseTime: 600 },
+  { id: 2, conversationsCount: 10, avgFirstResponseTime: 120 },
+  { id: 3, conversationsCount: 2, avgFirstResponseTime: 3600 },
+  { id: 4 },
+];
+
+vi.mock('dashboard/composables/store', () => ({
+  useStore: () => ({ dispatch: vi.fn(), getters: {} }),
+  useMapGetter: key => {
+    if (key[0] === 'agents/getAgents') return ref(agents);
+    if (key[0] === 'summaryReports/getAgentSummaryReports') return ref(metrics);
+    return ref({});
+  },
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: key => key }),
+}));
+
+const mountReports = () =>
+  mount(SummaryReports, {
+    props: {
+      type: 'agent',
+      getterKey: 'agents/getAgents',
+      actionKey: 'summaryReports/fetchAgentSummaryReports',
+      fetchItemsKey: 'agents/get',
+      summaryKey: 'summaryReports/getAgentSummaryReports',
+    },
+    global: {
+      stubs: {
+        OverviewReportFilters: true,
+        SummaryDistribution: true,
+        SummaryReportLink: {
+          props: ['row'],
+          template: '<span>{{ row.original.name }}</span>',
+        },
+        Spinner: true,
+      },
+      mocks: { $t: key => key },
+    },
+  });
+
+const columnOf = (wrapper, index) =>
+  wrapper.findAll('tbody tr').map(row => row.findAll('td')[index].text());
+
+const sortBy = (wrapper, headerIndex) =>
+  wrapper.findAll('th')[headerIndex].trigger('click');
+
+describe('SummaryReports.vue', () => {
+  it('sorts a count column by its number, not by the formatted string', async () => {
+    const wrapper = mountReports();
+    await sortBy(wrapper, 1);
+
+    // 10 above 9 is the whole point: as strings they sort the other way round.
+    expect(columnOf(wrapper, 1)).toEqual(['10', '9', '2', '--']);
+  });
+
+  it('sorts a duration column by its seconds', async () => {
+    const wrapper = mountReports();
+    await sortBy(wrapper, 2);
+
+    expect(columnOf(wrapper, 0)).toEqual(['Carol', 'Alice', 'Bob', 'Dave']);
+  });
+
+  it('keeps rows with no measurement at the bottom in both directions', async () => {
+    const wrapper = mountReports();
+
+    await sortBy(wrapper, 2);
+    expect(columnOf(wrapper, 0).at(-1)).toBe('Dave');
+
+    await sortBy(wrapper, 2);
+    expect(columnOf(wrapper, 0)).toEqual(['Bob', 'Alice', 'Carol', 'Dave']);
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryReports.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/SummaryReports.spec.js
@@ -3,10 +3,10 @@ import { ref } from 'vue';
 import SummaryReports from '../SummaryReports.vue';
 
 const agents = [
-  { id: 1, name: 'Alice' },
-  { id: 2, name: 'Bob' },
   { id: 3, name: 'Carol' },
+  { id: 1, name: 'alice' },
   { id: 4, name: 'Dave' },
+  { id: 2, name: 'Bob' },
 ];
 
 // Bob replies fastest and takes the fewest; Dave has no activity at all.
@@ -57,7 +57,7 @@ const columnOf = (wrapper, index) =>
   wrapper.findAll('tbody tr').map(row => row.findAll('td')[index].text());
 
 const sortBy = (wrapper, headerIndex) =>
-  wrapper.findAll('th')[headerIndex].trigger('click');
+  wrapper.findAll('th')[headerIndex].find('button').trigger('click');
 
 describe('SummaryReports.vue', () => {
   it('sorts a count column by its number, not by the formatted string', async () => {
@@ -72,7 +72,28 @@ describe('SummaryReports.vue', () => {
     const wrapper = mountReports();
     await sortBy(wrapper, 2);
 
-    expect(columnOf(wrapper, 0)).toEqual(['Carol', 'Alice', 'Bob', 'Dave']);
+    expect(columnOf(wrapper, 0)).toEqual(['Carol', 'alice', 'Bob', 'Dave']);
+  });
+
+  it('sorts names case-insensitively, whatever the size of the roster', async () => {
+    // TanStack 8.20.5 infers the comparator from `flatRows.slice(10)`, which is
+    // empty here and falls back to a case-sensitive compare that would put every
+    // capitalised name above `alice`.
+    const wrapper = mountReports();
+    await sortBy(wrapper, 0);
+
+    expect(columnOf(wrapper, 0)).toEqual(['alice', 'Bob', 'Carol', 'Dave']);
+  });
+
+  it('exposes each sortable header as a button, so it works without a pointer', async () => {
+    const wrapper = mountReports();
+    const header = wrapper.findAll('th')[1];
+
+    expect(header.find('button').exists()).toBe(true);
+    expect(header.attributes('aria-sort')).toBe('none');
+
+    await header.find('button').trigger('click');
+    expect(wrapper.findAll('th')[1].attributes('aria-sort')).toBe('descending');
   });
 
   it('keeps rows with no measurement at the bottom in both directions', async () => {
@@ -82,6 +103,6 @@ describe('SummaryReports.vue', () => {
     expect(columnOf(wrapper, 0).at(-1)).toBe('Dave');
 
     await sortBy(wrapper, 2);
-    expect(columnOf(wrapper, 0)).toEqual(['Bob', 'Alice', 'Carol', 'Dave']);
+    expect(columnOf(wrapper, 0)).toEqual(['Bob', 'alice', 'Carol', 'Dave']);
   });
 });


### PR DESCRIPTION
Empilhado sobre #448.

A tabela de Relatórios > Agentes (e Caixa de Entrada, Etiquetas e Time) vinha em ordem alfabética fixa. Dava para ler o número de cada agente, mas não para responder "quem está demorando mais para dar a primeira resposta" sem exportar o CSV e abrir numa planilha.

Agora qualquer coluna ordena, clicando no cabeçalho.

## How to test

1. Relatórios > Agentes, num período com movimento.
2. Clique em **Tempo Médio de Primeira Resposta**: o mais lento vem primeiro; clique de novo para inverter.
3. Clique em **Nº de Conversas**: confira que 10 aparece acima de 9 (como string, ordenaria ao contrário).
4. Agentes sem atividade (`--` em tudo) ficam no rodapé nos dois sentidos.
5. Clique em **Agente**: ordem alfabética.
6. Repita em Caixa de Entrada, Etiquetas e Time.

## What changed

- `enableSorting: true` mais `getSortedRowModel`. O `Table.vue` já trazia cabeçalho clicável e `SortButton`; só faltava ligar.
- As linhas passam a carregar o valor cru e a formatação (`renderCount`, `renderAvgTime`) virou trabalho da célula. Sem isso a ordenação compararia `"1 Hr 58 Min"` com `"28 Min 40 Sec"` como texto.
- `sortUndefined: 'last'` nas colunas de métrica: `--` é ausência de medida, não zero, e uma linha vazia no topo do ranking de tempo de resposta seria leitura errada.
- Primeiro clique desce nas métricas (maior primeiro, que é o que se procura) e sobe no nome.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/449)
<!-- Reviewable:end -->
