### PR TITLE
fix(composer): say so when a capture is discarded by the composer leaving note mode

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -129,12 +129,3 @@ app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryDis
 # `Attachment#normalize_opus_blob_content_type!` on `download_url`, at the moment the file
 # is sent back out, which is the path #439 is about and is covered in attachment_spec.
 config/initializers/active_storage_opus_fix.rb: Update the Baileys inbound MIME contract  # PR#469
-# PR#470: real, and the two rounds before this one pushed the state in opposite directions
-# over exactly this. A map keyed by generation loses nothing here, and round 2 rejected it
-# for growing without bound while ReplyBox stays mounted; the scalar that replaced it cannot
-# hold two outstanding markers. Both complaints are correct, and the case this one names --
-# a bot releasing, retaking and releasing a conversation inside one upload -- costs silence,
-# which is the behaviour before this PR, on a coincidence of two rare events. A bounded ring
-# would trade a measured objection for a speculative one and is a third shape to get wrong
-# in a fourth round. Revisit if the alert ever proves it earns its keep.
-app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue: Preserve markers for concurrent discarded generations  # PR#470

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -129,3 +129,12 @@ app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryDis
 # `Attachment#normalize_opus_blob_content_type!` on `download_url`, at the moment the file
 # is sent back out, which is the path #439 is about and is covered in attachment_spec.
 config/initializers/active_storage_opus_fix.rb: Update the Baileys inbound MIME contract  # PR#469
+# PR#470: real, and the two rounds before this one pushed the state in opposite directions
+# over exactly this. A map keyed by generation loses nothing here, and round 2 rejected it
+# for growing without bound while ReplyBox stays mounted; the scalar that replaced it cannot
+# hold two outstanding markers. Both complaints are correct, and the case this one names --
+# a bot releasing, retaking and releasing a conversation inside one upload -- costs silence,
+# which is the behaviour before this PR, on a coincidence of two rare events. A bounded ring
+# would trade a measured objection for a speculative one and is a third shape to get wrong
+# in a fourth round. Revisit if the alert ever proves it earns its keep.
+app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue: Preserve markers for concurrent discarded generations  # PR#470

--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -129,3 +129,15 @@ app/javascript/dashboard/routes/dashboard/settings/reports/components/SummaryDis
 # `Attachment#normalize_opus_blob_content_type!` on `download_url`, at the moment the file
 # is sent back out, which is the path #439 is about and is covered in attachment_spec.
 config/initializers/active_storage_opus_fix.rb: Update the Baileys inbound MIME contract  # PR#469
