### PR TITLE
feat(whatsapp): tell us when the vendored contract falls behind the connector

### DIFF
--- a/.github/workflows/fazer_ai_whatsapp_contract.yml
+++ b/.github/workflows/fazer_ai_whatsapp_contract.yml
@@ -13,7 +13,19 @@ on:
       - 'spec/fixtures/whatsapp/session/contract/**'
       - 'lib/whatsapp/session_contract.rb'
       - 'lib/tasks/whatsapp_session.rake'
+  # Weekly, because the drift this catches is not caused by anything happening in this
+  # repository: the connector ships an event or changes a payload and nothing here moves,
+  # so there is no push and no pull request for a check to hang off. Found the hard way at
+  # CONTRACT_REF 2c8da96, older than half the contract's own history, hiding a field the
+  # passkey flow needs and two event types with no model at all.
+  schedule:
+    - cron: '17 6 * * 1'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Connector ref to compare against (blank checks only the local copy)'
+        required: false
+        default: 'main'
 
 jobs:
   contract:
@@ -26,3 +38,21 @@ jobs:
       # No database or Redis: the task only reads the vendored files.
       - name: Verify the vendored contract
         run: bundle exec rails whatsapp:contract:verify
+
+  # Split from the job above so a pull request never reaches for the network, and so a
+  # connector that has moved ahead reads as its own failing check rather than as the
+  # contract job failing for a reason it does not own.
+  drift:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      # Never re-vendors on its own. A type the connector added needs a model and a
+      # decision about whether this side handles it or ignores it, and IGNORED is where
+      # that decision is recorded: a green sync would put the file in place and leave the
+      # decision unmade, which is the failure this check exists to make visible.
+      - name: Compare the vendored contract against the connector
+        run: bundle exec rails "whatsapp:contract:verify[${{ inputs.ref || 'main' }}]"

--- a/.github/workflows/fazer_ai_whatsapp_contract.yml
+++ b/.github/workflows/fazer_ai_whatsapp_contract.yml
@@ -2,6 +2,12 @@
 # vendored under spec/fixtures/whatsapp/session/contract, pinned by CONTRACT_REF. The
 # full spec suite only runs on tags, so this keeps a locally edited contract from
 # reaching main: re-vendor with `rails whatsapp:contract:sync[<ref>]` instead.
+#
+# It also runs the contract's own specs, and that is the half that matters on a
+# re-vendoring PR: `contract:verify` compares checksums, so a sync that brought a new event
+# type passes it while the model still answers Unknown and the dispatcher drops the event as
+# an unknown payload -- the exact silent drop the drift check exists to prevent, arriving
+# through the PR that was supposed to fix it.
 name: WhatsApp session contract
 
 permissions:
@@ -32,14 +38,41 @@ on:
 jobs:
   contract:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ''
+          POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:alpine
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      # No database or Redis: the task only reads the vendored files.
       - name: Verify the vendored contract
         run: bundle exec rails whatsapp:contract:verify
+      # These need the app booted, which is what the database above is for. They are the
+      # ones that fail when a type arrives with nothing to parse it: every golden frame has
+      # to build a typed payload and survive a round trip through the canonical model.
+      - name: Create database
+        run: bundle exec rake db:create db:schema:load
+      - name: Run the contract specs
+        run: bundle exec rspec spec/lib/whatsapp/session_contract_spec.rb spec/services/whatsapp/session/inbound/dispatcher_spec.rb
 
   # Split from the job above so a pull request never reaches for the network, and so a
   # connector that has moved ahead reads as its own failing check rather than as the

--- a/.github/workflows/fazer_ai_whatsapp_contract.yml
+++ b/.github/workflows/fazer_ai_whatsapp_contract.yml
@@ -22,8 +22,10 @@ on:
     - cron: '17 6 * * 1'
   workflow_dispatch:
     inputs:
+      # Blank means main: the drift job exists to compare, and the local-only check runs
+      # in the job above on every dispatch anyway.
       ref:
-        description: 'Connector ref to compare against (blank checks only the local copy)'
+        description: 'Connector ref to compare against (branch, tag or commit)'
         required: false
         default: 'main'
 

