### PR TITLE
feat(csat): rate from the survey email and brand what it looks like

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,12 +162,15 @@ Practical checklist for any change impacting core logic or public APIs
 
 ## Fork translations
 
-Upstream's locale files are byte-identical to the Chatwoot release we track. **Never add or edit a key inside `app/javascript/dashboard/i18n/locale/` or `config/locales/<locale>.yml`** — CI fails if you do, and the next upstream sync would conflict on every string we own.
+Upstream's locale files are byte-identical to the Chatwoot release we track. **Never add or edit a key inside an upstream locale tree** — `app/javascript/dashboard/i18n/locale/`, `app/javascript/survey/i18n/locale/`, or `config/locales/<locale>.yml`. CI fails if you do, and the next upstream sync would conflict on every string we own.
 
 We ship our features in **en, pt_BR and es**, and every key must exist in all three: `check` fails when a key present in `en` is missing from another language we ship. Upstream keeps translating the other ~55 languages, and our keys fall back to `en` there. Everything the fork translates lives in two places:
 
-- Frontend → `app/javascript/dashboard/i18n/fazer-ai/locale/<locale>/*.json`
+- Frontend, dashboard → `app/javascript/dashboard/i18n/fazer-ai/locale/<locale>/*.json`
+- Frontend, survey → `app/javascript/survey/i18n/fazer-ai/locale/<locale>.json` (one file, not a folder: it is a single small namespace)
 - Backend → `config/locales/fazer_ai.<locale>.yml` (and `fazer_ai.mailers.<locale>.yml` for the Chatwoot mailer copy upstream hardcodes in ERB)
+
+Each frontend bundle has its own upstream tree and its own overlay, merged by that bundle's `i18n/index.js`; the merging itself lives in `shared/helpers/forkTranslations`. `check`, `drift` and `scaffold` cover every tree listed in `FE_TREES`, so a new bundle means one entry there.
 
 Both are deep-merged on top of upstream's: the frontend in `i18n/index.js` via `withForkMessages`, the backend by Rails, which already loads every `config/locales/*.yml`. No registration step — files are picked up by directory scan, which is also why CE → Pro merges don't conflict here.
 

--- a/CUSTOM_BRANDING.md
+++ b/CUSTOM_BRANDING.md
@@ -21,6 +21,7 @@ bundle exec rails branding:update
 | `LOGO_THUMBNAIL`     | `/brand-assets/logo_thumbnail.svg`          | The thumbnail used for favicon (512px X 512px).                       |
 | `LOGO`               | `/brand-assets/logo.svg`                    | The logo used on the dashboard, login page, etc.                      |
 | `LOGO_DARK`          | `/brand-assets/logo_dark.svg`               | The logo used on the dashboard, login page, etc. for dark mode.       |
+| `LOGO_EMAIL`         | _(empty)_                                   | The logo shown at the top of outgoing emails. **PNG, JPG or GIF only** — email clients do not render SVG. A relative path resolves against `FRONTEND_URL`. Left empty, `LOGO` is used when it is one of those formats, and no logo is shown otherwise. |
 | `BRAND_URL`          | `https://www.chatwoot.com`                  | The URL used in emails under the section “Powered By”.                |
 | `WIDGET_BRAND_URL`   | `https://www.chatwoot.com`                  | The URL used in the widget under the section “Powered By”.            |
 | `BRAND_NAME`         | `Chatwoot`                                  | The name used in emails and the widget.                               |

--- a/app/javascript/dashboard/i18n/fazer-ai/index.js
+++ b/app/javascript/dashboard/i18n/fazer-ai/index.js
@@ -16,53 +16,23 @@
  * (`conversation.json` extends `../locale/<lang>/conversation.json`).
  */
 
-const isPlainObject = value =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
+import {
+  buildForkMessages,
+  mergeForkMessages,
+} from 'shared/helpers/forkTranslations';
 
-const deepMerge = (target, source) => {
-  const result = { ...target };
+const modules = import.meta.glob('./locale/*/*.json', { eager: true });
 
-  Object.entries(source).forEach(([key, value]) => {
-    result[key] =
-      isPlainObject(value) && isPlainObject(result[key])
-        ? deepMerge(result[key], value)
-        : value;
-  });
-
-  return result;
-};
-
-const buildForkMessages = () => {
-  const modules = import.meta.glob('./locale/*/*.json', { eager: true });
-  const messages = {};
-
-  // Sorted so `overrides.json` is applied after the file it may collide with,
-  // and so the result does not depend on the glob's traversal order.
-  Object.keys(modules)
-    .sort()
-    .forEach(path => {
-      const locale = path.split('/')[2];
-      const translations = modules[path].default ?? modules[path];
-      messages[locale] = deepMerge(messages[locale] ?? {}, translations);
-    });
-
-  return messages;
-};
-
-export const forkMessages = buildForkMessages();
+export const forkMessages = buildForkMessages(
+  modules,
+  path => path.split('/')[2]
+);
 
 /**
  * Deep merges the fork translations on top of upstream's, per locale.
  * Locales without a fork folder are returned untouched.
  */
-export const withForkMessages = upstreamMessages => {
-  const merged = { ...upstreamMessages };
-
-  Object.entries(forkMessages).forEach(([locale, translations]) => {
-    merged[locale] = deepMerge(merged[locale] ?? {}, translations);
-  });
-
-  return merged;
-};
+export const withForkMessages = upstreamMessages =>
+  mergeForkMessages(upstreamMessages, forkMessages);
 
 export default withForkMessages;

--- a/app/javascript/shared/helpers/forkTranslations.js
+++ b/app/javascript/shared/helpers/forkTranslations.js
@@ -1,0 +1,58 @@
+/**
+ * Shared plumbing for the fazer.ai translation overlays.
+ *
+ * Upstream's locale trees stay byte-identical to the Chatwoot release we track, so every
+ * string the fork owns lives in a sibling `fazer-ai/locale/` tree that is deep merged on
+ * top. The dashboard and the survey each have their own bundle and their own upstream
+ * tree, so each keeps its own overlay entry point; only the merging lives here.
+ *
+ * `import.meta.glob` resolves relative to the file that calls it, which is why the caller
+ * passes the already-globbed modules in.
+ */
+
+const isPlainObject = value =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const deepMerge = (target, source) => {
+  const result = { ...target };
+
+  Object.entries(source).forEach(([key, value]) => {
+    result[key] =
+      isPlainObject(value) && isPlainObject(result[key])
+        ? deepMerge(result[key], value)
+        : value;
+  });
+
+  return result;
+};
+
+/**
+ * Builds the per-locale fork tree from modules globbed as `<base>/<locale>/<file>.json`
+ * or `<base>/<locale>.json`, with `localeFromPath` telling the two apart.
+ */
+export const buildForkMessages = (modules, localeFromPath) => {
+  const messages = {};
+
+  // Sorted so `overrides.json` is applied after the file it may collide with, and so the
+  // result does not depend on the glob's traversal order.
+  Object.keys(modules)
+    .sort()
+    .forEach(path => {
+      const locale = localeFromPath(path);
+      const translations = modules[path].default ?? modules[path];
+      messages[locale] = deepMerge(messages[locale] ?? {}, translations);
+    });
+
+  return messages;
+};
+
+/** Deep merges the fork translations on top of upstream's, per locale. */
+export const mergeForkMessages = (upstreamMessages, forkMessages) => {
+  const merged = { ...upstreamMessages };
+
+  Object.entries(forkMessages).forEach(([locale, translations]) => {
+    merged[locale] = deepMerge(merged[locale] ?? {}, translations);
+  });
+
+  return merged;
+};

--- a/app/javascript/survey/i18n/fazer-ai/index.js
+++ b/app/javascript/survey/i18n/fazer-ai/index.js
@@ -1,0 +1,26 @@
+/**
+ * fazer.ai fork translations for the survey app.
+ *
+ * Same contract as the dashboard overlay: every key under `fazer-ai/locale/<lang>.json`
+ * belongs to this fork, and the upstream tree in `../locale/` stays byte-identical to the
+ * Chatwoot release we track, so upstream syncs never conflict with our strings.
+ *
+ * The survey ships one file per language rather than a folder, because it is a single
+ * small namespace.
+ */
+
+import {
+  buildForkMessages,
+  mergeForkMessages,
+} from 'shared/helpers/forkTranslations';
+
+const modules = import.meta.glob('./locale/*.json', { eager: true });
+
+export const forkMessages = buildForkMessages(modules, path =>
+  path.split('/').pop().replace('.json', '')
+);
+
+export const withForkMessages = upstreamMessages =>
+  mergeForkMessages(upstreamMessages, forkMessages);
+
+export default withForkMessages;

--- a/app/javascript/survey/i18n/fazer-ai/locale/en.json
+++ b/app/javascript/survey/i18n/fazer-ai/locale/en.json
@@ -1,0 +1,8 @@
+{
+  "SURVEY": {
+    "RATING": {
+      "CONFIRM_LABEL": "Confirm the rating you picked to send it.",
+      "CONFIRM_BUTTON": "Confirm rating"
+    }
+  }
+}

--- a/app/javascript/survey/i18n/fazer-ai/locale/es.json
+++ b/app/javascript/survey/i18n/fazer-ai/locale/es.json
@@ -1,0 +1,8 @@
+{
+  "SURVEY": {
+    "RATING": {
+      "CONFIRM_LABEL": "Confirma la puntuación que elegiste para enviarla.",
+      "CONFIRM_BUTTON": "Confirmar puntuación"
+    }
+  }
+}

--- a/app/javascript/survey/i18n/fazer-ai/locale/pt_BR.json
+++ b/app/javascript/survey/i18n/fazer-ai/locale/pt_BR.json
@@ -1,0 +1,8 @@
+{
+  "SURVEY": {
+    "RATING": {
+      "CONFIRM_LABEL": "Confirme a nota que você escolheu para enviá-la.",
+      "CONFIRM_BUTTON": "Confirmar nota"
+    }
+  }
+}

--- a/app/javascript/survey/i18n/fazer-ai/specs/index.spec.js
+++ b/app/javascript/survey/i18n/fazer-ai/specs/index.spec.js
@@ -1,0 +1,35 @@
+import messages from 'survey/i18n';
+import { forkMessages } from 'survey/i18n/fazer-ai';
+import upstreamEn from 'survey/i18n/locale/en.json';
+import upstreamPtBr from 'survey/i18n/locale/pt_BR.json';
+
+describe('fazer.ai survey translation overlay', () => {
+  it('exposes a fork tree for every language we translate', () => {
+    expect(Object.keys(forkMessages).sort()).toEqual(['en', 'es', 'pt_BR']);
+  });
+
+  it('adds the fork keys without touching upstream files', () => {
+    expect(upstreamEn.SURVEY.RATING.CONFIRM_BUTTON).toBeUndefined();
+    expect(messages.en.SURVEY.RATING.CONFIRM_BUTTON).toBe('Confirm rating');
+  });
+
+  it('keeps the upstream keys in the namespace it extends', () => {
+    Object.keys(upstreamPtBr.SURVEY.RATING).forEach(key => {
+      expect(messages.pt_BR.SURVEY.RATING[key]).toBe(
+        upstreamPtBr.SURVEY.RATING[key]
+      );
+    });
+  });
+
+  it('translates rather than copying the en tree', () => {
+    expect(messages.pt_BR.SURVEY.RATING.CONFIRM_BUTTON).toBe('Confirmar nota');
+    expect(messages.es.SURVEY.RATING.CONFIRM_BUTTON).not.toBe(
+      messages.en.SURVEY.RATING.CONFIRM_BUTTON
+    );
+  });
+
+  it('leaves a language without a fork file untouched', () => {
+    expect(messages.fr.SURVEY.RATING.CONFIRM_BUTTON).toBeUndefined();
+    expect(messages.fr.SURVEY.RATING.LABEL).toBeDefined();
+  });
+});

