### PR TITLE
fix(whatsapp): name an imported group instead of filing it under its jid

### DIFF
--- a/app/jobs/whatsapp/baileys/history_import_job.rb
+++ b/app/jobs/whatsapp/baileys/history_import_job.rb
@@ -26,7 +26,7 @@ class Whatsapp::Baileys::HistoryImportJob < ApplicationJob
   # serialization contract that outlives the deploy that changed it.
   #
   # `announce` is false for every dump the phone volunteers, which is all of them but the
-  # answer to a press. `group_names` is empty for a bridge too old to send it, and then the
+  # answer to a press. `group_name` is absent for a bridge too old to send it, and then the
   # importer falls back to naming a group by its jid, exactly as before.
   def perform(inbox, messages, watermark, requested, **filing)
     channel = inbox&.channel
@@ -36,7 +36,7 @@ class Whatsapp::Baileys::HistoryImportJob < ApplicationJob
       inbox: inbox,
       params: {
         messages: messages, watermark: watermark, requested: requested,
-        announce: filing.fetch(:announce, false), group_names: filing.fetch(:group_names, {})
+        announce: filing.fetch(:announce, false), group_name: filing[:group_name]
       }
     ).perform
   end

--- a/app/jobs/whatsapp/baileys/history_import_job.rb
+++ b/app/jobs/whatsapp/baileys/history_import_job.rb
@@ -20,15 +20,24 @@ class Whatsapp::Baileys::HistoryImportJob < ApplicationJob
   # group of 8,545 messages lost eleven batches to its own siblings.
   retry_on Whatsapp::Session::Inbound::Locks::Busy, wait: 30.seconds, attempts: 40
 
-  # `announce` defaults for the jobs already queued when this shipped, and for every dump
-  # the phone volunteers, which is all of them but the answer to a press.
-  def perform(inbox, messages, watermark, requested, announce: false)
+  # Everything past `requested` says how to file this dump rather than what is in it, and
+  # it is collected rather than listed because the list grows: each entry has to keep a
+  # default for the jobs already queued when it shipped, and a job argument list is a
+  # serialization contract that outlives the deploy that changed it.
+  #
+  # `announce` is false for every dump the phone volunteers, which is all of them but the
+  # answer to a press. `group_names` is empty for a bridge too old to send it, and then the
+  # importer falls back to naming a group by its jid, exactly as before.
+  def perform(inbox, messages, watermark, requested, **filing)
     channel = inbox&.channel
     return unless channel.is_a?(Channel::Whatsapp) && channel.provider == 'baileys'
 
     Whatsapp::Baileys::HistoryImporter.new(
       inbox: inbox,
-      params: { messages: messages, watermark: watermark, requested: requested, announce: announce }
+      params: {
+        messages: messages, watermark: watermark, requested: requested,
+        announce: filing.fetch(:announce, false), group_names: filing.fetch(:group_names, {})
+      }
     ).perform
   end
 end

--- a/app/services/whatsapp/baileys/history_importer.rb
+++ b/app/services/whatsapp/baileys/history_importer.rb
@@ -45,37 +45,51 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
 
   def perform
     @opened = Set.new
-    return if batch.empty?
+    return if messages.empty?
 
     Whatsapp::Session::Inbound::Locks.with_chat_lock(
       inbox, lock_ids, ttl: inbound::Locks::IMPORT_CHAT_LOCK_TTL, defer_to_waiters: true
     ) do
-      pending = unstored(batch.sort_by { |raw| timestamp_of(raw) })
-      runs = pending.group_by { |raw| gap?(raw) }
       Import::SilentWrite.wrap do
         rename_group
-        next if pending.empty?
-
-        # Archive first: the two halves land in different threads, and the older one has
-        # to exist before the reopen policy is asked which thread is current.
-        # An unrequested pile keeps only its gap. The phone offers its whole history at
-        # every pairing, and an inbox nobody asked would otherwise fill with a year of
-        # somebody's conversations. A first pairing has no coverage at all, so `gap?` calls
-        # the whole pile archive and this drops all of it, which is the privacy protection
-        # the old outright refusal was standing in for.
-        # The archive is silent because a pairing dump is a year of somebody else's
-        # conversations arriving at once, and nobody asked to watch that. An answer to a
-        # press is the opposite: the operator is looking at the thread it lands in.
-        archived = requested ? maybe_announcing { import_run(runs[false], archived: true) } : []
-        gap = announcing { import_run(runs[true], archived: false) }
-        settle(archived, gap)
+        file
       end
     end
   end
 
   private
 
