### PR TITLE
fix(whatsapp): refuse an edit older than the one already applied

### DIFF
--- a/app/services/whatsapp/baileys_handlers/messages_update.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_update.rb
@@ -105,15 +105,47 @@ module Whatsapp::BaileysHandlers::MessagesUpdate
   end
 
   def handle_edited_content
+    edited_at = edit_timestamp_ms
     @raw_message = @raw_message.dig(:update, :message, :editedMessage)
     content = message_content
 
-    if content
-      # Preserve original previous_content if message was already edited
-      previous_content_to_save = @message.is_edited ? @message.previous_content : @message.content
-      return @message.update!(content: content, is_edited: true, previous_content: previous_content_to_save)
+    if content.blank?
+      Rails.logger.warn 'No valid message content found in the edit event'
+      return
     end
 
-    Rails.logger.warn 'No valid message content found in the edit event'
+    # Read and write under the row lock, the same way the session layer applies an
+    # edit: during a force restart or a cluster handoff the discarded connection
+    # keeps draining its webhooks on purpose while the replacement already handles
+    # new events, so two edits of one message can be applied at once. A
+    # read-compare-write outside the lock lets both pass the staleness check and the
+    # older one land last.
+    @message.with_lock do
+      next if stale_edit?(edited_at)
+
+      # Preserve original previous_content if message was already edited
+      previous_content_to_save = @message.is_edited ? @message.previous_content : @message.content
+      @message.update!(content: content, is_edited: true, previous_content: previous_content_to_save, edited_at: edited_at)
+    end
+  end
+
+  # Older than the edit already stored, so it must not overwrite it. The comparison
+  # is on the provider's own clock rather than on arrival, since arrival is the
+  # thing that is out of order. Ties pass: WhatsApp stamps edits in whole seconds,
+  # so two edits inside one second carry no order to respect. An edit with no
+  # timestamp passes too -- refusing it would drop the edit outright, which is worse
+  # than applying it out of order.
+  def stale_edit?(edited_at)
+    edited_at.present? && @message.edited_at.present? && edited_at < @message.edited_at
+  end
+
+  # The provider stamps edits in whole seconds, on both the encrypted and the
+  # plaintext path. `edited_at` holds milliseconds, which is what the session layer
+  # writes and what the model documents, so the two providers stay comparable.
+  def edit_timestamp_ms
+    timestamp = @raw_message.dig(:update, :messageTimestamp)
+    return if timestamp.blank?
+
+    timestamp.to_i * 1000
   end
 end

--- a/app/services/whatsapp/baileys_handlers/messages_update.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_update.rb
@@ -1,5 +1,6 @@
 module Whatsapp::BaileysHandlers::MessagesUpdate
   include Whatsapp::BaileysHandlers::Helpers
+  include BaileysHelper
 
   class MessageNotFoundError < StandardError; end
 
@@ -109,7 +110,9 @@ module Whatsapp::BaileysHandlers::MessagesUpdate
     @raw_message = @raw_message.dig(:update, :message, :editedMessage)
     content = message_content
 
-    if content.blank?
+    # `nil` means no readable content; an empty string is a real edit that cleared
+    # a media caption, and dropping it would leave the old caption on screen.
+    if content.nil?
       Rails.logger.warn 'No valid message content found in the edit event'
       return
     end
@@ -125,7 +128,11 @@ module Whatsapp::BaileysHandlers::MessagesUpdate
 
       # Preserve original previous_content if message was already edited
       previous_content_to_save = @message.is_edited ? @message.previous_content : @message.content
-      @message.update!(content: content, is_edited: true, previous_content: previous_content_to_save, edited_at: edited_at)
+      attrs = { content: content, is_edited: true, previous_content: previous_content_to_save }
+      # Only when this edit carries one: writing nil would erase the watermark a
+      # later out-of-order edit is checked against.
+      attrs[:edited_at] = edited_at if edited_at.present?
+      @message.update!(attrs)
     end
   end
 
@@ -140,12 +147,14 @@ module Whatsapp::BaileysHandlers::MessagesUpdate
   end
 
   # The provider stamps edits in whole seconds, on both the encrypted and the
-  # plaintext path. `edited_at` holds milliseconds, which is what the session layer
-  # writes and what the model documents, so the two providers stay comparable.
+  # plaintext path, and a protobuf 64-bit field reaches us either as a number or as
+  # a `{ low, high }` hash — which is what the shared helper is for. `edited_at`
+  # holds milliseconds, which is what the session layer writes and what the model
+  # documents, so the two providers stay comparable.
   def edit_timestamp_ms
     timestamp = @raw_message.dig(:update, :messageTimestamp)
     return if timestamp.blank?
 
-    timestamp.to_i * 1000
+    baileys_extract_message_timestamp(timestamp) * 1000
   end
 end

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -1516,6 +1516,71 @@ describe Whatsapp::IncomingMessageBaileysService do
           expect(message.is_edited).to be(true)
           expect(message.previous_content).to eq(original_content)
         end
