### PR TITLE
fix(whatsapp): hold the chat lock for the work, not for the wait

### DIFF
--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -1,4 +1,10 @@
 module Whatsapp::IncomingMessageServiceHelpers # rubocop:disable Metrics/ModuleLength
+  # How long a message stands waiting for the chat before it gives up and lets the job come
+  # back for it. Sized by the album it exists for -- the sibling webhooks of one upload land
+  # within a second or two of each other -- and not by how long the work behind the lock
+  # takes, which is what `Locks::CHAT_LOCK_TTL` is for.
+  CONTACT_LOCK_WAIT = 5.seconds
+
   def download_attachment_file(attachment_payload)
     Down.download(inbox.channel.media_url(attachment_payload[:id]), headers: inbox.channel.api_headers)
   end
@@ -211,43 +217,23 @@ module Whatsapp::IncomingMessageServiceHelpers # rubocop:disable Metrics/ModuleL
   # from the same contact arrive simultaneously (e.g., WhatsApp albums).
   # Without this, each message could create its own conversation.
   #
-  # The spin covers what this lock was built for: two messages of the same chat landing
-  # together, where the first is done in well under a second. It does not cover the other
-  # holder of the same key. A history import leases the chat for a whole batch
-  # (`Locks::IMPORT_CHAT_LOCK_TTL`), which is two orders of magnitude longer than any wait
-  # a worker thread should sit through, so giving up is the right answer there -- as long
-  # as giving up means the job comes back. Hence `Locks::Busy`, which the caller retries,
-  # rather than a Timeout::Error nothing was listening for: that one took the message down
-  # with it, and an import runs precisely when a reconnected inbox is receiving again.
-  def with_contact_lock(phone, timeout: 5.seconds)
+  # The same lock the session layer takes, on the same key, and now through the same code:
+  # two implementations of one lock is how the legacy path came to release unconditionally
+  # while the session path released by token, and an overrunning worker here could delete
+  # the lease an import was still writing under.
+  #
+  # `wait` is what this path adds and the only thing it needs of its own. It covers what
+  # the lock was built for: two messages of the same chat landing together, where the first
+  # is done in well under a second, and a job retry a quarter of a minute later would be
+  # worse than a short park. It does not cover the other holder of the same key -- a
+  # history import leases the chat for a whole batch (`Locks::IMPORT_CHAT_LOCK_TTL`), two
+  # orders of magnitude longer than any wait a worker thread should sit through -- so past
+  # the wait it gives up with `Locks::Busy`, which the caller retries, rather than the
+  # Timeout::Error nothing was listening for that used to take the message down with it.
+  def with_contact_lock(phone, wait: CONTACT_LOCK_WAIT, &)
     raise ArgumentError, 'A block is required for with_contact_lock' unless block_given?
     return yield if phone.blank?
 
-    key = "WHATSAPP::CONTACT_LOCK::#{inbox.id}_#{phone}"
-    lock_acquired = spin_for_contact_lock(key, timeout)
-
-    unless lock_acquired
-      # Said out loud, so the import standing between this message and the chat gives way
-      # rather than handing the key to the next batch of its own dump. Without it the
-      # retry budget below is up against a queue of holders and not one.
-      Whatsapp::Session::Inbound::Locks.note_waiter(inbox, phone)
-      raise Whatsapp::Session::Inbound::Locks::Busy, "contact lock for #{phone} of inbox #{inbox.id} is held"
-    end
-
-    yield
-  ensure
-    Redis::Alfred.delete(key) if lock_acquired
-  end
-
-  def spin_for_contact_lock(key, timeout)
-    start_time = Time.now.to_i
-
-    while (Time.now.to_i - start_time) < timeout
-      return true if Redis::Alfred.set(key, 1, nx: true, ex: timeout)
-
-      sleep(0.1)
-    end
-
-    false
+    Whatsapp::Session::Inbound::Locks.with_chat_lock(inbox, phone, wait: wait, &)
   end
 end