-  def batch = @batch ||= Array(processed_params[:messages]).select { |raw| writable?(raw) }
+  # `batch` and not `messages`: what survives the filter is what there is to file, and a
+  # chat whose whole slice is markers must not leave a contact and an empty resolved
+  # conversation behind. The rename above it runs either way, because a numbered group's
+  # slice being all markers is the ordinary case rather than an exception -- 519 of 614
+  # threads on a real pairing.
+  def file
+    return if batch.empty?
+
+    pending = unstored(batch.sort_by { |raw| timestamp_of(raw) })
+    return if pending.empty?
+
+    runs = pending.group_by { |raw| gap?(raw) }
+    # Archive first: the two halves land in different threads, and the older one has to
+    # exist before the reopen policy is asked which thread is current.
+    #
+    # An unrequested pile keeps only its gap. The phone offers its whole history at every
+    # pairing, and an inbox nobody asked would otherwise fill with a year of somebody's
+    # conversations. A first pairing has no coverage at all, so `gap?` calls the whole pile
+    # archive and this drops all of it, which is the privacy protection the old outright
+    # refusal was standing in for.
+    #
+    # The archive is silent because a pairing dump is a year of somebody else's
+    # conversations arriving at once, and nobody asked to watch that. An answer to a press
+    # is the opposite: the operator is looking at the thread it lands in.
+    archived = requested ? maybe_announcing { import_run(runs[false], archived: true) } : []
+    gap = announcing { import_run(runs[true], archived: false) }
+    settle(archived, gap)
+  end
+
+  def messages = @messages ||= Array(processed_params[:messages])
+  def batch = @batch ||= messages.select { |raw| writable?(raw) }
   def requested = processed_params[:requested]
   def announce = processed_params[:announce]
   def maybe_announcing(&) = announce ? announcing(&) : yield
@@ -91,29 +105,33 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   # The subject rides on the frame (see the bridge's `groupNames`). Absent, this returns
   # nil and the jid is used exactly as before, which is also what a bridge too old to send
   # it produces.
-  def extract_group_name = group_names[extract_group_jid]
+  def extract_group_name = processed_params[:group_name]
 
-  # Renaming is not part of writing rows, and tying it to them would leave numbered
-  # exactly the groups this exists for: their messages are already stored, so the dump that
-  # finally carries their subject has nothing new to file and would stop above this. Ahead
-  # of the write for the same reason -- a batch that turns out to be all duplicates still
-  # got here holding the name.
+  # Clearing the backlog of groups filed under their own jid, which is a different job from
+  # naming the group a dump is currently filing messages for and follows different rules.
   #
-  # Only an existing contact, because that is the whole of what this adds: a group with new
-  # messages is named by `find_or_create_group_contact` on the way in, and one with neither
-  # rows nor a contact has nothing to rename. Silent like the rest of the import, so a
-  # backdated archive does not wake automations by changing a name.
+  # It cannot be tied to writing rows, because the groups it exists for are numbered exactly
+  # when their messages are already stored: the dump that finally carries a subject has
+  # nothing new to file, and every slice of it may be markers besides.
+  #
+  # And it only ever replaces the placeholder. A subject captured when the frame was queued
+  # is not news about a group somebody has already named -- a `groups.update` may have
+  # landed in between, and the frames carry no ordering to tell the two apart, so writing
+  # over a real name here would be a blind second writer on the field. A group that has one
+  # already has the live path keeping it current.
+  #
+  # Silent like the rest of the import, so a backdated archive does not wake automations by
+  # changing a name.
   def rename_group
-    @raw_message = batch.first
+    @raw_message = messages.first
     return unless jid_type == 'group'
+    return if extract_group_name.blank?
 
     contact = inbox.contact_inboxes.find_by(source_id: extract_group_source_id)&.contact
-    return if contact.nil?
+    return if contact.nil? || contact.name != extract_group_source_id
 
     update_group_contact_info(contact)
   end
-
-  def group_names = @group_names ||= (processed_params[:group_names] || {}).with_indifferent_access
 
   # A row that will never become a message: a system marker (`messageStubType`), a revoke
   # or a reaction removal, which mutate a row that has to exist rather than adding one and
@@ -136,7 +154,7 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   # in one message and by LID in the next, and the live path locks by whichever one its
   # message happened to carry.
   def lock_ids
-    @raw_message = batch.first
+    @raw_message = messages.first
     return [extract_group_jid] if jid_type == 'group'
 
     [extract_from_jid(type: 'pn'), extract_from_jid(type: 'lid')]

--- a/app/services/whatsapp/baileys/history_importer.rb
+++ b/app/services/whatsapp/baileys/history_importer.rb
@@ -81,6 +81,19 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   def watermark = processed_params[:watermark]
   def inbound = Whatsapp::Session::Inbound
 
+  # The live path answers this with nil -- a `messages.upsert` says nothing about what the
+  # group is called, and the subject arrives on its own through `groups.update`. A dump has
+  # no such event behind it, so an imported group was filed under its own jid and only a
+  # later live event ever fixed it: 34 of 46 groups on a real pairing, and the twelve that
+  # escaped were the ones somebody happened to write in afterwards.
+  #
+  # The subject rides on the frame (see the bridge's `groupNames`). Absent, this returns
+  # nil and the jid is used exactly as before, which is also what a bridge too old to send
+  # it produces.
+  def extract_group_name = group_names[extract_group_jid]
+
+  def group_names = @group_names ||= (processed_params[:group_names] || {}).with_indifferent_access
+
   # A row that will never become a message: a system marker (`messageStubType`), a revoke
   # or a reaction removal, which mutate a row that has to exist rather than adding one and
   # replayed out of a dump would either no-op or act on a row a later message in the same

