### PR TITLE
feat(automations): match message_created rules on the message sender

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -141,3 +141,15 @@ config/initializers/active_storage_opus_fix.rb: Update the Baileys inbound MIME 
 # note and reply more than five times, and it costs silence, which is what every discard did
 # before this PR. Revisit if the alert proves it earns more machinery.
 app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue: Retain markers for uploads that are still pending  # PR#470
+# PR#472: real, pre-existing, and wider than these two keys. `syncCustomAttributeTypes` resolves a
+# condition with `filterTypes.find(ft => ft.attributeKey === condition.attribute_key)` and
+# `manifestCustomAttributes` puts the standard conditions first, so an account attribute whose key
+# matches a standard one resolves to the standard entry and has its `custom_attribute_type` cleared on
+# save. `CustomAttributeDefinition::STANDARD_ATTRIBUTES` reserves only conversation and contact names,
+# so `content`, `message_type` and `private_note` have carried this exposure for as long as they have
+# existed; `sender_id` and `sender_type` add two names to it and change nothing else. Closing it means
+# keying options by (attributeKey, attributeModel) through FilterSelect and ConditionRow, which the
+# conversation filters share, and there is no cheap half: preserving an existing `custom_attribute_type`
+# on save would still clear it the first time the user picks the attribute. The backend half is fixed
+# in this PR, so a condition that reaches the API with its model declared is now resolved by it.
+app/javascript/dashboard/routes/dashboard/settings/automation/constants.js: Preserve custom attributes that use the new sender keys  # PR#472

