### PR TITLE
fix(whatsapp): stop dropping a live message that lands mid-import

### DIFF
--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -5,6 +5,16 @@ class Webhooks::WhatsappEventsJob < MutexApplicationJob
   # holder finishes and silently drop its message.
   retry_on LockAcquisitionError, wait: 2.seconds, attempts: 20
 
+  # The incoming services take a second lock, on the chat, and that one is also taken by
+  # the history import, which leases it for a whole batch. A budget sized for live
+  # contention runs out while the import is still writing, and the message this job is
+  # carrying is gone: nine were lost that way on a single reconnect, to a group that
+  # happened to be importing. So the budget is derived from the lease rather than picked,
+  # with half again on top for the batch that has to finish after the lease is taken.
+  CHAT_LOCK_RETRY_WAIT = 15.seconds
+  CHAT_LOCK_RETRY_ATTEMPTS = (Whatsapp::Session::Inbound::Locks::IMPORT_CHAT_LOCK_TTL.to_i / CHAT_LOCK_RETRY_WAIT.to_i * 1.5).ceil
+  retry_on Whatsapp::Session::Inbound::Locks::Busy, wait: CHAT_LOCK_RETRY_WAIT, attempts: CHAT_LOCK_RETRY_ATTEMPTS
+
   def perform(params = {})
     dump_raw_payload(params)
     channel = find_channel_from_whatsapp_business_payload(params)

--- a/app/jobs/webhooks/whatsapp_session_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_session_events_job.rb
@@ -21,7 +21,19 @@ class Webhooks::WhatsappSessionEventsJob < ApplicationJob
 
   # Another worker holds the chat or the message: retried rather than waited on, so a
   # Sidekiq thread is never parked on Redis.
-  retry_on Whatsapp::Session::Inbound::Locks::Busy, wait: :polynomially_longer, attempts: 6
+  #
+  # A flat wait rather than a growing one, and the value is not free. The note this job
+  # leaves on a chat it could not have is what makes an import stand aside for it, and the
+  # note expires: a gap wider than `WAITER_TTL` leaves the job queued with nothing on the
+  # chat saying so, and the import it was waiting out takes the key again. The polynomial
+  # ladder reached 81 seconds on its third step and 625 on its fifth.
+  #
+  # The budget has to outlast the longest anything holds a chat, which is the import lease,
+  # for the same reason the Cloud/Baileys webhook job's does: running out of attempts while
+  # the holder is still writing loses the message this job is carrying.
+  CHAT_LOCK_RETRY_WAIT = (Whatsapp::Session::Inbound::Locks::WAITER_TTL / 4)
+  CHAT_LOCK_RETRY_ATTEMPTS = (Whatsapp::Session::Inbound::Locks::IMPORT_CHAT_LOCK_TTL.to_i / CHAT_LOCK_RETRY_WAIT.to_i * 1.5).ceil
+  retry_on Whatsapp::Session::Inbound::Locks::Busy, wait: CHAT_LOCK_RETRY_WAIT, attempts: CHAT_LOCK_RETRY_ATTEMPTS
 
   # The wait for a message that has not arrived yet. Bounded, and dropped at the end
   # rather than re-raised: the target of a revoke or an edit can legitimately be a

--- a/app/jobs/whatsapp/baileys/history_import_job.rb
+++ b/app/jobs/whatsapp/baileys/history_import_job.rb
@@ -13,7 +13,12 @@ class Whatsapp::Baileys::HistoryImportJob < ApplicationJob
   # Live traffic for the same chat holds the same lock, and it is the shorter of the two:
   # waiting is the right answer, and the budget is sized so an import that lands mid-burst
   # still gets its turn.
-  retry_on Whatsapp::Session::Inbound::Locks::Busy, wait: 10.seconds, attempts: 10
+  #
+  # The other holder is this chat's own dump. A mature chat arrives in a dozen frames, each
+  # one a separate job filed under the same key, so what a batch waits out is the batches
+  # queued ahead of it and not a single hold. Ten ten-second retries covered neither: a
+  # group of 8,545 messages lost eleven batches to its own siblings.
+  retry_on Whatsapp::Session::Inbound::Locks::Busy, wait: 30.seconds, attempts: 40
 
   # `announce` defaults for the jobs already queued when this shipped, and for every dump
   # the phone volunteers, which is all of them but the answer to a press.