--- a/app/javascript/survey/i18n/index.js
+++ b/app/javascript/survey/i18n/index.js
@@ -1,3 +1,4 @@
+import { withForkMessages } from './fazer-ai';
 import ar from './locale/ar.json';
 import bg from './locale/bg.json';
 import ca from './locale/ca.json';
@@ -41,7 +42,7 @@ import vi from './locale/vi.json';
 import zh_CN from './locale/zh_CN.json';
 import zh_TW from './locale/zh_TW.json';
 
-export default {
+export default withForkMessages({
   ar,
   bg,
   ca,
@@ -84,4 +85,4 @@ export default {
   vi,
   zh_CN,
   zh_TW,
-};
+});

--- a/app/javascript/survey/i18n/locale/en.json
+++ b/app/javascript/survey/i18n/locale/en.json
@@ -3,9 +3,7 @@
     "DESCRIPTION": "Dear customer 👋, please take a few moments to share feedback about the conversation you had with {inboxName}.",
     "RATING": {
       "LABEL": "Rate your conversation",
-      "SUCCESS_MESSAGE": "Thank you for submitting the rating",
-      "CONFIRM_LABEL": "Confirm the rating you picked to send it.",
-      "CONFIRM_BUTTON": "Confirm rating"
+      "SUCCESS_MESSAGE": "Thank you for submitting the rating"
     },
     "FEEDBACK": {
       "LABEL": "Do you have any thoughts you'd like to share?",

--- a/app/javascript/survey/i18n/locale/en.json
+++ b/app/javascript/survey/i18n/locale/en.json
@@ -3,7 +3,9 @@
     "DESCRIPTION": "Dear customer 👋, please take a few moments to share feedback about the conversation you had with {inboxName}.",
     "RATING": {
       "LABEL": "Rate your conversation",
-      "SUCCESS_MESSAGE": "Thank you for submitting the rating"
+      "SUCCESS_MESSAGE": "Thank you for submitting the rating",
+      "CONFIRM_LABEL": "Confirm the rating you picked to send it.",
+      "CONFIRM_BUTTON": "Confirm rating"
     },
     "FEEDBACK": {
       "LABEL": "Do you have any thoughts you'd like to share?",

--- a/app/javascript/survey/i18n/locale/es.json
+++ b/app/javascript/survey/i18n/locale/es.json
@@ -3,9 +3,7 @@
     "DESCRIPTION": "Estimado cliente 👋, por favor tómate unos momentos para compartir tus comentarios sobre la conversación que tuviste con {inboxName}.",
     "RATING": {
       "LABEL": "Califica tu conversación",
-      "SUCCESS_MESSAGE": "Gracias por enviar la valoración",
-      "CONFIRM_LABEL": "Confirma la puntuación que elegiste para enviarla.",
-      "CONFIRM_BUTTON": "Confirmar puntuación"
+      "SUCCESS_MESSAGE": "Gracias por enviar la valoración"
     },
     "FEEDBACK": {
       "LABEL": "¿Tienes alguna idea que te gustaría compartir?",

--- a/app/javascript/survey/i18n/locale/es.json
+++ b/app/javascript/survey/i18n/locale/es.json
@@ -3,7 +3,9 @@
     "DESCRIPTION": "Estimado cliente 👋, por favor tómate unos momentos para compartir tus comentarios sobre la conversación que tuviste con {inboxName}.",
     "RATING": {
       "LABEL": "Califica tu conversación",
-      "SUCCESS_MESSAGE": "Gracias por enviar la valoración"
+      "SUCCESS_MESSAGE": "Gracias por enviar la valoración",
+      "CONFIRM_LABEL": "Confirma la puntuación que elegiste para enviarla.",
+      "CONFIRM_BUTTON": "Confirmar puntuación"
     },
     "FEEDBACK": {
       "LABEL": "¿Tienes alguna idea que te gustaría compartir?",

--- a/app/javascript/survey/i18n/locale/pt_BR.json
+++ b/app/javascript/survey/i18n/locale/pt_BR.json
@@ -3,7 +3,9 @@
     "DESCRIPTION": "Caro cliente 👋, por favor, reserve alguns instantes para compartilhar feedback sobre a conversa que você teve com {inboxName}.",
     "RATING": {
       "LABEL": "Avalie sua conversa",
-      "SUCCESS_MESSAGE": "Obrigado por enviar a classificação"
+      "SUCCESS_MESSAGE": "Obrigado por enviar a classificação",
+      "CONFIRM_LABEL": "Confirme a nota que você escolheu para enviá-la.",
+      "CONFIRM_BUTTON": "Confirmar nota"
     },
     "FEEDBACK": {
       "LABEL": "Você tem alguma opinião que gostaria de compartilhar?",

--- a/app/javascript/survey/i18n/locale/pt_BR.json
+++ b/app/javascript/survey/i18n/locale/pt_BR.json
@@ -3,9 +3,7 @@
     "DESCRIPTION": "Caro cliente 👋, por favor, reserve alguns instantes para compartilhar feedback sobre a conversa que você teve com {inboxName}.",
     "RATING": {
       "LABEL": "Avalie sua conversa",
-      "SUCCESS_MESSAGE": "Obrigado por enviar a classificação",
-      "CONFIRM_LABEL": "Confirme a nota que você escolheu para enviá-la.",
-      "CONFIRM_BUTTON": "Confirmar nota"
+      "SUCCESS_MESSAGE": "Obrigado por enviar a classificação"
     },
     "FEEDBACK": {
       "LABEL": "Você tem alguma opinião que gostaria de compartilhar?",

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -51,7 +51,12 @@ export default {
       return pathname.substring(pathname.lastIndexOf('/') + 1);
     },
     isRatingSubmitted() {
-      return this.surveyDetails && this.surveyDetails.rating;
+      // A pending confirmation means the rating on screen is not the stored one, so the
+      // page is not in its resolved state: the success banner, the hidden prompt and the
+      // feedback form all key off this.
+      if (this.isPendingConfirmation) return false;
+
+      return Boolean(this.surveyDetails?.rating);
     },
     isFeedbackSubmitted() {
       return (
@@ -73,17 +78,13 @@ export default {
       return this.isRatingSubmitted || this.errorMessage;
     },
     enableFeedbackForm() {
-      return (
-        !this.isFeedbackSubmitted &&
-        this.isRatingSubmitted &&
-        !this.isPendingConfirmation
-      );
+      return !this.isFeedbackSubmitted && this.isRatingSubmitted;
     },
     shouldShowErrorMessage() {
       return !!this.errorMessage;
     },
     shouldShowSuccessMessage() {
-      return !!this.isRatingSubmitted;
+      return this.isRatingSubmitted;
     },
     message() {
       if (this.errorMessage) {

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -111,6 +111,9 @@ export default {
       );
       if (!CSAT_RATINGS.some(({ value }) => value === rating)) return;
       if (this.isFeedbackSubmitted) return;
+      // Reopening the same link after confirming has nothing left to confirm, and asking
+      // again would hide the feedback form behind a second confirmation.
+      if (this.surveyDetails?.rating === rating) return;
 
       this.selectedRating = rating;
       this.isPendingConfirmation = true;

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -89,13 +89,15 @@ export default {
     },
   },
   async mounted() {
-    await this.getSurveyDetails();
-    this.applyRatingFromQuery();
+    const loaded = await this.getSurveyDetails();
+    if (loaded) this.applyRatingFromQuery();
   },
   methods: {
     // The survey email renders the scale inline, and each rating links here carrying its
     // value. Submitting from the page rather than from the link keeps the write on the
-    // API's PUT, which link scanners and mail client prefetching never reach.
+    // API's PUT, which link scanners and mail client prefetching never reach. It only runs
+    // once the details are loaded: submitting over a failed fetch would send the empty
+    // feedbackMessage this component starts with, wiping a comment already left.
     applyRatingFromQuery() {
       const rating = Number(
         new URLSearchParams(window.location.search).get('rating')
@@ -126,9 +128,11 @@ export default {
           result.data.content ||
           this.$t('SURVEY.DESCRIPTION', { inboxName: this.inboxName });
         this.setLocale(result.data.locale);
+        return true;
       } catch (error) {
         const errorMessage = error?.response?.data?.message;
         this.errorMessage = errorMessage || this.$t('SURVEY.API.ERROR_MESSAGE');
+        return false;
       } finally {
         this.isLoading = false;
       }

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -183,6 +183,10 @@ export default {
         if (markFeedbackSubmitted) {
           this.hasSubmittedFeedback = true;
         }
+        // A retry after a failed write is a real path now that the confirmation button
+        // survives the failure, and `message` prefers the error, so leaving it set would
+        // show the success and error banners at once over a rating that did save.
+        this.errorMessage = null;
         return true;
       } catch (error) {
         const errorMessage = error?.response?.data?.error;

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -126,11 +126,14 @@ export default {
       const saved = await this.updateSurveyDetails();
       if (saved) this.isPendingConfirmation = false;
     },
-    selectRating(rating) {
+    async selectRating(rating) {
       if (this.isFeedbackSubmitted || this.isUpdating) return;
-      this.isPendingConfirmation = false;
       this.selectedRating = rating;
-      this.updateSurveyDetails();
+      // Same rule as confirmRating: a revision stays pending until the write lands. Clearing
+      // it first would make isRatingSubmitted fall back to the stored rating, so a failed
+      // save would show the success banner for a rating the contact just replaced.
+      const saved = await this.updateSurveyDetails();
+      if (saved) this.isPendingConfirmation = false;
     },
     sendFeedback(message) {
       this.feedbackMessage = message;

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -119,9 +119,12 @@ export default {
       this.selectedRating = rating;
       this.isPendingConfirmation = true;
     },
-    confirmRating() {
-      this.isPendingConfirmation = false;
-      this.updateSurveyDetails();
+    async confirmRating() {
+      // Only on success: a failed write (an expired survey, a dropped connection) has to
+      // leave the button on screen, or the contact is left with no way to send the rating
+      // and, on a revised one, a page claiming the old rating went through.
+      const saved = await this.updateSurveyDetails();
+      if (saved) this.isPendingConfirmation = false;
     },
     selectRating(rating) {
       if (this.isFeedbackSubmitted || this.isUpdating) return;
@@ -180,10 +183,12 @@ export default {
         if (markFeedbackSubmitted) {
           this.hasSubmittedFeedback = true;
         }
+        return true;
       } catch (error) {
         const errorMessage = error?.response?.data?.error;
         this.errorMessage = errorMessage || this.$t('SURVEY.API.ERROR_MESSAGE');
         useAlert(this.errorMessage);
+        return false;
       } finally {
         this.isUpdating = false;
       }

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -5,6 +5,7 @@ import Spinner from 'shared/components/Spinner.vue';
 import Rating from 'survey/components/Rating.vue';
 import Feedback from 'survey/components/Feedback.vue';
 import Banner from 'survey/components/Banner.vue';
+import CustomButton from 'shared/components/Button.vue';
 import StarRating from 'shared/components/StarRating.vue';
 import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
 import { getSurveyDetails, updateSurvey } from 'survey/api/survey';
@@ -20,6 +21,7 @@ export default {
     Banner,
     Feedback,
     StarRating,
+    CustomButton,
   },
   setup() {
     const { formatMessage } = useMessageFormatter();
@@ -34,6 +36,7 @@ export default {
       feedbackMessage: '',
       hasSubmittedFeedback: false,
       isUpdating: false,
+      isPendingConfirmation: false,
       logo: '',
       inboxName: '',
       displayType: CSAT_DISPLAY_TYPES.EMOJI,
@@ -70,7 +73,11 @@ export default {
       return this.isRatingSubmitted || this.errorMessage;
     },
     enableFeedbackForm() {
-      return !this.isFeedbackSubmitted && this.isRatingSubmitted;
+      return (
+        !this.isFeedbackSubmitted &&
+        this.isRatingSubmitted &&
+        !this.isPendingConfirmation
+      );
     },
     shouldShowErrorMessage() {
       return !!this.errorMessage;
@@ -94,19 +101,27 @@ export default {
   },
   methods: {
     // The survey email renders the scale inline, and each rating links here carrying its
-    // value. Submitting from the page rather than from the link keeps the write on the
-    // API's PUT, which link scanners and mail client prefetching never reach. It only runs
-    // once the details are loaded: submitting over a failed fetch would send the empty
-    // feedbackMessage this component starts with, wiping a comment already left.
+    // value. It is only pre-selected, never submitted: email security gateways detonate
+    // every link in a sandbox that runs JavaScript, so an automatic write would let a
+    // scanner walk all five URLs and settle the rating before the recipient ever opens the
+    // message. Persisting waits for a real gesture on this page.
     applyRatingFromQuery() {
       const rating = Number(
         new URLSearchParams(window.location.search).get('rating')
       );
       if (!CSAT_RATINGS.some(({ value }) => value === rating)) return;
-      this.selectRating(rating);
+      if (this.isFeedbackSubmitted) return;
+
+      this.selectedRating = rating;
+      this.isPendingConfirmation = true;
+    },
+    confirmRating() {
+      this.isPendingConfirmation = false;
+      this.updateSurveyDetails();
     },
     selectRating(rating) {
       if (this.isFeedbackSubmitted || this.isUpdating) return;
+      this.isPendingConfirmation = false;
       this.selectedRating = rating;
       this.updateSurveyDetails();
     },
@@ -222,6 +237,18 @@ export default {
           class="[&>button>span]:text-4xl !justify-start !px-0"
           @select-rating="selectRating"
         />
+        <div
+          v-if="isPendingConfirmation"
+          class="mt-6 flex flex-col items-start gap-3"
+        >
+          <p class="text-base text-n-slate-11 m-0">
+            {{ $t('SURVEY.RATING.CONFIRM_LABEL') }}
+          </p>
+          <CustomButton :disabled="isUpdating" @click="confirmRating">
+            <Spinner v-if="isUpdating" class="p-0" />
+            {{ $t('SURVEY.RATING.CONFIRM_BUTTON') }}
+          </CustomButton>
+        </div>
         <Feedback
           v-if="enableFeedbackForm"
           :is-updating="isUpdating"

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -9,7 +9,7 @@ import StarRating from 'shared/components/StarRating.vue';
 import { useMessageFormatter } from 'shared/composables/useMessageFormatter';
 import { getSurveyDetails, updateSurvey } from 'survey/api/survey';
 
-import { CSAT_DISPLAY_TYPES } from 'shared/constants/messages';
+import { CSAT_DISPLAY_TYPES, CSAT_RATINGS } from 'shared/constants/messages';
 
 export default {
   name: 'Response',
@@ -42,8 +42,10 @@ export default {
   },
   computed: {
     surveyId() {
-      const pageURL = window.location.href;
-      return pageURL.substring(pageURL.lastIndexOf('/') + 1);
+      // Read the path, not the href: the rating links in the survey email carry a
+      // query string, which would otherwise be taken as part of the uuid.
+      const { pathname } = window.location;
+      return pathname.substring(pathname.lastIndexOf('/') + 1);
     },
     isRatingSubmitted() {
       return this.surveyDetails && this.surveyDetails.rating;
@@ -87,9 +89,20 @@ export default {
     },
   },
   async mounted() {
-    this.getSurveyDetails();
+    await this.getSurveyDetails();
+    this.applyRatingFromQuery();
   },
   methods: {
+    // The survey email renders the scale inline, and each rating links here carrying its
+    // value. Submitting from the page rather than from the link keeps the write on the
+    // API's PUT, which link scanners and mail client prefetching never reach.
+    applyRatingFromQuery() {
+      const rating = Number(
+        new URLSearchParams(window.location.search).get('rating')
+      );
+      if (!CSAT_RATINGS.some(({ value }) => value === rating)) return;
+      this.selectRating(rating);
+    },
     selectRating(rating) {
       if (this.isFeedbackSubmitted || this.isUpdating) return;
       this.selectedRating = rating;

--- a/app/javascript/survey/views/specs/Response.spec.js
+++ b/app/javascript/survey/views/specs/Response.spec.js
@@ -151,6 +151,18 @@ describe('Response', () => {
     expect(wrapper.vm.isPendingConfirmation).toBe(false);
   });
 
+  it('keeps the confirmation on screen when the write fails', async () => {
+    updateSurvey.mockRejectedValue(new Error('expired'));
+    setUrl('?rating=4');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    await wrapper.vm.confirmRating();
+
+    expect(wrapper.vm.isPendingConfirmation).toBe(true);
+    expect(wrapper.vm.selectedRating).toBe(4);
+  });
+
   it('writes immediately when a rating is clicked on the page itself', async () => {
     setUrl('');
     const wrapper = buildWrapper();

--- a/app/javascript/survey/views/specs/Response.spec.js
+++ b/app/javascript/survey/views/specs/Response.spec.js
@@ -163,6 +163,21 @@ describe('Response', () => {
     expect(wrapper.vm.selectedRating).toBe(4);
   });
 
+  it('clears the error banner once a retry goes through', async () => {
+    updateSurvey.mockRejectedValueOnce(new Error('flaky'));
+    setUrl('?rating=4');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    await wrapper.vm.confirmRating();
+    expect(wrapper.vm.shouldShowErrorMessage).toBe(true);
+
+    await wrapper.vm.confirmRating();
+
+    expect(wrapper.vm.shouldShowErrorMessage).toBe(false);
+    expect(wrapper.vm.isPendingConfirmation).toBe(false);
+  });
+
   it('writes immediately when a rating is clicked on the page itself', async () => {
     setUrl('');
     const wrapper = buildWrapper();

--- a/app/javascript/survey/views/specs/Response.spec.js
+++ b/app/javascript/survey/views/specs/Response.spec.js
@@ -122,6 +122,9 @@ describe('Response', () => {
 
     expect(wrapper.vm.isPendingConfirmation).toBe(true);
     expect(updateSurvey).not.toHaveBeenCalled();
+    // The stored rating is not the one on screen, so the page must not claim to be done.
+    expect(wrapper.vm.shouldShowSuccessMessage).toBe(false);
+    expect(wrapper.vm.enableFeedbackForm).toBe(false);
   });
 
   it('does not reopen a survey whose feedback was already submitted', async () => {

--- a/app/javascript/survey/views/specs/Response.spec.js
+++ b/app/javascript/survey/views/specs/Response.spec.js
@@ -188,4 +188,21 @@ describe('Response', () => {
 
     expect(updateSurvey).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps a revision pending when clicking another rating fails to save', async () => {
+    getSurveyDetails.mockResolvedValue(surveyPayload({ rating: 2 }));
+    updateSurvey.mockRejectedValue(new Error('expired'));
+    setUrl('?rating=5');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    await wrapper.vm.selectRating(3);
+
+    // Falling back to the stored 2 here would show the success banner and the feedback
+    // form for a rating the contact had already replaced twice.
+    expect(wrapper.vm.isPendingConfirmation).toBe(true);
+    expect(wrapper.vm.selectedRating).toBe(3);
+    expect(wrapper.vm.shouldShowSuccessMessage).toBe(false);
+    expect(wrapper.vm.enableFeedbackForm).toBe(false);
+  });
 });

--- a/app/javascript/survey/views/specs/Response.spec.js
+++ b/app/javascript/survey/views/specs/Response.spec.js
@@ -1,0 +1,161 @@
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Response from '../Response.vue';
+import { getSurveyDetails, updateSurvey } from 'survey/api/survey';
+
+vi.mock('survey/api/survey', () => ({
+  getSurveyDetails: vi.fn(),
+  updateSurvey: vi.fn(),
+}));
+
+vi.mock('dashboard/composables', () => ({ useAlert: vi.fn() }));
+
+const UUID = 'a555eb24-7462-4221-9cdb-b758711b4fcb';
+
+describe('Response', () => {
+  let originalLocation;
+
+  const setUrl = search => {
+    delete window.location;
+    window.location = new URL(
+      `https://support.example.com/survey/responses/${UUID}${search}`
+    );
+  };
+
+  const surveyPayload = (csatSurveyResponse = null) => ({
+    data: {
+      id: 1,
+      csat_survey_response: csatSurveyResponse,
+      display_type: 'emoji',
+      content: 'How did we do?',
+      inbox_avatar_url: '',
+      inbox_name: 'Support',
+      locale: 'en',
+    },
+  });
+
+  const buildWrapper = () =>
+    shallowMount(Response, {
+      global: {
+        mocks: { $t: key => key },
+        directives: { 'dompurify-html': () => {} },
+        stubs: { Branding: true, Spinner: true, CustomButton: true },
+        config: { globalProperties: { $root: { $i18n: { locale: 'en' } } } },
+      },
+    });
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    getSurveyDetails.mockResolvedValue(surveyPayload());
+    updateSurvey.mockResolvedValue();
+  });
+
+  afterEach(() => {
+    window.location = originalLocation;
+    vi.clearAllMocks();
+  });
+
+  it('reads the uuid from the path, ignoring the rating query string', async () => {
+    setUrl('?rating=4');
+    buildWrapper();
+    await flushPromises();
+
+    expect(getSurveyDetails).toHaveBeenCalledWith({ uuid: UUID });
+  });
+
+  // The rating links live in an email, and security gateways detonate every URL in a
+  // sandboxed browser that runs JavaScript. Writing on load would let a scanner walk all
+  // five links and settle the response before the recipient ever opened the message.
+  it('never writes on load, only pre-selects what the link carries', async () => {
+    setUrl('?rating=4');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    expect(updateSurvey).not.toHaveBeenCalled();
+    expect(wrapper.vm.selectedRating).toBe(4);
+    expect(wrapper.vm.isPendingConfirmation).toBe(true);
+  });
+
+  it('writes the pre-selected rating once it is confirmed', async () => {
+    setUrl('?rating=4');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    wrapper.vm.confirmRating();
+    await flushPromises();
+
+    expect(updateSurvey).toHaveBeenCalledTimes(1);
+    expect(
+      updateSurvey.mock.calls[0][0].data.message.submitted_values
+        .csat_survey_response.rating
+    ).toBe(4);
+    expect(wrapper.vm.isPendingConfirmation).toBe(false);
+  });
+
+  it.each([['?rating=9'], ['?rating=abc'], ['']])(
+    'ignores a rating the scale does not offer: %s',
+    async search => {
+      setUrl(search);
+      const wrapper = buildWrapper();
+      await flushPromises();
+
+      expect(wrapper.vm.isPendingConfirmation).toBe(false);
+      expect(updateSurvey).not.toHaveBeenCalled();
+    }
+  );
+
+  it('leaves the page alone when the link repeats the rating already stored', async () => {
+    getSurveyDetails.mockResolvedValue(surveyPayload({ rating: 4 }));
+    setUrl('?rating=4');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    expect(wrapper.vm.isPendingConfirmation).toBe(false);
+    expect(wrapper.vm.enableFeedbackForm).toBe(true);
+  });
+
+  it('still asks to confirm when the link carries a different rating', async () => {
+    getSurveyDetails.mockResolvedValue(surveyPayload({ rating: 2 }));
+    setUrl('?rating=5');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    expect(wrapper.vm.isPendingConfirmation).toBe(true);
+    expect(updateSurvey).not.toHaveBeenCalled();
+  });
+
+  it('does not reopen a survey whose feedback was already submitted', async () => {
+    getSurveyDetails.mockResolvedValue(
+      surveyPayload({ rating: 2, feedback_message: 'all good' })
+    );
+    setUrl('?rating=5');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    expect(wrapper.vm.isPendingConfirmation).toBe(false);
+    expect(updateSurvey).not.toHaveBeenCalled();
+  });
+
+  // A failed fetch leaves feedbackMessage at its empty initial value, so submitting over
+  // it would wipe a comment the contact had already left.
+  it('does not submit when the details request failed', async () => {
+    getSurveyDetails.mockRejectedValue(new Error('boom'));
+    setUrl('?rating=4');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    expect(updateSurvey).not.toHaveBeenCalled();
+    expect(wrapper.vm.isPendingConfirmation).toBe(false);
+  });
+
+  it('writes immediately when a rating is clicked on the page itself', async () => {
+    setUrl('');
+    const wrapper = buildWrapper();
+    await flushPromises();
+
+    wrapper.vm.selectRating(3);
+    await flushPromises();
+
+    expect(updateSurvey).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,8 @@
 class ApplicationMailer < ActionMailer::Base
   include ActionView::Helpers::SanitizeHelper
 
+  EMAIL_SAFE_LOGO_FORMATS = %w[.png .jpg .jpeg .gif].freeze
+
   default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
   around_action :with_isolated_current
   around_action :switch_locale
@@ -57,14 +59,39 @@ class ApplicationMailer < ActionMailer::Base
 
   def liquid_locals
     # expose variables you want to be exposed in liquid
+    config = GlobalConfig.get('BRAND_NAME', 'BRAND_URL', 'BRAND_COLOR', 'LOGO_EMAIL', 'LOGO')
     locals = {
-      global_config: GlobalConfig.get('BRAND_NAME', 'BRAND_URL'),
+      global_config: config,
+      # Two roles, because one hex cannot serve both: see BrandColor.
+      brand_color: BrandColor.surface(config['BRAND_COLOR']),
+      brand_color_text: BrandColor.on_light(config['BRAND_COLOR']),
+      brand_logo_url: absolute_asset_url(email_logo(config)),
       action_url: @action_url
     }
 
     locals.merge({ attachment_url: @attachment_url }) if @attachment_url
     locals.merge({ failed_contacts: @failed_contacts, imported_contacts: @imported_contacts })
     locals
+  end
+
+  # Falling back to LOGO covers the installation that already has a raster logo without asking
+  # it to configure a second one. It is guarded on the extension because LOGO is an SVG by
+  # default, and email clients render none: an unconditional fallback would put a broken image
+  # in every email, which reads worse than the no-logo layout it replaced.
+  def email_logo(config)
+    return config['LOGO_EMAIL'] if config['LOGO_EMAIL'].present?
+
+    logo = config['LOGO'].to_s
+    logo if EMAIL_SAFE_LOGO_FORMATS.any? { |format| logo.split('?').first.to_s.downcase.end_with?(format) }
+  end
+
+  # LOGO_EMAIL is configured the way LOGO is, as a path served by this installation, but an
+  # email is read outside it and a relative src resolves against nothing.
+  def absolute_asset_url(path)
+    value = path.to_s.strip
+    return value if value.blank? || value.start_with?('http://', 'https://')
+
+    "#{ENV.fetch('FRONTEND_URL', nil)}#{value}"
   end
 
   def locale_from_account(account)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -91,7 +91,7 @@ class ApplicationMailer < ActionMailer::Base
     value = path.to_s.strip
     return value if value.blank? || value.start_with?('http://', 'https://')
 
-    "#{ENV.fetch('FRONTEND_URL', nil)}#{value}"
+    "#{ENV.fetch('FRONTEND_URL', nil).to_s.chomp('/')}/#{value.delete_prefix('/')}"
   end
 
   def locale_from_account(account)

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -221,7 +221,9 @@ class ConversationReplyMailer < ApplicationMailer
   def csat_survey_action?
     return @message.input_csat? if @message.present?
 
-    @messages.present? && @messages.all?(&:input_csat?)
+    # any?, not all?: the notification debounce can batch a plain reply together with the
+    # survey, and that batch still has to carry the branding the survey depends on.
+    @messages.present? && @messages.any?(&:input_csat?)
   end
 
   def branded_email_layout_action?

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -207,10 +207,21 @@ class ConversationReplyMailer < ApplicationMailer
   end
 
   def choose_layout
-    return 'mailer/base' if branded_email_layout_action?
+    return 'mailer/base' if branded_email_layout_action? || csat_survey_action?
     return false if action_name == 'reply_without_summary' || action_name == 'email_reply'
 
     'mailer/base'
+  end
+
+  # Replies go out bare because they are turns inside an email thread, and wrapping each one
+  # in a branded card would clutter the exchange. The CSAT survey is the opposite: a
+  # self-contained system message that closes the conversation, and the layout is what gives
+  # it the installation's logo and colours. This is the file layout, which every other
+  # notification already uses; replacing it with a database one stays premium.
+  def csat_survey_action?
+    return @message.input_csat? if @message.present?
+
+    @messages.present? && @messages.all?(&:input_csat?)
   end
 
   def branded_email_layout_action?

--- a/app/views/layouts/mailer/base.liquid
+++ b/app/views/layouts/mailer/base.liquid
@@ -27,7 +27,7 @@
       }
 
       a {
-        color: #2781F6;
+        color: {{ brand_color_text }};
       }
 
       .email-container {
@@ -46,7 +46,7 @@
 
       .accent-bar {
         height: 6px;
-        background-color: #2781F6;
+        background-color: {{ brand_color }};
         font-size: 0;
         line-height: 0;
       }
@@ -64,7 +64,7 @@
       }
 
       .footer a {
-        color: #2781F6;
+        color: {{ brand_color_text }};
         font-weight: 600;
         text-decoration: none;
       }
@@ -105,8 +105,15 @@
               <td style="margin: 0;">
                 <table class="main-card" role="presentation" width="100%" cellpadding="0" cellspacing="0" itemprop="action" itemscope itemtype="http://schema.org/ConfirmAction" style="width: 100%; border: 1px solid #DCE7F5; border-radius: 24px; background-color: #FFFFFF; box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06); overflow: hidden;" bgcolor="#FFFFFF">
                   <tr style="margin: 0;">
-                    <td class="accent-bar" style="height: 6px; background-color: #2781F6; font-size: 0; line-height: 0;">&nbsp;</td>
+                    <td class="accent-bar" style="height: 6px; background-color: {{ brand_color }}; font-size: 0; line-height: 0;">&nbsp;</td>
                   </tr>
+                  {% if brand_logo_url != nil and brand_logo_url != '' %}
+                    <tr style="margin: 0;">
+                      <td style="padding: 32px 36px 0; margin: 0;" align="left">
+                        <img src="{{ brand_logo_url }}" alt="{{ brand_name }}" height="36" style="height: 36px; width: auto; border: none; display: block;" />
+                      </td>
+                    </tr>
+                  {% endif %}
                   <tr style="margin: 0;">
                     <td class="content-wrap" style="vertical-align: top; margin: 0; padding: 40px 36px 20px; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;" valign="top">
                       <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; margin: 0;">
@@ -122,7 +129,7 @@
                 <td class="footer" style="padding: 20px 8px 0; text-align: center; color: #64748B; font-size: 13px; line-height: 21px;">
                   {{ 'mailer.common.sent_by_prefix' | t }}
                   {% if brand_url != nil and brand_url != '' %}
-                    <a href="{{ brand_url }}" style="color: #2781F6; font-weight: 600; text-decoration: none;">{{ brand_name }}</a>.
+                    <a href="{{ brand_url }}" style="color: {{ brand_color_text }}; font-weight: 600; text-decoration: none;">{{ brand_name }}</a>.
                   {% else %}
                     <span style="color: #0F172A; font-weight: 600;">{{ brand_name }}</span>.
                   {% endif %}
@@ -133,7 +140,7 @@
               <tr style="margin: 0;">
                 <td class="footer" style="padding: 8px 8px 0; text-align: center; color: #64748B; font-size: 13px; line-height: 21px;">
                   You're receiving this email because email notifications are enabled for your account.
-                  <a href="{{ notification_settings_url }}" style="color: #2781F6; font-weight: 600; text-decoration: none;">Manage notification preferences</a>.
+                  <a href="{{ notification_settings_url }}" style="color: {{ brand_color_text }}; font-weight: 600; text-decoration: none;">Manage notification preferences</a>.
                 </td>
               </tr>
             {% endif %}

--- a/app/views/mailers/conversation_reply_mailer/_csat_survey.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/_csat_survey.html.erb
@@ -4,35 +4,34 @@
   page reads it and submits, which keeps the write on the API's PUT. A GET that recorded
   the rating would be triggered by link scanners and mail client prefetching.
 %>
-<%# Emitted as a table row: the branded layout drops content_for_layout straight inside a
-    <table>, and a div or table there is not a valid child -- the parser fosters it out of
-    the card, and Outlook's Word engine is free to reorder or drop it. %>
+<%# Self-contained flow markup, valid under a <body>, a <div> or a <td>. It deliberately is
+    not a <tr>: a branded layout stored in the database only has to contain the
+    content_for_layout placeholder, so the slot is not guaranteed to be a table, and a bare
+    row there would be worse than what the file layout does with flow content -- which is
+    foster it into the surrounding cell, the same treatment the <p> that upstream's
+    reply_with_summary already emits in that slot gets. %>
 <% ratings = CsatRatings::RATINGS %>
 <% starred = message.content_attributes['display_type'] == 'star' %>
 <% survey_link = message.conversation.csat_survey_link %>
 <%# The prompt is admin-authored copy from csat_config, so it goes through the renderer the
     other message bodies use: Markdown and line breaks would otherwise reach the contact literally. %>
-<tr>
-  <td style="margin: 0; padding: 0;">
-    <div style="margin: 0 0 8px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 15px; line-height: 22px; color: #0F172A;">
-      <%= ChatwootMarkdownRenderer.new(message.content).render_message %>
-    </div>
-    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: separate;">
-      <tr>
-        <% ratings.each do |rating| %>
-          <td align="center" valign="top" style="padding: 0 6px;">
-            <a href="<%= "#{survey_link}?rating=#{rating[:value]}" %>" target="_blank" style="display: block; padding: 6px 4px; text-decoration: none; color: #64748B;">
-              <span style="font-size: 30px; line-height: 38px; <%= "color: #{CsatRatings::STAR_COLOR};" if starred %>">
-                <%= starred ? CsatRatings::STAR_GLYPH : rating[:emoji] %>
-              </span>
-              <br />
-              <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 12px; line-height: 18px; color: #64748B;">
-                <%= t("mailer.conversation_reply.csat.ratings.#{rating[:key]}") %>
-              </span>
-            </a>
+<div style="margin: 0 0 8px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 15px; line-height: 22px; color: #0F172A;">
+  <%= ChatwootMarkdownRenderer.new(message.content).render_message %>
+</div>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: separate;">
+  <tr>
+    <% ratings.each do |rating| %>
+      <td align="center" valign="top" style="padding: 0 6px;">
+        <a href="<%= "#{survey_link}?rating=#{rating[:value]}" %>" target="_blank" style="display: block; padding: 6px 4px; text-decoration: none; color: #64748B;">
+          <span style="font-size: 30px; line-height: 38px; <%= "color: #{CsatRatings::STAR_COLOR};" if starred %>">
+            <%= starred ? CsatRatings::STAR_GLYPH : rating[:emoji] %>
+          </span>
+          <br />
+          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 12px; line-height: 18px; color: #64748B;">
+            <%= t("mailer.conversation_reply.csat.ratings.#{rating[:key]}") %>
+          </span>
+        </a>
       </td>
     <% end %>
   </tr>
 </table>
-  </td>
-</tr>

--- a/app/views/mailers/conversation_reply_mailer/_csat_survey.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/_csat_survey.html.erb
@@ -1,0 +1,29 @@
+<%#
+  The CSAT scale, rendered inline so the contact rates from the email itself instead of
+  clicking through to the survey page. Each rating is a link that carries the value; the
+  page reads it and submits, which keeps the write on the API's PUT. A GET that recorded
+  the rating would be triggered by link scanners and mail client prefetching.
+%>
+<% ratings = CsatRatings::RATINGS %>
+<% starred = message.content_attributes['display_type'] == 'star' %>
+<% survey_link = message.conversation.csat_survey_link %>
+<p style="margin: 0 0 16px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 15px; line-height: 22px; color: #0F172A;">
+  <%= message.content %>
+</p>
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: separate;">
+  <tr>
+    <% ratings.each do |rating| %>
+      <td align="center" valign="top" style="padding: 0 6px;">
+        <a href="<%= "#{survey_link}?rating=#{rating[:value]}" %>" target="_blank" style="display: block; padding: 6px 4px; text-decoration: none; color: #64748B;">
+          <span style="font-size: 30px; line-height: 38px; <%= "color: #{CsatRatings::STAR_COLOR};" if starred %>">
+            <%= starred ? CsatRatings::STAR_GLYPH : rating[:emoji] %>
+          </span>
+          <br />
+          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 12px; line-height: 18px; color: #64748B;">
+            <%= t("mailer.conversation_reply.csat.ratings.#{rating[:key]}") %>
+          </span>
+        </a>
+      </td>
+    <% end %>
+  </tr>
+</table>

--- a/app/views/mailers/conversation_reply_mailer/_csat_survey.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/_csat_survey.html.erb
@@ -7,9 +7,11 @@
 <% ratings = CsatRatings::RATINGS %>
 <% starred = message.content_attributes['display_type'] == 'star' %>
 <% survey_link = message.conversation.csat_survey_link %>
-<p style="margin: 0 0 16px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 15px; line-height: 22px; color: #0F172A;">
-  <%= message.content %>
-</p>
+<%# The prompt is admin-authored copy from csat_config, so it goes through the renderer the
+    other message bodies use: Markdown and line breaks would otherwise reach the contact literally. %>
+<div style="margin: 0 0 8px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 15px; line-height: 22px; color: #0F172A;">
+  <%= ChatwootMarkdownRenderer.new(message.content).render_message %>
+</div>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: separate;">
   <tr>
     <% ratings.each do |rating| %>

--- a/app/views/mailers/conversation_reply_mailer/_csat_survey.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/_csat_survey.html.erb
@@ -4,28 +4,35 @@
   page reads it and submits, which keeps the write on the API's PUT. A GET that recorded
   the rating would be triggered by link scanners and mail client prefetching.
 %>
+<%# Emitted as a table row: the branded layout drops content_for_layout straight inside a
+    <table>, and a div or table there is not a valid child -- the parser fosters it out of
+    the card, and Outlook's Word engine is free to reorder or drop it. %>
 <% ratings = CsatRatings::RATINGS %>
 <% starred = message.content_attributes['display_type'] == 'star' %>
 <% survey_link = message.conversation.csat_survey_link %>
 <%# The prompt is admin-authored copy from csat_config, so it goes through the renderer the
     other message bodies use: Markdown and line breaks would otherwise reach the contact literally. %>
-<div style="margin: 0 0 8px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 15px; line-height: 22px; color: #0F172A;">
-  <%= ChatwootMarkdownRenderer.new(message.content).render_message %>
-</div>
-<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: separate;">
-  <tr>
-    <% ratings.each do |rating| %>
-      <td align="center" valign="top" style="padding: 0 6px;">
-        <a href="<%= "#{survey_link}?rating=#{rating[:value]}" %>" target="_blank" style="display: block; padding: 6px 4px; text-decoration: none; color: #64748B;">
-          <span style="font-size: 30px; line-height: 38px; <%= "color: #{CsatRatings::STAR_COLOR};" if starred %>">
-            <%= starred ? CsatRatings::STAR_GLYPH : rating[:emoji] %>
-          </span>
-          <br />
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 12px; line-height: 18px; color: #64748B;">
-            <%= t("mailer.conversation_reply.csat.ratings.#{rating[:key]}") %>
-          </span>
-        </a>
+<tr>
+  <td style="margin: 0; padding: 0;">
+    <div style="margin: 0 0 8px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 15px; line-height: 22px; color: #0F172A;">
+      <%= ChatwootMarkdownRenderer.new(message.content).render_message %>
+    </div>
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: separate;">
+      <tr>
+        <% ratings.each do |rating| %>
+          <td align="center" valign="top" style="padding: 0 6px;">
+            <a href="<%= "#{survey_link}?rating=#{rating[:value]}" %>" target="_blank" style="display: block; padding: 6px 4px; text-decoration: none; color: #64748B;">
+              <span style="font-size: 30px; line-height: 38px; <%= "color: #{CsatRatings::STAR_COLOR};" if starred %>">
+                <%= starred ? CsatRatings::STAR_GLYPH : rating[:emoji] %>
+              </span>
+              <br />
+              <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 12px; line-height: 18px; color: #64748B;">
+                <%= t("mailer.conversation_reply.csat.ratings.#{rating[:key]}") %>
+              </span>
+            </a>
       </td>
     <% end %>
   </tr>
 </table>
+  </td>
+</tr>

--- a/app/views/mailers/conversation_reply_mailer/email_reply.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/email_reply.html.erb
@@ -1,4 +1,6 @@
-<% if @message.content_attributes.dig('email', 'html_content', 'reply').present? %>
+<% if @message.input_csat? %>
+<%= render 'mailers/conversation_reply_mailer/csat_survey', message: @message %>
+<% elsif @message.content_attributes.dig('email', 'html_content', 'reply').present? %>
 <%= @message.content_attributes.dig('email', 'html_content', 'reply').html_safe %>
 <% elsif @message.content %>
 <%= @message.outgoing_content.html_safe %>

--- a/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
@@ -10,8 +10,8 @@
   </tr>
   <tr>
     <td style="padding: 0px 16px; margin: 4px 0 8px 0; background: #F5FAFF; border-radius: 5px; display: inline-block; font-family: 'Helvetica Neue',Tahoma,Arial,sans-serif; text-align: start; unicode-bidi: plaintext;">
-      <% if (message.content_type == 'input_csat' && message.message_type == 'template') %>
-        <p>Click <a href="<%= message.conversation.csat_survey_link %>" _target="blank">here</a> to rate the conversation.</p>
+      <% if message.input_csat? %>
+        <%= render 'mailers/conversation_reply_mailer/csat_survey', message: message %>
       <% elsif message.content.present? %>
         <%= ChatwootMarkdownRenderer.new(message.content).render_message %>
       <% end %>

--- a/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/reply_with_summary.html.erb
@@ -3,6 +3,9 @@
 <p>You have new messages on your conversation.</p>
 
 <% @messages.each do |message| %>
+  <% if message.input_csat? %>
+    <%= render 'mailers/conversation_reply_mailer/csat_survey', message: message %>
+  <% else %>
   <tr>
     <td>
       <b><%= message.incoming? ? 'You' : message.sender&.available_name || message.sender&.name || 'Bot' %></b>
@@ -10,9 +13,7 @@
   </tr>
   <tr>
     <td style="padding: 0px 16px; margin: 4px 0 8px 0; background: #F5FAFF; border-radius: 5px; display: inline-block; font-family: 'Helvetica Neue',Tahoma,Arial,sans-serif; text-align: start; unicode-bidi: plaintext;">
-      <% if message.input_csat? %>
-        <%= render 'mailers/conversation_reply_mailer/csat_survey', message: message %>
-      <% elsif message.content.present? %>
+      <% if message.content.present? %>
         <%= ChatwootMarkdownRenderer.new(message.content).render_message %>
       <% end %>
       <% if message.attachments.count.positive? %>
@@ -29,4 +30,5 @@
       <% end %>
     </td>
   </tr>
+  <% end %>
 <% end %>

--- a/app/views/mailers/conversation_reply_mailer/reply_without_summary.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/reply_without_summary.html.erb
@@ -1,8 +1,9 @@
 <% @messages.each do |message| %>
+  <% if message.input_csat? %>
+    <%= render 'mailers/conversation_reply_mailer/csat_survey', message: message %>
+  <% else %>
   <p style="font-family: Roboto,"Helvetica Neue",Tahoma,Arial,sans-serif; text-align: start; unicode-bidi: plaintext;">
-    <% if message.input_csat? %>
-      <%= render 'mailers/conversation_reply_mailer/csat_survey', message: message %>
-    <% elsif message.content %>
+    <% if message.content %>
       <%= ChatwootMarkdownRenderer.new(message.content).render_message %>
     <% end %>
     <% if message.attachments.present? %>
@@ -12,4 +13,5 @@
       <% end %>
     <% end %>
   </p>
+  <% end %>
 <% end %>

--- a/app/views/mailers/conversation_reply_mailer/reply_without_summary.html.erb
+++ b/app/views/mailers/conversation_reply_mailer/reply_without_summary.html.erb
@@ -1,6 +1,8 @@
 <% @messages.each do |message| %>
   <p style="font-family: Roboto,"Helvetica Neue",Tahoma,Arial,sans-serif; text-align: start; unicode-bidi: plaintext;">
-    <% if message.content %>
+    <% if message.input_csat? %>
+      <%= render 'mailers/conversation_reply_mailer/csat_survey', message: message %>
+    <% elsif message.content %>
       <%= ChatwootMarkdownRenderer.new(message.content).render_message %>
     <% end %>
     <% if message.attachments.present? %>

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -30,6 +30,10 @@
   value: '/brand-assets/logo_dark.svg'
   display_title: 'Logo Dark Mode'
   description: 'The logo that would be used on the dashboard, login page etc. for dark mode'
+- name: LOGO_EMAIL
+  value: ''
+  display_title: 'Email Logo'
+  description: 'The logo shown at the top of outgoing emails. Must be a PNG, JPG or GIF -- email clients do not render SVG. A relative path is resolved against FRONTEND_URL. Left empty, LOGO is used when it is one of those formats, and no logo is shown otherwise.'
 - name: BRAND_URL
   value: 'https://www.chatwoot.com'
   display_title: 'Brand URL'

--- a/config/locales/fazer_ai.mailers.en.yml
+++ b/config/locales/fazer_ai.mailers.en.yml
@@ -17,6 +17,14 @@ en:
       attachment_click_to_view: Attachment [<a href="%{url}" target="_blank">Click here to view</a>]
       click_here_to_get_cracking: Click <a href="%{url}">here</a> to get cracking.
       the_chatwoot_team: The %{brand_name} Team
+    conversation_reply:
+      csat:
+        ratings:
+          poor: Poor
+          fair: Fair
+          average: Average
+          good: Good
+          excellent: Excellent
     agent_notifications:
       conversation_creation:
         subject: "%{agent_name}, A new conversation [ID - %{conversation_id}] has been created in %{inbox_name}."

--- a/config/locales/fazer_ai.mailers.es.yml
+++ b/config/locales/fazer_ai.mailers.es.yml
@@ -17,6 +17,14 @@ es:
       attachment_click_to_view: Archivo adjunto [<a href="%{url}" target="_blank">Haga clic aquí para verlo</a>]
       click_here_to_get_cracking: Haga clic <a href="%{url}">aquí</a> y manos a la obra.
       the_chatwoot_team: El equipo de %{brand_name}
+    conversation_reply:
+      csat:
+        ratings:
+          poor: Malo
+          fair: Regular
+          average: Normal
+          good: Bueno
+          excellent: Excelente
     agent_notifications:
       conversation_creation:
         subject: "%{agent_name}: se creó una conversación nueva [ID - %{conversation_id}] en %{inbox_name}."

--- a/config/locales/fazer_ai.mailers.pt_BR.yml
+++ b/config/locales/fazer_ai.mailers.pt_BR.yml
@@ -17,6 +17,14 @@ pt_BR:
       attachment_click_to_view: Anexo [<a href="%{url}" target="_blank">Clique aqui para visualizar</a>]
       click_here_to_get_cracking: Clique <a href="%{url}">aqui</a> para acessar.
       the_chatwoot_team: Equipe %{brand_name}
+    conversation_reply:
+      csat:
+        ratings:
+          poor: Ruim
+          fair: Regular
+          average: Neutro
+          good: Bom
+          excellent: Excelente
     agent_notifications:
       conversation_creation:
         subject: "%{agent_name}, Uma nova conversa [ID - %{conversation_id}] foi criada em %{inbox_name}."

--- a/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
+++ b/enterprise/app/controllers/enterprise/super_admin/app_configs_controller.rb
@@ -23,6 +23,7 @@ module Enterprise::SuperAdmin::AppConfigsController
       LOGO_THUMBNAIL
       LOGO
       LOGO_DARK
+      LOGO_EMAIL
       BRAND_NAME
       BRAND_COLOR
       INSTALLATION_NAME

--- a/enterprise/config/premium_installation_config.yml
+++ b/enterprise/config/premium_installation_config.yml
@@ -7,6 +7,10 @@
   value: '/brand-assets/logo.svg'
 - name: LOGO_DARK
   value: '/brand-assets/logo_dark.svg'
+- name: LOGO_EMAIL
+  value: ''
+- name: BRAND_COLOR
+  value: '#1f93ff'
 - name: BRAND_URL
   value: 'https://www.chatwoot.com'
 - name: WIDGET_BRAND_URL

--- a/lib/brand_color.rb
+++ b/lib/brand_color.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# BRAND_COLOR is the one colour an installation configures, and email needs it in two
+# roles that a single hex cannot fill. As a surface -- an accent bar, a button fill -- any
+# hex works. As text it has to clear WCAG AA against the email's white card, and a brand
+# colour rarely does: Chatwoot's own default sits at 3.15:1, and a bright green or yellow
+# lands near 2:1, which is unreadable rather than merely off-brand.
+module BrandColor
+  DEFAULT = '#1F93FF'
+  # WCAG 2.1 AA for body text.
+  MIN_CONTRAST = 4.5
+  HEX_PATTERN = /\A#(?:\h{3}|\h{6})\z/
+  WHITE_LUMINANCE = 1.0
+
+  def self.surface(hex = nil)
+    normalize(hex) || DEFAULT
+  end
+
+  # The brand colour darkened just enough to be readable on the white card. Darkening keeps
+  # the hue, so the result still reads as the brand rather than as an unrelated colour.
+  def self.on_light(hex = nil)
+    rgb = to_rgb(surface(hex))
+    factor = 1.0
+    factor -= 0.05 while factor.positive? && contrast_with_white(scale(rgb, factor)) < MIN_CONTRAST
+    to_hex(scale(rgb, [factor, 0].max))
+  end
+
+  def self.normalize(hex)
+    value = hex.to_s.strip
+    return nil unless value.match?(HEX_PATTERN)
+
+    value = "##{value[1..].chars.flat_map { |char| [char, char] }.join}" if value.length == 4
+    value.upcase
+  end
+
+  def self.to_rgb(hex)
+    hex[1..].scan(/\h{2}/).map { |pair| pair.to_i(16) }
+  end
+
+  def self.to_hex(rgb)
+    "##{rgb.map { |channel| channel.to_s(16).rjust(2, '0') }.join.upcase}"
+  end
+
+  def self.scale(rgb, factor)
+    rgb.map { |channel| (channel * factor).round.clamp(0, 255) }
+  end
+
+  def self.contrast_with_white(rgb)
+    (WHITE_LUMINANCE + 0.05) / (relative_luminance(rgb) + 0.05)
+  end
+
+  def self.relative_luminance(rgb)
+    linear = rgb.map do |channel|
+      value = channel / 255.0
+      value <= 0.03928 ? value / 12.92 : (((value + 0.055) / 1.055)**2.4)
+    end
+    (0.2126 * linear[0]) + (0.7152 * linear[1]) + (0.0722 * linear[2])
+  end
+
+  private_class_method :normalize, :to_rgb, :to_hex, :scale, :contrast_with_white, :relative_luminance
+end

--- a/lib/csat_ratings.rb
+++ b/lib/csat_ratings.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# The scale the CSAT survey offers, mirroring CSAT_RATINGS in
+# app/javascript/shared/constants/messages.js. The email templates render the scale
+# server-side, so the values cannot live in the frontend bundle alone.
+module CsatRatings
+  STAR_GLYPH = '★'
+  STAR_COLOR = '#F5A524'
+
+  RATINGS = [
+    { key: 'poor', value: 1, emoji: '😞' },
+    { key: 'fair', value: 2, emoji: '😑' },
+    { key: 'average', value: 3, emoji: '😐' },
+    { key: 'good', value: 4, emoji: '😀' },
+    { key: 'excellent', value: 5, emoji: '😍' }
+  ].freeze
+
+  VALUES = RATINGS.pluck(:value).freeze
+end

--- a/lib/tasks/branding.rake
+++ b/lib/tasks/branding.rake
@@ -11,6 +11,8 @@ namespace :branding do
       'LOGO' => '/brand-assets/logo.svg',
       # The logo that would be used on the dashboard, login page etc. for dark mode
       'LOGO_DARK' => '/brand-assets/logo_dark.svg',
+      # The logo shown at the top of outgoing emails (PNG or JPG; email clients do not render SVG)
+      'LOGO_EMAIL' => '',
       # The URL that would be used in emails under the section “Powered By”
       'BRAND_URL' => 'https://www.chatwoot.com',
       # The URL that would be used in the widget under the section “Powered By”

--- a/scripts/i18n/fork_translations.rb
+++ b/scripts/i18n/fork_translations.rb
@@ -152,9 +152,12 @@ class ForkTranslations
 
   # Overrides are upstream keys we replace, so they are deliberately absent from
   # the fork's own key set and never count towards translation coverage.
-  def fork_keys(locale)
-    paths = FE_TREES.flat_map { |tree| tree_fork_paths(tree, locale) }
-    keys_in(paths).merge(keys_in(Dir["config/locales/fazer_ai*.#{locale}.yml"]))
+  # Coverage is measured per bundle, not on the union: the dashboard and the survey load
+  # different message trees at runtime, so one having a key translated says nothing about
+  # the other, and merging them lets a translated dashboard key mask a missing survey one.
+  def key_scopes(locale)
+    scopes = FE_TREES.to_h { |tree| [tree[:fork], keys_in(tree_fork_paths(tree, locale))] }
+    scopes.merge('config/locales' => keys_in(Dir["config/locales/fazer_ai*.#{locale}.yml"]))
   end
 
   def tree_fork_paths(tree, locale)
@@ -201,12 +204,13 @@ class ForkTranslations
   def check_every_key_exists_in_reference
     return unless fork_locales.include?(REFERENCE_LOCALE)
 
-    reference = fork_keys(REFERENCE_LOCALE).keys
     (fork_locales - [REFERENCE_LOCALE]).each do |locale|
-      orphans = fork_keys(locale).keys - reference
-      next if orphans.empty?
+      key_scopes(locale).each do |scope, keys|
+        orphans = keys.keys - key_scopes(REFERENCE_LOCALE).fetch(scope, {}).keys
+        next if orphans.empty?
 
-      @errors << "#{locale}: #{orphans.size} chaves nao existem em #{REFERENCE_LOCALE} (#{orphans.first(3).join(', ')})"
+        @errors << "#{scope} #{locale}: #{orphans.size} chaves nao existem em #{REFERENCE_LOCALE} (#{orphans.first(3).join(', ')})"
+      end
     end
   end
 
@@ -219,12 +223,15 @@ class ForkTranslations
   def check_reference_keys_are_translated_everywhere
     return unless fork_locales.include?(REFERENCE_LOCALE)
 
-    reference = fork_keys(REFERENCE_LOCALE).keys
+    reference = key_scopes(REFERENCE_LOCALE)
     (fork_locales - [REFERENCE_LOCALE]).each do |locale|
-      missing = reference - fork_keys(locale).keys
-      next if missing.empty?
+      scopes = key_scopes(locale)
+      reference.each do |scope, keys|
+        missing = keys.keys - scopes.fetch(scope, {}).keys
+        next if missing.empty?
 
-      @errors << "#{locale}: #{missing.size} chaves de #{REFERENCE_LOCALE} sem traducao (#{missing.first(3).join(', ')})"
+        @errors << "#{scope} #{locale}: #{missing.size} chaves de #{REFERENCE_LOCALE} sem traducao (#{missing.first(3).join(', ')})"
+      end
     end
   end
 
@@ -239,10 +246,12 @@ class ForkTranslations
   def report_coverage
     return unless fork_locales.include?(REFERENCE_LOCALE)
 
-    total = fork_keys(REFERENCE_LOCALE).size
+    reference = key_scopes(REFERENCE_LOCALE)
+    total = reference.values.sum(&:size)
     puts "chaves do fork em #{REFERENCE_LOCALE}: #{total}"
     (fork_locales - [REFERENCE_LOCALE]).each do |locale|
-      translated = (fork_keys(locale).keys & fork_keys(REFERENCE_LOCALE).keys).size
+      scopes = key_scopes(locale)
+      translated = reference.sum { |scope, keys| (keys.keys & scopes.fetch(scope, {}).keys).size }
       puts format('  %<locale>-8s %<done>4d/%<total>d traduzidas (%<percent>d%%)',
                   locale: locale, done: translated, total: total, percent: (translated * 100.0 / total).round)
     end

--- a/scripts/i18n/fork_translations.rb
+++ b/scripts/i18n/fork_translations.rb
@@ -16,8 +16,15 @@ require 'yaml'
 require 'open3'
 require 'fileutils'
 
-FE_UPSTREAM = 'app/javascript/dashboard/i18n/locale'
-FE_FORK = 'app/javascript/dashboard/i18n/fazer-ai/locale'
+# Each frontend bundle carries its own translations, so the fork has one overlay per
+# bundle. They differ in layout: the dashboard ships a folder per language (one file per
+# namespace), the survey a single file, since it is one small namespace.
+FE_TREES = [
+  { upstream: 'app/javascript/dashboard/i18n/locale', fork: 'app/javascript/dashboard/i18n/fazer-ai/locale', layout: :directory },
+  { upstream: 'app/javascript/survey/i18n/locale', fork: 'app/javascript/survey/i18n/fazer-ai/locale', layout: :file }
+].freeze
+FE_UPSTREAM = FE_TREES.first[:upstream]
+FE_FORK = FE_TREES.first[:fork]
 BE_FORK_GLOB = 'config/locales/fazer_ai*.yml'
 OVERRIDES = 'overrides.json'
 REFERENCE_LOCALE = 'en'
@@ -47,7 +54,7 @@ class ForkTranslations
       abort "tag #{base} nao esta disponivel neste clone (git fetch --tags)"
     end
 
-    changed = capture('git', 'diff', '--name-only', base, '--', FE_UPSTREAM, 'config/locales')
+    changed = capture('git', 'diff', '--name-only', base, '--', *FE_TREES.map { |tree| tree[:upstream] }, 'config/locales')
               .split("\n")
               .reject { |path| File.fnmatch(BE_FORK_GLOB, path) }
 
@@ -59,11 +66,9 @@ class ForkTranslations
 
   def scaffold(locale)
     abort 'informe o locale, ex: scaffold es' if locale.to_s.empty?
+    abort "#{locale} ja existe em #{FE_FORK}" if Dir.exist?(File.join(FE_FORK, locale))
 
-    target = File.join(FE_FORK, locale)
-    abort "#{target} ja existe" if Dir.exist?(target)
-
-    scaffold_frontend(locale, target)
+    FE_TREES.each { |tree| scaffold_tree(tree, locale) }
     scaffold_backend(locale)
 
     puts "traduza os valores; chaves nao traduzidas caem no fallback em #{REFERENCE_LOCALE}"
@@ -71,11 +76,20 @@ class ForkTranslations
 
   private
 
-  def scaffold_frontend(_locale, target)
-    FileUtils.mkdir_p(target)
-    reference = Dir[File.join(FE_FORK, REFERENCE_LOCALE, '*.json')]
-    reference.each { |path| FileUtils.cp(path, File.join(target, File.basename(path))) }
-    puts "criado #{target}/ com #{reference.size} arquivos copiados de #{REFERENCE_LOCALE}"
+  def scaffold_tree(tree, locale)
+    reference = tree_paths(tree[:fork], tree[:layout], REFERENCE_LOCALE)
+    return puts("#{tree[:fork]} nao tem #{REFERENCE_LOCALE}; nada a copiar") if reference.empty?
+
+    if tree[:layout] == :directory
+      target = File.join(tree[:fork], locale)
+      FileUtils.mkdir_p(target)
+      reference.each { |path| FileUtils.cp(path, File.join(target, File.basename(path))) }
+      puts "criado #{target}/ com #{reference.size} arquivos copiados de #{REFERENCE_LOCALE}"
+    else
+      target = File.join(tree[:fork], "#{locale}.json")
+      FileUtils.cp(reference.first, target)
+      puts "criado #{target} copiado de #{REFERENCE_LOCALE}"
+    end
   end
 
   def scaffold_backend(locale)
@@ -98,7 +112,20 @@ class ForkTranslations
   end
 
   def fork_locales
-    @fork_locales ||= Dir["#{FE_FORK}/*"].select { |path| File.directory?(path) }.map { |path| File.basename(path) }.sort
+    @fork_locales ||= FE_TREES.flat_map { |tree| locales_in(tree) }.uniq.sort
+  end
+
+  def locales_in(tree)
+    if tree[:layout] == :directory
+      Dir["#{tree[:fork]}/*"].select { |path| File.directory?(path) }.map { |path| File.basename(path) }
+    else
+      Dir["#{tree[:fork]}/*.json"].map { |path| File.basename(path, '.json') }
+    end
+  end
+
+  # Files a tree holds for one language, on either side of the boundary.
+  def tree_paths(root, layout, locale)
+    layout == :directory ? Dir["#{root}/#{locale}/*.json"] : Dir["#{root}/#{locale}.json"]
   end
 
   def flatten(obj, prefix = '', acc = {})
@@ -126,12 +153,20 @@ class ForkTranslations
   # Overrides are upstream keys we replace, so they are deliberately absent from
   # the fork's own key set and never count towards translation coverage.
   def fork_keys(locale)
-    paths = Dir["#{FE_FORK}/#{locale}/*.json"].reject { |path| File.basename(path) == OVERRIDES }
+    paths = FE_TREES.flat_map { |tree| tree_fork_paths(tree, locale) }
     keys_in(paths).merge(keys_in(Dir["config/locales/fazer_ai*.#{locale}.yml"]))
   end
 
-  def override_keys(locale)
-    path = File.join(FE_FORK, locale, OVERRIDES)
+  def tree_fork_paths(tree, locale)
+    tree_paths(tree[:fork], tree[:layout], locale).reject { |path| File.basename(path) == OVERRIDES }
+  end
+
+  # Only a directory-layout tree can carry overrides; a single-file tree has nowhere to
+  # put them, and none of them needs to replace an upstream string today.
+  def override_keys(tree, locale)
+    return {} unless tree[:layout] == :directory
+
+    path = File.join(tree[:fork], locale, OVERRIDES)
     File.exist?(path) ? keys_in([path]) : {}
   end
 
@@ -143,20 +178,22 @@ class ForkTranslations
 
   # A fork key living in both trees means someone edited an upstream file.
   def check_fork_keys_are_not_duplicated_upstream
-    fork_locales.each do |locale|
-      upstream = keys_in(Dir["#{FE_UPSTREAM}/#{locale}/*.json"])
-      duplicated = fork_keys(locale).keys & upstream.keys
-      unless duplicated.empty?
-        @errors << "#{locale}: #{duplicated.size} chaves do fork tambem existem no upstream (#{duplicated.first(3).join(', ')})"
-      end
+    FE_TREES.product(fork_locales).each { |tree, locale| check_tree_not_duplicated(tree, locale) }
+  end
 
-      # The mirror case: an override that upstream does not define replaces
-      # nothing, so it belongs in a regular fork file instead.
-      dangling = override_keys(locale).keys - upstream.keys
-      next if dangling.empty?
-
-      @errors << "#{locale}: #{dangling.size} overrides nao existem no upstream (#{dangling.first(3).join(', ')})"
+  def check_tree_not_duplicated(tree, locale)
+    upstream = keys_in(tree_paths(tree[:upstream], tree[:layout], locale))
+    duplicated = keys_in(tree_fork_paths(tree, locale)).keys & upstream.keys
+    unless duplicated.empty?
+      @errors << "#{tree[:fork]} #{locale}: #{duplicated.size} chaves do fork tambem existem no upstream (#{duplicated.first(3).join(', ')})"
     end
+
+    # The mirror case: an override that upstream does not define replaces nothing, so it
+    # belongs in a regular fork file instead.
+    dangling = override_keys(tree, locale).keys - upstream.keys
+    return if dangling.empty?
+
+    @errors << "#{tree[:fork]} #{locale}: #{dangling.size} overrides nao existem no upstream (#{dangling.first(3).join(', ')})"
   end
 
   # Anything translated in another language but absent from the reference is
@@ -192,7 +229,7 @@ class ForkTranslations
   end
 
   def check_upstream_indexes_ignore_the_fork
-    Dir["#{FE_UPSTREAM}/*/index.js"].each do |path|
+    FE_TREES.flat_map { |tree| Dir["#{tree[:upstream]}/*/index.js"] }.each do |path|
       next unless File.read(path).include?('fazer-ai')
 
       @errors << "#{path} referencia a arvore do fork; o merge acontece em i18n/index.js"

--- a/spec/enterprise/services/internal/reconcile_plan_config_service_spec.rb
+++ b/spec/enterprise/services/internal/reconcile_plan_config_service_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe Internal::ReconcilePlanConfigService do
         expect(InstallationConfig.find_by(name: 'INSTALLATION_NAME').value).to eq('Chatwoot')
         expect(InstallationConfig.find_by(name: 'LOGO').value).to eq('/brand-assets/logo.svg')
       end
+
+      it 'resets the email branding, which reaches the customer the same way the dashboard logo does' do
+        create(:installation_config, name: 'LOGO_EMAIL', value: 'https://cdn.example.com/logo.png')
+        create(:installation_config, name: 'BRAND_COLOR', value: '#11D135')
+        service.perform
+        expect(InstallationConfig.find_by(name: 'LOGO_EMAIL').value).to eq('')
+        expect(InstallationConfig.find_by(name: 'BRAND_COLOR').value).to eq('#1f93ff')
+      end
     end
 
     context 'when pricing plan is not community' do

--- a/spec/lib/brand_color_spec.rb
+++ b/spec/lib/brand_color_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BrandColor do
+  describe '.surface' do
+    it 'keeps a configured colour as it is' do
+      expect(described_class.surface('#11D135')).to eq '#11D135'
+    end
+
+    it 'expands the shorthand form' do
+      expect(described_class.surface('#0af')).to eq '#00AAFF'
+    end
+
+    it 'falls back to the default when the value is missing or not a colour' do
+      expect(described_class.surface(nil)).to eq described_class::DEFAULT
+      expect(described_class.surface('rebeccapurple')).to eq described_class::DEFAULT
+    end
+  end
+
+  describe '.on_light' do
+    it 'darkens a brand colour that would be unreadable on the white card' do
+      # #11D135 sits at 2.06:1 against white, well under AA.
+      expect(described_class.on_light('#11D135')).to eq '#0B8822'
+    end
+
+    it 'reaches AA contrast for every colour it returns' do
+      ['#11D135', '#FFEE00', '#00CFCF', '#1F93FF', '#FFFFFF'].each do |hex|
+        expect(contrast_with_white(described_class.on_light(hex))).to be >= described_class::MIN_CONTRAST
+      end
+    end
+
+    it 'leaves a colour that already clears AA alone' do
+      expect(described_class.on_light('#000000')).to eq '#000000'
+    end
+  end
+
+  def contrast_with_white(hex)
+    linear = hex[1..].scan(/\h{2}/).map do |pair|
+      value = pair.to_i(16) / 255.0
+      value <= 0.03928 ? value / 12.92 : (((value + 0.055) / 1.055)**2.4)
+    end
+    luminance = (0.2126 * linear[0]) + (0.7152 * linear[1]) + (0.0722 * linear[2])
+    1.05 / (luminance + 0.05)
+  end
+end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -42,4 +42,50 @@ RSpec.describe ApplicationMailer do
 
     expect(Current.account).to be_nil
   end
+
+  context 'with the branded layout' do
+    before { InstallationConfig.where(name: 'BRAND_COLOR').first_or_create!(value: '#11D135') }
+
+    it 'splits the brand colour by role: raw on the accent bar, darkened on link text' do
+      body = deliver.body.decoded
+
+      expect(body).to include 'background-color: #11D135'
+      expect(body).to include "color: #{BrandColor.on_light('#11D135')}"
+    end
+
+    it 'falls back to LOGO when it is a format email clients render' do
+      InstallationConfig.where(name: 'LOGO').first_or_initialize.update!(value: '/brand-assets/logo.png')
+
+      with_modified_env 'FRONTEND_URL' => 'https://atendimento.example.com' do
+        expect(deliver.body.decoded).to include 'src="https://atendimento.example.com/brand-assets/logo.png"'
+      end
+    end
+
+    it 'shows no logo when LOGO is an SVG, which no email client renders' do
+      InstallationConfig.where(name: 'LOGO').first_or_initialize.update!(value: '/brand-assets/logo.svg')
+
+      expect(deliver.body.decoded).not_to include '<img'
+    end
+
+    it 'prefers LOGO_EMAIL over the LOGO fallback' do
+      InstallationConfig.where(name: 'LOGO').first_or_initialize.update!(value: '/brand-assets/logo.png')
+      InstallationConfig.where(name: 'LOGO_EMAIL').first_or_initialize.update!(value: 'https://cdn.example.com/email.png')
+
+      expect(deliver.body.decoded).to include 'src="https://cdn.example.com/email.png"'
+    end
+
+    it 'resolves a configured logo path against FRONTEND_URL' do
+      InstallationConfig.where(name: 'LOGO_EMAIL').first_or_create!(value: '/logo_email.png')
+
+      with_modified_env 'FRONTEND_URL' => 'https://atendimento.example.com' do
+        expect(deliver.body.decoded).to include 'src="https://atendimento.example.com/logo_email.png"'
+      end
+    end
+
+    it 'leaves a logo already given as a full URL alone' do
+      InstallationConfig.where(name: 'LOGO_EMAIL').first_or_create!(value: 'https://cdn.example.com/logo.png')
+
+      expect(deliver.body.decoded).to include 'src="https://cdn.example.com/logo.png"'
+    end
+  end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe ApplicationMailer do
       end
     end
 
+    it 'joins a path-relative logo without doubling or dropping the separator' do
+      InstallationConfig.where(name: 'LOGO_EMAIL').first_or_initialize.update!(value: 'brand-assets/logo.png')
+
+      with_modified_env 'FRONTEND_URL' => 'https://atendimento.example.com/' do
+        expect(deliver.body.decoded).to include 'src="https://atendimento.example.com/brand-assets/logo.png"'
+      end
+    end
+
     it 'leaves a logo already given as a full URL alone' do
       InstallationConfig.where(name: 'LOGO_EMAIL').first_or_create!(value: 'https://cdn.example.com/logo.png')
 

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -442,6 +442,19 @@ RSpec.describe ConversationReplyMailer do
           end
         end
 
+        it 'wraps the survey in the branded layout, unlike the replies around it' do
+          with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
+            expect(described_class.email_reply(csat_message).deliver_now.body.decoded).to include 'accent-bar'
+          end
+        end
+
+        it 'still sends an ordinary reply bare' do
+          reply = create(:message, conversation: conversation, account: account, message_type: 'outgoing',
+                                   content: 'Sure, here is the answer.', sender: agent)
+
+          expect(described_class.email_reply(reply).deliver_now.body.decoded).not_to include 'accent-bar'
+        end
+
         it 'drops the bare survey link the presenter appends for the other channels' do
           with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
             mail = described_class.email_reply(csat_message).deliver_now

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -448,6 +448,19 @@ RSpec.describe ConversationReplyMailer do
           end
         end
 
+        # The layout drops content_for_layout straight inside a <table>, so the survey has to
+        # be a row. Anything else is fostered out of the card by the parser, which Chrome does
+        # silently and Outlook's Word engine is free to do worse with.
+        it 'sits inside the layout table rather than being fostered out of it' do
+          with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
+            body = described_class.email_reply(csat_message).deliver_now.body.decoded
+            slot = Nokogiri::HTML(body).at_css('td.content-wrap > table')
+
+            expect(slot.element_children.map(&:name)).to all(eq('tr'))
+            expect(slot.css('a').map { |a| a['href'] }).to include(/rating=5/)
+          end
+        end
+
         it 'still sends an ordinary reply bare' do
           reply = create(:message, conversation: conversation, account: account, message_type: 'outgoing',
                                    content: 'Sure, here is the answer.', sender: agent)

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -173,6 +173,21 @@ RSpec.describe ConversationReplyMailer do
             end
           end
         end
+
+        # The debounce window can close on a plain reply and the survey together, and the
+        # branding the survey depends on has to survive that batch.
+        it 'keeps the branded layout when the batch also carries a plain reply' do
+          reply = create(:message, conversation: conversation, account: account, message_type: 'outgoing',
+                                   content: 'Sure, here is the answer.')
+          csat_message.update!(created_at: reply.created_at + 1.second)
+
+          with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
+            body = described_class.reply_without_summary(conversation, reply.id).deliver_now.body.decoded
+
+            expect(body).to include 'accent-bar'
+            expect(body).to include "#{conversation.uuid}?rating=5"
+          end
+        end
       end
     end
 
@@ -448,16 +463,18 @@ RSpec.describe ConversationReplyMailer do
           end
         end
 
-        # The layout drops content_for_layout straight inside a <table>, so the survey has to
-        # be a row. Anything else is fostered out of the card by the parser, which Chrome does
-        # silently and Outlook's Word engine is free to do worse with.
-        it 'sits inside the layout table rather than being fostered out of it' do
+        # The layout drops content_for_layout inside a <table>, so flow content there is
+        # fostered into the surrounding cell -- the same treatment upstream's own <p> gets.
+        # What has to hold is that the scale lands inside the card, whichever level it ends
+        # up on, because a parser is free to move it further than that.
+        it 'lands inside the branded card rather than outside it' do
           with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
             body = described_class.email_reply(csat_message).deliver_now.body.decoded
-            slot = Nokogiri::HTML(body).at_css('td.content-wrap > table')
+            # HTML5, not HTML: only the spec-compliant parser foster-parents the way a browser
+            # and a mail client do, and that relocation is the whole point of this example.
+            card = Nokogiri::HTML5(body).at_css('td.content-wrap')
 
-            expect(slot.element_children.map(&:name)).to all(eq('tr'))
-            expect(slot.css('a').map { |a| a['href'] }).to include(/rating=5/)
+            expect(card.css('a').map { |a| a['href'] }).to include(/rating=5/)
           end
         end
 

--- a/spec/mailers/conversation_reply_mailer_spec.rb
+++ b/spec/mailers/conversation_reply_mailer_spec.rb
@@ -79,6 +79,28 @@ RSpec.describe ConversationReplyMailer do
         expect(cc_mail.cc.first).to eq(cc_message.content_attributes[:cc_emails])
         expect(cc_mail.bcc.first).to eq(cc_message.content_attributes[:bcc_emails])
       end
+
+      context 'when the summary carries a CSAT survey' do
+        # MessageTemplates::Template::CsatSurvey creates the survey with no sender; the factory
+        # always assigns one, so it is cleared here to match what production actually stores.
+        let!(:csat_message) do
+          create(:message, conversation: conversation, account: account, message_type: 'template',
+                           content_type: 'input_csat', content: 'How would you rate our support?',
+                           content_attributes: { display_type: 'emoji' }).tap { |message| message.update!(sender: nil) }
+        end
+
+        it 'renders the rating scale instead of a link to the survey page' do
+          with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
+            survey_url = "https://app.chatwoot.com/survey/responses/#{conversation.uuid}"
+
+            CsatRatings::VALUES.each do |value|
+              expect(mail.body.decoded).to include "#{survey_url}?rating=#{value}"
+            end
+            expect(mail.body.decoded).to include csat_message.content
+            expect(mail.body.decoded).not_to include 'to rate the conversation'
+          end
+        end
+      end
     end
 
     context 'without assignee' do
@@ -134,6 +156,23 @@ RSpec.describe ConversationReplyMailer do
         create(:message, message_type: 'outgoing', account: account, conversation: conversation)
         conversation.update!(contact_last_seen_at: Time.zone.now)
         expect(mail).to be_nil
+      end
+
+      context 'when the message is a CSAT survey' do
+        let(:csat_message) do
+          create(:message, conversation: conversation, account: account, message_type: 'template',
+                           content_type: 'input_csat', content: 'How would you rate our support?',
+                           content_attributes: { display_type: 'emoji' })
+        end
+        let(:mail) { described_class.reply_without_summary(conversation, csat_message.id).deliver_now }
+
+        it 'renders the rating scale' do
+          with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
+            CsatRatings::VALUES.each do |value|
+              expect(mail.body.decoded).to include "https://app.chatwoot.com/survey/responses/#{conversation.uuid}?rating=#{value}"
+            end
+          end
+        end
       end
     end
 
@@ -364,20 +403,50 @@ RSpec.describe ConversationReplyMailer do
       context 'when message is a CSAT survey' do
         let(:csat_message) do
           create(:message, conversation: conversation, account: account, message_type: 'template',
-                           content_type: 'input_csat', content: 'How would you rate our support?', sender: agent)
+                           content_type: 'input_csat', content: 'How would you rate our support?', sender: agent,
+                           content_attributes: { display_type: display_type })
         end
+        let(:display_type) { 'emoji' }
+        let(:survey_url) { "https://app.chatwoot.com/survey/responses/#{conversation.uuid}" }
 
-        it 'includes CSAT survey URL in outgoing_content' do
+        it 'renders one link per rating so the contact answers from the email' do
           with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
             mail = described_class.email_reply(csat_message).deliver_now
-            expect(mail.decoded).to include "https://app.chatwoot.com/survey/responses/#{conversation.uuid}"
+
+            CsatRatings::VALUES.each do |value|
+              expect(mail.decoded).to include "#{survey_url}?rating=#{value}"
+            end
           end
         end
 
-        it 'uses outgoing_content for CSAT message body' do
+        it 'renders the emoji scale with its labels' do
           with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
             mail = described_class.email_reply(csat_message).deliver_now
-            expect(mail.decoded).to include csat_message.outgoing_content
+
+            expect(mail.decoded).to include '😞'
+            expect(mail.decoded).to include '😍'
+            expect(mail.decoded).to include 'Excellent'
+            expect(mail.decoded).not_to include CsatRatings::STAR_GLYPH
+          end
+        end
+
+        it 'renders stars instead of emoji when the inbox asks for a star scale' do
+          csat_message.update!(content_attributes: { display_type: 'star' })
+
+          with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
+            mail = described_class.email_reply(csat_message).deliver_now
+
+            expect(mail.decoded).to include CsatRatings::STAR_GLYPH
+            expect(mail.decoded).not_to include '😞'
+            expect(mail.decoded).to include "#{survey_url}?rating=5"
+          end
+        end
+
+        it 'drops the bare survey link the presenter appends for the other channels' do
+          with_modified_env 'FRONTEND_URL' => 'https://app.chatwoot.com' do
+            mail = described_class.email_reply(csat_message).deliver_now
+
+            expect(mail.decoded).not_to include "#{csat_message.content} #{survey_url}"
           end
         end
       end


### PR DESCRIPTION
The CSAT survey used to reach the customer as its message text followed by the bare survey URL, and the reply email carried no layout at all. The last thing someone saw at the end of a conversation was a 70-character link in the middle of a sentence.

Now the rating scale renders inside the email itself. The customer picks a rating from their inbox and lands on the survey page with it already selected, needing one confirmation instead of reading the prompt, opening a page and choosing from scratch.

The same email also picks up the installation's branding. `BRAND_COLOR` already existed but only ever reached the PWA manifest, while the email layout carried a hardcoded blue that was not even the default; it now paints the layout. A new `LOGO_EMAIL` puts the company's logo at the top.

## How to test

1. In Super Admin → Custom branding, set **Brand Color** to something recognisable and, optionally, **Email Logo** to a PNG or JPG URL.
2. On an email inbox, enable CSAT and set the display type to emoji (then repeat with star).
3. Resolve a conversation so the survey fires, and open the email that arrives.
4. The scale is in the email. Click one of the ratings: the survey page opens with that rating selected and a confirmation button. Nothing is stored until you confirm.
5. Click a different rating on the page instead: that writes immediately, as it always did.
6. Check the accent bar carries the brand colour and the footer link is a readable, darker shade of it.
7. Leave `LOGO_EMAIL` empty with an SVG `LOGO` configured: no logo is shown, as before. Point `LOGO` at a PNG: it is used automatically.

## What changed

- **The scale is a partial**, shared by `email_reply`, `reply_with_summary` and `reply_without_summary`, following the inbox's `display_type`. `CsatRatings` carries the values, which until now only existed in the frontend bundle. The prompt goes through `ChatwootMarkdownRenderer`, so admin-authored Markdown and line breaks survive.
- **The link never writes.** It pre-selects the rating and the page asks for one confirmation. Email security gateways detonate URLs in a sandboxed browser that runs JavaScript — evasion research tracks whether a given sandbox executes it fully — so a write on page load would let a gateway walk all five rating links and settle the response before the recipient opened the message.
- **`BrandColor` splits the brand colour by role.** One hex cannot serve as both a surface and text: a brand colour rarely clears WCAG AA's 4.5:1 against the white card (Chatwoot's own `#1f93ff` sits at 3.15:1, and a bright green lands near 2:1). The accent bar takes the colour as configured; link text takes it darkened until it passes, which keeps the hue.
- **`LOGO_EMAIL`** is a new installation config, editable in Super Admin and covered in `CUSTOM_BRANDING.md`. It falls back to `LOGO` only when that is already a raster format, because `LOGO` defaults to an SVG and no email client renders one: an unconditional fallback would put a broken image in every email. Both it and `BRAND_COLOR` join the premium config the community plan reconciles, where every other branding key already lives.

Three bugs surfaced on the way:

- `reply_without_summary` let the CSAT message through the mailer but had no branch to render it, so on those inboxes the survey went out with no way to answer it.
- `reply_with_summary` hardcoded `Click here to rate the conversation` in English, ignoring the account's locale.
- The survey page read its uuid off the full `href`, which any query string would have broken.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/474)
<!-- Reviewable:end -->