--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 # rubocop:disable Metrics/BlockLength
 namespace :whatsapp do
   namespace :contract do
@@ -6,18 +8,27 @@ namespace :whatsapp do
       puts Whatsapp::SessionContract.checksum
     end
 
-    desc 'Fail when the vendored contract no longer matches CONTRACT_REF (used by CI)'
-    task verify: :environment do
+    # Two different questions, and only the first one used to be asked. Without a ref this
+    # compares the vendored files against the checksum CONTRACT_REF recorded, which catches
+    # a local edit to the copy and nothing else: the connector can add an event, change a
+    # payload, and this side stays silently behind until somebody happens to re-vendor for
+    # an unrelated reason. With a ref it also fetches the connector at that ref and says
+    # what is actually different.
+    desc 'Fail when the vendored contract no longer matches CONTRACT_REF; with a ref, also when it is behind the connector'
+    task :verify, [:ref] => :environment do |_task, args|
       reference = Whatsapp::SessionContract.reference
       actual = Whatsapp::SessionContract.checksum
 
-      if reference['checksum'] == actual
-        puts "contract ok (#{reference['repo']}@#{reference['ref'][0, 12]}, protocol v#{Whatsapp::SessionContract.protocol_version})"
-      else
+      unless reference['checksum'] == actual
         warn "contract drift: CONTRACT_REF says #{reference['checksum']}, files hash to #{actual}"
         warn 'Run `rails whatsapp:contract:sync[<ref>]` to re-vendor, or revert the local edit.'
         exit 1
       end
+
+      puts "contract ok (#{reference['repo']}@#{reference['ref'][0, 12]}, protocol v#{Whatsapp::SessionContract.protocol_version})"
+      next if args[:ref].blank?
+
+      WhatsappContractDrift.against(args[:ref], repo: reference['repo'])
     end
 
     desc 'Re-vendor the contract from a whatsapp-connector checkout (WHATSAPP_CONNECTOR_PATH)'
@@ -291,6 +302,53 @@ module WhatsappProviderConversion
 
       puts "  #{verb}    #{label}#{note ? ": #{note}" : ''}"
       true
+    end
+  end
+end
+
+# Comparing the vendored contract against the connector it came from. Kept out of
+# Whatsapp::SessionContract because it is the only part that needs the network: the app
+# reads the vendored copy and nothing else, and a checkout belongs to the task that asked
+# for one.
+module WhatsappContractDrift
+  class << self
+    def against(ref, repo:)
+      Dir.mktmpdir do |dir|
+        fetch(repo, ref, dir)
+        report(Whatsapp::SessionContract.diff(File.join(dir, 'contract')), "#{repo}@#{ref}")
+      end
+    end
+
+    private
+
+    # Fetching the ref rather than cloning a branch, because a branch, a tag and a bare
+    # commit then all work the same way, which is what lets the weekly run ask for `main`
+    # and a person ask for the exact commit a connector release was cut from.
+    def fetch(repo, ref, dir)
+      url = "https://github.com/#{repo}.git"
+      fetched = system('git', 'init', '--quiet', dir) &&
+                system('git', '-C', dir, 'fetch', '--quiet', '--depth', '1', url, ref) &&
+                system('git', '-C', dir, 'checkout', '--quiet', 'FETCH_HEAD')
+      abort "could not fetch #{repo}@#{ref}" unless fetched
+      abort "#{repo}@#{ref} carries no contract/ directory" unless File.directory?(File.join(dir, 'contract'))
+    end
+
+    def report(diff, label)
+      if diff.values.all?(&:empty?)
+        puts "in sync with #{label}"
+        return
+      end
+
+      warn "vendored contract differs from #{label}:"
+      { behind: 'only in the connector', stale: 'differs here', ahead: 'only here' }.each do |key, description|
+        diff[key].each { |path| warn "  #{description}: #{path}" }
+      end
+      # Never automatic. A type the connector added needs a model and a decision about
+      # whether this side handles it or ignores it, and IGNORED is where that decision is
+      # recorded -- re-vendoring on its own would put the file in place and leave the
+      # decision unmade.
+      warn 'Run `rails whatsapp:contract:sync[<ref>]` to re-vendor, then model or ignore whatever it brought.'
+      exit 1
     end
   end
 end