--- a/app/services/whatsapp/baileys/history_importer.rb
+++ b/app/services/whatsapp/baileys/history_importer.rb
@@ -47,7 +47,9 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
     @opened = Set.new
     return if batch.empty?
 
-    Whatsapp::Session::Inbound::Locks.with_chat_lock(inbox, lock_ids, ttl: inbound::Locks::IMPORT_CHAT_LOCK_TTL) do
+    Whatsapp::Session::Inbound::Locks.with_chat_lock(
+      inbox, lock_ids, ttl: inbound::Locks::IMPORT_CHAT_LOCK_TTL, defer_to_waiters: true
+    ) do
       pending = unstored(batch.sort_by { |raw| timestamp_of(raw) })
       next if pending.empty?
 

--- a/app/services/whatsapp/baileys/history_importer.rb
+++ b/app/services/whatsapp/baileys/history_importer.rb
@@ -33,11 +33,6 @@
 class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysService
   include Import::HistorySettlement
 
-  # A batch is up to a few hundred messages with a contact resolution behind the first of
-  # them. The ordinary thirty seconds is a lease that would expire mid-import, and a lease
-  # that expires is not a lock.
-  CHAT_LOCK_TTL = 5.minutes
-
   # All Inbound::Coverage asks of a message is when it was sent. The raw Baileys hash is
   # not a model and never will be, so it is asked through this rather than by teaching
   # Coverage a second shape.
@@ -52,7 +47,7 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
     @opened = Set.new
     return if batch.empty?
 
-    Whatsapp::Session::Inbound::Locks.with_chat_lock(inbox, lock_ids, ttl: CHAT_LOCK_TTL) do
+    Whatsapp::Session::Inbound::Locks.with_chat_lock(inbox, lock_ids, ttl: inbound::Locks::IMPORT_CHAT_LOCK_TTL) do
       pending = unstored(batch.sort_by { |raw| timestamp_of(raw) })
       next if pending.empty?
 

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -210,6 +210,15 @@ module Whatsapp::IncomingMessageServiceHelpers # rubocop:disable Metrics/ModuleL
   # Lock by contact phone to prevent race conditions when multiple messages
   # from the same contact arrive simultaneously (e.g., WhatsApp albums).
   # Without this, each message could create its own conversation.
+  #
+  # The spin covers what this lock was built for: two messages of the same chat landing
+  # together, where the first is done in well under a second. It does not cover the other
+  # holder of the same key. A history import leases the chat for a whole batch
+  # (`Locks::IMPORT_CHAT_LOCK_TTL`), which is two orders of magnitude longer than any wait
+  # a worker thread should sit through, so giving up is the right answer there -- as long
+  # as giving up means the job comes back. Hence `Locks::Busy`, which the caller retries,
+  # rather than a Timeout::Error nothing was listening for: that one took the message down
+  # with it, and an import runs precisely when a reconnected inbox is receiving again.
   def with_contact_lock(phone, timeout: 5.seconds)
     raise ArgumentError, 'A block is required for with_contact_lock' unless block_given?
     return yield if phone.blank?
@@ -227,7 +236,7 @@ module Whatsapp::IncomingMessageServiceHelpers # rubocop:disable Metrics/ModuleL
       sleep(0.1)
     end
 
-    raise Timeout::Error, "Timeout acquiring contact lock for #{phone}" unless lock_acquired
+    raise Whatsapp::Session::Inbound::Locks::Busy, "contact lock for #{phone} of inbox #{inbox.id} is held" unless lock_acquired
 
     yield
   ensure

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -234,7 +234,6 @@ module Whatsapp::IncomingMessageServiceHelpers # rubocop:disable Metrics/ModuleL
       raise Whatsapp::Session::Inbound::Locks::Busy, "contact lock for #{phone} of inbox #{inbox.id} is held"
     end
 
