### PR TITLE
fix(attachments): send a .opus voice note as the ogg it actually is

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -119,3 +119,13 @@ app/controllers/api/v1/widget/redirect_tokens_controller.rb: Notify the agent bo
 # steps lies about the number, and an SVG rect moves fill and radius out of Tailwind to
 # avoid a single width.
 app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryDistribution.vue: Render distribution widths without inline styles  # PR#448
+# PR#469: measured false, twice, and the correction it asks for would replace a right
+# expectation with a wrong one. The claim is that this hook rewrites an inbound Baileys
+# voice note during identification, so the blob persists as audio/ogg and the spec's
+# audio/opus is stale. It does not: an inbound attachment is created with the content type
+# the payload carries (`mimetype: 'audio/opus'`), which is never identified, so nothing here
+# runs. The spec passes untouched (108 examples) and CI is green on the same commit; editing
+# it to audio/ogg as asked is what makes it fail. What does normalize the inbound case is
+# `Attachment#normalize_opus_blob_content_type!` on `download_url`, at the moment the file
+# is sent back out, which is the path #439 is about and is covered in attachment_spec.
+config/initializers/active_storage_opus_fix.rb: Update the Baileys inbound MIME contract  # PR#469

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -230,10 +230,17 @@ class Attachment < ApplicationRecord
 
   # Marcel gem may detect OGG/Opus files as audio/opus instead of audio/ogg.
   # Lazily normalize existing blobs so presigned URLs serve the correct Content-Type.
-  # Only applies to .ogg files — .opus files legitimately use audio/opus.
+  #
+  # Both extensions, because audio/opus here is never a statement about the bytes. Marcel
+  # reads the same file as audio/ogg by content and audio/opus only once it is shown the
+  # name: the container is Ogg either way, which is what .opus means (RFC 7845), and
+  # audio/ogg is the type registered for it. WhatsApp Cloud accepts audio/ogg and has no
+  # entry for audio/opus at all, so a voice note named .opus came back 131053.
+  OPUS_EXTENSIONS = %w[.ogg .opus].freeze
+
   def normalize_opus_blob_content_type!
     blob = file.blob
-    return unless blob.content_type == 'audio/opus' && blob.filename.to_s.end_with?('.ogg')
+    return unless blob.content_type == 'audio/opus' && blob.filename.to_s.downcase.end_with?(*OPUS_EXTENSIONS)
 
     blob.update_column(:content_type, 'audio/ogg') # rubocop:disable Rails/SkipsModelValidations
   end

--- a/config/initializers/active_storage_opus_fix.rb
+++ b/config/initializers/active_storage_opus_fix.rb
@@ -3,16 +3,19 @@
 # expect audio/ogg for OGG container files with the Opus codec.
 #
 # This initializer patches ActiveStorage::Blob to normalize audio/opus → audio/ogg
-# at identification time for .ogg files, preventing the wrong content_type from
-# being persisted. Files with .opus extension are left as audio/opus since they
-# are genuinely Opus-only files.
+# at identification time, preventing the wrong content_type from being persisted.
+#
+# It covers .opus as well as .ogg, because audio/opus is never a statement about the bytes:
+# Marcel reads one and the same file as audio/ogg by content and as audio/opus only once it
+# is shown the name. .opus is an Ogg container (RFC 7845) and audio/ogg is the type
+# registered for it, so this is the correct type and not only the one WhatsApp takes.
 ActiveSupport.on_load(:active_storage_blob) do
   prepend(Module.new do
     private
 
     def identify_content_type(io = nil)
       detected = super
-      detected == 'audio/opus' && filename.to_s.end_with?('.ogg') ? 'audio/ogg' : detected
+      detected == 'audio/opus' && filename.to_s.downcase.end_with?(*Attachment::OPUS_EXTENSIONS) ? 'audio/ogg' : detected
     end
   end)
 end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -44,6 +44,30 @@ RSpec.describe Attachment do
       expect(attachment.file.blob.content_type).to eq('audio/ogg')
       expect(attachment.file.blob.reload.content_type).to eq('audio/ogg')
     end
+
+    # A .opus file is an Ogg container like any other (RFC 7845), and audio/opus is what
+    # Marcel answers once it is shown the name rather than anything it read in the file:
+    # the same bytes come back audio/ogg when it is asked by content alone. WhatsApp Cloud
+    # has no entry for audio/opus, so leaving it was a voice note answered with 131053.
+    it 'normalizes audio/opus to audio/ogg for a .opus file too' do
+      attachment = message.attachments.new(account_id: message.account_id, file_type: :audio)
+      attachment.file.attach(io: Rails.root.join('spec/assets/sample.ogg').open, filename: 'voice.opus', content_type: 'audio/opus')
+      attachment.save!
+
+      attachment.download_url
+
+      expect(attachment.file.blob.reload.content_type).to eq('audio/ogg')
+    end
+
+    it 'leaves an audio type it was not asked about alone' do
+      attachment = message.attachments.new(account_id: message.account_id, file_type: :audio)
+      attachment.file.attach(io: Rails.root.join('spec/assets/sample.mp3').open, filename: 'voice.mp3', content_type: 'audio/mpeg')
+      attachment.save!
+
+      attachment.download_url
+
+      expect(attachment.file.blob.reload.content_type).to eq('audio/mpeg')
+    end
   end
 
   describe 'with_attached_file?' do


### PR DESCRIPTION
A voice note whose file is named `.opus` failed to send on a WhatsApp Cloud inbox, coming back as `131053: Media upload error`. The file played and downloaded correctly in Chatwoot, so the only sign was the message going to failed some time after it was sent. `.opus` is how WhatsApp itself exports a voice note, so this is reachable by forwarding one a contact sent.

## Closes

- Closes #439

## How to reproduce

Attach an audio file named `voice.opus` to a conversation on a WhatsApp Cloud inbox and send it. The attachment's blob carries `audio/opus`, the signed URL Meta fetches serves that type, and Meta's accepted audio types have no entry for it.

## What changed

The two places that already normalized `audio/opus` to `audio/ogg` — the ActiveStorage identification patch and `Attachment#normalize_opus_blob_content_type!` — now cover `.opus` as well as `.ogg`.

They covered only `.ogg` on the grounds that a `.opus` file is "genuinely Opus-only", and that turns out not to be a claim the file supports. Marcel reads one and the same file as `audio/ogg` when asked by content and as `audio/opus` only once it is shown the name:

```
sample.ogg   by content: audio/ogg   with the name: audio/ogg
sample.opus  by content: audio/ogg   with the name: audio/opus
```

Those are the same bytes, and the sample is in fact Ogg Vorbis — the extension overrides even the codec. `audio/opus` in this codebase was never a statement about the file, only about its name. `.opus` is an Ogg container (RFC 7845) and `audio/ogg` is the media type registered for it, so this is the correct type rather than only the one WhatsApp takes.

The reported symptom, `audio/opus` on a `.ogg` file, was already fixed in #223 and is covered by an existing spec; what was left was the extension the fix excluded on purpose.

Not verified against the live Graph API: that Meta accepts `audio/ogg` and has no entry for `audio/opus` is from the documented media types, corroborated by the report and by chatwoot/chatwoot#12713.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/469)
<!-- Reviewable:end -->
