### PR TITLE
fix(whatsapp): stop rendering an encrypted edit as an unsupported message

### DIFF
--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -88,6 +88,8 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
       'location'
     elsif msg.key?(:protocolMessage)
       'protocol'
+    elsif msg.key?(:secretEncryptedMessage)
+      'secret'
     elsif msg.key?(:albumMessage)
       'album'
     elsif msg.key?(:messageContextInfo) && msg.keys.count == 1
@@ -312,8 +314,14 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
   # An albumMessage is only the marker announcing a media group; each item
   # arrives as its own associatedChildMessage upsert, so the marker itself
   # renders nothing.
+  #
+  # A secretEncryptedMessage is an edit of an existing message, encrypted under
+  # that message's secret. The provider is the only side that can decrypt it and
+  # it delivers the result as a messages.update; anything still arriving here is
+  # a blob we have no key for, and rendering it as an unsupported message is
+  # worse than dropping it.
   def ignore_message?
-    message_type.in?(%w[protocol context edited album])
+    message_type.in?(%w[protocol context edited album secret])
   end
 
   # A protocolMessage of type REVOKE is the contact deleting a message for everyone.

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -429,6 +429,40 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
       end
     end
 
+    # WhatsApp stopped sending message edits as a plaintext protocolMessage and
+    # now encrypts them under the original message's secret. Only the provider
+    # can decrypt one, and it delivers the result as a messages.update; a blob
+    # that still reaches here has no key and rendering it told the agent the
+    # contact had sent an unsupported message.
+    context 'when receiving an encrypted message edit the provider could not decrypt' do
+      it 'ignores it and creates no message' do
+        raw_message = {
+          key: { id: 'msg_secret_edit', remoteJid: "#{phone}@s.whatsapp.net", remoteJidAlt: "#{lid}@lid", fromMe: false,
+                 addressingMode: 'pn' },
+          pushName: 'Gabriel',
+          messageTimestamp: timestamp,
+          message: {
+            messageContextInfo: { deviceListMetadata: {}, deviceListMetadataVersion: 2 },
+            secretEncryptedMessage: {
+              targetMessageKey: { id: 'msg_original', remoteJid: "#{lid}@lid", fromMe: true },
+              encPayload: 'ZW5jcnlwdGVk',
+              encIv: 'aXY=',
+              secretEncType: 2
+            }
+          }
+        }
+        params = {
+          webhookVerifyToken: webhook_verify_token,
+          event: 'messages.upsert',
+          data: { type: 'notify', messages: [raw_message] }
+        }
+
+        expect do
+          Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+        end.not_to change(Message, :count)
+      end
+    end
+
     context 'when receiving an album child image message' do
       it 'unwraps the wrapper and processes the message with media' do
         raw_message = {


### PR DESCRIPTION
An agent no longer sees an orange "this message is not supported" bubble every time a customer corrects a typo on WhatsApp.

## Closes

- Reported in the community: https://www.lucasmoreira.ai/c/perguntas-e-respostas/mensagem-editada-nao-suportada
- Provider half of the same fix: fazer-ai/baileys-api#392

## How to reproduce

1. On a Baileys inbox, have the contact send a message and then edit it on WhatsApp.
2. Before: a second message appears in the thread reading "Esta mensagem não é suportada. Você pode visualizar esta mensagem no aplicativo do WhatsApp." After: nothing extra appears.

## What changed

WhatsApp stopped sending an incoming edit as a plaintext `protocolMessage` and now sends `secretEncryptedMessage`, encrypted under the original message's secret. `message_type` had no branch for it, so it fell through to `unsupported` and became a message in the thread.

Only the provider holds the key, and it delivers the decrypted result as a `messages.update` — which `messages_update.rb` already applies correctly, updating the content and setting `is_edited`. Anything still reaching the upsert handler is therefore a blob this side cannot read, so it is ignored the way the plaintext `protocolMessage` edit already is.

Applying the edit is fazer-ai/baileys-api#392; this half is what an installation running an older provider needs to at least stop showing the bubble.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/454)
<!-- Reviewable:end -->