--- a/app/services/whatsapp/baileys/history_importer.rb
+++ b/app/services/whatsapp/baileys/history_importer.rb
@@ -51,10 +51,11 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
       inbox, lock_ids, ttl: inbound::Locks::IMPORT_CHAT_LOCK_TTL, defer_to_waiters: true
     ) do
       pending = unstored(batch.sort_by { |raw| timestamp_of(raw) })
-      next if pending.empty?
-
       runs = pending.group_by { |raw| gap?(raw) }
       Import::SilentWrite.wrap do
+        rename_group
+        next if pending.empty?
+
         # Archive first: the two halves land in different threads, and the older one has
         # to exist before the reopen policy is asked which thread is current.
         # An unrequested pile keeps only its gap. The phone offers its whole history at
@@ -91,6 +92,26 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   # nil and the jid is used exactly as before, which is also what a bridge too old to send
   # it produces.
   def extract_group_name = group_names[extract_group_jid]
+
+  # Renaming is not part of writing rows, and tying it to them would leave numbered
+  # exactly the groups this exists for: their messages are already stored, so the dump that
+  # finally carries their subject has nothing new to file and would stop above this. Ahead
+  # of the write for the same reason -- a batch that turns out to be all duplicates still
+  # got here holding the name.
+  #
+  # Only an existing contact, because that is the whole of what this adds: a group with new
+  # messages is named by `find_or_create_group_contact` on the way in, and one with neither
+  # rows nor a contact has nothing to rename. Silent like the rest of the import, so a
+  # backdated archive does not wake automations by changing a name.
+  def rename_group
+    @raw_message = batch.first
+    return unless jid_type == 'group'
+
+    contact = inbox.contact_inboxes.find_by(source_id: extract_group_source_id)&.contact
+    return if contact.nil?
+
+    update_group_contact_info(contact)
+  end
 
   def group_names = @group_names ||= (processed_params[:group_names] || {}).with_indifferent_access
 

--- a/app/services/whatsapp/baileys/history_importer.rb
+++ b/app/services/whatsapp/baileys/history_importer.rb
@@ -46,6 +46,12 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   def perform
     @opened = Set.new
     return if messages.empty?