-    Whatsapp::Session::Inbound::Locks.clear_waiter(inbox, phone)
     yield
   ensure
     Redis::Alfred.delete(key) if lock_acquired

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -224,22 +224,31 @@ module Whatsapp::IncomingMessageServiceHelpers # rubocop:disable Metrics/ModuleL
     return yield if phone.blank?
 
     key = "WHATSAPP::CONTACT_LOCK::#{inbox.id}_#{phone}"
+    lock_acquired = spin_for_contact_lock(key, timeout)
+
+    unless lock_acquired
+      # Said out loud, so the import standing between this message and the chat gives way
+      # rather than handing the key to the next batch of its own dump. Without it the
+      # retry budget below is up against a queue of holders and not one.
+      Whatsapp::Session::Inbound::Locks.note_waiter(inbox, phone)
+      raise Whatsapp::Session::Inbound::Locks::Busy, "contact lock for #{phone} of inbox #{inbox.id} is held"
+    end
+
+    Whatsapp::Session::Inbound::Locks.clear_waiter(inbox, phone)
+    yield
+  ensure
+    Redis::Alfred.delete(key) if lock_acquired
+  end
+
+  def spin_for_contact_lock(key, timeout)
     start_time = Time.now.to_i
-    lock_acquired = false
 
     while (Time.now.to_i - start_time) < timeout
-      if Redis::Alfred.set(key, 1, nx: true, ex: timeout)
-        lock_acquired = true
-        break
-      end
+      return true if Redis::Alfred.set(key, 1, nx: true, ex: timeout)
 
       sleep(0.1)
     end
 
-    raise Whatsapp::Session::Inbound::Locks::Busy, "contact lock for #{phone} of inbox #{inbox.id} is held" unless lock_acquired
-
-    yield
-  ensure
-    Redis::Alfred.delete(key) if lock_acquired
+    false
   end
 end

--- a/app/services/whatsapp/session/inbound/history_importer.rb
+++ b/app/services/whatsapp/session/inbound/history_importer.rb
@@ -83,7 +83,7 @@ class Whatsapp::Session::Inbound::HistoryImporter
     ordered = batch.sort_by { |message| message.timestamp.to_i }
 
     lock_ids = inbound::ChatIdentity.lock_ids(ordered.first)
-    inbound::Locks.with_chat_lock(inbox, lock_ids, ttl: inbound::Locks::IMPORT_CHAT_LOCK_TTL) do
+    inbound::Locks.with_chat_lock(inbox, lock_ids, ttl: inbound::Locks::IMPORT_CHAT_LOCK_TTL, defer_to_waiters: true) do
       pending = unstored(ordered)
       next if pending.empty?
 

--- a/app/services/whatsapp/session/inbound/history_importer.rb
+++ b/app/services/whatsapp/session/inbound/history_importer.rb
@@ -22,13 +22,6 @@
 class Whatsapp::Session::Inbound::HistoryImporter
   include Import::HistorySettlement
 
-  # A chat's whole batch is written under one lock, and a batch can be two hundred
-  # messages with an avatar lookup and a contact resolution behind the first of them. The
-  # ordinary thirty seconds is a lease that would expire mid-import, and a lease that
-  # expires is not a lock: a live message for the same chat would take the key and open a
-  # second conversation alongside the one being filled.
-  CHAT_LOCK_TTL = 5.minutes
-
   attr_reader :channel, :messages
 
   # Threads this run created, which is what tells an artifact from a fact. A new
@@ -89,7 +82,8 @@ class Whatsapp::Session::Inbound::HistoryImporter
   def import_chat(batch, watermark)
     ordered = batch.sort_by { |message| message.timestamp.to_i }
 
-    inbound::Locks.with_chat_lock(inbox, inbound::ChatIdentity.lock_ids(ordered.first), ttl: CHAT_LOCK_TTL) do
+    lock_ids = inbound::ChatIdentity.lock_ids(ordered.first)
+    inbound::Locks.with_chat_lock(inbox, lock_ids, ttl: inbound::Locks::IMPORT_CHAT_LOCK_TTL) do
       pending = unstored(ordered)
       next if pending.empty?
 

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -21,9 +21,15 @@ module Whatsapp::Session::Inbound::Locks
   # two drift until a live message gives up on a lock that was going to be released.
   IMPORT_CHAT_LOCK_TTL = 5.minutes
   # How long a note that somebody wanted a chat and could not have it outlives the attempt