--- a/app/javascript/dashboard/composables/useAutomationValues.js
+++ b/app/javascript/dashboard/composables/useAutomationValues.js
@@ -11,6 +11,7 @@ import {
 import {
   MESSAGE_CONDITION_VALUES,
   PRIORITY_CONDITION_VALUES,
+  SENDER_TYPE_CONDITION_VALUES,
 } from 'dashboard/constants/automation';
 
 /**
@@ -71,6 +72,13 @@ export default function useAutomationValues() {
     }))
   );
 
+  const senderTypeOptions = computed(() =>
+    SENDER_TYPE_CONDITION_VALUES.map(item => ({
+      id: item.id,
+      name: t(`AUTOMATION.SENDER_TYPES.${item.i18nKey}`),
+    }))
+  );
+
   const priorityOptions = computed(() =>
     PRIORITY_CONDITION_VALUES.map(item => ({
       id: item.id,
@@ -108,6 +116,7 @@ export default function useAutomationValues() {
       statusFilterOptions: statusFilterOptions.value,
       priorityOptions: priorityOptions.value,
       messageTypeOptions: messageTypeOptions.value,
+      senderTypeOptions: senderTypeOptions.value,
       teams: teams.value,
       languages,
       countries,
@@ -150,6 +159,7 @@ export default function useAutomationValues() {
     statusFilterOptions,
     priorityOptions,
     messageTypeOptions,
+    senderTypeOptions,
     getConditionDropdownValues,
     getActionDropdownValues,
     agents,

--- a/app/javascript/dashboard/constants/automation.js
+++ b/app/javascript/dashboard/constants/automation.js
@@ -61,6 +61,10 @@ export const SENDER_TYPE_CONDITION_VALUES = [
     id: 'AgentBot',
     i18nKey: 'AGENT_BOT',
   },
+  {
+    id: 'Captain::Assistant',
+    i18nKey: 'CAPTAIN',
+  },
 ];
 
 export const PRIORITY_CONDITION_VALUES = [

--- a/app/javascript/dashboard/constants/automation.js
+++ b/app/javascript/dashboard/constants/automation.js
@@ -48,6 +48,21 @@ export const MESSAGE_CONDITION_VALUES = [
   },
 ];
 
+export const SENDER_TYPE_CONDITION_VALUES = [
+  {
+    id: 'Contact',
+    i18nKey: 'CONTACT',
+  },
+  {
+    id: 'User',
+    i18nKey: 'USER',
+  },
+  {
+    id: 'AgentBot',
+    i18nKey: 'AGENT_BOT',
+  },
+];
+
 export const PRIORITY_CONDITION_VALUES = [
   {
     id: 'nil',

--- a/app/javascript/dashboard/helper/automationHelper.js
+++ b/app/javascript/dashboard/helper/automationHelper.js
@@ -182,6 +182,7 @@ export const getConditionOptions = ({
   type,
   priorityOptions,
   messageTypeOptions,
+  senderTypeOptions,
 }) => {
   if (isCustomAttributeCheckbox(customAttributes, type)) {
     return booleanFilterOptions;
@@ -203,6 +204,8 @@ export const getConditionOptions = ({
     country_code: countries,
     message_type: messageTypeOptions,
     private_note: booleanFilterOptions,
+    sender_id: agents,
+    sender_type: senderTypeOptions,
     priority: priorityOptions,
     group_type: [
       { id: 'individual', name: 'Individual' },

--- a/app/javascript/dashboard/helper/specs/automationHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/automationHelper.spec.js
@@ -179,6 +179,22 @@ describe('getConditionOptions', () => {
     ).toEqual(testOptions);
   });
 
+  it('returns sender type options for sender_type', () => {
+    const senderTypeOptions = [
+      { id: 'Contact', name: 'Contact' },
+      { id: 'User', name: 'Agent' },
+      { id: 'AgentBot', name: 'Bot' },
+    ];
+
+    expect(
+      helpers.getConditionOptions({
+        senderTypeOptions,
+        customAttributes,
+        type: 'sender_type',
+      })
+    ).toEqual(senderTypeOptions);
+  });
+
   it('returns boolean options for private_note', () => {
     const booleanOptions = [
       { id: true, name: 'True' },

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/automation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/automation.json
@@ -17,7 +17,8 @@
     "SENDER_TYPES": {
       "CONTACT": "Contact",
       "USER": "Agent",
-      "AGENT_BOT": "Bot"
+      "AGENT_BOT": "Bot",
+      "CAPTAIN": "Captain"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/automation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/automation.json
@@ -9,6 +9,15 @@
     },
     "ACTIONS": {
       "CREATE_SCHEDULED_MESSAGE": "Create Scheduled Message"
+    },
+    "ATTRIBUTES": {
+      "SENDER": "Sender",
+      "SENDER_TYPE": "Sender Type"
+    },
+    "SENDER_TYPES": {
+      "CONTACT": "Contact",
+      "USER": "Agent",
+      "AGENT_BOT": "Bot"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/automation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/automation.json
@@ -17,7 +17,8 @@
     "SENDER_TYPES": {
       "CONTACT": "Contacto",
       "USER": "Agente",
-      "AGENT_BOT": "Bot"
+      "AGENT_BOT": "Bot",
+      "CAPTAIN": "Captain"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/automation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/automation.json
@@ -9,6 +9,15 @@
     },
     "ACTIONS": {
       "CREATE_SCHEDULED_MESSAGE": "Crear mensaje programado"
+    },
+    "ATTRIBUTES": {
+      "SENDER": "Remitente",
+      "SENDER_TYPE": "Tipo de remitente"
+    },
+    "SENDER_TYPES": {
+      "CONTACT": "Contacto",
+      "USER": "Agente",
+      "AGENT_BOT": "Bot"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/automation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/automation.json
@@ -17,7 +17,8 @@
     "SENDER_TYPES": {
       "CONTACT": "Contato",
       "USER": "Agente",
-      "AGENT_BOT": "Bot"
+      "AGENT_BOT": "Bot",
+      "CAPTAIN": "Captain"
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/automation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/automation.json
@@ -9,6 +9,15 @@
     },
     "ACTIONS": {
       "CREATE_SCHEDULED_MESSAGE": "Criar Mensagem Agendada"
+    },
+    "ATTRIBUTES": {
+      "SENDER": "Remetente",
+      "SENDER_TYPE": "Tipo de remetente"
+    },
+    "SENDER_TYPES": {
+      "CONTACT": "Contato",
+      "USER": "Agente",
+      "AGENT_BOT": "Bot"
     }
   }
 }

--- a/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/automation/constants.js
@@ -21,6 +21,18 @@ export const AUTOMATIONS = {
         filterOperators: OPERATOR_TYPES_1,
       },
       {
+        key: 'sender_id',
+        name: 'SENDER',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
+        key: 'sender_type',
+        name: 'SENDER_TYPE',
+        inputType: 'search_select',
+        filterOperators: OPERATOR_TYPES_1,
+      },
+      {
         key: 'content',
         name: 'MESSAGE_CONTAINS',
         inputType: 'comma_separated_plain_text',

--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -51,7 +51,7 @@ class AutomationRule < ApplicationRecord
 
   def conditions_attributes
     %w[content email country_code status message_type browser_language assignee_id team_id referer city company_name inbox_id
-       mail_subject phone_number priority conversation_language labels private_note]
+       mail_subject phone_number priority conversation_language labels private_note sender_id sender_type]
   end
 
   def actions_attributes

--- a/app/services/automation_rules/condition_validation_service.rb
+++ b/app/services/automation_rules/condition_validation_service.rb
@@ -34,16 +34,16 @@ class AutomationRules::ConditionValidationService
 
   def valid_condition?(condition)
     key = condition['attribute_key']
+    attribute_model = condition['custom_attribute_type']
+    # Same precedence as ConditionsFilterService#apply_filter: a condition that declares a
+    # custom_attribute_type is about an account attribute, so it must not be validated against a
+    # standard key that happens to share the name -- its operators are a different set.
+    return custom_attribute_present?(key, attribute_model) if attribute_model.present?
 
-    conversation_filter = @conversation_filters[key]
-    contact_filter = @contact_filters[key]
-    message_filter = @message_filters[key]
+    standard_filter = @conversation_filters[key] || @contact_filters[key] || @message_filters[key]
+    return operation_valid?(condition, standard_filter) if standard_filter
 
-    if conversation_filter || contact_filter || message_filter
-      operation_valid?(condition, conversation_filter || contact_filter || message_filter)
-    else
-      custom_attribute_present?(key, condition['custom_attribute_type'])
-    end
+    custom_attribute_present?(key, attribute_model)
   end
 
   def operation_valid?(condition, filter)

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -61,6 +61,12 @@ class AutomationRules::ConditionsFilterService < FilterService
   end
 
   def apply_filter(query_hash, current_index)
+    # A condition that names an account attribute says so in custom_attribute_type. The standard keys
+    # are resolved first below, and message keys are not reserved names -- CustomAttributeDefinition
+    # only guards the conversation and contact ones -- so an account attribute called `sender_id` or
+    # `content` would otherwise be answered by the message column instead, silently.
+    return apply_custom_attribute_filter(query_hash, current_index) if query_hash['custom_attribute_type'].present?
+
     conversation_filter = @conversation_filters[query_hash['attribute_key']]
     contact_filter = @contact_filters[query_hash['attribute_key']]
     message_filter = @message_filters[query_hash['attribute_key']]
@@ -71,10 +77,16 @@ class AutomationRules::ConditionsFilterService < FilterService
       @query_string += contact_query_string(contact_filter, query_hash.with_indifferent_access, current_index)
     elsif message_filter
       @query_string += message_query_string(message_filter, query_hash.with_indifferent_access, current_index)
-    elsif custom_attribute(query_hash['attribute_key'], @account, query_hash['custom_attribute_type'])
-      # send table name according to attribute key right now we are supporting contact based custom attribute filter
-      @query_string += custom_attribute_query(query_hash.with_indifferent_access, query_hash['custom_attribute_type'], current_index)
+    else
+      apply_custom_attribute_filter(query_hash, current_index)
     end
+  end
+
+  def apply_custom_attribute_filter(query_hash, current_index)
+    return unless custom_attribute(query_hash['attribute_key'], @account, query_hash['custom_attribute_type'])
+
+    # send table name according to attribute key right now we are supporting contact based custom attribute filter
+    @query_string += custom_attribute_query(query_hash.with_indifferent_access, query_hash['custom_attribute_type'], current_index)
   end
 
   # If attribute_changed type filter is present perform this against array

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -82,9 +82,9 @@ class AutomationRules::ConditionsFilterService < FilterService
     end
   end
 
+  # custom_attribute_query answers '' when the account has no attribute by that name, so the missing
+  # case needs no guard of its own here.
   def apply_custom_attribute_filter(query_hash, current_index)
-    return unless custom_attribute(query_hash['attribute_key'], @account, query_hash['custom_attribute_type'])
-
     # send table name according to attribute key right now we are supporting contact based custom attribute filter
     @query_string += custom_attribute_query(query_hash.with_indifferent_access, query_hash['custom_attribute_type'], current_index)
   end
@@ -137,6 +137,8 @@ class AutomationRules::ConditionsFilterService < FilterService
     attribute_key = query_hash['attribute_key']
     query_operator = query_hash['query_operator']
 
+    return sender_id_query_string(query_hash, current_index) if attribute_key == 'sender_id'
+
     attribute_key = 'processed_message_content' if attribute_key == 'content'
     attribute_key = 'private' if attribute_key == 'private_note'
 
@@ -150,6 +152,16 @@ class AutomationRules::ConditionsFilterService < FilterService
         " messages.#{attribute_key} #{filter_operator_value} #{query_operator} "
       end
     end
+  end
+
+  # The Sender condition offers agents, so it has to mean an agent. messages.sender_id is polymorphic
+  # and contacts, users and bots number their rows independently, so an id on its own is satisfied by
+  # the contact that happens to hold it too, firing a rule about one agent for a stranger.
+  def sender_id_query_string(query_hash, current_index)
+    membership = filter_operation(query_hash.merge('filter_operator' => 'equal_to'), current_index)
+    clause = "(messages.sender_type = 'User' AND messages.sender_id #{membership})"
+    clause = "NOT #{clause}" if query_hash['filter_operator'] == 'not_equal_to'
+    " #{clause} #{query_hash['query_operator']} "
   end
 
   # This will be used in future for contact automation rule

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -47,6 +47,12 @@ class FilterService
     attribute_key = query_hash['attribute_key']
     values = query_hash['values']
 
+    # The cases below translate the UI's labels for standard keys. A condition that declares a
+    # custom_attribute_type is about an account attribute that merely shares one of those names, and
+    # its values are the attribute's own: a checkbox attribute holds a boolean, which has no #downcase,
+    # and the NoMethodError is swallowed upstream, leaving the rule quietly dead.
+    return case_insensitive_values(query_hash) if query_hash['custom_attribute_type'].present?
+
     return conversation_status_values(values) if attribute_key == 'status'
     return conversation_priority_values(values) if attribute_key == 'priority'
     return conversation_group_type_values(values) if attribute_key == 'group_type'

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -51,7 +51,7 @@ class FilterService
     return conversation_priority_values(values) if attribute_key == 'priority'
     return conversation_group_type_values(values) if attribute_key == 'group_type'
     return message_type_values(values) if attribute_key == 'message_type'
-    return downcase_array_values(values) if attribute_key == 'content'
+    return downcase_array_values(values) if attribute_key.in?(%w[content sender_type])
 
     case_insensitive_values(query_hash)
   end

--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -240,5 +240,17 @@ messages:
       - "not_equal_to"
       - "contains"
       - "does_not_contain"
+  sender_id:
+    attribute_type: "standard"
+    data_type: "numeric"
+    filter_operators:
+      - "equal_to"
+      - "not_equal_to"
+  sender_type:
+    attribute_type: "standard"
+    data_type: "text"
+    filter_operators:
+      - "equal_to"
+      - "not_equal_to"
 
 ### ----- End of Message Filters ----- ###

--- a/spec/services/automation_rules/condition_validation_service_spec.rb
+++ b/spec/services/automation_rules/condition_validation_service_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe AutomationRules::ConditionValidationService do
           { 'values': ['open'], 'attribute_key': 'status', 'query_operator': nil, 'filter_operator': 'equal_to' },
           { 'values': ['+918484'], 'attribute_key': 'phone_number', 'query_operator': 'OR', 'filter_operator': 'contains' },
           { 'values': ['test'], 'attribute_key': 'email', 'query_operator': 'OR', 'filter_operator': 'contains' },
-          { 'values': [true], 'attribute_key': 'private_note', 'query_operator': nil, 'filter_operator': 'equal_to' }
+          { 'values': [true], 'attribute_key': 'private_note', 'query_operator': 'OR', 'filter_operator': 'equal_to' },
+          { 'values': [1], 'attribute_key': 'sender_id', 'query_operator': 'OR', 'filter_operator': 'not_equal_to' },
+          { 'values': ['User'], 'attribute_key': 'sender_type', 'query_operator': nil, 'filter_operator': 'equal_to' }
         ]
         rule.save # rubocop:disable Rails/SaveBang
       end

--- a/spec/services/automation_rules/condition_validation_service_spec.rb
+++ b/spec/services/automation_rules/condition_validation_service_spec.rb
@@ -23,6 +23,24 @@ RSpec.describe AutomationRules::ConditionValidationService do
       end
     end
 
+    context 'with an account attribute that shares its name with a message attribute' do
+      before do
+        create(:custom_attribute_definition, attribute_key: 'sender_id', account: account,
+                                             attribute_model: 'conversation_attribute', attribute_display_type: 'text')
+        # `contains` is not a valid operator for the sender_id message key, so validating against it
+        # would reject a condition that is about the account attribute.
+        rule.conditions = [
+          { 'values': ['crm'], 'attribute_key': 'sender_id', 'query_operator': nil,
+            'filter_operator': 'contains', 'custom_attribute_type': 'conversation_attribute' }
+        ]
+        rule.save # rubocop:disable Rails/SaveBang
+      end
+
+      it 'returns true' do
+        expect(described_class.new(rule).perform).to be(true)
+      end
+    end
+
     context 'with wrong attribute' do
       before do
         rule.conditions = [

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -202,6 +202,26 @@ RSpec.describe AutomationRules::ConditionsFilterService do
 
           expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(false)
         end
+
+        it 'will return true for the agent holding the id when the rule does not pin the sender type' do
+          rule.update!(conditions: [
+                         { 'values': [agent.id], 'attribute_key': 'sender_id', 'query_operator': nil, 'filter_operator': 'equal_to' }
+                       ])
+          message.update!(sender: agent)
+
+          expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(true)
+        end
+
+        # sender_id is polymorphic and contacts number their rows independently of users, so an
+        # unpinned id would otherwise be answered by whichever contact happens to hold it.
+        it 'will return false for a contact holding the agent id when the rule does not pin the sender type' do
+          rule.update!(conditions: [
+                         { 'values': [agent.id], 'attribute_key': 'sender_id', 'query_operator': nil, 'filter_operator': 'equal_to' }
+                       ])
+          message.update!(sender_type: 'Contact', sender_id: agent.id)
+
+          expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(false)
+        end
       end
 
       context 'when an account attribute shares its name with a message attribute' do
@@ -217,6 +237,19 @@ RSpec.describe AutomationRules::ConditionsFilterService do
         end
 
         it 'resolves the account attribute instead of the message column' do
+          expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(true)
+        end
+
+        # A checkbox attribute holds a boolean, and the standard sender_type key is compared downcased.
+        it 'leaves a checkbox account attribute alone instead of downcasing its boolean' do
+          create(:custom_attribute_definition, attribute_key: 'sender_type', account: account,
+                                               attribute_model: 'conversation_attribute', attribute_display_type: 'checkbox')
+          conversation.update!(custom_attributes: { sender_type: true })
+          rule.update!(conditions: [
+                         { 'values': [true], 'attribute_key': 'sender_type', 'query_operator': nil,
+                           'filter_operator': 'equal_to', 'custom_attribute_type': 'conversation_attribute' }
+                       ])
+
           expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(true)
         end
       end

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -165,6 +165,45 @@ RSpec.describe AutomationRules::ConditionsFilterService do
         end
       end
 
+      context 'when filtering by the message sender' do
+        let(:agent) { create(:user, account: account, role: :agent) }
+        let(:bot_agent) { create(:user, account: account, role: :agent) }
+
+        before do
+          rule.conditions = [
+            { 'values': [bot_agent.id], 'attribute_key': 'sender_id', 'query_operator': 'AND', 'filter_operator': 'not_equal_to' },
+            { 'values': ['User'], 'attribute_key': 'sender_type', 'query_operator': nil, 'filter_operator': 'equal_to' }
+          ]
+          rule.save!
+        end
+
+        it 'will return true when another agent sent the message' do
+          message.update!(sender: agent)
+
+          expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(true)
+        end
+
+        it 'will return false when the excluded agent sent the message' do
+          message.update!(sender: bot_agent)
+
+          expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(false)
+        end
+
+        # sender_id is a polymorphic id: without sender_type a contact sharing the agent's id would match.
+        it 'will return false when a contact sent the message' do
+          message.update!(sender: conversation.contact)
+
+          expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(false)
+        end
+
+        # `sender_id != x` is NULL, not true, for a message nobody signed. Not matching is the intended read.
+        it 'will return false when the message has no sender' do
+          message.update!(sender: nil)
+
+          expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(false)
+        end
+      end
+
       context 'when filter_operator is on processed_message_content' do
         before do
           rule.conditions = [

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -204,6 +204,23 @@ RSpec.describe AutomationRules::ConditionsFilterService do
         end
       end
 
+      context 'when an account attribute shares its name with a message attribute' do
+        before do
+          create(:custom_attribute_definition, attribute_key: 'sender_id', account: account,
+                                               attribute_model: 'conversation_attribute', attribute_display_type: 'text')
+          conversation.update!(custom_attributes: { sender_id: 'crm-42' })
+          rule.conditions = [
+            { 'values': ['crm-42'], 'attribute_key': 'sender_id', 'query_operator': nil,
+              'filter_operator': 'equal_to', 'custom_attribute_type': 'conversation_attribute' }
+          ]
+          rule.save!
+        end
+
+        it 'resolves the account attribute instead of the message column' do
+          expect(described_class.new(rule, conversation, { message: message, changed_attributes: {} }).perform).to be(true)
+        end
+      end
+
       context 'when filter_operator is on processed_message_content' do
         before do
           rule.conditions = [


### PR DESCRIPTION
Automation rules can now match on **who** sent the message. A Message Created rule can single out a reply written by a particular agent, or exclude the ones a bot account posts, instead of guessing from the text of the message.

## How to test

1. Settings → Automation → new rule on **Message Created**.
2. Add **Sender Type** = Agent and **Sender** ≠ *(the bot account)*, plus an action such as adding a label.
3. Reply in a conversation as any other agent: the action runs.
4. Reply as the excluded account: it does not.
5. Point the same rule at **Sender Type** = Contact and it matches the customer's own messages instead.

A message nobody signed (a system or template message with no sender) never matches a Sender condition, in either direction.

## What changed

- `sender_id` and `sender_type` added to the message filter keys and to the rule's allowed conditions.
- `sender_type` values are downcased before comparison, because message filters compare text columns through `LOWER()`. Without it the condition would silently never match, since the column stores `Contact` / `User` / `AgentBot`.
- `sender_type` is exposed next to `sender_id` rather than on its own: `messages.sender_id` is a polymorphic id shared by contacts, agents and bots, so a rule pinning only the id would also match a contact that happens to hold that id.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/472)
<!-- Reviewable:end -->