+    # The kill switch, asked once for the whole batch rather than at each write. A dump is
+    # not filtered by the bridge the way live traffic is, so a build that handles no groups
+    # is still sent theirs -- and everything this class would do with them, filing rows and
+    # naming the chat alike, is group processing. Asked here so there is one answer: the
+    # rename below is a write of its own and would otherwise reach a subsystem that is off.
+    return if group? && !Whatsapp::Providers::WhatsappBaileysService.groups_enabled?
 
     Whatsapp::Session::Inbound::Locks.with_chat_lock(
       inbox, lock_ids, ttl: inbound::Locks::IMPORT_CHAT_LOCK_TTL, defer_to_waiters: true
@@ -134,8 +140,7 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   # Silent like the rest of the import, so a backdated archive does not wake automations by
   # changing a name.
   def rename_group
-    @raw_message = messages.first
-    return unless jid_type == 'group'
+    return unless group?
     return if extract_group_name.blank?
 
     contact = inbox.contact_inboxes.find_by(source_id: extract_group_source_id)&.contact
@@ -165,10 +170,16 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   # in one message and by LID in the next, and the live path locks by whichever one its
   # message happened to carry.
   def lock_ids
-    @raw_message = messages.first
-    return [extract_group_jid] if jid_type == 'group'
+    return [extract_group_jid] if group?
 
     [extract_from_jid(type: 'pn'), extract_from_jid(type: 'lid')]
+  end
+
+  # One batch is one chat: the handler groups a frame by `remoteJid` before enqueueing it,
+  # so the first message answers this for all of them.
+  def group?
+    @raw_message = messages.first
+    jid_type == 'group'
   end
 
   # One query for the chat rather than one per message, and inside the lock, so a
@@ -220,8 +231,6 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   # A group is the one chat whose author changes from message to message, so its sender is
   # resolved per message while the group contact and its thread are resolved once.
   def import_group_run(run, archived)
-    return [] unless Whatsapp::Providers::WhatsappBaileysService.groups_enabled?
-
     @group_contact_inbox, @group_contact = find_or_create_group_contact
     conversation = track(conversation_for(@group_contact_inbox, run.first, archived))
 

--- a/app/services/whatsapp/baileys/history_importer.rb
+++ b/app/services/whatsapp/baileys/history_importer.rb
@@ -107,18 +107,29 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
   # it produces.
   def extract_group_name = processed_params[:group_name]
 
+  # What an import may do to a group's name, and it is the same answer on both paths that
+  # reach here: name a group that has none, and leave alone one that has.
+  #
+  # The subject was read when the frame was queued, and the frames carry no ordering. A
+  # `groups.update` may have landed in between and is then the fresher fact, which this has
+  # no way to see -- so writing over a real name would make the import a second writer on
+  # the field, blind to the first. A group that has a name has the live path keeping it
+  # current; a group that has only its jid has nobody.
+  #
+  # Only the name is withheld. `group_type` is a fact about the chat rather than a race.
+  def update_group_contact_info(contact)
+    return super if contact.name.blank? || contact.name == extract_group_source_id
+
+    contact.update!(group_type: :group) unless contact.group_type_group?
+  end
+
   # Clearing the backlog of groups filed under their own jid, which is a different job from
-  # naming the group a dump is currently filing messages for and follows different rules.
+  # naming the group a dump is currently filing messages for, even though the rule above is
+  # shared.
   #
   # It cannot be tied to writing rows, because the groups it exists for are numbered exactly
   # when their messages are already stored: the dump that finally carries a subject has
   # nothing new to file, and every slice of it may be markers besides.
-  #
-  # And it only ever replaces the placeholder. A subject captured when the frame was queued
-  # is not news about a group somebody has already named -- a `groups.update` may have
-  # landed in between, and the frames carry no ordering to tell the two apart, so writing
-  # over a real name here would be a blind second writer on the field. A group that has one
-  # already has the live path keeping it current.
   #
   # Silent like the rest of the import, so a backdated archive does not wake automations by
   # changing a name.
@@ -128,7 +139,7 @@ class Whatsapp::Baileys::HistoryImporter < Whatsapp::IncomingMessageBaileysServi
     return if extract_group_name.blank?
 
     contact = inbox.contact_inboxes.find_by(source_id: extract_group_source_id)&.contact
-    return if contact.nil? || contact.name != extract_group_source_id
+    return if contact.nil?
 
     update_group_contact_info(contact)
   end

--- a/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
+++ b/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
@@ -63,15 +63,23 @@ module Whatsapp::BaileysHandlers::MessagingHistorySet
     # so without this an imported group is filed under its own jid and stays that way until
     # somebody writes in it: 34 of 46 groups on a real pairing.
     group_names = Array(data[:groupNames]).to_h
-    # Left off the payload when it is empty, which is every dump from a bridge that does not
-    # send subjects yet -- the two ship separately, so that is a period and not a corner.
-    # A worker from before this keyword raises ArgumentError on it, and the deploy that
-    # replaces it does not empty the queue first.
-    filing = { announce: announce }
-    filing[:group_names] = group_names if group_names.present?
-    batches.each_value do |batch|
-      Whatsapp::Baileys::HistoryImportJob.perform_later(inbox, batch, watermark, requested, **filing)
+    batches.each do |jid, batch|
+      Whatsapp::Baileys::HistoryImportJob.perform_later(inbox, batch, watermark, requested, **filing(announce, group_names[jid]))
     end
+  end
+
+  # One chat's name and not the dump's whole map: a job is enqueued per chat per frame, so
+  # the map would be serialized into Redis once per batch, and most of those batches are
+  # not even groups.
+  #
+  # Left off entirely when there is nothing to say, which is every dump from a bridge that
+  # does not send subjects yet -- the two ship separately, so that is a period and not a
+  # corner. A worker from before this keyword raises ArgumentError on it, and the deploy
+  # that replaces it does not empty the queue first.
+  def filing(announce, group_name)
+    filing = { announce: announce }
+    filing[:group_name] = group_name if group_name.present?
+    filing
   end
 
   # WhatsApp saying a chat has nothing older left, which it says on the answer to a

--- a/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
+++ b/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
@@ -63,10 +63,14 @@ module Whatsapp::BaileysHandlers::MessagingHistorySet
     # so without this an imported group is filed under its own jid and stays that way until
     # somebody writes in it: 34 of 46 groups on a real pairing.
     group_names = Array(data[:groupNames]).to_h
+    # Left off the payload when it is empty, which is every dump from a bridge that does not
+    # send subjects yet -- the two ship separately, so that is a period and not a corner.
+    # A worker from before this keyword raises ArgumentError on it, and the deploy that
+    # replaces it does not empty the queue first.
+    filing = { announce: announce }
+    filing[:group_names] = group_names if group_names.present?
     batches.each_value do |batch|
-      Whatsapp::Baileys::HistoryImportJob.perform_later(
-        inbox, batch, watermark, requested, announce: announce, group_names: group_names
-      )
+      Whatsapp::Baileys::HistoryImportJob.perform_later(inbox, batch, watermark, requested, **filing)
     end
   end
 

--- a/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
+++ b/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
@@ -59,8 +59,14 @@ module Whatsapp::BaileysHandlers::MessagingHistorySet
     # announced rather than filed in silence -- otherwise the press does nothing visible
     # until the page is reloaded. Every other type is the phone volunteering.
     announce = sync_type.to_i == ON_DEMAND
+    # What the groups in this dump are called. A dump strips `groupName` from the messages,
+    # so without this an imported group is filed under its own jid and stays that way until
+    # somebody writes in it: 34 of 46 groups on a real pairing.
+    group_names = Array(data[:groupNames]).to_h
     batches.each_value do |batch|
-      Whatsapp::Baileys::HistoryImportJob.perform_later(inbox, batch, watermark, requested, announce: announce)
+      Whatsapp::Baileys::HistoryImportJob.perform_later(
+        inbox, batch, watermark, requested, announce: announce, group_names: group_names
+      )
     end
   end
 

--- a/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
+++ b/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
@@ -72,10 +72,16 @@ module Whatsapp::BaileysHandlers::MessagingHistorySet
   # the map would be serialized into Redis once per batch, and most of those batches are
   # not even groups.
   #
-  # Left off entirely when there is nothing to say, which is every dump from a bridge that
-  # does not send subjects yet -- the two ship separately, so that is a period and not a
-  # corner. A worker from before this keyword raises ArgumentError on it, and the deploy
-  # that replaces it does not empty the queue first.
+  # Left off entirely when there is nothing to say. A worker from before this keyword raises
+  # ArgumentError on it, and that covers the one window where the two are guaranteed to
+  # disagree: this half and the bridge half ship separately, so between them every dump
+  # arrives with no subjects at all.
+  #
+  # It does not cover a rollback or the overlap of a deploy, where a named group can reach a
+  # worker that predates the keyword. That batch fails and lands in the dead set with its
+  # payload intact, to be re-driven; a signature is a serialization contract, and the only
+  # thing that would close that window is shipping the tolerant worker a release ahead of
+  # the producer.
   def filing(announce, group_name)
     filing = { announce: announce }
     filing[:group_name] = group_name if group_name.present?

--- a/spec/services/whatsapp/baileys/history_importer_spec.rb
+++ b/spec/services/whatsapp/baileys/history_importer_spec.rb
@@ -392,6 +392,20 @@ describe Whatsapp::Baileys::HistoryImporter do
       expect(inbox.messages.find_by(source_id: 'REAL').conversation.contact.name).to eq('Nome atual')
     end
 
+    # The kill switch is about the subsystem and not about writing rows. A dump reaches a
+    # build that handles no groups either way -- the bridge filters live traffic, not
+    # history -- and renaming the contact an earlier pairing left behind is as much group
+    # processing as filing the messages is.
+    it 'leaves the group alone when the build handles no groups' do
+      import([group_message('FIRST')], watermark: 3.days.ago)
+      allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:groups_enabled?).and_return(false)
+
+      import([group_message('SECOND')], watermark: 3.days.ago, group_name: 'Obra da casa')
+
+      expect(inbox.messages.find_by(source_id: 'FIRST').conversation.contact.name).to eq('120363000000000000')
+      expect(inbox.messages.pluck(:source_id)).to eq(%w[FIRST])
+    end
+
     # The same rule on the other path in: a frame that does have messages to file goes
     # through `find_or_create_group_contact`, which renames unconditionally. An import must
     # not overwrite a name there either, and the stale subject is just as stale.

