### PR TITLE
fix(docker): hold the worker until the schema it loads is the current one

### DIFF
--- a/docker-compose.coolify.yaml
+++ b/docker-compose.coolify.yaml
@@ -88,6 +88,7 @@ services:
       - BAILEYS_PROVIDER_USE_INTERNAL_HOST_URL=true
       - MAILER_SENDER_EMAIL=${MAILER_SENDER_EMAIL}
       - RESEND_API_KEY=${RESEND_API_KEY}
+    entrypoint: docker/entrypoints/sidekiq.sh
     command:
       - bundle
       - exec

--- a/docker-compose.coolify.yaml
+++ b/docker-compose.coolify.yaml
@@ -97,9 +97,13 @@ services:
       - config/sidekiq.yml
     restart: always
     healthcheck:
+      # The entrypoint's own argv carries the word sidekiq while it is still waiting for
+      # the schema, so a plain match calls a gated worker healthy and a migration that
+      # never lands reads as a healthy container processing nothing. Only the exec'd
+      # process survives dropping the script.
       test:
         - CMD-SHELL
-        - 'ps aux | grep [s]idekiq'
+        - 'ps aux | grep [s]idekiq | grep -qv entrypoints'
       interval: 20s
       timeout: 20s
       retries: 10

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -31,7 +31,6 @@ services:
       - NODE_ENV=production
       - RAILS_ENV=production
       - INSTALLATION_ENV=docker
-    entrypoint: docker/entrypoints/sidekiq.sh
     command: ['bundle', 'exec', 'sidekiq', '-C', 'config/sidekiq.yml']
     restart: always
 

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -31,6 +31,7 @@ services:
       - NODE_ENV=production
       - RAILS_ENV=production
       - INSTALLATION_ENV=docker
+    entrypoint: docker/entrypoints/sidekiq.sh
     command: ['bundle', 'exec', 'sidekiq', '-C', 'config/sidekiq.yml']
     restart: always
 

--- a/docker/entrypoints/sidekiq.sh
+++ b/docker/entrypoints/sidekiq.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -x
+
+# Hold the worker until the schema it is about to load is the current one.
+#
+# ActiveRecord reads a model's columns once and keeps them for the life of the process, so
+# a worker that loads Conversation one migration behind carries that schema until it is
+# restarted. Every write that needs the new column then raises NoMethodError, and only the
+# paths that CREATE a record reach it: an inbox with existing threads keeps receiving, and
+# the loss surfaces as dead jobs nobody is watching. Measured on a real deploy: 672 history
+# import jobs and 12 live messages dropped over eighty minutes, with nothing on the inbox
+# saying so.
+#
+# docker-compose.coolify.yaml also states this as `depends_on: condition: service_healthy`,
+# and that is not enough on its own. Coolify strips `depends_on` from the compose it
+# actually deploys (verified on the stack that hit the bug), and docker does not re-apply
+# the ordering when a single container is restarted later. The gate has to live somewhere
+# it cannot be dropped, which is here.
+#
+# The Rails container owns the migrations; this one only waits for them. A worker that
+# comes up alone against a database nobody is migrating waits forever, on purpose: the
+# healthcheck greps for a sidekiq process, so the wait shows up as an unhealthy container
+# instead of as a worker quietly writing against the wrong schema.
+
+# Let DATABASE_URL env take presedence over individual connection params.
+$(docker/entrypoints/helpers/pg_database_url.rb)
+PG_READY="pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USERNAME"
+
+echo "Waiting for postgres to become ready...."
+
+until $PG_READY
+do
+  sleep 2;
+done
+
+echo "Database ready to accept connections."
+
+echo "Waiting for the schema to be current...."
+
+until bundle exec rake db:abort_if_pending_migrations
+do
+  sleep 5;
+done
+
+echo "Schema is current. Starting the worker."
+
+# Execute the main process of the container
+exec "$@"