--- a/lib/whatsapp/session_contract.rb
+++ b/lib/whatsapp/session_contract.rb
@@ -7,6 +7,10 @@
 module Whatsapp::SessionContract
   ROOT = 'spec/fixtures/whatsapp/session/contract'.freeze
   REFERENCE_FILE = 'CONTRACT_REF'.freeze
+  # Not part of the contract. CONTRACT_REF stores the result of hashing it, and the
+  # connector's README describes the directory to somebody reading it there -- `sync` drops
+  # it, so counting it would make every comparison against the connector report drift.
+  UNVENDORED = [REFERENCE_FILE, 'README.md'].freeze
 
   class << self
     def root
@@ -38,13 +42,40 @@ module Whatsapp::SessionContract
     end
 
     # Content hash of every vendored file, so a drift check does not depend on git.
-    # CONTRACT_REF itself is excluded: it stores the result.
+    #
+    # The formula is load-bearing: every CONTRACT_REF ever written records its output, so
+    # concatenating each path with the file's raw bytes is not a detail to tidy up. Hashing
+    # the files individually first and folding those digests together produces a different
+    # answer and unpins every copy in the fleet.
     def checksum(directory = root)
-      files = Dir.glob("#{directory}/**/*").select { |path| File.file?(path) && File.basename(path) != REFERENCE_FILE }.sort
-      digest = files.sum('') do |path|
-        "#{Pathname.new(path).relative_path_from(directory)}\0#{File.read(path)}\0"
+      digest = contract_files(directory).sum('') do |path|
+        "#{Pathname.new(path).relative_path_from(Pathname.new(directory))}\0#{File.read(path)}\0"
       end
       Digest::SHA256.hexdigest(digest)
+    end
+
+    # Every contract file with the hash of its contents, keyed by its path inside the
+    # contract directory, so two copies can be compared file by file rather than only
+    # judged equal or not.
+    def manifest(directory = root)
+      contract_files(directory).to_h do |path|
+        [Pathname.new(path).relative_path_from(Pathname.new(directory)).to_s, Digest::SHA256.hexdigest(File.read(path))]
+      end
+    end
+
+    # What this copy is missing, carrying or holding a stale version of, against another
+    # checkout of the contract. `behind` is the one that matters: a type the connector has
+    # added and this side has no model for is dispatched as Unknown and logged as an unknown
+    # payload, which is the same shape as a type we deliberately ignore -- so the IGNORED
+    # list, which exists so a dropped type is a decision on the record, is bypassed entirely.
+    def diff(other)
+      ours = manifest
+      theirs = manifest(other)
+      shared = ours.keys & theirs.keys
+
+      { stale: shared.reject { |path| ours[path] == theirs[path] }.sort,
+        behind: (theirs.keys - ours.keys).sort,
+        ahead: (ours.keys - theirs.keys).sort }
     end
 
     # Parsed CONTRACT_REF: which connector commit this copy came from, and the checksum
@@ -65,6 +96,10 @@ module Whatsapp::SessionContract
     end
 
     private
+
+    def contract_files(directory)
+      Dir.glob("#{directory}/**/*").select { |path| File.file?(path) && UNVENDORED.exclude?(File.basename(path)) }.sort
+    end
 
     # json_schemer resolves $ref against the document root, so a sub-schema is validated
     # by pointing a tiny wrapper document at it.

--- a/spec/lib/whatsapp/session_contract_spec.rb
+++ b/spec/lib/whatsapp/session_contract_spec.rb
@@ -25,6 +25,46 @@ RSpec.describe Whatsapp::SessionContract do
     expect(described_class.protocol_version).to eq(Whatsapp::Session::PROTOCOL_VERSION)
   end
 