-  # that left it. It has to cover the gap between two of that caller's retries, and no more:
-  # a worker killed between noting it and taking the key would otherwise hold an import off
-  # for as long as the note lived.
+  # that left it, and the only thing that ends it. Nobody clears it: the note is shared by
+  # every caller waiting on that chat, so the first one to be served would be deleting a
+  # claim the others still hold, and an import could cut back in ahead of them.
+  #
+  # Expiry therefore has to outlast the gap between two attempts by the same caller, or the
+  # note is gone while its author is still queued -- which is why the live retry waits below
+  # are stated in terms of it rather than chosen. The cost of the other end is one window of
+  # imports held off a chat after the last live message was served, which an import can
+  # afford and a message cannot.
   WAITER_TTL = 1.minute
   # Reading a group's whole roster is the one guarded operation that can run for minutes:
   # each participant is resolved, and a large group has hundreds. A lease that expires
@@ -108,10 +114,6 @@ module Whatsapp::Session::Inbound::Locks
     waiter_keys(inbox, chats).each { |key| Redis::Alfred.set(key, 1, ex: WAITER_TTL) }
   end
 
-  def clear_waiter(inbox, *chats)
-    waiter_keys(inbox, chats).each { |key| Redis::Alfred.delete(key) }
-  end
-
   # Kept to the claiming, not wrapped around the block: a Busy raised by something the
   # block itself locks says nothing about this chat, and noting it would hold imports off
   # a chat nobody is actually waiting for.
@@ -119,7 +121,6 @@ module Whatsapp::Session::Inbound::Locks
   # `note` carries the chats to record against, or nil for the caller that gives way.
   def take(keys, inbox, ttl, held, note:)
     keys.each { |key| held[key] = claim(key, inbox, ttl) }
-    clear_waiter(inbox, note) if note
   rescue Busy
     note_waiter(inbox, note) if note
     raise

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -20,6 +20,11 @@ module Whatsapp::Session::Inbound::Locks
   # retry budget of whoever might be waiting on one -- and a copy per importer is how those
   # two drift until a live message gives up on a lock that was going to be released.
   IMPORT_CHAT_LOCK_TTL = 5.minutes
+  # How long a note that somebody wanted a chat and could not have it outlives the attempt
+  # that left it. It has to cover the gap between two of that caller's retries, and no more:
+  # a worker killed between noting it and taking the key would otherwise hold an import off
+  # for as long as the note lived.
+  WAITER_TTL = 1.minute
   # Reading a group's whole roster is the one guarded operation that can run for minutes:
   # each participant is resolved, and a large group has hundreds. A lease that expires
   # mid-way is not a lock at all, because a second worker takes the key and the two
@@ -68,17 +73,56 @@ module Whatsapp::Session::Inbound::Locks
   # is released by token: `Redis::LockManager#unlock` deletes unconditionally, so an
   # operation that outran the TTL (syncing a large group roster is the realistic one)
   # would delete a lock a second worker had already taken.
-  def with_chat_lock(inbox, *chats, ttl: CHAT_LOCK_TTL)
+  #
+  # `defer_to_waiters` marks the caller as the one that gives way, which an import is and
+  # nothing else is. Two things follow from it, and they are the same rule read from both
+  # ends: it stands aside while somebody is waiting, and it does not register itself as a
+  # waiter when it cannot have the key.
+  #
+  # Without that the batches of one dump hand the chat to each other for as long as the dump
+  # is long, and a live message beside them can lose every attempt it has against a lock
+  # that is never free at the moment it looks -- a retry budget covers one holder, and what
+  # it is really up against is a queue of them. And an import that noted itself would be
+  # standing aside for its own siblings, which is a deadlock spelled differently.
+  def with_chat_lock(inbox, *chats, ttl: CHAT_LOCK_TTL, defer_to_waiters: false)
     keys = chats.flatten.compact_blank.uniq.sort.map { |chat| chat_key(inbox, chat) }
     return yield if keys.empty?