--- a/spec/services/whatsapp/baileys/history_importer_spec.rb
+++ b/spec/services/whatsapp/baileys/history_importer_spec.rb
@@ -391,6 +391,17 @@ describe Whatsapp::Baileys::HistoryImporter do
 
       expect(inbox.messages.find_by(source_id: 'REAL').conversation.contact.name).to eq('Nome atual')
     end
+
+    # The same rule on the other path in: a frame that does have messages to file goes
+    # through `find_or_create_group_contact`, which renames unconditionally. An import must
+    # not overwrite a name there either, and the stale subject is just as stale.
+    it 'leaves a named group alone even when the frame has messages to file' do
+      import([group_message('REAL')], watermark: 3.days.ago, group_name: 'Nome atual')
+
+      import([group_message('NOVA')], watermark: 3.days.ago, group_name: 'Nome de ontem')
+
+      expect(inbox.messages.find_by(source_id: 'NOVA').conversation.contact.name).to eq('Nome atual')
+    end
   end
 
   # Not filed: they mutate a row that has to exist, and replaying them out of a dump either

--- a/spec/services/whatsapp/baileys/history_importer_spec.rb
+++ b/spec/services/whatsapp/baileys/history_importer_spec.rb
@@ -356,6 +356,16 @@ describe Whatsapp::Baileys::HistoryImporter do
 
       expect(inbox.messages.find_by(source_id: 'FIRST').conversation.contact.name).to eq('Obra da casa')
     end