--- a/app/services/whatsapp/session/inbound/locks.rb
+++ b/app/services/whatsapp/session/inbound/locks.rb
@@ -40,6 +40,11 @@ module Whatsapp::Session::Inbound::Locks
   # Long enough to cover one processing pass, short enough that a marker orphaned by a
   # killed worker heals on its own within the job's retry budget.
   MESSAGE_LOCK_TTL = 30.seconds
+  # How often a caller that was given a `wait` looks again. Waiting at all is the exception
+  # here -- everything else answers Busy and lets the job retry, so a Sidekiq thread is
+  # never parked on Redis -- and it is granted only for the seconds an album takes to
+  # finish arriving, where a retry a quarter of a minute later is worse than a short park.
+  SPIN_INTERVAL = 0.1
 
   module_function
 
@@ -80,6 +85,12 @@ module Whatsapp::Session::Inbound::Locks
   # operation that outran the TTL (syncing a large group roster is the realistic one)
   # would delete a lock a second worker had already taken.
   #
+  # `ttl` and `wait` are the two numbers a lock has, and conflating them is the failure this
+  # signature exists to prevent: `ttl` is how long the work behind the key may run, `wait`
+  # is how long it is worth standing here to get the key. A `ttl` sized by somebody's
+  # patience expires mid-block, and from there the guarded work runs unguarded. `wait` is
+  # nil by default, so the answer is Busy and the job retries.
+  #
   # `defer_to_waiters` marks the caller as the one that gives way, which an import is and
   # nothing else is. Two things follow from it, and they are the same rule read from both
   # ends: it stands aside while somebody is waiting, and it does not register itself as a
@@ -90,14 +101,15 @@ module Whatsapp::Session::Inbound::Locks
   # that is never free at the moment it looks -- a retry budget covers one holder, and what
   # it is really up against is a queue of them. And an import that noted itself would be
   # standing aside for its own siblings, which is a deadlock spelled differently.
-  def with_chat_lock(inbox, *chats, ttl: CHAT_LOCK_TTL, defer_to_waiters: false)
+  def with_chat_lock(inbox, *chats, ttl: CHAT_LOCK_TTL, wait: nil, defer_to_waiters: false)
     keys = chats.flatten.compact_blank.uniq.sort.map { |chat| chat_key(inbox, chat) }
     return yield if keys.empty?
     raise Busy, "#{keys.first} of inbox #{inbox.id} has a caller waiting on it" if defer_to_waiters && waiting?(inbox, chats)
 
     held = {}
+    note = defer_to_waiters ? nil : waiter_keys(inbox, chats)
     begin
-      take(keys, inbox, ttl, held, note: defer_to_waiters ? nil : chats)
+      take(keys, held, ttl: ttl, deadline: deadline_for(wait), note: note)
       yield
     ensure
       held.each { |key, token| Redis::Alfred.delete_if_equals(key, token) }
@@ -111,7 +123,7 @@ module Whatsapp::Session::Inbound::Locks
   end
 
   def note_waiter(inbox, *chats)
-    waiter_keys(inbox, chats).each { |key| Redis::Alfred.set(key, 1, ex: WAITER_TTL) }
+    mark_waiting(waiter_keys(inbox, chats))
   end
 
   # Kept to the claiming, not wrapped around the block: a Busy raised by something the
@@ -119,18 +131,34 @@ module Whatsapp::Session::Inbound::Locks
   # a chat nobody is actually waiting for.
   #
   # `note` carries the chats to record against, or nil for the caller that gives way.
-  def take(keys, inbox, ttl, held, note:)
-    keys.each { |key| held[key] = claim(key, inbox, ttl) }
+  # nil means take it or answer Busy, which is what every caller but the live inbound path
+  # wants: a Sidekiq thread that parks on Redis is a thread not processing anything else.
+  def deadline_for(wait) = wait && (Time.now.to_f + wait)
+
+  def take(keys, held, ttl:, deadline:, note:)
+    keys.each { |key| held[key] = claim(key, ttl, deadline) }
   rescue Busy
