### PR TITLE
fix(automation): stop an attribute_changed rule from raising on an untouched attribute

### DIFF
--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -92,11 +92,23 @@ class AutomationRules::ConditionsFilterService < FilterService
       @changed_attributes = @changed_attributes.with_indifferent_access
       changed_attribute = @changed_attributes[filter['attribute_key']].presence
 
-      if changed_attribute[0].in?(filter['values']['from']) && changed_attribute[1].in?(filter['values']['to'])
+      if changed_from_to?(changed_attribute, filter)
         @attribute_changed_records = attribute_changed_filter_query(filter, records, current_attribute_changed_record)
       end
       current_attribute_changed_record = @attribute_changed_records
     end
+  end
+
+  # An event that never touched the attribute is this condition not being met, which is the
+  # same answer as an event that touched it and moved it somewhere the filter does not ask
+  # for -- and not the same as the filter not being there. The loop still has to hand the
+  # set it has accumulated to the next filter: skipping the iteration outright would leave
+  # the next one combining against every conversation in the account, which for an OR is a
+  # rule that fires on all of them.
+  def changed_from_to?(changed_attribute, filter)
+    return false if changed_attribute.blank?
+
+    changed_attribute[0].in?(filter['values']['from']) && changed_attribute[1].in?(filter['values']['to'])
   end
 
   # We intersect with the record if query_operator-AND is present and union if query_operator-OR is present

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -88,45 +88,28 @@ class AutomationRules::ConditionsFilterService < FilterService
 
   # Loop through attribute_changed_query_filter
   def filter_based_on_attribute_change(records, current_attribute_changed_record)
-    @attribute_changed_query_filter.each_with_index do |filter, index|
-      unless condition_met?(filter)
-        # A condition that is not met and joined to another by AND makes that conjunction
-        # false whatever the rest of the chain says, so there is nothing left to fold.
-        # Passing over it instead is how a rule asking for two changes came to fire on one
-        # of them: the next filter unions against the set accumulated so far and carries the
-        # rule on its own.
-        return @attribute_changed_records = [] if conjunctive?(index)
+    @attribute_changed_query_filter.each do |filter|
+      changed_attribute = @changed_attributes.with_indifferent_access[filter['attribute_key']].presence
+      # An event that changed something else carries nothing under this filter's key, and
+      # the line below used to index that nil. `perform`'s rescue swallowed the
+      # NoMethodError, so the rule was abandoned here with its remaining conditions never
+      # evaluated and the whole evaluation answered false -- hundreds of times a day on an
+      # account with one such rule, with a log line the only thing to show for it.
+      #
+      # Answering false directly is what that exception already amounted to, and it is
+      # deliberately all this does: it is not the right answer for a rule whose other
+      # conditions could still be met on their own, but working that out is not something
+      # this method can do. It folds the two halves of a rule -- the conditions that became
+      # SQL and the ones that can only be asked of the event -- after `perform` has already
+      # dropped where each sat in the chain, so `A AND B OR C` cannot be told from
+      # `A AND (B OR C)` here. See #468.
+      return @attribute_changed_records = [] if changed_attribute.blank?
 
-        next
+      if changed_attribute[0].in?(filter['values']['from']) && changed_attribute[1].in?(filter['values']['to'])
+        @attribute_changed_records = attribute_changed_filter_query(filter, records, current_attribute_changed_record)
       end
-
-      @attribute_changed_records = attribute_changed_filter_query(filter, records, current_attribute_changed_record)
       current_attribute_changed_record = @attribute_changed_records
     end
