### PR TITLE
test(agent-bots): fence the name a bot's own token already writes on an activity line

### DIFF
--- a/spec/controllers/api/v1/accounts/bot_token_activity_actor_spec.rb
+++ b/spec/controllers/api/v1/accounts/bot_token_activity_actor_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+# A request authenticated with an agent bot token NAMES THE BOT on every activity line it writes.
+#
+# This is a fence, not a new behaviour. `authenticate_access_token!` assigns `Current.user = @resource`
+# for an AgentBot (`allowed_current_user_type?` accepts one), and `determine_user_name` reads
+# `Current.user&.name` — so the bot's name has always been there. It is fenced because it is easy to
+# read the code the other way: `current_user` (the Devise helper) IS nil for a token request, which is
+# why `ensure_current_account` has a separate bot branch, and `Current.executed_by` is never assigned.
+# fazer-ai/chatwoot#456 was filed on exactly that reading and turned out to be wrong.
+#
+# What depends on it: the fazer.ai agents runtime writes conversation labels with the INSTANCE ADMIN
+# token today, which signs an automated verdict with a person's name (fazer-ai/agents#493). Moving
+# that write to the bot's own token is only correct because of what this spec asserts.
+RSpec.describe 'activity written by an agent bot token', type: :request do
+  let(:account) { create(:account) }
+  let(:agent_bot) { create(:agent_bot, name: 'Observadora', account: account) }
+  let(:conversation) { create(:conversation, account: account) }
+  let(:headers) { { api_access_token: agent_bot.access_token.token } }
+
+  it 'names the bot on a label line' do
+    expect do
+      post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
+           params: { labels: %w[cancelamento] }, headers: headers, as: :json
+    end.to have_enqueued_job(Conversations::ActivityMessageJob)
+      .with(conversation, hash_including(content: 'Observadora added cancelamento'))
+
+    expect(response).to have_http_status(:success)
+  end
+
+  it 'names the bot on a status line' do
+    expect do
+      post toggle_status_api_v1_account_conversation_url(account_id: account.id, id: conversation.display_id),
+           params: { status: 'resolved' }, headers: headers, as: :json
+    end.to have_enqueued_job(Conversations::ActivityMessageJob)
+      .with(conversation, hash_including(content: 'Conversation was marked resolved by Observadora'))
+  end
+
+  it 'names the bot on a priority line' do
+    expect do
+      post toggle_priority_api_v1_account_conversation_url(account_id: account.id, id: conversation.display_id),
+           params: { priority: 'high' }, headers: headers, as: :json
+    end.to have_enqueued_job(Conversations::ActivityMessageJob)
+      .with(conversation, hash_including(content: 'Observadora set the priority to high'))
+  end
+
+  # The other half of why the runtime can move the write: reading and replacing a conversation's
+  # labels is on the bot allowlist (`BOT_ACCESSIBLE_ENDPOINTS`), and `ConversationPolicy#show?`, which
+  # is what the labels controller authorizes against, accepts an agent bot.
+  it 'lets the bot read the labels back' do
+    conversation.update_labels('cancelamento')
+
+    get api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
+        headers: headers, as: :json
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).to include('cancelamento')
+  end
+
+  it 'refuses a bot that is not authorized on this account' do
+    other_bot = create(:agent_bot, name: 'Alheia', account: create(:account))
+
+    post api_v1_account_conversation_labels_url(account_id: account.id, conversation_id: conversation.display_id),
+         params: { labels: %w[cancelamento] },
+         headers: { api_access_token: other_bot.access_token.token }, as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+end


### PR DESCRIPTION
## A #456 estava errada, e esta PR é o que sobrou dela

A issue afirmava que uma requisição autenticada com token de **agent bot** não define ator nenhum, e que por isso toda atividade que ela escreve sai sem nome (`" added cancelamento"`) ou não sai (status). **As duas afirmações são falsas.** Provado contra os endpoints reais, com e sem qualquer mudança de código:

| linha | o que a #456 dizia | o que acontece hoje |
|---|---|---|
| etiqueta | `" added cancelamento"` | `Observadora added cancelamento` |
| status | nenhuma atividade escrita | `Conversation was marked resolved by Observadora` |
| prioridade | sem nome | `Observadora set the priority to high` |

O raciocínio da issue foi que `Current.user` fica nil numa requisição por token. Não fica: `authenticate_access_token!` faz `Current.user = @resource` quando o dono do token é um `AgentBot`, porque `allowed_current_user_type?` aceita um. O que é nil é o **`current_user` do Devise**, e é por isso que `ensure_current_account` tem um ramo separado para bot. São duas coisas diferentes com nomes parecidos, e a issue leu uma pela outra.

O `Current.executed_by` realmente nunca é atribuído, mas isso não deixa nada sem nome: `status_change_activity` só consulta o ramo de automação quando ele está presente, e sem ele cai no ramo do usuário, que já tem o nome do bot.

Restava uma afirmação verdadeira: `performed_by` nos eventos despachados carrega `Current.executed_by`, então vai nil. Não está sendo consertado aqui porque o único consumidor é o `AutomationRuleListener`, que testa `instance_of?(AutomationRule)` e portanto trata um bot exatamente como trata o nil. Definir o campo não mudaria comportamento nenhum, e mudaria o caminho da linha de status do ramo do usuário para o de automação sem ganho.

## O que esta PR entrega

Uma cerca, sem mudança de comportamento. Ela existe porque o código lê ao contrário à primeira vista (foi o que aconteceu comigo ao abrir a #456) e porque tem coisa apoiada nesse fato.

O que se apoia: o runtime do fazer.ai agents escreve as etiquetas com o token de **administrador** da instância, o que assina um veredito automático com o nome de uma pessoa (fazer-ai/agents#493). Na instalação medida esse token de admin é o pessoal de um operador, então cada etiqueta que o observador escrever apareceria assinada por ele. Mover a escrita para o token do próprio bot só é correto por causa do que este spec afirma, então ele afirma.

Os 5 exemplos cobrem as três linhas de atividade, a leitura de volta das etiquetas (que depende de `conversations/labels#index` estar em `BOT_ACCESSIBLE_ENDPOINTS` e de `ConversationPolicy#show?` aceitar `agent_bot?`), e a recusa de um bot que não é autorizado naquela conta.

Closes #456

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/476)
<!-- Reviewable:end -->