-    note_waiter(inbox, note) if note
+    mark_waiting(note) if note
     raise
   end
 
-  def claim(key, inbox, ttl)
+  # `ttl` is how long the work behind the lock may take; `deadline` is how long it is worth
+  # standing here to get it. They are unrelated numbers, and the one bug this module exists
+  # to not have is a lock that expires while the block it guards is still running.
+  def claim(key, ttl, deadline)
     token = SecureRandom.uuid
-    raise Busy, "#{key} of inbox #{inbox.id} is locked" unless Redis::Alfred.set(key, token, nx: true, ex: ttl)
+    loop do
+      return token if Redis::Alfred.set(key, token, nx: true, ex: ttl)
+      break if deadline.nil? || Time.now.to_f >= deadline
 
-    token
+      sleep(SPIN_INTERVAL)
+    end
+
+    raise Busy, "#{key} is locked"
+  end
+
+  def mark_waiting(keys)
+    keys.each { |key| Redis::Alfred.set(key, 1, ex: WAITER_TTL) }
   end
 
   def processing?(inbox, message_id)

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -237,7 +237,37 @@ describe Whatsapp::IncomingMessageService do
 
         described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
 
-        expect(Redis::Alfred).to have_received(:set).with(contact_lock_key, 1, nx: true, ex: 5.seconds)
+        expect(Redis::Alfred).to have_received(:set).with(contact_lock_key, anything, nx: true, ex: 30.seconds)
+      end
+
+      # The two numbers used to be one, and five seconds was the wait: a message with an
+      # attachment to download outran its own lock and the block went on running unguarded,
+      # which is the race the lock exists for happening inside it.
+      it 'holds the chat for the work and not for the wait' do
+        phone_number = '2423423243'
+        service = described_class.new(inbox: whatsapp_channel.inbox, params: params)
+
+        service.with_contact_lock(phone_number, wait: 0.2.seconds) do
+          expect(Redis::Alfred.ttl("WHATSAPP::CONTACT_LOCK::#{whatsapp_channel.inbox.id}_#{phone_number}"))
+            .to be > 0.2
+        end
+      end
+
+      # And the release is by token, so a block that did outrun its lock cannot free the key
+      # a second worker already holds -- an import's five-minute lease being the one that
+      # matters, since deleting it lets a live message open a conversation beside the one
+      # being filled.
+      it 'leaves a lock another worker took over in place' do
+        phone_number = '2423423243'
+        key = "WHATSAPP::CONTACT_LOCK::#{whatsapp_channel.inbox.id}_#{phone_number}"
+        service = described_class.new(inbox: whatsapp_channel.inbox, params: params)
+
+        service.with_contact_lock(phone_number) do
+          Redis::Alfred.delete(key)
+          Redis::Alfred.set(key, 'another-worker', ex: 30)
+        end
+
+        expect(Redis::Alfred.get(key)).to eq('another-worker')
       end
 
       it 'gives up on a held contact lock with an error the job retries' do
@@ -249,7 +279,7 @@ describe Whatsapp::IncomingMessageService do
         Redis::Alfred.set("WHATSAPP::CONTACT_LOCK::#{whatsapp_channel.inbox.id}_#{phone_number}", 1)
         service = described_class.new(inbox: whatsapp_channel.inbox, params: params)
 
-        expect { service.with_contact_lock(phone_number, timeout: 0.2.seconds) { raise 'ran the block' } }
+        expect { service.with_contact_lock(phone_number, wait: 0.2.seconds) { raise 'ran the block' } }
           .to raise_error(Whatsapp::Session::Inbound::Locks::Busy)
       end
 