-  end
-
-  # Whether this condition is joined to a neighbour by AND. The operator sits on the
-  # condition it joins forward from, so a condition is conjunctive through its own operator
-  # or through the one before it -- the last condition in a rule carries none and is bound
-  # backwards only.
-  def conjunctive?(index)
-    return true if and_join?(@attribute_changed_query_filter[index])
-
-    index.positive? && and_join?(@attribute_changed_query_filter[index - 1])
-  end
-
-  def and_join?(filter) = filter['query_operator'].to_s.casecmp('AND').zero?
-
-  # An event that never touched the attribute is this condition not being met, which is the
-  # same answer as an event that moved it somewhere the filter does not ask for, because it
-  # is the same statement about the event. It used to be `nil[0]`: a NoMethodError swallowed
-  # by `perform`'s rescue, which abandoned the rule with its remaining conditions never
-  # evaluated and left nothing behind but a log line.
-  def condition_met?(filter)
-    changed_attribute = @changed_attributes.with_indifferent_access[filter['attribute_key']].presence
-    return false if changed_attribute.blank?
-
-    changed_attribute[0].in?(filter['values']['from']) && changed_attribute[1].in?(filter['values']['to'])
   end
 
   # We intersect with the record if query_operator-AND is present and union if query_operator-OR is present

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -88,24 +88,42 @@ class AutomationRules::ConditionsFilterService < FilterService
 
   # Loop through attribute_changed_query_filter
   def filter_based_on_attribute_change(records, current_attribute_changed_record)
-    @attribute_changed_query_filter.each do |filter|
-      @changed_attributes = @changed_attributes.with_indifferent_access
-      changed_attribute = @changed_attributes[filter['attribute_key']].presence
+    @attribute_changed_query_filter.each_with_index do |filter, index|
+      unless condition_met?(filter)
+        # A condition that is not met and joined to another by AND makes that conjunction
+        # false whatever the rest of the chain says, so there is nothing left to fold.
+        # Passing over it instead is how a rule asking for two changes came to fire on one
+        # of them: the next filter unions against the set accumulated so far and carries the
+        # rule on its own.
+        return @attribute_changed_records = [] if conjunctive?(index)
 
-      if changed_from_to?(changed_attribute, filter)
-        @attribute_changed_records = attribute_changed_filter_query(filter, records, current_attribute_changed_record)
+        next
       end
+
+      @attribute_changed_records = attribute_changed_filter_query(filter, records, current_attribute_changed_record)
       current_attribute_changed_record = @attribute_changed_records
     end
   end
 
+  # Whether this condition is joined to a neighbour by AND. The operator sits on the
+  # condition it joins forward from, so a condition is conjunctive through its own operator
+  # or through the one before it -- the last condition in a rule carries none and is bound
+  # backwards only.
+  def conjunctive?(index)
+    return true if and_join?(@attribute_changed_query_filter[index])
+
+    index.positive? && and_join?(@attribute_changed_query_filter[index - 1])
+  end
+
+  def and_join?(filter) = filter['query_operator'].to_s.casecmp('AND').zero?
+
   # An event that never touched the attribute is this condition not being met, which is the
-  # same answer as an event that touched it and moved it somewhere the filter does not ask
-  # for -- and not the same as the filter not being there. The loop still has to hand the
-  # set it has accumulated to the next filter: skipping the iteration outright would leave
-  # the next one combining against every conversation in the account, which for an OR is a
-  # rule that fires on all of them.
-  def changed_from_to?(changed_attribute, filter)
+  # same answer as an event that moved it somewhere the filter does not ask for, because it
+  # is the same statement about the event. It used to be `nil[0]`: a NoMethodError swallowed
+  # by `perform`'s rescue, which abandoned the rule with its remaining conditions never
+  # evaluated and left nothing behind but a log line.
+  def condition_met?(filter)
+    changed_attribute = @changed_attributes.with_indifferent_access[filter['attribute_key']].presence
     return false if changed_attribute.blank?
 
     changed_attribute[0].in?(filter['values']['from']) && changed_attribute[1].in?(filter['values']['to'])

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -41,98 +41,41 @@ RSpec.describe AutomationRules::ConditionsFilterService do
     # These are evaluated against the event's `changed_attributes` rather than against the
     # record, so an event that touched something else has nothing under the filter's key.
     context 'when conditions based on filter_operator attribute_changed' do