+    raise Busy, "#{keys.first} of inbox #{inbox.id} has a caller waiting on it" if defer_to_waiters && waiting?(inbox, chats)
 
     held = {}
     begin
-      keys.each { |key| held[key] = claim(key, inbox, ttl) }
+      take(keys, inbox, ttl, held, note: defer_to_waiters ? nil : chats)
       yield
     ensure
       held.each { |key, token| Redis::Alfred.delete_if_equals(key, token) }
     end
+  end
+
+  # Whether anybody has said they want one of these chats and could not have it. Read by
+  # the callers that give way, and by nothing else.
+  def waiting?(inbox, *chats)
+    waiter_keys(inbox, chats).any? { |key| Redis::Alfred.get(key).present? }
+  end
+
+  def note_waiter(inbox, *chats)
+    waiter_keys(inbox, chats).each { |key| Redis::Alfred.set(key, 1, ex: WAITER_TTL) }
+  end
+
+  def clear_waiter(inbox, *chats)
+    waiter_keys(inbox, chats).each { |key| Redis::Alfred.delete(key) }
+  end
+
+  # Kept to the claiming, not wrapped around the block: a Busy raised by something the
+  # block itself locks says nothing about this chat, and noting it would hold imports off
+  # a chat nobody is actually waiting for.
+  #
+  # `note` carries the chats to record against, or nil for the caller that gives way.
+  def take(keys, inbox, ttl, held, note:)
+    keys.each { |key| held[key] = claim(key, inbox, ttl) }
+    clear_waiter(inbox, note) if note
+  rescue Busy
+    note_waiter(inbox, note) if note
+    raise
   end
 
   def claim(key, inbox, ttl)
@@ -98,5 +142,9 @@ module Whatsapp::Session::Inbound::Locks
 
   def chat_key(inbox, chat)
     "WHATSAPP::CONTACT_LOCK::#{inbox.id}_#{chat}"
+  end
+
+  def waiter_keys(inbox, chats)
+    chats.flatten.compact_blank.uniq.map { |chat| "#{chat_key(inbox, chat)}::WAITING" }
   end
 end

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -10,6 +10,16 @@ module Whatsapp::Session::Inbound::Locks
   class Busy < StandardError; end
 
   CHAT_LOCK_TTL = 30.seconds
+  # What a history import leases the chat for. A batch is a few hundred messages with a
+  # contact resolution behind the first of them, and a lease that expires mid-import is not
+  # a lock: a live message for the same chat would take the key and open a second
+  # conversation beside the one being filled.
+  #
+  # It lives here rather than in either importer because it is not only the importer's
+  # business. It is the longest anything holds a chat key, so it is also the floor for the
+  # retry budget of whoever might be waiting on one -- and a copy per importer is how those
+  # two drift until a live message gives up on a lock that was going to be released.
+  IMPORT_CHAT_LOCK_TTL = 5.minutes
   # Reading a group's whole roster is the one guarded operation that can run for minutes:
   # each participant is resolved, and a large group has hundreds. A lease that expires
   # mid-way is not a lock at all, because a second worker takes the key and the two

--- a/spec/jobs/webhooks/whatsapp_events_job_spec.rb
+++ b/spec/jobs/webhooks/whatsapp_events_job_spec.rb
@@ -469,4 +469,14 @@ RSpec.describe Webhooks::WhatsappEventsJob do
       job.perform_now(wb_params)
     end
   end
+
+  describe 'chat lock retry budget' do
+    it 'outlasts the lease a history import takes on the same key' do
+      # The budget is the whole fix: an import holds the chat for a batch, and a job that
+      # runs out of attempts before it lets go drops the message it was carrying.
+      budget = described_class::CHAT_LOCK_RETRY_WAIT * (described_class::CHAT_LOCK_RETRY_ATTEMPTS - 1)
+
+      expect(budget).to be > Whatsapp::Session::Inbound::Locks::IMPORT_CHAT_LOCK_TTL
+    end
+  end
 end

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -240,6 +240,19 @@ describe Whatsapp::IncomingMessageService do
         expect(Redis::Alfred).to have_received(:set).with(contact_lock_key, 1, nx: true, ex: 5.seconds)
       end
 