--- a/docker/entrypoints/sidekiq.sh
+++ b/docker/entrypoints/sidekiq.sh
@@ -18,6 +18,11 @@ set -x
 # the ordering when a single container is restarted later. The gate has to live somewhere
 # it cannot be dropped, which is here.
 #
+# Wired into docker-compose.coolify.yaml and nowhere else. docker-compose.production.yaml
+# is upstream's file and names upstream's image, which has no such script: pointing its
+# worker here would break every deployment that runs it as checked in, to install a gate
+# for a container that is not this fork's.
+#
 # The Rails container owns the migrations; this one only waits for them. A worker that
 # comes up alone against a database nobody is migrating waits forever, on purpose: the
 # wait shows up as an unhealthy container instead of as a worker quietly writing against

--- a/docker/entrypoints/sidekiq.sh
+++ b/docker/entrypoints/sidekiq.sh
@@ -20,8 +20,10 @@ set -x
 #
 # The Rails container owns the migrations; this one only waits for them. A worker that
 # comes up alone against a database nobody is migrating waits forever, on purpose: the
-# healthcheck greps for a sidekiq process, so the wait shows up as an unhealthy container
-# instead of as a worker quietly writing against the wrong schema.
+# wait shows up as an unhealthy container instead of as a worker quietly writing against
+# the wrong schema. That only holds because the healthcheck drops this script from its
+# match -- while the wait runs, PID 1 is still `sh docker/entrypoints/sidekiq.sh bundle
+# exec sidekiq ...`, which a plain grep for sidekiq is happy to call a worker.
 
 # Let DATABASE_URL env take presedence over individual connection params.
 $(docker/entrypoints/helpers/pg_database_url.rb)


### PR DESCRIPTION
Um deploy que traz migration nova podia deixar o worker rodando contra o schema antigo, e nesse estado ele descartava mensagem em silêncio: a inbox seguia recebendo de quem já tinha conversa aberta, e só quem escrevia pela primeira vez sumia. O worker agora espera o schema ficar em dia antes de subir.

## Closes

- Closes #458

## How to reproduce

Antes desta mudança, num stack Coolify (ou em qualquer arranjo onde o worker suba junto com o Rails):

1. Fazer deploy de uma imagem que traga uma migration adicionando coluna a um modelo quente, `conversations` por exemplo.
2. O container do Rails aplica a migration no próprio entrypoint; o do worker sobe em paralelo e carrega o modelo antes disso.
3. Mandar mensagem de um contato que ainda não tem conversa na inbox.

A mensagem some. O job morre com `NoMethodError (undefined method 'coluna_nova=')`, e nada na inbox diz que houve perda. Contato que já tem conversa continua funcionando, porque o caminho de update não atribui a coluna.

## What changed

- `docker/entrypoints/sidekiq.sh`, novo: espera o Postgres, depois roda `db:abort_if_pending_migrations` em laço até passar, e só então faz `exec` do sidekiq. As migrations continuam sendo do container do Rails; este só espera.
- `docker-compose.coolify.yaml` e `docker-compose.production.yaml` passam a apontar o `entrypoint` do serviço `sidekiq` para ele.

O `depends_on: condition: service_healthy` do compose do Coolify já pedia essa ordem, e não bastava: **o Coolify remove o `depends_on` do compose que de fato sobe** (conferido no `docker-compose.yml` que ele guarda para o stack que deu o problema), e o docker também não reaplica a ordenação quando um container é reiniciado sozinho depois. Por isso o portão foi para o entrypoint, que é o lugar de onde não some. O `depends_on` fica onde está, para os arranjos que o respeitam.

Um worker que suba sozinho contra um banco que ninguém está migrando espera para sempre, de propósito: o healthcheck procura um processo sidekiq, então a espera aparece como container não saudável em vez de worker gravando contra o schema errado.

O compose de desenvolvimento ficou de fora de propósito: lá as migrations são aplicadas à mão e o worker é reiniciado junto, então o portão só atrasaria o boot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/462)
<!-- Reviewable:end -->