+
+    # And this is the shape that backlog actually arrives in: the group is numbered
+    # precisely because its messages are already stored, so the dump that finally names it
+    # has nothing new to file. Renaming only alongside a write would skip every one of them.
+    it 'renames a group whose dump carries nothing it has not already stored' do
+      import([group_message('ONLY')], watermark: 3.days.ago)
+      import([group_message('ONLY')], watermark: 3.days.ago, group_names: { group_jid => 'Obra da casa' })
+
+      expect(inbox.messages.find_by(source_id: 'ONLY').conversation.contact.name).to eq('Obra da casa')
+    end
   end
 
   # Not filed: they mutate a row that has to exist, and replaying them out of a dump either

--- a/spec/services/whatsapp/baileys/history_importer_spec.rb
+++ b/spec/services/whatsapp/baileys/history_importer_spec.rb
@@ -22,10 +22,10 @@ describe Whatsapp::Baileys::HistoryImporter do
     }.with_indifferent_access
   end
 
-  def import(messages, watermark: nil, requested: true, group_names: {})
+  def import(messages, watermark: nil, requested: true, group_name: nil)
     described_class.new(
       inbox: inbox,
-      params: { messages: messages, watermark: watermark, requested: requested, group_names: group_names }
+      params: { messages: messages, watermark: watermark, requested: requested, group_name: group_name }
     ).perform
   end
 
@@ -335,7 +335,7 @@ describe Whatsapp::Baileys::HistoryImporter do
     end
 
     it 'takes the subject the dump carries' do
-      import([group_message('GRP')], watermark: 3.days.ago, group_names: { group_jid => 'Obra da casa' })
+      import([group_message('GRP')], watermark: 3.days.ago, group_name: 'Obra da casa')
 
       expect(inbox.messages.find_by(source_id: 'GRP').conversation.contact.name).to eq('Obra da casa')
     end
@@ -352,7 +352,7 @@ describe Whatsapp::Baileys::HistoryImporter do
     # from an earlier pairing are the whole backlog this has to clear.
     it 'renames a group an earlier import left under its jid' do
       import([group_message('FIRST')], watermark: 3.days.ago)
-      import([group_message('SECOND')], watermark: 3.days.ago, group_names: { group_jid => 'Obra da casa' })
+      import([group_message('SECOND')], watermark: 3.days.ago, group_name: 'Obra da casa')
 
       expect(inbox.messages.find_by(source_id: 'FIRST').conversation.contact.name).to eq('Obra da casa')
     end
@@ -362,9 +362,34 @@ describe Whatsapp::Baileys::HistoryImporter do
     # has nothing new to file. Renaming only alongside a write would skip every one of them.
     it 'renames a group whose dump carries nothing it has not already stored' do
       import([group_message('ONLY')], watermark: 3.days.ago)
-      import([group_message('ONLY')], watermark: 3.days.ago, group_names: { group_jid => 'Obra da casa' })
+      import([group_message('ONLY')], watermark: 3.days.ago, group_name: 'Obra da casa')
 
       expect(inbox.messages.find_by(source_id: 'ONLY').conversation.contact.name).to eq('Obra da casa')
+    end
+
+    # Markers are the ordinary content of a numbered group's slice, not an exception: 519 of
+    # 614 threads on a real pairing had nothing else. A rename that waited for something
+    # writable would skip most of the backlog it exists to clear.
+    it 'renames a group whose whole slice is markers' do
+      import([group_message('REAL')], watermark: 3.days.ago)
+      marker = group_message('STUB').merge('messageStubType' => 2)
+
+      import([marker], watermark: 3.days.ago, group_name: 'Obra da casa')
+
+      expect(inbox.messages.find_by(source_id: 'REAL').conversation.contact.name).to eq('Obra da casa')
+    end
+
+    # The subject was read when the frame was queued, and the frames carry no ordering: a
+    # `groups.update` may have renamed the group in between, and this has no way to tell.
+    # So it only ever replaces the placeholder -- a group that already has a name has the
+    # live path keeping it current, and a blind second writer on that field would undo it.
+    it 'leaves a group that already has a name alone' do
+      import([group_message('REAL')], watermark: 3.days.ago, group_name: 'Nome atual')
+      marker = group_message('STUB').merge('messageStubType' => 2)
+
+      import([marker], watermark: 3.days.ago, group_name: 'Nome de ontem')
+
+      expect(inbox.messages.find_by(source_id: 'REAL').conversation.contact.name).to eq('Nome atual')
     end
   end
 

--- a/spec/services/whatsapp/baileys/history_importer_spec.rb
+++ b/spec/services/whatsapp/baileys/history_importer_spec.rb
@@ -22,10 +22,10 @@ describe Whatsapp::Baileys::HistoryImporter do
     }.with_indifferent_access
   end
 
-  def import(messages, watermark: nil, requested: true)
+  def import(messages, watermark: nil, requested: true, group_names: {})
     described_class.new(
       inbox: inbox,
-      params: { messages: messages, watermark: watermark, requested: requested }
+      params: { messages: messages, watermark: watermark, requested: requested, group_names: group_names }
     ).perform
   end
 