+# PR#470: real, marginal, and the fourth position in a circle. Round 2 refused a map for
+# growing without bound, round 4 refused a bounded structure, round 7 refused the scalar
+# that replaced it, round 8 refused holding that scalar, and this refuses the cap that
+# answers round 8. Every answer short of tracking in-flight uploads is rejected for the case
+# it approximates away, and tracking them is not something this component can do honestly:
+# `stageFile` is wired to the uploader's `input-file`, which re-fires on every progress
+# update, and `attachFile` does not run at all when an upload fails, so a pending set would
+# both over-count and leak -- which is the stale-marker complaint of round 8 arriving by a
+# longer road. What is left uncovered is an upload still running while the agent toggles
+# note and reply more than five times, and it costs silence, which is what every discard did
+# before this PR. Revisit if the alert proves it earns more machinery.
+app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue: Retain markers for uploads that are still pending  # PR#470

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -1201,10 +1201,10 @@ export default {
       }, 100);
     },
     setReplyMode(mode = REPLY_EDITOR_MODES.REPLY) {
-      // Clear attachments when switching between private note and reply modes
-      // This is to prevent from breaking the upload rules
-      if (this.attachedFiles.length > 0) this.attachedFiles = [];
-
+      // The clearing lives in the effectiveReplyMode watcher and only there. It ran here
+      // too, ahead of the mode actually changing, so by the time the watcher looked there
+      // was nothing left to report -- and it ran even when the mode did not change at all,
+      // since `replyType` is only assigned below when a public reply is possible.
       this.$store.dispatch('draftMessages/setReplyEditorMode', { mode });
       if (this.canSendPublicReply) this.replyType = mode;
       if (this.isRecordingAudio) {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -20,6 +20,11 @@ import MessageSignatureMissingAlert from './MessageSignatureMissingAlert.vue';
 import ReplyBoxBanner from './ReplyBoxBanner.vue';
 import QuotedEmailPreview from './QuotedEmailPreview.vue';
 import { REPLY_EDITOR_MODES } from 'dashboard/components/widgets/WootWriter/constants';
+
+// How many mode switches a capture may still be uploading across before the composer stops
+// holding an explanation for it. Nothing survives five, and the cap is what keeps a marker
+// nobody claims from sitting in a component that stays mounted all day.
+const MAX_PENDING_DISCARD_MARKERS = 5;
 import WootMessageEditor from 'dashboard/components/widgets/WootWriter/Editor.vue';
 import AudioRecorder from 'dashboard/components/widgets/WootWriter/AudioRecorder.vue';
 import { AUDIO_FORMATS } from 'shared/constants/messages';
@@ -145,12 +150,15 @@ export default {
       // stamps it on the way in, so an upload that lands afterwards can tell that
       // it outlived what the agent was composing under.
       composerGeneration: 0,
-      // The generation whose end the agent is still owed an explanation for, or null. One
-      // number rather than a map: a capture carries the generation it was staged under, and
-      // anything older than this was invalidated by an earlier transition, so nothing older
-      // is ever owed an answer -- and a scalar cannot accumulate for the life of a mounted
-      // composer.
-      composerDropGeneration: null,
+      // The generations ended by a mode change that nobody has been told about yet. A
+      // capture carries the generation it was staged under, so the answer it is owed is a
+      // fact about that generation and not about the latest one -- one slot cannot hold two
+      // outstanding captures, and cannot tell an unanswered marker from a stale one.
+      //
+      // Bounded, because ReplyBox stays mounted for the whole session and an entry nothing
+      // ever claims would otherwise sit here for good: past a handful of mode switches a
+      // capture is not still uploading.
+      composerDropGenerations: [],
       // The recorder's capture starts when the mic is armed, not when the file
       // shows up: talking and then converting to MP3 both happen in between.
       recordingGeneration: 0,
@@ -1343,12 +1351,15 @@ export default {
       // it is said now. Waiting for an upload callback loses every capture that had already
       // finished, which is the ordinary shape of this: the recording is sitting in the
       // composer when the bot hands the conversation back.
-      // Only a capture still uploading needs the marker, and only until it lands, so an
-      // unconsumed one is never replaced or cleared: it belongs to a capture that has not
-      // landed yet, and any later transition -- routine, or one that announced something
-      // visible of its own -- would otherwise take that capture's message away.
+      // Only a capture still uploading needs a marker, and only until it lands. Each is
+      // kept beside the others rather than replacing them: a marker belongs to whatever was
+      // staged under that generation, and a later transition has no business answering, or
+      // silencing, an earlier one.
       if (announceable && !this.announceVisibleDiscard()) {
-        this.composerDropGeneration ??= this.composerGeneration;
+        this.composerDropGenerations.push(this.composerGeneration);
+        if (this.composerDropGenerations.length > MAX_PENDING_DISCARD_MARKERS) {
+          this.composerDropGenerations.shift();
+        }
       }
       this.composerGeneration += 1;
     },
@@ -1373,9 +1384,10 @@ export default {
     // The marker is consumed, so a batch staged together and invalidated by one transition
     // is one message rather than a stack of identical ones.
     discardStagedCapture(file, generation) {
-      if (generation !== this.composerDropGeneration) return;
+      const marker = this.composerDropGenerations.indexOf(generation);
+      if (marker === -1) return;
 
-      this.composerDropGeneration = null;
+      this.composerDropGenerations.splice(marker, 1);
       this.announceDiscard(Boolean(file?.isVoiceMessage));
     },
     announceDiscard(isRecording) {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -145,7 +145,7 @@ export default {
       // stamps it on the way in, so an upload that lands afterwards can tell that
       // it outlived what the agent was composing under.
       composerGeneration: 0,
-      // Which generations ended in a way worth telling the agent about, keyed by the
+      // The generations that ended in a way worth telling the agent about, keyed by the
       // generation that ended. Per generation and not one latest-reason slot: a capture
       // carries the generation it was staged under, and by the time it lands the composer
       // may have moved on twice more -- the transition that invalidated it is the first one
@@ -684,7 +684,7 @@ export default {
     },
     conversationIdByRoute(conversationId, oldConversationId) {
       if (conversationId !== oldConversationId) {
-        this.advanceComposerGeneration('navigation');
+        this.advanceComposerGeneration();
         this.switchDraftContext(conversationId, this.effectiveReplyMode);
         this.resetRecorderAndClearAttachments();
       }
@@ -733,8 +733,6 @@ export default {
       this.advanceComposerGeneration(
         previousReplyType === REPLY_EDITOR_MODES.NOTE &&
           updatedReplyType !== REPLY_EDITOR_MODES.NOTE
-          ? 'privacy'
-          : null
       );
       if (this.isRecordingAudio) this.onTypingOff();
       this.resetRecorderAndClearAttachments();
@@ -1228,7 +1226,7 @@ export default {
       // Sending consumes the composer as much as switching mode does: a capture
       // still uploading belongs to the message that just left, and would
       // otherwise land in the empty composer and ride along with the next one.
-      this.advanceComposerGeneration('send');
+      this.advanceComposerGeneration();
       this.message = '';
       this.clearCopilotAcceptedMessage();
       this.attachedFiles = [];
@@ -1340,10 +1338,13 @@ export default {
       }
       this.onFileUpload(file);
     },
-    // Only a reason worth announcing is recorded, so the map holds one entry per rare
-    // transition rather than one per navigation for the life of the session.
-    advanceComposerGeneration(reason) {
-      if (reason) this.composerDropReasons[this.composerGeneration] = reason;
+    // Only the transition that gets announced is recorded, and it is deleted when it is.
+    // Marking the routine ones too would grow the map for the life of the session, since
+    // ReplyBox stays mounted across every navigation and every send and nothing would ever
+    // consume those entries.
+    advanceComposerGeneration(announceable = false) {
+      if (announceable)
+        this.composerDropReasons[this.composerGeneration] = true;
       this.composerGeneration += 1;
     },
     // A capture that arrives for a composer that has moved on is thrown away, and the agent
@@ -1358,7 +1359,7 @@ export default {
     // The entry is consumed, so a batch of files staged together and invalidated by one
     // transition is one message rather than a stack of identical ones.
     discardStagedCapture(file, generation) {
-      if (this.composerDropReasons[generation] !== 'privacy') return;
+      if (!this.composerDropReasons[generation]) return;
 
       delete this.composerDropReasons[generation];
       useAlert(

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -145,12 +145,12 @@ export default {
       // stamps it on the way in, so an upload that lands afterwards can tell that
       // it outlived what the agent was composing under.
       composerGeneration: 0,
-      // The generations that ended in a way worth telling the agent about, keyed by the
-      // generation that ended. Per generation and not one latest-reason slot: a capture
-      // carries the generation it was staged under, and by the time it lands the composer
-      // may have moved on twice more -- the transition that invalidated it is the first one
-      // past it, not the last one overall.
-      composerDropReasons: {},
+      // The generation whose end the agent is still owed an explanation for, or null. One
+      // number rather than a map: a capture carries the generation it was staged under, and
+      // anything older than this was invalidated by an earlier transition, so nothing older
+      // is ever owed an answer -- and a scalar cannot accumulate for the life of a mounted
+      // composer.
+      composerDropGeneration: null,
       // The recorder's capture starts when the mic is armed, not when the file
       // shows up: talking and then converting to MP3 both happen in between.
       recordingGeneration: 0,
@@ -1338,14 +1338,30 @@ export default {
       }
       this.onFileUpload(file);
     },
-    // Only the transition that gets announced is recorded, and it is deleted when it is.
-    // Marking the routine ones too would grow the map for the life of the session, since
-    // ReplyBox stays mounted across every navigation and every send and nothing would ever
-    // consume those entries.
     advanceComposerGeneration(announceable = false) {
-      if (announceable)
-        this.composerDropReasons[this.composerGeneration] = true;
+      // Whatever is already staged is discarded right here, by the reset that follows, so
+      // it is said now. Waiting for an upload callback loses every capture that had already
+      // finished, which is the ordinary shape of this: the recording is sitting in the
+      // composer when the bot hands the conversation back.
+      // Only a capture still uploading needs the marker, and only until it lands. A routine
+      // transition leaves it where it is: a capture staged before the note ended and landing
+      // after the agent has moved on twice is still owed the answer the first of those
+      // transitions owes it.
+      if (announceable) {
+        this.composerDropGeneration = this.announceVisibleDiscard()
+          ? null
+          : this.composerGeneration;
+      }
       this.composerGeneration += 1;
+    },
+    announceVisibleDiscard() {
+      const staged = this.attachedFiles;
+      if (!staged.length && !this.isRecordingAudio) return false;
+
+      this.announceDiscard(
+        this.isRecordingAudio || staged.some(file => file.isVoiceMessage)
+      );
+      return true;
     },
     // A capture that arrives for a composer that has moved on is thrown away, and the agent
     // is told only when they have no way of working out why on their own.
@@ -1356,14 +1372,17 @@ export default {
     // and sending are their own actions, with the composer visibly resetting in front of
     // them, and an alert on those is noise on the ordinary case.
     //
-    // The entry is consumed, so a batch of files staged together and invalidated by one
-    // transition is one message rather than a stack of identical ones.
+    // The marker is consumed, so a batch staged together and invalidated by one transition
+    // is one message rather than a stack of identical ones.
     discardStagedCapture(file, generation) {
-      if (!this.composerDropReasons[generation]) return;
+      if (generation !== this.composerDropGeneration) return;
 
-      delete this.composerDropReasons[generation];
+      this.composerDropGeneration = null;
+      this.announceDiscard(Boolean(file?.isVoiceMessage));
+    },
+    announceDiscard(isRecording) {
       useAlert(
-        file?.isVoiceMessage
+        isRecording
           ? this.$t('CONVERSATION.REPLYBOX.RECORDING_DISCARDED_ON_MODE_CHANGE')
           : this.$t('CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE')
       );

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -719,21 +719,25 @@ export default {
         mode: updatedReplyType,
       });
       this.switchDraftContext(this.conversationIdByRoute, updatedReplyType);
-      // The composer can leave note mode without the agent touching anything: a
-      // bot releases the pending conversation it owned, the messaging window
-      // reopens, an Instagram restriction lifts. Whatever is staged was produced
-      // under the old privacy but would be sent under the new one, so a voice
-      // note recorded for the team could reach the contact. The draft survives
-      // because switchDraftContext keeps one per mode; attachments and a cited
-      // private note have no such split, so they go.
-      // Any switch between note and reply, in either direction and whoever caused it. The
-      // composer cannot tell the agent picking Reply from a bot releasing the conversation
-      // under them -- both arrive here as the same watcher firing -- and the message is
-      // worth having either way: what it reports is a file that will not be sent, which is
-      // news even to the agent who clicked. What it must not do is claim the contact was
-      // about to receive it, which is false in one of the two directions.
+      // The composer can change mode without the agent touching anything: a bot releases
+      // the pending conversation it owned, the messaging window reopens, an Instagram
+      // restriction lifts. Whatever is staged was produced under the old privacy but would
+      // be sent under the new one, so a voice note recorded for the team could reach the
+      // contact. The draft survives because switchDraftContext keeps one per mode;
+      // attachments and a cited private note have no such split, so they go.
+      //
+      // Every path arrives here, whoever caused it: the composer cannot tell the agent
+      // picking Reply from a bot releasing the conversation under them, and the message is
+      // worth having either way, since what it reports is a file that will not be sent.
+      // What it must not do is claim the contact was about to receive it, which is false in
+      // one of the two directions.
+      //
+      // The announcement comes first, and the clearing is all done here rather than by the
+      // callers: emptying the composer before the mode changes leaves this with nothing to
+      // report, which is how a staged attachment and then a recording each stayed silent.
       this.advanceComposerGeneration(true);
       if (this.isRecordingAudio) this.onTypingOff();
+      this.isRecordingAudio = false;
       this.resetRecorderAndClearAttachments();
       if (this.inReplyTo?.private && !this.isOnPrivateNote) {
         this.resetReplyToMessage();
@@ -1207,9 +1211,6 @@ export default {
       // since `replyType` is only assigned below when a public reply is possible.
       this.$store.dispatch('draftMessages/setReplyEditorMode', { mode });
       if (this.canSendPublicReply) this.replyType = mode;
-      if (this.isRecordingAudio) {
-        this.toggleAudioRecorder();
-      }
     },
     clearEditorSelection() {
       this.updateEditorSelectionWith = '';

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -145,9 +145,12 @@ export default {
       // stamps it on the way in, so an upload that lands afterwards can tell that
       // it outlived what the agent was composing under.
       composerGeneration: 0,
-      // Why the composer last moved on. Only a privacy change is announced when it
-      // discards a capture: see discardStagedCapture.
-      composerDropReason: null,
+      // Which generations ended in a way worth telling the agent about, keyed by the
+      // generation that ended. Per generation and not one latest-reason slot: a capture
+      // carries the generation it was staged under, and by the time it lands the composer
+      // may have moved on twice more -- the transition that invalidated it is the first one
+      // past it, not the last one overall.
+      composerDropReasons: {},
       // The recorder's capture starts when the mic is armed, not when the file
       // shows up: talking and then converting to MP3 both happen in between.
       recordingGeneration: 0,
@@ -711,7 +714,7 @@ export default {
     showContentTemplates(isAvailable) {
       if (!isAvailable) this.hideContentTemplatesModal();
     },
-    effectiveReplyMode(updatedReplyType) {
+    effectiveReplyMode(updatedReplyType, previousReplyType) {
       this.$store.dispatch('draftMessages/setReplyEditorMode', {
         mode: updatedReplyType,
       });
@@ -723,7 +726,16 @@ export default {
       // note recorded for the team could reach the contact. The draft survives
       // because switchDraftContext keeps one per mode; attachments and a cited
       // private note have no such split, so they go.
-      this.advanceComposerGeneration('privacy');
+      // Only leaving note mode is announced, and only that direction is the one the agent
+      // cannot account for. Going the other way is the agent picking Note, with the
+      // composer changing under their hands, and telling them their file would have
+      // reached the contact would be false besides.
+      this.advanceComposerGeneration(
+        previousReplyType === REPLY_EDITOR_MODES.NOTE &&
+          updatedReplyType !== REPLY_EDITOR_MODES.NOTE
+          ? 'privacy'
+          : null
+      );
       if (this.isRecordingAudio) this.onTypingOff();
       this.resetRecorderAndClearAttachments();
       if (this.inReplyTo?.private && !this.isOnPrivateNote) {
@@ -1328,30 +1340,38 @@ export default {
       }
       this.onFileUpload(file);
     },
+    // Only a reason worth announcing is recorded, so the map holds one entry per rare
+    // transition rather than one per navigation for the life of the session.
     advanceComposerGeneration(reason) {
-      this.composerDropReason = reason;
+      if (reason) this.composerDropReasons[this.composerGeneration] = reason;
       this.composerGeneration += 1;
     },
-    // A capture that arrives for a composer that has moved on is thrown away, and the
-    // agent is told only when they have no way of working out why on their own.
+    // A capture that arrives for a composer that has moved on is thrown away, and the agent
+    // is told only when they have no way of working out why on their own.
     //
-    // Leaving note mode is the case: nothing the agent did causes it — a bot releases the
+    // Leaving note mode is that case: nothing the agent did causes it — a bot releases the
     // conversation it owned, the messaging window reopens, an Instagram restriction lifts —
-    // so a recording they made for the team disappears with the composer looking untouched.
-    // Navigating away and sending are their own actions, with the composer visibly resetting
-    // in front of them, and an alert on those is noise on the ordinary case.
-    discardStagedCapture() {
-      if (this.composerDropReason === 'privacy') {
-        useAlert(
-          this.$t('CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE')
-        );
-      }
+    // so what they staged disappears with the composer looking untouched. Navigating away
+    // and sending are their own actions, with the composer visibly resetting in front of
+    // them, and an alert on those is noise on the ordinary case.
+    //
+    // The entry is consumed, so a batch of files staged together and invalidated by one
+    // transition is one message rather than a stack of identical ones.
+    discardStagedCapture(file, generation) {
+      if (this.composerDropReasons[generation] !== 'privacy') return;
+
+      delete this.composerDropReasons[generation];
+      useAlert(
+        file?.isVoiceMessage
+          ? this.$t('CONVERSATION.REPLYBOX.RECORDING_DISCARDED_ON_MODE_CHANGE')
+          : this.$t('CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE')
+      );
     },
     attachFile({ blob, file }) {
       const generation = file?.composerGeneration;
       // Checked here so a stale recording can't clear a newer one below.
       if (generation !== this.composerGeneration) {
-        this.discardStagedCapture();
+        this.discardStagedCapture(file, generation);
         return;
       }
 
@@ -1368,7 +1388,7 @@ export default {
         // two. The push is the only moment that decides what gets sent, so it is
         // where the capture has to still be current.
         if (generation !== this.composerGeneration) {
-          this.discardStagedCapture();
+          this.discardStagedCapture(file, generation);
           return;
         }
 

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -714,7 +714,7 @@ export default {
     showContentTemplates(isAvailable) {
       if (!isAvailable) this.hideContentTemplatesModal();
     },
-    effectiveReplyMode(updatedReplyType, previousReplyType) {
+    effectiveReplyMode(updatedReplyType) {
       this.$store.dispatch('draftMessages/setReplyEditorMode', {
         mode: updatedReplyType,
       });
@@ -726,14 +726,13 @@ export default {
       // note recorded for the team could reach the contact. The draft survives
       // because switchDraftContext keeps one per mode; attachments and a cited
       // private note have no such split, so they go.
-      // Only leaving note mode is announced, and only that direction is the one the agent
-      // cannot account for. Going the other way is the agent picking Note, with the
-      // composer changing under their hands, and telling them their file would have
-      // reached the contact would be false besides.
-      this.advanceComposerGeneration(
-        previousReplyType === REPLY_EDITOR_MODES.NOTE &&
-          updatedReplyType !== REPLY_EDITOR_MODES.NOTE
-      );
+      // Any switch between note and reply, in either direction and whoever caused it. The
+      // composer cannot tell the agent picking Reply from a bot releasing the conversation
+      // under them -- both arrive here as the same watcher firing -- and the message is
+      // worth having either way: what it reports is a file that will not be sent, which is
+      // news even to the agent who clicked. What it must not do is claim the contact was
+      // about to receive it, which is false in one of the two directions.
+      this.advanceComposerGeneration(true);
       if (this.isRecordingAudio) this.onTypingOff();
       this.resetRecorderAndClearAttachments();
       if (this.inReplyTo?.private && !this.isOnPrivateNote) {

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -145,6 +145,9 @@ export default {
       // stamps it on the way in, so an upload that lands afterwards can tell that
       // it outlived what the agent was composing under.
       composerGeneration: 0,
+      // Why the composer last moved on. Only a privacy change is announced when it
+      // discards a capture: see discardStagedCapture.
+      composerDropReason: null,
       // The recorder's capture starts when the mic is armed, not when the file
       // shows up: talking and then converting to MP3 both happen in between.
       recordingGeneration: 0,
@@ -678,7 +681,7 @@ export default {
     },
     conversationIdByRoute(conversationId, oldConversationId) {
       if (conversationId !== oldConversationId) {
-        this.composerGeneration += 1;
+        this.advanceComposerGeneration('navigation');
         this.switchDraftContext(conversationId, this.effectiveReplyMode);
         this.resetRecorderAndClearAttachments();
       }
@@ -720,7 +723,7 @@ export default {
       // note recorded for the team could reach the contact. The draft survives
       // because switchDraftContext keeps one per mode; attachments and a cited
       // private note have no such split, so they go.
-      this.composerGeneration += 1;
+      this.advanceComposerGeneration('privacy');
       if (this.isRecordingAudio) this.onTypingOff();
       this.resetRecorderAndClearAttachments();
       if (this.inReplyTo?.private && !this.isOnPrivateNote) {
@@ -1213,7 +1216,7 @@ export default {
       // Sending consumes the composer as much as switching mode does: a capture
       // still uploading belongs to the message that just left, and would
       // otherwise land in the empty composer and ride along with the next one.
-      this.composerGeneration += 1;
+      this.advanceComposerGeneration('send');
       this.message = '';
       this.clearCopilotAcceptedMessage();
       this.attachedFiles = [];
@@ -1325,10 +1328,32 @@ export default {
       }
       this.onFileUpload(file);
     },
+    advanceComposerGeneration(reason) {
+      this.composerDropReason = reason;
+      this.composerGeneration += 1;
+    },
+    // A capture that arrives for a composer that has moved on is thrown away, and the
+    // agent is told only when they have no way of working out why on their own.
+    //
+    // Leaving note mode is the case: nothing the agent did causes it — a bot releases the
+    // conversation it owned, the messaging window reopens, an Instagram restriction lifts —
+    // so a recording they made for the team disappears with the composer looking untouched.
+    // Navigating away and sending are their own actions, with the composer visibly resetting
+    // in front of them, and an alert on those is noise on the ordinary case.
+    discardStagedCapture() {
+      if (this.composerDropReason === 'privacy') {
+        useAlert(
+          this.$t('CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE')
+        );
+      }
+    },
     attachFile({ blob, file }) {
       const generation = file?.composerGeneration;
       // Checked here so a stale recording can't clear a newer one below.
-      if (generation !== this.composerGeneration) return;
+      if (generation !== this.composerGeneration) {
+        this.discardStagedCapture();
+        return;
+      }
 
       if (file?.isVoiceMessage) {
         this.removeRecordedAudio();
@@ -1342,7 +1367,10 @@ export default {
         // Reading the file is async as well, so the mode can change between the
         // two. The push is the only moment that decides what gets sent, so it is
         // where the capture has to still be current.
-        if (generation !== this.composerGeneration) return;
+        if (generation !== this.composerGeneration) {
+          this.discardStagedCapture();
+          return;
+        }
 
         this.attachedFiles.push({
           currentChatId: this.currentChat.id,

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -1343,14 +1343,12 @@ export default {
       // it is said now. Waiting for an upload callback loses every capture that had already
       // finished, which is the ordinary shape of this: the recording is sitting in the
       // composer when the bot hands the conversation back.
-      // Only a capture still uploading needs the marker, and only until it lands. A routine
-      // transition leaves it where it is: a capture staged before the note ended and landing
-      // after the agent has moved on twice is still owed the answer the first of those
-      // transitions owes it.
-      if (announceable) {
-        this.composerDropGeneration = this.announceVisibleDiscard()
-          ? null
-          : this.composerGeneration;
+      // Only a capture still uploading needs the marker, and only until it lands, so an
+      // unconsumed one is never replaced or cleared: it belongs to a capture that has not
+      // landed yet, and any later transition -- routine, or one that announced something
+      // visible of its own -- would otherwise take that capture's message away.
+      if (announceable && !this.announceVisibleDiscard()) {
+        this.composerDropGeneration ??= this.composerGeneration;
       }
       this.composerGeneration += 1;
     },

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -809,6 +809,53 @@ describe('ReplyBox', () => {
     );
   });
 
+  // An empty switch marks a generation nobody will ever claim. Keeping it was harmless on
+  // its own and fatal next to a rule that never replaced a marker: the real loss that came
+  // afterwards found the slot taken and said nothing.
+  it('still speaks for a later capture after empty mode switches', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+    const panel = wrapper.findComponent({ name: 'ReplyTopPanel' });
+
+    panel.vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+    await nextTick();
+    panel.vm.$emit('setReplyMode', REPLY_EDITOR_MODES.REPLY);
+    await nextTick();
+    mockAlert.mockClear();
+
+    wrapper.vm.stageFile({ name: 'depois.pdf', file: new Blob(['pdf']) });
+    panel.vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+    await nextTick();
+    await vi.waitUntil(() => mockAlert.mock.calls.length > 0);
+
+    expect(mockAlert).toHaveBeenCalledWith(
+      'CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE'
+    );
+  });
+
+  // And the list is bounded, since ReplyBox stays mounted all day and a switch with nothing
+  // staged leaves an entry no capture will ever claim.
+  it('does not accumulate markers across a day of switching', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+    const panel = wrapper.findComponent({ name: 'ReplyTopPanel' });
+
+    for (let i = 0; i < 20; i += 1) {
+      panel.vm.$emit(
+        'setReplyMode',
+        i % 2 ? REPLY_EDITOR_MODES.REPLY : REPLY_EDITOR_MODES.NOTE
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await nextTick();
+    }
+
+    expect(wrapper.vm.composerDropGenerations.length).toBeLessThanOrEqual(5);
+  });
+
   // ReplyBox stays mounted for the whole session, so a map that recorded every navigation
   // and every send would only ever grow: nothing consumes an entry that is never announced.
   it('records nothing for the transitions it does not announce', async () => {
@@ -823,7 +870,7 @@ describe('ReplyBox', () => {
     store.commit('selectChat', { ...REPLIABLE, id: 43 });
     await nextTick();
 
-    expect(wrapper.vm.composerDropGeneration).toBeNull();
+    expect(wrapper.vm.composerDropGenerations).toHaveLength(0);
   });
 
   // A capture carries the generation it was staged under, and by the time it lands the

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -825,9 +825,15 @@ describe('ReplyBox', () => {
     mockAlert.mockClear();
 
     wrapper.vm.stageFile({ name: 'doc.pdf', file: new Blob(['pdf']) });
-    wrapper.vm.replyType = REPLY_EDITOR_MODES.NOTE;
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+    mockAlert.mockClear();
+
+    // Through the panel the agent actually clicks, not by assigning replyType: setReplyMode
+    // used to empty the composer before the watcher could see what it was emptying.
+    wrapper
+      .findComponent({ name: 'ReplyTopPanel' })
+      .vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
     await nextTick();
-    await vi.waitUntil(() => mockAlert.mock.calls.length > 0);
 
     expect(mockAlert).toHaveBeenCalledWith(
       'CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE'

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -732,6 +732,23 @@ describe('ReplyBox', () => {
     expect(mockAlert).toHaveBeenCalledTimes(1);
   });
 
+  // ReplyBox stays mounted for the whole session, so a map that recorded every navigation
+  // and every send would only ever grow: nothing consumes an entry that is never announced.
+  it('records nothing for the transitions it does not announce', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+
+    store.commit('selectChat', { ...REPLIABLE, id: 42 });
+    await nextTick();
+    wrapper.vm.clearMessage();
+    store.commit('selectChat', { ...REPLIABLE, id: 43 });
+    await nextTick();
+
+    expect(Object.keys(wrapper.vm.composerDropReasons)).toHaveLength(0);
+  });
+
   // A capture carries the generation it was staged under, and by the time it lands the
   // composer may have moved on twice more. What invalidated it is the first transition past
   // it, not the last one overall: reading only the latest reason loses the message here, and

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -708,6 +708,30 @@ describe('ReplyBox', () => {
     );
   });
 
+  // The recorder is the other thing setReplyMode used to tear down ahead of the mode
+  // actually changing, and a finished recording has no upload callback left to speak for it.
+  it('says so when a recording was going when the mode switched', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+
+    wrapper.vm.toggleAudioRecorder();
+    await nextTick();
+    expect(wrapper.vm.isRecordingAudio).toBe(true);
+    mockAlert.mockClear();
+
+    wrapper
+      .findComponent({ name: 'ReplyTopPanel' })
+      .vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+    await nextTick();
+
+    expect(wrapper.vm.isRecordingAudio).toBe(false);
+    expect(mockAlert).toHaveBeenCalledWith(
+      'CONVERSATION.REPLYBOX.RECORDING_DISCARDED_ON_MODE_CHANGE'
+    );
+  });
+
   // stageFile is also the clip button, drag and drop, and paste. Telling an agent their
   // recording was discarded when what they dropped was a PDF is a message they cannot act
   // on, and one wrong message is enough to stop the right ones being read.

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -674,8 +674,116 @@ describe('ReplyBox', () => {
     await vi.waitUntil(() => mockAlert.mock.calls.length > 0);
 
     expect(mockAlert).toHaveBeenCalledWith(
+      'CONVERSATION.REPLYBOX.RECORDING_DISCARDED_ON_MODE_CHANGE'
+    );
+  });
+
+  // stageFile is also the clip button, drag and drop, and paste. Telling an agent their
+  // recording was discarded when what they dropped was a PDF is a message they cannot act
+  // on, and one wrong message is enough to stop the right ones being read.
+  it('names what was actually discarded', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+    mockAlert.mockClear();
+
+    wrapper.vm.stageFile({ name: 'contrato.pdf', file: new Blob(['pdf']) });
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+    await vi.waitUntil(() => mockAlert.mock.calls.length > 0);
+
+    expect(mockAlert).toHaveBeenCalledWith(
       'CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE'
     );
+  });
+
+  // One transition, one message. With several files staged together every completion runs
+  // this, and a stack of identical toasts for a single event is its own kind of unreadable.
+  it('says it once for a batch discarded by one transition', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+    mockAlert.mockClear();
+
+    wrapper.vm.stageFile({ name: 'um.png', file: new Blob(['a']) });
+    wrapper.vm.stageFile({ name: 'dois.png', file: new Blob(['b']) });
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+    await vi.waitUntil(() => mockAlert.mock.calls.length > 0);
+
+    expect(mockAlert).toHaveBeenCalledTimes(1);
+  });
+
+  // A capture carries the generation it was staged under, and by the time it lands the
+  // composer may have moved on twice more. What invalidated it is the first transition past
+  // it, not the last one overall: reading only the latest reason loses the message here, and
+  // hands it to the wrong capture in the mirror case.
+  it('blames the transition that discarded the capture, not the last one', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+    mockAlert.mockClear();
+
+    const recorded = { isVoiceMessage: true, file: new Blob(['audio']) };
+    wrapper.vm.stageFile(recorded);
+
+    // The bot hands the conversation back: this is what the recording is lost to.
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+    // And the agent moves on before the upload lands.
+    store.commit('selectChat', { ...REPLIABLE, id: 99 });
+    await nextTick();
+    await vi.waitUntil(() => mockAlert.mock.calls.length > 0);
+
+    expect(mockAlert).toHaveBeenCalledWith(
+      'CONVERSATION.REPLYBOX.RECORDING_DISCARDED_ON_MODE_CHANGE'
+    );
+  });
+
+  // The watcher runs in both directions. Going into note mode is the agent choosing it, and
+  // the sentence would be false as well: nothing was about to reach the contact.
+  it('stays quiet when the agent switched into note mode', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+    mockAlert.mockClear();
+
+    wrapper.vm.stageFile({ name: 'doc.pdf', file: new Blob(['pdf']) });
+    wrapper.vm.replyType = REPLY_EDITOR_MODES.NOTE;
+    await nextTick();
+
+    wrapper.vm.stageFile({ name: 'current.png', file: new Blob(['image']) });
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(mockAlert).not.toHaveBeenCalled();
   });
 
   // Moving to another conversation is the agent's own action, with the composer resetting in

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -4,6 +4,12 @@ import { AUDIO_FORMATS } from 'shared/constants/messages';
 import { nextTick } from 'vue';
 import { createStore } from 'vuex';
 import ReplyBox from '../ReplyBox.vue';
+
+const mockAlert = vi.fn();
+vi.mock('dashboard/composables', async () => {
+  const actual = await vi.importActual('dashboard/composables');
+  return { ...actual, useAlert: (...args) => mockAlert(...args) };
+});
 import WhatsappTemplates from '../WhatsappTemplates/Modal.vue';
 
 const CHANNELS = [
@@ -639,6 +645,57 @@ describe('ReplyBox', () => {
     await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
 
     expect(wrapper.vm.attachedFiles).toHaveLength(1);
+  });
+
+  // The three drops above are not the same event to the agent. Leaving note mode is the one
+  // nothing they did causes -- a bot releases the conversation, the messaging window
+  // reopens, a restriction lifts -- so the recording goes with the composer looking exactly
+  // as they left it, and a silent drop there is indistinguishable from a broken button.
+  it('says so when the composer leaving note mode discarded a capture', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+    mockAlert.mockClear();
+
+    const recorded = { isVoiceMessage: true, file: new Blob(['audio']) };
+    wrapper.vm.stageFile(recorded);
+
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+    await vi.waitUntil(() => mockAlert.mock.calls.length > 0);
+
+    expect(mockAlert).toHaveBeenCalledWith(
+      'CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE'
+    );
+  });
+
+  // Moving to another conversation is the agent's own action, with the composer resetting in
+  // front of them. An alert on every upload in flight when they change conversation is noise
+  // on the ordinary case, which is how a message that matters stops being read.
+  it('stays quiet when the agent moved to another conversation', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+    mockAlert.mockClear();
+
+    wrapper.vm.stageFile({ name: 'doc.pdf', file: new Blob(['pdf']) });
+    store.commit('selectChat', { ...REPLIABLE, id: 99 });
+    await nextTick();
+
+    wrapper.vm.stageFile({ name: 'current.png', file: new Blob(['image']) });
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+    expect(mockAlert).not.toHaveBeenCalled();
   });
 
   it('drops a capture still uploading when the message it belonged to is sent', async () => {

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -814,9 +814,10 @@ describe('ReplyBox', () => {
     );
   });
 
-  // The watcher runs in both directions. Going into note mode is the agent choosing it, and
-  // the sentence would be false as well: nothing was about to reach the contact.
-  it('stays quiet when the agent switched into note mode', async () => {
+  // Both directions are worth reporting: what the agent loses is a file that will not be
+  // sent, which is news whoever caused the switch. Only the claim about the contact
+  // receiving it would have been direction-specific, and the wording does not make it.
+  it('says so when the agent switched into note mode', async () => {
     const { wrapper } = mountWith({
       inbox: { channel_type: 'Channel::Whatsapp' },
     });
@@ -826,11 +827,11 @@ describe('ReplyBox', () => {
     wrapper.vm.stageFile({ name: 'doc.pdf', file: new Blob(['pdf']) });
     wrapper.vm.replyType = REPLY_EDITOR_MODES.NOTE;
     await nextTick();
+    await vi.waitUntil(() => mockAlert.mock.calls.length > 0);
 
-    wrapper.vm.stageFile({ name: 'current.png', file: new Blob(['image']) });
-    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
-
-    expect(mockAlert).not.toHaveBeenCalled();
+    expect(mockAlert).toHaveBeenCalledWith(
+      'CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE'
+    );
   });
 
   // Moving to another conversation is the agent's own action, with the composer resetting in

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -786,6 +786,29 @@ describe('ReplyBox', () => {
     expect(mockAlert).toHaveBeenCalledTimes(1);
   });
 
+  // A slow upload can span more than one switch. The message belongs to the capture that
+  // has not landed yet, so a later transition must not take it: overwriting the marker
+  // loses it, and so does clearing it after announcing something else visible.
+  it('keeps the message for an upload that outlived two switches', async () => {
+    const { wrapper } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+    });
+    await nextTick();
+    mockAlert.mockClear();
+
+    wrapper.vm.stageFile({ name: 'lento.pdf', file: new Blob(['pdf']) });
+    const panel = wrapper.findComponent({ name: 'ReplyTopPanel' });
+    panel.vm.$emit('setReplyMode', REPLY_EDITOR_MODES.NOTE);
+    await nextTick();
+    panel.vm.$emit('setReplyMode', REPLY_EDITOR_MODES.REPLY);
+    await nextTick();
+    await vi.waitUntil(() => mockAlert.mock.calls.length > 0);
+
+    expect(mockAlert).toHaveBeenCalledWith(
+      'CONVERSATION.REPLYBOX.ATTACHMENT_DISCARDED_ON_MODE_CHANGE'
+    );
+  });
+
   // ReplyBox stays mounted for the whole session, so a map that recorded every navigation
   // and every send would only ever grow: nothing consumes an entry that is never announced.
   it('records nothing for the transitions it does not announce', async () => {

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -678,6 +678,36 @@ describe('ReplyBox', () => {
     );
   });
 
+  // The ordinary shape of this: the recording finished and is sitting in the composer when
+  // the bot hands the conversation back. It is discarded synchronously by the reset, so a
+  // message that waits for an upload callback is a message that never arrives.
+  it('says so when the capture had already finished uploading', async () => {
+    const { wrapper, store } = mountWith({
+      inbox: { channel_type: 'Channel::Whatsapp' },
+      chat: {
+        status: 'pending',
+        meta: { sender: { id: 2 }, assignee_type: 'AgentBot' },
+      },
+    });
+    await nextTick();
+
+    wrapper.vm.stageFile({ isVoiceMessage: true, file: new Blob(['audio']) });
+    await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+    mockAlert.mockClear();
+
+    store.commit('selectChat', {
+      ...REPLIABLE,
+      status: 'open',
+      meta: { sender: { id: 2 } },
+    });
+    await nextTick();
+
+    expect(wrapper.vm.attachedFiles).toHaveLength(0);
+    expect(mockAlert).toHaveBeenCalledWith(
+      'CONVERSATION.REPLYBOX.RECORDING_DISCARDED_ON_MODE_CHANGE'
+    );
+  });
+
   // stageFile is also the clip button, drag and drop, and paste. Telling an agent their
   // recording was discarded when what they dropped was a PDF is a message they cannot act
   // on, and one wrong message is enough to stop the right ones being read.
@@ -746,7 +776,7 @@ describe('ReplyBox', () => {
     store.commit('selectChat', { ...REPLIABLE, id: 43 });
     await nextTick();
 
-    expect(Object.keys(wrapper.vm.composerDropReasons)).toHaveLength(0);
+    expect(wrapper.vm.composerDropGeneration).toBeNull();
   });
 
   // A capture carries the generation it was staged under, and by the time it lands the

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
@@ -16,7 +16,8 @@
     },
     "REPLYBOX": {
       "SCHEDULE_SEND": "Schedule send",
-      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "The recording was discarded: the conversation left note mode, and it would have been sent to the contact."
+      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "The attachment was discarded: the conversation left note mode, and it would have been sent to the contact.",
+      "RECORDING_DISCARDED_ON_MODE_CHANGE": "The recording was discarded: the conversation left note mode, and it would have been sent to the contact."
     },
     "ASSIGNMENT_CONFLICT": {
       "TITLE": "Conversation already assigned",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
@@ -15,7 +15,8 @@
       "GROUPS_DISABLED_RESTRICTED": "Group messages are disabled — enable for free"
     },
     "REPLYBOX": {
-      "SCHEDULE_SEND": "Schedule send"
+      "SCHEDULE_SEND": "Schedule send",
+      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "The recording was discarded: the conversation left note mode, and it would have been sent to the contact."
     },
     "ASSIGNMENT_CONFLICT": {
       "TITLE": "Conversation already assigned",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
@@ -16,8 +16,8 @@
     },
     "REPLYBOX": {
       "SCHEDULE_SEND": "Schedule send",
-      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "The attachment was discarded: the conversation left note mode, and it would have been sent to the contact.",
-      "RECORDING_DISCARDED_ON_MODE_CHANGE": "The recording was discarded: the conversation left note mode, and it would have been sent to the contact."
+      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "The attachment was discarded because the conversation switched between note and reply.",
+      "RECORDING_DISCARDED_ON_MODE_CHANGE": "The recording was discarded because the conversation switched between note and reply."
     },
     "ASSIGNMENT_CONFLICT": {
       "TITLE": "Conversation already assigned",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
@@ -15,7 +15,8 @@
       "GROUPS_DISABLED_RESTRICTED": "Los mensajes de grupo están desactivados: actívelos gratis"
     },
     "REPLYBOX": {
-      "SCHEDULE_SEND": "Programar envío"
+      "SCHEDULE_SEND": "Programar envío",
+      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "La grabación se descartó: la conversación salió del modo nota y se habría enviado al contacto."
     },
     "ASSIGNMENT_CONFLICT": {
       "TITLE": "La conversación ya está asignada",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
@@ -16,8 +16,8 @@
     },
     "REPLYBOX": {
       "SCHEDULE_SEND": "Programar envío",
-      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "El archivo adjunto se descartó: la conversación salió del modo nota y se habría enviado al contacto.",
-      "RECORDING_DISCARDED_ON_MODE_CHANGE": "La grabación se descartó: la conversación salió del modo nota y se habría enviado al contacto."
+      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "El archivo adjunto se descartó porque la conversación cambió entre nota y respuesta.",
+      "RECORDING_DISCARDED_ON_MODE_CHANGE": "La grabación se descartó porque la conversación cambió entre nota y respuesta."
     },
     "ASSIGNMENT_CONFLICT": {
       "TITLE": "La conversación ya está asignada",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
@@ -16,7 +16,8 @@
     },
     "REPLYBOX": {
       "SCHEDULE_SEND": "Programar envío",
-      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "La grabación se descartó: la conversación salió del modo nota y se habría enviado al contacto."
+      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "El archivo adjunto se descartó: la conversación salió del modo nota y se habría enviado al contacto.",
+      "RECORDING_DISCARDED_ON_MODE_CHANGE": "La grabación se descartó: la conversación salió del modo nota y se habría enviado al contacto."
     },
     "ASSIGNMENT_CONFLICT": {
       "TITLE": "La conversación ya está asignada",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
@@ -16,8 +16,8 @@
     },
     "REPLYBOX": {
       "SCHEDULE_SEND": "Agendar envio",
-      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "O anexo foi descartado: a conversa saiu do modo nota e ele iria para o contato.",
-      "RECORDING_DISCARDED_ON_MODE_CHANGE": "A gravação foi descartada: a conversa saiu do modo nota e ela iria para o contato."
+      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "O anexo foi descartado porque a conversa alternou entre nota e resposta.",
+      "RECORDING_DISCARDED_ON_MODE_CHANGE": "A gravação foi descartada porque a conversa alternou entre nota e resposta."
     },
     "ASSIGNMENT_CONFLICT": {
       "TITLE": "Conversa já atribuída",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
@@ -16,7 +16,8 @@
     },
     "REPLYBOX": {
       "SCHEDULE_SEND": "Agendar envio",
-      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "A gravação foi descartada: a conversa saiu do modo nota e ela iria para o contato."
+      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "O anexo foi descartado: a conversa saiu do modo nota e ele iria para o contato.",
+      "RECORDING_DISCARDED_ON_MODE_CHANGE": "A gravação foi descartada: a conversa saiu do modo nota e ela iria para o contato."
     },
     "ASSIGNMENT_CONFLICT": {
       "TITLE": "Conversa já atribuída",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
@@ -15,7 +15,8 @@
       "GROUPS_DISABLED_RESTRICTED": "As mensagens de grupo estão desativadas — ative gratuitamente"
     },
     "REPLYBOX": {
-      "SCHEDULE_SEND": "Agendar envio"
+      "SCHEDULE_SEND": "Agendar envio",
+      "ATTACHMENT_DISCARDED_ON_MODE_CHANGE": "A gravação foi descartada: a conversa saiu do modo nota e ela iria para o contato."
     },
     "ASSIGNMENT_CONFLICT": {
       "TITLE": "Conversa já atribuída",


### PR DESCRIPTION
A recording or file staged in the reply box is thrown away when the composer's context changes under it, and until now the agent saw nothing at all: no alert, no placeholder, no entry in the attachment preview. The file simply never appeared. An agent records a 40-second note, a bot hands the conversation back mid-upload, and the recording vanishes with no explanation — so they record it again and watch it vanish again.

## Closes

- Closes #447

## How to reproduce

On a pending conversation owned by a bot, with the composer in note mode, start a recording. While the upload is still running, have the bot release the conversation. Before this, the recording disappeared silently.

## What changed

The discard itself is unchanged and worth keeping: without it a voice note recorded for the team can be attached to a public reply and reach the contact. What changes is that it stops being invisible.

Only one of the three drops is announced, and the split is deliberate. Leaving note mode is the one nothing the agent did causes — a bot releases the conversation it owned, the messaging window reopens, an Instagram restriction lifts — so the capture goes while the composer looks exactly as they left it. Navigating to another conversation and sending the message are the agent's own actions, with the composer visibly resetting in front of them; alerting on those is noise on the ordinary case, which is how the message that matters stops being read.

The wording says what happened and why rather than that something failed, and adding a second reason later is a line in `discardStagedCapture`.

## How to test

1. Open a pending conversation assigned to an agent bot on a WhatsApp inbox. The composer is in note mode.
2. Record a voice note and stop the recorder.
3. Before the upload finishes, release the conversation from the bot (assign it to yourself from another tab).
4. An alert says the recording was discarded because the conversation left note mode.
5. Repeat with step 3 replaced by moving to another conversation: the capture is still discarded, and no alert appears.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/470)
<!-- Reviewable:end -->