--- a/spec/services/whatsapp/session/inbound/locks_spec.rb
+++ b/spec/services/whatsapp/session/inbound/locks_spec.rb
@@ -61,6 +61,48 @@ RSpec.describe Whatsapp::Session::Inbound::Locks do
     end
   end
 
+  # Two numbers, not one. The live inbound path is the only caller that stands and waits,
+  # and it waits for the seconds an album takes to finish arriving -- which says nothing
+  # about how long the work behind the key runs once it has it.
+  describe 'waiting for a chat' do
+    it 'answers Busy without waiting when it was given no wait' do
+      Redis::Alfred.set(described_class.chat_key(inbox, chat), 'other', ex: 30)
+
+      elapsed = Benchmark.realtime do
+        expect { described_class.with_chat_lock(inbox, chat) { :never } }.to raise_error(described_class::Busy)
+      end
+
+      expect(elapsed).to be < 0.1
+    end
+
+    it 'takes the chat when the holder releases it inside the wait' do
+      key = described_class.chat_key(inbox, chat)
+      Redis::Alfred.set(key, 'other', ex: 30)
+      Thread.new do
+        sleep(0.2)
+        Redis::Alfred.delete(key)
+      end
+
+      expect(described_class.with_chat_lock(inbox, chat, wait: 2.seconds) { :taken }).to eq(:taken)
+    end
+
+    it 'gives up once the wait is spent' do
+      Redis::Alfred.set(described_class.chat_key(inbox, chat), 'other', ex: 30)
+
+      expect { described_class.with_chat_lock(inbox, chat, wait: 0.2.seconds) { :never } }
+        .to raise_error(described_class::Busy)
+    end
+
+    # The whole point of separating them: a caller that waited a moment still holds the key
+    # for as long as its own work needs, and a lock that expires under the block it guards
+    # is not a lock.
+    it 'holds the chat for its ttl and not for what it waited' do
+      described_class.with_chat_lock(inbox, chat, wait: 0.2.seconds, ttl: 45.seconds) do
+        expect(Redis::Alfred.ttl(described_class.chat_key(inbox, chat))).to be > 40
+      end
+    end
+  end
+
   describe '.with_message_lock' do
     it 'releases the marker so a later pass can run' do
       described_class.with_message_lock(inbox, message_id) { :first }


### PR DESCRIPTION
An inbound WhatsApp message locks its chat so two messages of the same conversation cannot each open their own. That lock was expiring while the message it protected was still being processed: a message carrying an attachment spends longer downloading it than the lock lasted, and from there the work ran with no lock at all, which is the race the lock exists for happening inside it. A second message of the same chat could then take the key and open a conversation beside the one being written.

The same method also freed the key without checking it still owned it, so a block that had already outrun its lock deleted whatever the next holder had taken. With history imports now leasing that same key for five minutes at a time, that was a live message quietly unlocking an import mid-batch.

## Closes

- Closes #464

## How to reproduce

Send a message with an image to a WhatsApp inbox and watch `WHATSAPP::CONTACT_LOCK::<inbox>_<phone>` in Redis: before this the key was gone while the message was still being written, since the download alone outlasts the five seconds the lock was given. Send two messages of the same chat a few seconds apart, the second while the first is still downloading, and both find no conversation and open one.

## What changed

`with_contact_lock` no longer implements a lock of its own. It calls `Session::Inbound::Locks.with_chat_lock`, which was already locking the exact same key, and which releases by token. Two implementations of one lock on one key is how the two came to disagree about releasing in the first place.

`with_chat_lock` gains `wait:`, the only thing the live path needed that the session layer did not have. It is nil everywhere else, so every other caller still answers `Busy` immediately and lets the job retry rather than parking a Sidekiq thread on Redis. `ttl` and `wait` are now separate numbers: 30 seconds of holding, 5 seconds of waiting, sized by the work and by the album respectively.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/466)
<!-- Reviewable:end -->
