### PR TITLE
ci: CE spec on ubuntu-latest, 8 shards, affected specs by default on dispatch

### DIFF
--- a/.claude/skills/sync-fork/SKILL.md
+++ b/.claude/skills/sync-fork/SKILL.md
@@ -393,11 +393,11 @@ The subagent panel COMPLEMENTS but never REPLACES the CI gate below — agents r
 
 ### Validate on upstream CI (GitHub Actions) before merging
 
-Local specs cover the resolved files, but the authoritative gate is the fork's own CI. After committing the merge and pushing the `chore/merge-upstream-X.Y.Z` branch, **trigger the CE spec workflow on the branch and wait for green before merging the PR** (the `Run Chatwoot CE spec` workflow, `run_foss_spec.yml`, only fires on tag pushes + `workflow_dispatch`, so a branch push alone does NOT run it):
+Local specs cover the resolved files, but the authoritative gate is the fork's own CI. After committing the merge and pushing the `chore/merge-upstream-X.Y.Z` branch, **trigger the CE spec workflow on the branch and wait for green before merging the PR** (the `Run Chatwoot CE spec` workflow, `run_foss_spec.yml`, fires on pushes to main and tags plus `workflow_dispatch`, so a branch push alone does NOT run it):
 
 ```bash
 git push -u origin chore/merge-upstream-X.Y.Z
-gh workflow run run_foss_spec.yml --ref chore/merge-upstream-X.Y.Z
+gh workflow run run_foss_spec.yml --ref chore/merge-upstream-X.Y.Z -f full=true   # full=true: a sync touches everything, the default dispatch runs only the specs the diff maps to
 gh run list --workflow=run_foss_spec.yml --branch chore/merge-upstream-X.Y.Z --limit 1   # grab the run id
 gh run watch <run-id>                                                                    # or poll with `gh run view <run-id>`
 ```

--- a/.github/workflows/run_foss_spec.yml
+++ b/.github/workflows/run_foss_spec.yml
@@ -1,19 +1,148 @@
 name: Run Chatwoot CE spec
 permissions:
   contents: read
+
+# Two modes. A push to main or a tag runs the WHOLE suite. A manual dispatch runs only the specs the
+# branch touches (diff against `base`, mapped app/x/y.rb -> spec/x/y_spec.rb, plus the spec files
+# themselves), which is what the "fix one thing, run again" loop needs; pass `full=true` for the
+# whole suite (the sync-fork skill does, before merging an upstream sync). Changes to shared files
+# (Gemfile, config/, db/, lib/, spec/support, this workflow) fall back to the full suite on their own.
+#
+# Public repo: GitHub-hosted runners are free here, so this stays on ubuntu-latest (upstream does the
+# same). Between 2026-03 and 2026-09 it ran on Blacksmith 4 vCPU, where 4 vCPU bills 2x and each
+# dispatch cost ~75 billed minutes: 191 manual dispatches in August alone. Eight shards, not sixteen:
+# per shard the setup (containers, checkout, ruby, node, db) costs more than the rspec run did, and
+# the org's Free plan caps concurrent jobs at 20, so 16 shards starved every other workflow.
 on:
   push:
+    branches: [main]
     tags:
       - '*'
   workflow_dispatch:
+    inputs:
+      full:
+        description: Run the whole suite instead of only the specs affected by the diff against `base`.
+        type: boolean
+        default: false
+      specs:
+        description: Explicit spec paths, space-separated (overrides the diff-based selection).
+        type: string
+        default: ''
+      base:
+        description: Branch the affected-spec diff is computed against.
+        type: string
+        default: main
+
+# A newer run on the same ref supersedes the older one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  # Separate linting jobs for faster feedback
-  lint-backend:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.plan.outputs.mode }}
+      run_backend: ${{ steps.plan.outputs.run_backend }}
+      run_frontend: ${{ steps.plan.outputs.run_frontend }}
+      backend_specs: ${{ steps.plan.outputs.backend_specs }}
+      shard_total: ${{ steps.plan.outputs.shard_total }}
+      shard_indices: ${{ steps.plan.outputs.shard_indices }}
     steps:
       - uses: actions/checkout@v4