@@ -315,6 +315,46 @@ describe Whatsapp::Baileys::HistoryImporter do
       sender = inbox.messages.find_by(source_id: 'GRP').sender
       expect(sender.phone_number).to be_nil
       expect(sender.identifier).to eq("#{lid}@lid")
+    end
+  end
+
+  # A dump strips `groupName` from every message, and no `groups.update` follows it, so
+  # before this an imported group was filed under its own jid and only a later live event
+  # ever fixed it: 34 of 46 groups on a real pairing.
+  describe 'what an imported group is called' do
+    let(:group_jid) { '120363000000000000@g.us' }
+
+    before { allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:groups_enabled?).and_return(true) }
+
+    def group_message(id)
+      {
+        key: { id: id, remoteJid: group_jid, participant: jid, fromMe: false },
+        messageTimestamp: 10.days.ago.to_i,
+        message: { conversation: "in the group, #{id}" }
+      }.with_indifferent_access
+    end
+
+    it 'takes the subject the dump carries' do
+      import([group_message('GRP')], watermark: 3.days.ago, group_names: { group_jid => 'Obra da casa' })
+
+      expect(inbox.messages.find_by(source_id: 'GRP').conversation.contact.name).to eq('Obra da casa')
+    end
+
+    # What a bridge too old to send the subjects produces, and what every import did before
+    # this: the group is still filed, it just has nothing to be called by.
+    it 'falls back to the jid when the dump names no group' do
+      import([group_message('GRP')], watermark: 3.days.ago)
+
+      expect(inbox.messages.find_by(source_id: 'GRP').conversation.contact.name).to eq('120363000000000000')
+    end
+
+    # The frames of one dump are separate jobs, and the groups already sitting under a jid
+    # from an earlier pairing are the whole backlog this has to clear.
+    it 'renames a group an earlier import left under its jid' do
+      import([group_message('FIRST')], watermark: 3.days.ago)
+      import([group_message('SECOND')], watermark: 3.days.ago, group_names: { group_jid => 'Obra da casa' })
+
+      expect(inbox.messages.find_by(source_id: 'FIRST').conversation.contact.name).to eq('Obra da casa')
     end
   end
 

--- a/spec/services/whatsapp/baileys_handlers/messaging_history_set_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messaging_history_set_spec.rb
@@ -59,7 +59,7 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
               groupNames: { group_jid => 'Obra da casa' } })
 
     expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(
-      inbox, anything, anything, anything, hash_including(group_names: { group_jid => 'Obra da casa' })
+      inbox, anything, anything, anything, hash_including(group_name: 'Obra da casa')
     )
   end
 

--- a/spec/services/whatsapp/baileys_handlers/messaging_history_set_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messaging_history_set_spec.rb
@@ -48,6 +48,38 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
     end
   end
 
+  # The subject travels on the frame because the messages do not carry it, and it has to
+  # survive the trip through the queue: an argument list is a serialization contract, and
+  # the group would otherwise reach the importer nameless after a round trip that looked
+  # fine in every unit test.
+  it 'hands the worker what the groups in the dump are called' do
+    group_jid = '120363000000000000@g.us'
+
+    perform({ syncType: 3, messages: [raw_message('A', group_jid)],
+              groupNames: { group_jid => 'Obra da casa' } })
+
+    expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(
+      inbox, anything, anything, anything, hash_including(group_names: { group_jid => 'Obra da casa' })
+    )
+  end
+
+  # The same claim, made against the round trip rather than the call: the enqueue above
+  # reads the arguments in memory, where a keyword that the queue mangles still looks right.
+  it 'names the group once the worker has run' do
+    group_jid = '120363000000000000@g.us'
+    allow(Whatsapp::Providers::WhatsappBaileysService).to receive(:groups_enabled?).and_return(true)
+
+    perform_enqueued_jobs(only: Whatsapp::Baileys::HistoryImportJob) do
+      # ON_DEMAND, so the archive half is kept: this inbox never asked for standing consent
+      # and the dump has no coverage to sit newer than.
+      perform({ syncType: 6,
+                messages: [raw_message('A', group_jid).deep_merge(key: { participant: '5511912345678@s.whatsapp.net' })],
+                groupNames: { group_jid => 'Obra da casa' } })
+    end
+
+    expect(inbox.messages.find_by(source_id: 'A').conversation.contact.name).to eq('Obra da casa')
+  end
+
   # One job per chat, so a chat locked by live traffic retries alone instead of holding up
   # the rest of the import.
   it 'hands each chat to its own worker' do
@@ -80,7 +112,7 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
     it 'counts an on-demand answer as requested' do
       perform({ syncType: 6, messages: [raw_message('A', '5511912345678@s.whatsapp.net')] })
 