+  # `drifted?` above only compares the copy against the checksum it was vendored with, so it
+  # catches a local edit and nothing else. Saying what is different from another checkout is
+  # what lets the weekly run name the event the connector added while this side was not
+  # looking, which otherwise reaches the dispatcher as Unknown and is logged as an unknown
+  # payload -- the same shape as a type we deliberately ignore.
+  describe '.diff' do
+    let(:other) { Pathname.new(Dir.mktmpdir) }
+
+    before { FileUtils.cp_r("#{described_class.root}/.", other) }
+
+    after { FileUtils.rm_rf(other) }
+
+    it 'finds nothing between two copies of the same contract' do
+      expect(described_class.diff(other).values.flatten).to be_empty
+    end
+
+    it 'names a file the other copy has and this one does not' do
+      other.join('fixtures/events/session_something_the_connector_added.json').write('{}')
+
+      expect(described_class.diff(other))
+        .to include(behind: ['fixtures/events/session_something_the_connector_added.json'], stale: [], ahead: [])
+    end
+
+    it 'names a file whose contents moved on' do
+      other.join('PROTOCOL_VERSION').write('99')
+
+      expect(described_class.diff(other)).to include(stale: ['PROTOCOL_VERSION'], behind: [], ahead: [])
+    end
+
+    # CONTRACT_REF records the result of hashing the contract and the connector's README
+    # describes the directory to whoever reads it there. Counting either would report drift
+    # on every comparison, for ever.
+    it 'ignores the files that are not part of the contract' do
+      other.join('README.md').write('the contract lives here')
+      other.join('CONTRACT_REF').write('repo=someone/else\nref=deadbeef\nchecksum=nonsense\n')
+
+      expect(described_class.diff(other).values.flatten).to be_empty
+    end
+  end
+
   it 'has not been edited locally' do
     expect(described_class.drifted?).to be(false),
                                         'the vendored contract no longer matches CONTRACT_REF; run rails whatsapp:contract:sync'


### PR DESCRIPTION
The WhatsApp session protocol contract is owned by the connector and vendored here. Nothing was watching whether the copy was still current: the check we had compares the vendored files against the checksum recorded when they were vendored, so it catches somebody editing the copy and nothing else. The connector could add an event, change a payload, and this side stayed silently behind until somebody happened to re-vendor for an unrelated reason.

That is not hypothetical. `CONTRACT_REF` once sat at `2c8da96`, a commit older than more than half the contract's own history, and re-vendoring surfaced a field the passkey flow needs to tie an answer to its request, two event types with no model at all (so a connector reporting how much a session missed while it was down was reaching a shrug), and two fixtures simply absent. None of it failed anything.

## Closes

- Closes #443

## What changed

`whatsapp:contract:verify` now takes an optional ref. Without one it behaves exactly as before. With one it fetches the connector at that ref and reports, per file, what is only in the connector, what differs here, and what is only here — the per-file answer being the point, since "the checksums differ" does not tell you an event type arrived with no model behind it.

A weekly job runs it against `main`. Weekly rather than per-push because the drift is not caused by anything happening in this repository: there is no commit here to hang a check on. It is a separate job from the existing one, so a pull request never reaches for the network and a connector that has moved ahead reads as its own failing check.

It never re-vendors on its own, and that is deliberate. A type the connector added needs a model and a decision about whether this side handles it or ignores it, and `IGNORED` is where that decision is recorded — a green automatic sync would put the file in place and leave the decision unmade, which is exactly the failure this check exists to make visible.

## How to test

```
bundle exec rails whatsapp:contract:verify          # local check, unchanged
bundle exec rails "whatsapp:contract:verify[main]"  # also compares against the connector
```

The second prints `in sync with fazer-ai/whatsapp-connector@main`, or lists the differing files and exits non-zero. Any branch, tag or commit works as the ref, so a connector release can be checked by the exact commit it was cut from. The connector repo is public, so no credential is involved.

## What this does not do

A scheduled workflow that fails notifies by email rather than anywhere the team is actually looking. If a weekly email turns out to be too quiet, the same task is what a Discord notification step would wrap — the check is in place either way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/471)
<!-- Reviewable:end -->