-      - uses: useblacksmith/setup-ruby@v2
+      - name: Decide what to run
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          INPUT_FULL: ${{ inputs.full }}
+          INPUT_SPECS: ${{ inputs.specs }}
+          INPUT_BASE: ${{ inputs.base || 'main' }}
+          FULL_SHARDS: 8
+          SPECS_PER_SHARD: 40
+        run: |
+          set -euo pipefail
+          emit() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
+          indices() { printf '[%s]' "$(seq 0 $(( $1 - 1 )) | paste -sd, -)"; }
+
+          full_run() {
+            echo "::notice title=CE spec::full suite, $FULL_SHARDS shards ($1)"
+            emit mode full; emit run_backend true; emit run_frontend true; emit backend_specs ""
+            emit shard_total "$FULL_SHARDS"; emit shard_indices "$(indices "$FULL_SHARDS")"
+            exit 0
+          }
+
+          if [ "$EVENT" != "workflow_dispatch" ]; then full_run "$EVENT"; fi
+          if [ "$INPUT_FULL" = "true" ]; then full_run "full=true"; fi
+
+          changed=""
+          if [ -n "$INPUT_SPECS" ]; then
+            specs=$(tr ' ' '\n' <<<"$INPUT_SPECS" | grep -v '^$' | sort -u)
+            while read -r f; do
+              [ -f "$f" ] || { echo "::error::spec not found: $f"; exit 1; }
+            done <<<"$specs"
+            echo "::notice title=CE spec::explicit specs"
+          else
+            # Three-dot compare: files changed on this ref since it diverged from base, as "status<TAB>path".
+            changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/compare/$INPUT_BASE...$GITHUB_SHA" --jq '.files[] | "\(.status)\t\(.filename)"')
+            if [ -z "$changed" ]; then
+              echo "::notice title=CE spec::no diff against $INPUT_BASE, nothing to run"
+              emit mode affected; emit run_backend false; emit run_frontend false; emit backend_specs ""
+              emit shard_total 1; emit shard_indices "[0]"
+              exit 0
+            fi
+            # Files the whole suite depends on: run everything. Routes, locales, migrations and the
+            # schema are left out on purpose (a feature branch nearly always touches them, and the
+            # model/controller it adds is picked up below); an ADDED factory is local too.
+            TAB=$'\t'
+            shared=$(grep -vE "${TAB}config/(routes\.rb|locales/)" <<<"$changed" \
+              | grep -E "^[a-z]+${TAB}(Gemfile|Gemfile\.lock|\.ruby-version|config/|spec/support/|spec/(rails_helper|spec_helper|coverage_helper)\.rb|\.github/workflows/run_foss_spec\.yml|app/.*/(application_[a-z_]+|base|base_[a-z_]+)\.rb)" || true)
+            if [ -n "$shared" ]; then full_run "shared file changed: $(head -1 <<<"$shared" | cut -f2)"; fi
+            if grep -qE "^(modified|removed|renamed)${TAB}spec/factories/" <<<"$changed"; then
+              full_run "factory changed"
+            fi
+            specs=""
+            while IFS=$'\t' read -r _status f; do
+              case "$f" in
+                spec/enterprise/*|enterprise/*) continue ;;   # stripped before the suite runs
+                spec/*_spec.rb) [ -f "$f" ] && specs+="$f"$'\n' ;;
+                app/javascript/*) continue ;;
+                app/*.rb|lib/*.rb)
+                  # Every spec named after the file, wherever it sits (spec/models, spec/requests...).
+                  base=$(basename "$f" .rb)
+                  found=$(find spec -path spec/enterprise -prune -o -name "${base}_spec.rb" -print)
+                  [ -n "$found" ] && specs+="$found"$'\n'
+                  ;;
+                *) continue ;;
+              esac
+            done <<<"$changed"
+            specs=$(sort -u <<<"$specs" | grep -v '^$' || true)
+            echo "::notice title=CE spec::affected specs from diff against $INPUT_BASE"
+          fi
+
+          run_frontend=false
+          TAB=$'\t'
+          if grep -qE "^[a-z]+${TAB}(app/javascript/|package\.json|pnpm-lock\.yaml|vite\.config|vitest\.config|\.eslintrc|jsconfig)" <<<"$changed"; then run_frontend=true; fi
+
+          n=$(grep -c . <<<"$specs" || true)
+          echo "changed files: $(grep -c . <<<"$changed" || true) | backend specs: $n | frontend: $run_frontend"
+          printf '%s\n' "$specs"
+          if [ "$n" -eq 0 ]; then
+            emit run_backend false; emit backend_specs ""; emit shard_total 1; emit shard_indices "[0]"
+          else
+            total=$(( (n + SPECS_PER_SHARD - 1) / SPECS_PER_SHARD ))
+            [ "$total" -gt "$FULL_SHARDS" ] && total=$FULL_SHARDS
+            emit run_backend true; emit backend_specs "$(tr '\n' ' ' <<<"$specs" | sed 's/ $//')"
+            emit shard_total "$total"; emit shard_indices "$(indices "$total")"
+          fi
+          emit mode affected; emit run_frontend "$run_frontend"
+
+  # Separate linting jobs for faster feedback
+  lint-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: Run Rubocop
@@ -38,11 +167,11 @@ jobs:
           bundle exec bundle-audit check
 
   lint-frontend:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: 'pnpm'
@@ -53,11 +182,13 @@ jobs:
 
   # Frontend tests run in parallel with backend
   frontend-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: plan
+    if: needs.plan.outputs.run_frontend == 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: 'pnpm'
@@ -66,14 +197,15 @@ jobs:
       - name: Run frontend tests
         run: pnpm run test:coverage
 
-  # Backend tests with parallelization
+  # Backend tests, sharded round-robin over the selected spec files
   backend-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: plan
+    if: needs.plan.outputs.run_backend == 'true'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [16]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        ci_node_index: ${{ fromJSON(needs.plan.outputs.shard_indices) }}
 
     services:
       postgres:
@@ -100,15 +232,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - uses: useblacksmith/setup-ruby@v2
+      - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: 'pnpm'
@@ -128,24 +257,31 @@ jobs:
         run: bundle exec rake db:schema:load
 
       - name: Run backend tests (parallelized)
+        env:
+          CI_NODE_TOTAL: ${{ needs.plan.outputs.shard_total }}
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+          BACKEND_SPECS: ${{ needs.plan.outputs.backend_specs }}
+          NODE_OPTIONS: --openssl-legacy-provider
         run: |
-          # Get all spec files and split them using round-robin distribution
-          # This ensures slow tests are distributed evenly across all nodes
-          SPEC_FILES=($(find spec -name '*_spec.rb' | sort))
+          # Explicit list from the plan job (affected mode) or every spec file (full mode), split
+          # round-robin so slow tests are distributed evenly across the shards.
+          # shellcheck disable=SC2206,SC2207
+          if [ -n "$BACKEND_SPECS" ]; then
+            SPEC_FILES=($BACKEND_SPECS)
+          else
+            SPEC_FILES=($(find spec -name '*_spec.rb' | sort))
+          fi
           TESTS=""
-
           for i in "${!SPEC_FILES[@]}"; do
-            # Assign spec to this node if: index % total == node_index
-            if [ $(( i % ${{ matrix.ci_node_total }} )) -eq ${{ matrix.ci_node_index }} ]; then
+            if [ $(( i % CI_NODE_TOTAL )) -eq "$CI_NODE_INDEX" ]; then
               TESTS="$TESTS ${SPEC_FILES[$i]}"
             fi
           done
-
+          echo "shard $CI_NODE_INDEX/$CI_NODE_TOTAL: $(wc -w <<<"$TESTS") spec files"
           if [ -n "$TESTS" ]; then
+            # shellcheck disable=SC2086
             bundle exec rspec --profile=10 --format progress --format json --out tmp/rspec_results.json $TESTS
           fi
-        env:
-          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,12 @@ When unsure, be explicit: `gh pr create --repo fazer-ai/chatwoot` (for Pro PRs, 
 - **Pro's living trunk is `chatwoot-pro-main`.** The `main` branch in `fazer-ai/chatwoot-pro` is a stale ancestor kept only as the repo's nominal GitHub default. A workflow copied over from CE with `push: branches: [main]` therefore never fires there — swap the filter for `chatwoot-pro-main`.
 - **Pro's enterprise specs have no CI.** `run_foss_spec.yml` runs `rm -rf enterprise spec/enterprise` before the suite, so nothing in `spec/enterprise` is ever executed by a workflow. Run it locally before merging anything that touches `enterprise/`.
 
+## CI: the CE spec workflow
+
+- `run_foss_spec.yml` runs the whole suite on every push to `main` and on tags. On a branch, nothing runs until you dispatch it, and the dispatch default is **affected mode**: the specs the branch's diff against `main` maps to (`app/x/y.rb` and `lib/x/y.rb` to every `y_spec.rb`, plus the spec files themselves), in one shard per 40 files. Shared files (Gemfile, `config/` other than routes and locales, `spec/support`, the helpers, base classes, a modified factory) fall back to the full suite on their own.
+- `gh workflow run run_foss_spec.yml --ref <branch>` runs affected mode; add `-f full=true` for the whole suite (mandatory before merging an upstream sync, see the `sync-fork` skill) or `-f specs="spec/a_spec.rb spec/b_spec.rb"` for an explicit list. Affected mode is a pre-check, not the gate: the push to `main` runs everything.
+- Do not re-dispatch the full suite after every fix. Between 2026-08-12 and 2026-09-05 this workflow was dispatched 191 times by hand (23 on one branch), each run costing ~75 billed Blacksmith minutes; that is the whole reason the affected mode exists.
+
 ## PR Description Format
 
 - Start with a short, user-facing paragraph describing the product change.


### PR DESCRIPTION
Cuts the org's Blacksmith bill at its source. This workflow moved to Blacksmith 4 vCPU in March (f3e2b315); on this public repo GitHub-hosted runners are free, and Blacksmith bills 4 vCPU at 2x, so each of the 191 manual dispatches between 12/aug and 05/sep cost ~75 billed minutes: 13k of the org's 16k Blacksmith minutes in August.

## What changed

- `runs-on: ubuntu-latest` (what upstream uses), `ruby/setup-ruby` and `actions/setup-node` instead of the Blacksmith flavours.
- Full suite on push to `main` and on tags. Before, nothing ran on `main` at all.
- `workflow_dispatch` default is **affected mode**: a `plan` job diffs the ref against `base` (three-dot compare via the API, no deep clone) and maps `app/**.rb` and `lib/**.rb` to every `<name>_spec.rb`, plus changed spec files, one shard per 40 files. `full=true` runs everything; `specs="..."` runs an explicit list. Shared files (Gemfile, `config/` except routes and locales, `spec/support`, helpers, base classes, a modified factory) fall back to full. Frontend tests run only when `app/javascript` or the JS toolchain changed. Lints and the security scan always run.
- 8 shards instead of 16 in full mode. Per shard the setup (containers, checkout, ruby, node, db) cost more than the rspec run; 16 + 3 jobs also sat at the Free plan's cap of 20 concurrent jobs and starved every other workflow.
- `concurrency` per ref with `cancel-in-progress`.
- `sync-fork` skill dispatches with `-f full=true`; AGENTS.md documents the modes.

## Validation

Dry-run of the plan script against the two open PRs: #472 maps to 5 specs, #453 to 8 (instead of 1,020). CI runs on this branch linked in the comments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/473)
<!-- Reviewable:end -->
