### PR TITLE
fix(whatsapp): say WhatsApp withheld a verification code, not that the type is unknown

### DIFF
--- a/app/javascript/dashboard/components-next/message/bubbles/Unsupported.vue
+++ b/app/javascript/dashboard/components-next/message/bubbles/Unsupported.vue
@@ -4,7 +4,7 @@ import { useMessageContext } from '../provider.js';
 import { useInbox } from 'dashboard/composables/useInbox';
 import BaseBubble from './Base.vue';
 
-const { inboxId } = useMessageContext();
+const { inboxId, contentAttributes } = useMessageContext();
 
 const {
   isAFacebookInbox,
@@ -14,6 +14,10 @@ const {
 } = useInbox(inboxId.value);
 
 const unsupportedMessageKey = computed(() => {
+  // WhatsApp withholds verification codes from linked devices: the row is empty
+  // because the content never arrived, not because the type is unknown.
+  if (contentAttributes.value?.isMasked)
+    return 'CONVERSATION.MASKED_MESSAGE_WHATSAPP';
   if (isAFacebookInbox.value)
     return 'CONVERSATION.UNSUPPORTED_MESSAGE_FACEBOOK';
   if (isAnInstagramChannel.value)

--- a/app/javascript/dashboard/components-next/message/bubbles/specs/Unsupported.spec.js
+++ b/app/javascript/dashboard/components-next/message/bubbles/specs/Unsupported.spec.js
@@ -1,0 +1,64 @@
+import { defineComponent, ref, computed } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import Unsupported from '../Unsupported.vue';
+import { provideMessageContext } from '../../provider.js';
+
+vi.mock('dashboard/composables/useInbox', () => ({
+  useInbox: () => ({
+    isAFacebookInbox: computed(() => false),
+    isAnInstagramChannel: computed(() => false),
+    isATiktokChannel: computed(() => false),
+    isAWhatsAppChannel: computed(() => true),
+  }),
+}));
+
+const mountUnsupported = contentAttributes => {
+  const TestHost = defineComponent({
+    components: { Unsupported },
+    setup() {
+      provideMessageContext({
+        inboxId: ref(1),
+        contentAttributes: ref(contentAttributes),
+      });
+    },
+    template: '<Unsupported />',
+  });
+
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: {
+      en: {
+        CONVERSATION: {
+          UNSUPPORTED_MESSAGE_WHATSAPP: 'This message is not supported.',
+          MASKED_MESSAGE_WHATSAPP:
+            'WhatsApp does not deliver verification codes to linked devices.',
+        },
+      },
+    },
+  });
+
+  return mount(TestHost, {
+    global: {
+      plugins: [i18n],
+      stubs: { BaseBubble: { template: '<div><slot /></div>' } },
+    },
+  });
+};
+
+describe('Unsupported', () => {
+  it('explains the masking when WhatsApp withheld the content', () => {
+    const wrapper = mountUnsupported({ isUnsupported: true, isMasked: true });
+
+    expect(wrapper.text()).toBe(
+      'WhatsApp does not deliver verification codes to linked devices.'
+    );
+  });
+
+  it('falls back to the channel copy when the type is simply unknown', () => {
+    const wrapper = mountUnsupported({ isUnsupported: true });
+
+    expect(wrapper.text()).toBe('This message is not supported.');
+  });
+});

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
@@ -25,6 +25,7 @@
     },
     "CHANGE_TEAM_FAILED": "Team change failed",
     "MESSAGE_DELETED_BY_CONTACT": "Deleted by the contact",