+
+        it 'records the edit timestamp in milliseconds so a later update can be ordered against it' do
+          update_payload[:update] = {
+            message: { editedMessage: { message: { conversation: 'New message content' } } },
+            messageTimestamp: 1_700_000_000
+          }
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.edited_at).to eq(1_700_000_000_000)
+        end
+
+        # A force restart or a cluster handoff leaves the discarded connection
+        # draining its webhooks while the replacement already handles new events,
+        # so an older edit retrying on the old one can land after a newer one.
+        it 'ignores an edit older than the one already applied' do
+          message.update!(edited_at: 1_700_000_060_000)
+          update_payload[:update] = {
+            message: { editedMessage: { message: { conversation: 'Stale message content' } } },
+            messageTimestamp: 1_700_000_000
+          }
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.content).not_to eq('Stale message content')
+          expect(message.is_edited).to be_falsey
+        end
+
+        it 'applies an edit newer than the one already applied' do
+          message.update!(edited_at: 1_700_000_000_000)
+          update_payload[:update] = {
+            message: { editedMessage: { message: { conversation: 'Newer message content' } } },
+            messageTimestamp: 1_700_000_060
+          }
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.content).to eq('Newer message content')
+          expect(message.edited_at).to eq(1_700_000_060_000)
+        end
+
+        # Equal timestamps carry no order to respect, and WhatsApp stamps edits in
+        # whole seconds.
+        it 'applies an edit stamped in the same second as the one already applied' do
+          message.update!(edited_at: 1_700_000_000_000)
+          update_payload[:update] = {
+            message: { editedMessage: { message: { conversation: 'Same second content' } } },
+            messageTimestamp: 1_700_000_000
+          }
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.content).to eq('Same second content')
+        end
+
+        # Refusing it would drop the edit outright, which is worse than applying
+        # it out of order.
+        it 'applies an edit that carries no timestamp' do
+          message.update!(edited_at: 1_700_000_060_000)
+          update_payload[:update] = { message: { editedMessage: { message: { conversation: 'Undated content' } } } }
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.content).to eq('Undated content')
+        end
       end
     end
 

--- a/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_baileys_service_spec.rb
@@ -1581,6 +1581,44 @@ describe Whatsapp::IncomingMessageBaileysService do
 
           expect(message.reload.content).to eq('Undated content')
         end
+
+        # Writing nil would erase what a later out-of-order edit is checked against.
+        it 'keeps the stored timestamp when an undated edit is applied' do
+          message.update!(edited_at: 1_700_000_060_000)
+          update_payload[:update] = { message: { editedMessage: { message: { conversation: 'Undated content' } } } }
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.edited_at).to eq(1_700_000_060_000)
+        end
+
+        # A protobuf 64-bit field reaches us either as a number or as a { low, high }
+        # hash, and calling to_i on the hash would raise and drop the edit.
+        it 'reads a timestamp that arrives as a structured protobuf long' do
+          update_payload[:update] = {
+            message: { editedMessage: { message: { conversation: 'Structured stamp' } } },
+            messageTimestamp: { 'low' => 1_700_000_000, 'high' => 0, 'unsigned' => true }
+          }
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.content).to eq('Structured stamp')
+          expect(message.edited_at).to eq(1_700_000_000_000)
+        end
+
+        # An edit that clears an image caption sends an empty string, and dropping it
+        # would leave the old caption on screen.
+        it 'applies an edit that clears the content' do
+          update_payload[:update] = {
+            message: { editedMessage: { message: { imageMessage: { caption: '' } } } },
+            messageTimestamp: 1_700_000_000
+          }
+
+          described_class.new(inbox: inbox, params: params).perform
+
+          expect(message.reload.content).to eq('')
+          expect(message.is_edited).to be(true)
+        end
       end
     end
 


### PR DESCRIPTION
Fecha o último resíduo de ordenação de edições, que ficou registrado em fazer-ai/baileys-api#393 quando a #454 foi cortada.

## O problema

O provedor não consegue ordenar duas edições da mesma mensagem sozinho. Num force restart ou num handoff de cluster a conexão descartada continua drenando seus webhooks de propósito, enquanto a substituta já processa eventos novos. Nessa janela uma edição mais velha retentando na conexão antiga pode chegar depois de uma mais nova vinda da substituta, e o texto velho fica valendo.

Pôr a guarda no Redis custaria uma ida à rede por edição entregue, em todas as edições, para cobrir uma janela que só existe durante um handoff. O consumidor é o único lado que sabe o que já aplicou, e a decisão é local.

## A correção

`handle_edited_content` passa a guardar o timestamp da própria edição em `edited_at` e recusa um update carimbado antes. Leitura e escrita acontecem sob o lock da linha, do mesmo jeito que `Whatsapp::Session::Inbound::Handlers::MessageEdited` já faz: um ler-comparar-escrever fora do lock deixa as duas edições passarem na checagem.

Alinhado com a camada de sessão em três pontos: mesmo campo, mesma unidade (milissegundos, que é o que o model documenta) e mesma regra de empate.

Empates e payloads sem timestamp passam. O WhatsApp carimba edição em segundos inteiros, então duas edições no mesmo segundo não trazem ordem a respeitar; e recusar uma edição sem timestamp a descartaria de vez, o que é pior que aplicar fora de ordem.

Cobre também o caminho de edição em texto claro do Baileys, que não tinha ordenação nenhuma.

## Testes

Cinco guardas novas em `incoming_message_baileys_service_spec.rb`: grava o timestamp em ms, recusa a mais velha, aplica a mais nova, aplica a do mesmo segundo, aplica a sem timestamp. Removendo a guarda de ordem quebra a de recusa; removendo a conversão para ms quebram três.

214 exemplos da suíte de WhatsApp verdes, rubocop limpo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/455)
<!-- Reviewable:end -->