-      expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(inbox, anything, anything, true, announce: anything)
+      expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(inbox, anything, anything, true, hash_including(announce: anything))
     end
 
     it 'counts standing consent on the inbox as requested' do
@@ -88,7 +120,7 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
 
       perform({ syncType: 0, messages: [raw_message('A', '5511912345678@s.whatsapp.net')] })
 
-      expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(inbox, anything, anything, true, announce: anything)
+      expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(inbox, anything, anything, true, hash_including(announce: anything))
     end
 
     it 'counts an open backfill window as requested, and holds it open for the next frame' do
@@ -96,7 +128,7 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
 
       perform({ syncType: 0, messages: [raw_message('A', '5511912345678@s.whatsapp.net')] })
 
-      expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(inbox, anything, anything, true, announce: anything)
+      expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(inbox, anything, anything, true, hash_including(announce: anything))
       expect(Whatsapp::Session::HistoryBackfill.pending?(whatsapp_channel)).to be(true)
     end
 
@@ -105,7 +137,7 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
     it 'is unrequested when the phone volunteered it' do
       perform({ syncType: 0, messages: [raw_message('A', '5511912345678@s.whatsapp.net')] })
 
-      expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(inbox, anything, anything, false, announce: anything)
+      expect(Whatsapp::Baileys::HistoryImportJob).to have_been_enqueued.with(inbox, anything, anything, false, hash_including(announce: anything))
     end
   end
 
@@ -117,7 +149,7 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
       perform({ syncType: 6, messages: [raw_message('A', '5511912345678@s.whatsapp.net')] })
 
       expect(Whatsapp::Baileys::HistoryImportJob)
-        .to have_been_enqueued.with(inbox, anything, anything, anything, announce: true)
+        .to have_been_enqueued.with(inbox, anything, anything, anything, hash_including(announce: true))
     end
 
     # The pairing dump, which is a year of somebody else's conversations arriving at once
@@ -126,7 +158,7 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
       perform({ syncType: 0, messages: [raw_message('A', '5511912345678@s.whatsapp.net')] })
 
       expect(Whatsapp::Baileys::HistoryImportJob)
-        .to have_been_enqueued.with(inbox, anything, anything, anything, announce: false)
+        .to have_been_enqueued.with(inbox, anything, anything, anything, hash_including(announce: false))
     end
   end
 


### PR DESCRIPTION
Um grupo que entrava pelo histórico aparecia na lista com o número dele no lugar do nome, e continuava assim até alguém escrever no grupo. Agora entra com o nome certo, e os que já estão como número se arrumam no próximo sync.

## Closes

- Closes #460
- Depende de fazer-ai/baileys-api#394, que é de onde o nome passa a vir

## How to reproduce

1. Ligar o `history_sync` numa inbox baileys e parear um número que participe de grupos.
2. Olhar a lista de conversas.

Os grupos aparecem como `120363400000000001`. Medido numa importação real: 34 dos 46 grupos. Os 12 que escaparam foram os que receberam um `groups.update` depois, que é o único caminho que hoje escreve o assunto.

## What changed

`extract_group_name` do caminho baileys sempre devolveu `nil`: uma `messages.upsert` não diz como o grupo se chama, e o assunto chega por conta própria em `groups.update`. Um despejo não tem esse evento atrás dele, então o grupo era criado com o jid e ninguém voltava para corrigir.

- A bridge passa a mandar `groupNames` no frame (PR acima), tirado dos registros de chat do próprio despejo.
- O handler repassa o mapa ao job, e o importador responde `extract_group_name` com o assunto do chat da vez.
- O resto vem de graça do `GroupConversationHandler`: `find_or_create_group_contact` já usa `extract_group_name || source_id`, e `update_group_contact_info` já renomeia um contato cujo nome não bate. Ou seja, os 34 grupos que já estão como número se corrigem sozinhos no próximo despejo que os nomeie.

Sem o mapa, `extract_group_name` volta a devolver `nil` e o jid é usado exatamente como antes. É o que uma bridge velha demais para mandar o campo produz, e é por isso que esta metade pode entrar antes ou depois da outra sem quebrar nada.

A lista de argumentos do job virou `**filing` em vez de mais um keyword: tudo depois de `requested` diz **como** arquivar o despejo e não o que tem dentro, cada entrada precisa de um default para os jobs já enfileirados quando ela subiu, e uma lista de argumentos de job é contrato de serialização. Tem spec fazendo a volta inteira pela fila, porque o `have_been_enqueued` sozinho lê os argumentos em memória, onde um keyword que a fila embaralha ainda parece certo.

## Fora do escopo

O lado uazapi tem o mesmo buraco por outro caminho: o tradutor de histórico dele também não carrega `groupName`, e o `GroupResolver` da camada de sessão responde `extract_group_name` com o `subject` que não vem. Não mexi porque o provedor não expõe os registros de chat do jeito que o Baileys expõe, então a correção lá é outra investigação.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/465)
<!-- Reviewable:end -->