+    "MASKED_MESSAGE_WHATSAPP": "WhatsApp does not deliver verification codes to linked devices. This message can only be read on the paired phone.",
     "WHATSAPP": "WhatsApp",
     "CONTEXT_MENU": {
       "EDIT": {

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
@@ -25,6 +25,7 @@
     },
     "CHANGE_TEAM_FAILED": "No se pudo cambiar el equipo",
     "MESSAGE_DELETED_BY_CONTACT": "Eliminado por el contacto",
+    "MASKED_MESSAGE_WHATSAPP": "WhatsApp no entrega códigos de verificación a los dispositivos vinculados. Este mensaje solo se puede leer en el teléfono vinculado.",
     "WHATSAPP": "WhatsApp",
     "CONTEXT_MENU": {
       "EDIT": {

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
@@ -25,6 +25,7 @@
     },
     "CHANGE_TEAM_FAILED": "Falha ao alterar o time",
     "MESSAGE_DELETED_BY_CONTACT": "Apagada pelo contato",
+    "MASKED_MESSAGE_WHATSAPP": "O WhatsApp não entrega códigos de verificação a dispositivos conectados. Esta mensagem só pode ser lida no celular pareado.",
     "WHATSAPP": "WhatsApp",
     "CONTEXT_MENU": {
       "EDIT": {

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -122,12 +122,13 @@ class Message < ApplicationRecord
   # [:deleted_by_contact] : The contact deleted/revoked the message on WhatsApp; we keep the content visible and only flag it
   # [:pending_source_id] : Provider message id reserved before the send (Baileys), used to match the provider echo back to this row
   # [:edited_at] : Provider timestamp (ms) of the edit currently stored, so an edit that arrives out of order is refused
+  # [:is_masked] : WhatsApp withheld the content from linked devices (verification codes); set alongside :is_unsupported
 
   store :content_attributes, accessors: [:submitted_email, :items, :submitted_values, :email, :in_reply_to, :deleted,
                                          :external_created_at, :story_sender, :story_id, :external_error,
                                          :translations, :in_reply_to_external_id, :is_unsupported, :data,
                                          :is_reaction, :is_edited, :previous_content, :zapi_args, :referral, :rich,
-                                         :deleted_by_contact, :pending_source_id, :edited_at], coder: JSON
+                                         :deleted_by_contact, :pending_source_id, :edited_at, :is_masked], coder: JSON
 
   store :external_source_ids, accessors: [:slack], coder: JSON, prefix: :external_source_id
 

--- a/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
+++ b/app/services/whatsapp/baileys_handlers/concerns/message_creation_handler.rb
@@ -172,8 +172,8 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
       content_attributes[:is_reaction] = true
     elsif reply_to_message_id
       content_attributes[:in_reply_to_external_id] = reply_to_message_id
-    elsif type == 'unsupported'
-      content_attributes[:is_unsupported] = true
+    elsif type.in?(%w[unsupported masked])
+      add_contentless_attributes(content_attributes, type)
     end
 
     add_rich_content_attributes(content_attributes, msg) if type == 'rich'
@@ -182,6 +182,15 @@ module Whatsapp::BaileysHandlers::Concerns::MessageCreationHandler # rubocop:dis
     content_attributes[:referral] = referral if referral.present?
 
     content_attributes
+  end
+
+  # A row with nothing to render. Both kinds go through the unsupported bubble, which
+  # is what already strips the reply/reaction affordances an empty row must not offer;
+  # the masked flag only swaps the copy for one that names WhatsApp's masking instead
+  # of blaming a message type we failed to parse.
+  def add_contentless_attributes(content_attributes, type)
+    content_attributes[:is_unsupported] = true
+    content_attributes[:is_masked] = true if type == 'masked'
   end
 
   # Persists the structured card payload. A rich shape with neither text/buttons

--- a/app/services/whatsapp/baileys_handlers/helpers.rb
+++ b/app/services/whatsapp/baileys_handlers/helpers.rb
@@ -92,6 +92,12 @@ module Whatsapp::BaileysHandlers::Helpers # rubocop:disable Metrics/ModuleLength
       'secret'
     elsif msg.key?(:albumMessage)
       'album'
+    # WhatsApp withholds authentication-template messages (verification codes) from
+    # linked devices and delivers a placeholder in their place, so the content never
+    # reaches the connector. Classified apart from `unsupported` because there is
+    # nothing to parse here: the bubble has to explain the masking, not a missing type.
+    elsif msg.key?(:placeholderMessage)
+      'masked'
     elsif msg.key?(:messageContextInfo) && msg.keys.count == 1
       'context'
     elsif Whatsapp::Baileys::RichMessageParser.rich?(msg)

--- a/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messages_upsert_spec.rb
@@ -1482,6 +1482,52 @@ describe Whatsapp::BaileysHandlers::MessagesUpsert do
     end
   end
 
+  describe 'masked message handling' do
+    let(:phone) { '18668392077' }
+
+    after do
+      Redis::Alfred.scan_each(match: "MESSAGE_SOURCE_KEY::#{inbox.id}_*") { |key| Redis::Alfred.delete(key) }
+    end
+
+    # WhatsApp withholds an authentication template (a verification code) from linked
+    # devices and sends a placeholder in its place, so the connector never sees content.
+    it 'flags the message as masked so the bubble can name the reason' do
+      raw_message = {
+        key: { id: 'masked_1', remoteJid: "#{phone}@s.whatsapp.net", fromMe: false },
+        messageTimestamp: timestamp,
+        message: { messageContextInfo: { deviceListMetadataVersion: 2 }, placeholderMessage: { type: 0 } },
+        verifiedBizName: 'OpenAI'
+      }
+      params = { webhookVerifyToken: webhook_verify_token, event: 'messages.upsert',
+                 data: { type: 'notify', messages: [raw_message] } }
+
+      expect do
+        Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+      end.to change(Message, :count).by(1)
+
+      message = inbox.messages.last
+      expect(message.content).to be_nil
+      expect(message.is_unsupported).to be(true)
+      expect(message.is_masked).to be(true)
+    end
+
+    it 'leaves an unsupported message unflagged, so the two read apart' do
+      raw_message = {
+        key: { id: 'masked_2', remoteJid: "#{phone}@s.whatsapp.net", fromMe: false },
+        messageTimestamp: timestamp,
+        message: { someUnknownMessage: {} }
+      }
+      params = { webhookVerifyToken: webhook_verify_token, event: 'messages.upsert',
+                 data: { type: 'notify', messages: [raw_message] } }
+
+      Whatsapp::IncomingMessageBaileysService.new(inbox: inbox, params: params).perform
+
+      message = inbox.messages.last
+      expect(message.is_unsupported).to be(true)
+      expect(message.is_masked).to be_nil
+    end
+  end
+
   describe 'location message handling' do
     let(:phone) { '5511912345678' }
     let(:lid) { '12345678' }


### PR DESCRIPTION
A WhatsApp verification code (an OTP from an authentication template) now says why it cannot be read, instead of reading as a message type Chatwoot failed to parse.

WhatsApp masks authentication-template messages on every linked device and sends a placeholder in their place, on by default and with no opt-out, so the code exists only on the paired phone and never reaches the connector. The bubble said "This message is not supported. You can view this message in the WhatsApp app", which is the generic fallback for a type we have no renderer for, and it left the agent thinking the connector was behind.

Confirmed against a real phone on 03/09/2026: two codes from OpenAI arrived at 15:02 and 15:10 BRT, both as `{"messageContextInfo":{...},"placeholderMessage":{"type":0}}` and nothing else (`type: 0` is `MASK_LINKED_DEVICES`), while the phone showed both codes in full.

## How to reproduce

Send an OTP from any Cloud API authentication template to a number paired with a Baileys inbox, or replay a `messages.upsert` whose `message` is `{ messageContextInfo: {...}, placeholderMessage: { type: 0 } }`.

Before: the generic unsupported bubble. After: "WhatsApp does not deliver verification codes to linked devices. This message can only be read on the paired phone."

## What changed

`placeholderMessage` is its own message type (`masked`) rather than falling through to `unsupported`, and it writes `is_masked` alongside `is_unsupported`. The `is_unsupported` flag is kept on purpose: it is what already strips the reply and reaction affordances an empty row must not offer, so the new flag only swaps the copy. The bubble stays `Unsupported.vue`, which now picks the masked string when the flag is set.

This also stops a masked code and a genuine parser gap from producing the same row, which is what made the two indistinguishable in the field.

Baileys only. The native path lands in the connector's `unreadableBody` and is published as `unknown_type`, and separating it there needs a new `UnsupportedReason` in the contract: fazer-ai/whatsapp-connector#80.

## Related

- fazer-ai/whatsapp-connector#80, the native half of the same gap. Not closed by this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/457)
<!-- Reviewable:end -->