+      it 'gives up on a held contact lock with an error the job retries' do
+        # The history import leases the same key for a whole batch, which is minutes. What
+        # matters here is the class: a Timeout::Error nothing was listening for took the
+        # message down with it, and an import runs exactly when a reconnected inbox is
+        # receiving again.
+        phone_number = '2423423243'
+        Redis::Alfred.set("WHATSAPP::CONTACT_LOCK::#{whatsapp_channel.inbox.id}_#{phone_number}", 1)
+        service = described_class.new(inbox: whatsapp_channel.inbox, params: params)
+
+        expect { service.with_contact_lock(phone_number, timeout: 0.2.seconds) { raise 'ran the block' } }
+          .to raise_error(Whatsapp::Session::Inbound::Locks::Busy)
+      end
+
       it 'creates a contact and conversation when only BSUID is present' do
         params = {
           'contacts' => [{

--- a/spec/services/whatsapp/session/inbound/locks_spec.rb
+++ b/spec/services/whatsapp/session/inbound/locks_spec.rb
@@ -131,14 +131,28 @@ RSpec.describe Whatsapp::Session::Inbound::Locks do
       expect(described_class.waiting?(inbox, chat)).to be(true)
     end
 
-    # The note is a claim on the next turn, not a standing one: left behind, it would hold
-    # every later import off the chat until the TTL ran out.
-    it 'stops waiting once it has the chat' do
+    # Nothing clears the note, and that is the point: it is shared by everybody waiting on
+    # the chat, so the first caller to be served would be deleting a claim the others still
+    # hold and an import could cut in ahead of them. It ends by expiring.
+    it 'keeps standing aside while a second caller is still waiting' do
+      described_class.with_chat_lock(inbox, chat) do
+        expect { described_class.with_chat_lock(inbox, chat) { :live_one } }.to raise_error(described_class::Busy)
+        expect { described_class.with_chat_lock(inbox, chat) { :live_two } }.to raise_error(described_class::Busy)
+      end
+
+      described_class.with_chat_lock(inbox, chat) { :live_one_served }
+
+      expect(described_class.waiting?(inbox, chat)).to be(true)
+    end
+
+    # And it is a claim on the next turn rather than a standing one, so an import is held
+    # off for one window and not forever.
+    it 'stops standing aside once the note has expired' do
       described_class.note_waiter(inbox, chat)
 
-      described_class.with_chat_lock(inbox, chat) { :live }
-
-      expect(described_class.waiting?(inbox, chat)).to be(false)
+      travel(described_class::WAITER_TTL + 1.second) do
+        expect(described_class.with_chat_lock(inbox, chat, defer_to_waiters: true) { :imported }).to eq(:imported)
+      end
     end
   end
 end

--- a/spec/services/whatsapp/session/inbound/locks_spec.rb
+++ b/spec/services/whatsapp/session/inbound/locks_spec.rb
@@ -95,4 +95,50 @@ RSpec.describe Whatsapp::Session::Inbound::Locks do
       expect(described_class.with_message_lock(inbox, nil) { :ran }).to eq(:ran)
     end
   end
+
+  # An import holds a chat for a whole batch, and one dump is a dozen batches: they hand
+  # the key to each other, so a live message beside them can lose every attempt it has
+  # against a lock that is never free at the moment it looks. Retrying harder does not fix
+  # that -- a budget covers one holder, and this is a queue of them.
+  describe 'giving way to a caller that is waiting' do
+    it 'stands aside for a chat somebody said they wanted' do
+      described_class.note_waiter(inbox, chat)
+
+      expect { described_class.with_chat_lock(inbox, chat, defer_to_waiters: true) { :imported } }
+        .to raise_error(described_class::Busy)
+    end
+
+    it 'takes a free chat nobody is waiting for' do
+      expect(described_class.with_chat_lock(inbox, chat, defer_to_waiters: true) { :imported }).to eq(:imported)
+    end
+
+    # Otherwise the batches of one dump stand aside for each other and the import never
+    # runs, which is a deadlock wearing the fix's clothes.
+    it 'does not register itself as waiting when it is refused' do
+      described_class.with_chat_lock(inbox, chat) do
+        expect { described_class.with_chat_lock(inbox, chat, defer_to_waiters: true) { :imported } }
+          .to raise_error(described_class::Busy)
+      end
+
+      expect(described_class.waiting?(inbox, chat)).to be(false)
+    end
+
+    it 'says it is waiting when it is refused a chat' do
+      described_class.with_chat_lock(inbox, chat) do
+        expect { described_class.with_chat_lock(inbox, chat) { :live } }.to raise_error(described_class::Busy)
+      end
+
+      expect(described_class.waiting?(inbox, chat)).to be(true)
+    end
+
+    # The note is a claim on the next turn, not a standing one: left behind, it would hold
+    # every later import off the chat until the TTL ran out.
+    it 'stops waiting once it has the chat' do
+      described_class.note_waiter(inbox, chat)
+
+      described_class.with_chat_lock(inbox, chat) { :live }
+
+      expect(described_class.waiting?(inbox, chat)).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Uma mensagem que chegava enquanto o histórico daquele mesmo chat estava sendo importado era descartada em silêncio: o agente não via nada, e o celular de quem mandou dizia entregue. Agora ela espera o import terminar e entra.

## Closes

- Closes #459

## How to reproduce

Antes desta mudança, numa inbox baileys:

1. Ligar o `history_sync` e reconectar o número, de preferência com um grupo grande no histórico.
2. Enquanto o import daquele grupo roda, mandar mensagem nele.

A mensagem some. O job morre com `Timeout::Error: Timeout acquiring contact lock for <jid>`. Medido numa reconexão real: nove mensagens ao vivo perdidas para um grupo que estava importando.

## What changed

O import e o caminho ao vivo disputam a mesma chave, `WHATSAPP::CONTACT_LOCK::<inbox>_<chat>`, com prazos que não se conheciam: o import arrenda por 5 minutos, e o caminho ao vivo desistia depois de 5 segundos levantando um erro que ninguém escutava.

- `with_contact_lock` passa a levantar `Locks::Busy` em vez de `Timeout::Error`. A espera curta continua, porque é ela que cobre o caso para o qual o lock foi feito (duas mensagens do mesmo chat chegando juntas, resolvidas em muito menos de um segundo). O que muda é o desfecho quando a espera não basta: `Busy` é o erro que o job retenta, e era o que faltava.
- `Webhooks::WhatsappEventsJob` ganha o `retry_on` correspondente, com o orçamento **derivado** do arrendamento em vez de escolhido, mais metade em cima. O orçamento do mutex de álbum fica intacto, com os 2 segundos que a latência dele pede.
- O arrendamento de 5 minutos virou uma constante só, `Locks::IMPORT_CHAT_LOCK_TTL`, em vez de uma cópia em cada um dos dois importadores. Ele não é assunto só do import: é o tempo máximo que qualquer coisa segura uma chave de chat, portanto é o piso do orçamento de quem espera por ela, e duas cópias são exatamente como esses dois números se separam.
- `HistoryImportJob` também teve o orçamento aumentado, por um motivo vizinho e diferente: o outro concorrente de um batch é o próprio despejo dele. Um chat maduro chega em uma dúzia de frames, cada um um job na mesma chave, então o que um batch espera são os irmãos à frente, e não uma retenção só. Dez tentativas de dez segundos não cobriam: um grupo de 8.545 mensagens perdeu onze batches para si mesmo.

## Fora do escopo, de propósito

O caminho ao vivo do `native` (`ShardWorker::BUSY_WAITS`) soma 170 segundos, menos que o arrendamento. Hoje não dá problema porque `native` não declara `history_sync` e portanto nunca roda import, mas passa a dar no dia em que a #407 entregar isso. Anotado lá.

O TTL do lock ao vivo é igual à espera dele, 5 segundos, então ele expira no meio de qualquer processamento mais lento que isso. É defeito real e independente deste, com correção independente; fica para issue própria.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/463)
<!-- Reviewable:end -->