-      before do
-        rule.conditions = [
-          { 'values': { 'from': [nil], 'to': ['1'] }, 'attribute_key': 'assignee_id', 'query_operator': 'AND',
+      def two_conditions(operator)
+        [
+          { 'values': { 'from': [nil], 'to': ['1'] }, 'attribute_key': 'assignee_id', 'query_operator': operator,
             'filter_operator': 'attribute_changed' },
-          { 'values': { 'from': ['open'], 'to': ['resolved'] }, 'attribute_key': 'status', 'query_operator': 'OR',
-            'filter_operator': 'attribute_changed' },
-          { 'values': ['resolved'], 'attribute_key': 'status', 'query_operator': nil, 'filter_operator': 'equal_to' }
+          { 'values': { 'from': ['open'], 'to': ['resolved'] }, 'attribute_key': 'status', 'query_operator': nil,
+            'filter_operator': 'attribute_changed' }
         ]
-        rule.save!
       end
 
-      # An attribute the event never touched is this condition not being met, and the filter
-      # after it still has to be combined against what the loop has accumulated so far.
-      # Dropping the iteration instead leaves that next filter combining against every
-      # conversation in the account, and an OR beside it then fires the rule on all of them.
-      it 'does not fire on an event that never touched the attribute' do
-        expect(described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform).to be(false)
-      end
-
-      # The same statement said two ways: the assignee did not become 1. They have to agree,
-      # and the one on the left used to be `nil[0]`.
-      it 'answers an absent attribute the way it answers one that moved somewhere else' do
-        absent = described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform
-        elsewhere = described_class.new(
-          rule, conversation, { changed_attributes: { assignee_id: %w[7 9], status: %w[open resolved] } }
-        ).perform
-
-        expect(absent).to eq(elsewhere)
-      end
-
-      # The NoMethodError was swallowed by `perform`'s rescue, so the only sign of it was a
-      # log line -- hundreds a day on an account with one such rule -- and a rule abandoned
-      # with its remaining conditions never evaluated.
-      it 'evaluates the rule instead of abandoning it on the first untouched attribute' do
+      # The NoMethodError this used to raise was swallowed by `perform`'s rescue, so the only
+      # sign of it was a log line -- and the rule was abandoned with whatever conditions came
+      # after the untouched one never evaluated.
+      it 'evaluates the rule instead of abandoning it on an untouched attribute' do
+        rule.update!(conditions: two_conditions('AND'))
         expect(Rails.logger).not_to receive(:error)
 
         described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform
       end
 
-      # The operator sits on the condition it joins forward from, so the `AND` binding these
-      # two is the first one's. Reading each condition's own operator is off by one, and
-      # since the last one's is nil every chain ended in a union: an AND between two of
-      # these was never applied.
-      context 'when two of them are joined' do
-        def two_conditions(operator)
-          [
-            { 'values': { 'from': [nil], 'to': ['1'] }, 'attribute_key': 'assignee_id', 'query_operator': operator,
-              'filter_operator': 'attribute_changed' },
-            { 'values': { 'from': ['open'], 'to': ['resolved'] }, 'attribute_key': 'status', 'query_operator': nil,
-              'filter_operator': 'attribute_changed' }
-          ]
-        end
+      # Answering false is what the swallowed exception already amounted to, and holding that
+      # answer is the point: the fix is not allowed to make a rule fire that does not fire
+      # today. Whether false is *right* for a rule whose other conditions could stand on
+      # their own is #468, which this method cannot decide.
+      it 'does not fire when the event never touched the attribute' do
+        rule.update!(conditions: two_conditions('AND'))
 
-        it 'does not fire an AND rule when only one of the changes happened' do
-          rule.update!(conditions: two_conditions('AND'))
-
-          expect(described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform).to be(false)
-        end
-
-        it 'does not fire an AND rule when one attribute moved somewhere the filter does not ask for' do
-          rule.update!(conditions: two_conditions('AND'))
-
-          expect(
-            described_class.new(rule, conversation, { changed_attributes: { assignee_id: %w[7 9], status: %w[open resolved] } }).perform
-          ).to be(false)
-        end
-
-        it 'fires an AND rule when both changes happened' do
-          rule.update!(conditions: two_conditions('AND'))
-
-          expect(
-            described_class.new(rule, conversation, { changed_attributes: { assignee_id: [nil, '1'], status: %w[open resolved] } }).perform
-          ).to be(true)
-        end
-
-        # And the other half of the same rule: an OR fires on the change that did happen,
-        # which is what the swallowed NoMethodError used to prevent.
-        it 'fires an OR rule on the change that did happen' do
-          rule.update!(conditions: two_conditions('OR'))
-
-          expect(described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform).to be(true)
-        end
+        expect(described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform).to be(false)
       end
 
-      it 'still fires when the attribute changed the way the filter asks for' do
-        rule.conditions = [
-          { 'values': { 'from': ['open'], 'to': ['resolved'] }, 'attribute_key': 'status', 'query_operator': nil,
-            'filter_operator': 'attribute_changed' }
-        ]
-        rule.save!
+      it 'still fires when every attribute changed the way the filters ask for' do
+        rule.update!(conditions: two_conditions('AND'))
 
-        expect(described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform).to be(true)
+        expect(
+          described_class.new(rule, conversation, { changed_attributes: { assignee_id: [nil, '1'], status: %w[open resolved] } }).perform
+        ).to be(true)
       end
     end
 

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -38,6 +38,59 @@ RSpec.describe AutomationRules::ConditionsFilterService do
       end
     end
 
+    # These are evaluated against the event's `changed_attributes` rather than against the
+    # record, so an event that touched something else has nothing under the filter's key.
+    context 'when conditions based on filter_operator attribute_changed' do
+      before do
+        rule.conditions = [
+          { 'values': { 'from': [nil], 'to': ['1'] }, 'attribute_key': 'assignee_id', 'query_operator': 'AND',
+            'filter_operator': 'attribute_changed' },
+          { 'values': { 'from': ['open'], 'to': ['resolved'] }, 'attribute_key': 'status', 'query_operator': 'OR',
+            'filter_operator': 'attribute_changed' },
+          { 'values': ['resolved'], 'attribute_key': 'status', 'query_operator': nil, 'filter_operator': 'equal_to' }
+        ]
+        rule.save!
+      end
+
+      # An attribute the event never touched is this condition not being met, and the filter
+      # after it still has to be combined against what the loop has accumulated so far.
+      # Dropping the iteration instead leaves that next filter combining against every
+      # conversation in the account, and an OR beside it then fires the rule on all of them.
+      it 'does not fire on an event that never touched the attribute' do
+        expect(described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform).to be(false)
+      end
+
+      # The same statement said two ways: the assignee did not become 1. They have to agree,
+      # and the one on the left used to be `nil[0]`.
+      it 'answers an absent attribute the way it answers one that moved somewhere else' do
+        absent = described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform
+        elsewhere = described_class.new(
+          rule, conversation, { changed_attributes: { assignee_id: %w[7 9], status: %w[open resolved] } }
+        ).perform
+
+        expect(absent).to eq(elsewhere)
+      end
+
+      # The NoMethodError was swallowed by `perform`'s rescue, so the only sign of it was a
+      # log line -- hundreds a day on an account with one such rule -- and a rule abandoned
+      # with its remaining conditions never evaluated.
+      it 'evaluates the rule instead of abandoning it on the first untouched attribute' do
+        expect(Rails.logger).not_to receive(:error)
+
+        described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform
+      end
+
+      it 'still fires when the attribute changed the way the filter asks for' do
+        rule.conditions = [
+          { 'values': { 'from': ['open'], 'to': ['resolved'] }, 'attribute_key': 'status', 'query_operator': nil,
+            'filter_operator': 'attribute_changed' }
+        ]
+        rule.save!
+
+        expect(described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform).to be(true)
+      end
+    end
+
     context 'when conditions based on filter_operator start_with' do
       before do
         contact = conversation.contact

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -80,6 +80,51 @@ RSpec.describe AutomationRules::ConditionsFilterService do
         described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform
       end
 
+      # The operator sits on the condition it joins forward from, so the `AND` binding these
+      # two is the first one's. Reading each condition's own operator is off by one, and
+      # since the last one's is nil every chain ended in a union: an AND between two of
+      # these was never applied.
+      context 'when two of them are joined' do
+        def two_conditions(operator)
+          [
+            { 'values': { 'from': [nil], 'to': ['1'] }, 'attribute_key': 'assignee_id', 'query_operator': operator,
+              'filter_operator': 'attribute_changed' },
+            { 'values': { 'from': ['open'], 'to': ['resolved'] }, 'attribute_key': 'status', 'query_operator': nil,
+              'filter_operator': 'attribute_changed' }
+          ]
+        end
+
+        it 'does not fire an AND rule when only one of the changes happened' do
+          rule.update!(conditions: two_conditions('AND'))
+
+          expect(described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform).to be(false)
+        end
+
+        it 'does not fire an AND rule when one attribute moved somewhere the filter does not ask for' do
+          rule.update!(conditions: two_conditions('AND'))
+
+          expect(
+            described_class.new(rule, conversation, { changed_attributes: { assignee_id: %w[7 9], status: %w[open resolved] } }).perform
+          ).to be(false)
+        end
+
+        it 'fires an AND rule when both changes happened' do
+          rule.update!(conditions: two_conditions('AND'))
+
+          expect(
+            described_class.new(rule, conversation, { changed_attributes: { assignee_id: [nil, '1'], status: %w[open resolved] } }).perform
+          ).to be(true)
+        end
+
+        # And the other half of the same rule: an OR fires on the change that did happen,
+        # which is what the swallowed NoMethodError used to prevent.
+        it 'fires an OR rule on the change that did happen' do
+          rule.update!(conditions: two_conditions('OR'))
+
+          expect(described_class.new(rule, conversation, { changed_attributes: { status: %w[open resolved] } }).perform).to be(true)
+        end
+      end
+
       it 'still fires when the attribute changed the way the filter asks for' do
         rule.conditions = [
           { 'values': { 'from': ['open'], 'to': ['resolved'] }, 'attribute_key': 'status', 'query_operator': nil,


### PR DESCRIPTION
An automation rule that watches an attribute for a change was raising on every event that changed something else. The rule was abandoned mid-evaluation, so any condition after the untouched one was never looked at, and on an account with one such rule this happened hundreds of times a day with nothing visible but log noise and a job's work thrown away.

The rule now answers the same thing it already answered, without the exception.

## Closes

- Closes #451

## How to reproduce

Create a rule on `conversation_updated` with a condition `attribute_changed` on `assignee_id`, then change a conversation's status without touching the assignee. Before this, the log records `Error in AutomationRules::ConditionsFilterService: undefined method '[]' for nil` on every such update.

## What changed

An untouched attribute answers false directly. That is what the swallowed `NoMethodError` already amounted to, so **no rule changes the answer it gives today** — the specs added here pass against the old code as well, except the one asserting the rule is not abandoned.

That deliberately leaves the answer itself wrong for a rule whose other conditions could be met on their own, and the reason is #468: `perform` splits a rule's conditions into the ones that become SQL and the ones that can only be asked of the event, and drops where each sat in the chain. `A AND B OR C` and `A AND (B OR C)` arrive here indistinguishable, so two narrower fixes were tried and each one regressed a different arrangement. Correcting the evaluation needs the positions back, which is a redesign rather than a bug fix.

The same code is in `chatwoot/chatwoot` on `develop`, so this is not a fork regression and the fix applies there unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/467)
<!-- Reviewable:end -->
