### PR TITLE
fix(whatsapp): size a send's wait from the file it carries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -357,6 +357,16 @@ WHATSAPP_CONNECTOR_ENABLED=false
 # (`rails whatsapp:consumer`), or nowhere.
 # WHATSAPP_CONNECTOR_CONSUMER=sidekiq
 # WHATSAPP_CONNECTOR_REDIS_POOL=5
+# How long a send that carries a file is allowed to take, sized from the length the
+# sender declared: the wait is the ordinary RPC timeout plus one second per this many
+# bytes. The connector fetches the file from this app's storage, encrypts it and uploads
+# it to WhatsApp before it can answer, so the number to picture is the slowest of those
+# links rather than the one inside the datacentre. Raise it where the link out is fast.
+# WHATSAPP_MEDIA_SEND_RATE_BYTES=1048576
+# The ceiling on that wait, in seconds. A send holds a Redis connection out of the pool
+# and the worker that called it for as long as it runs, so a file too big to move inside
+# this is one this deployment does not send.
+# WHATSAPP_MEDIA_SEND_MAX_TIMEOUT=180
 
 RESEND_API_KEY=
 # Publish Sidekiq queue metrics to AWS CloudWatch for autoscaling. Off by default.

--- a/app/services/whatsapp/session/backends/connector/backend.rb
+++ b/app/services/whatsapp/session/backends/connector/backend.rb
@@ -9,6 +9,19 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
   # itself stops well below this; the limit is there so a wrong URL cannot fill a disk.
   MAX_MEDIA_BYTES = 100.megabytes
 
+  # How fast a file is assumed to move, end to end, when sizing the wait for a send that
+  # carries one. Deliberately pessimistic: the connector has to fetch the file from this
+  # app's storage, encrypt it into a temporary file and upload it to WhatsApp before it
+  # can answer, and the number that matters is the slowest of those links rather than the
+  # one inside the datacentre.
+  MEDIA_SEND_RATE = ENV.fetch('WHATSAPP_MEDIA_SEND_RATE_BYTES', 1.megabyte).to_i
+
+  # The ceiling on that wait. A send holds a Redis connection out of the pool and the
+  # worker that called it for as long as it runs, so a file too big to move inside this
+  # is one this deployment does not send -- and it says so on the deadline rather than by
+  # holding a worker indefinitely.
+  MEDIA_SEND_MAX_TIMEOUT = ENV.fetch('WHATSAPP_MEDIA_SEND_MAX_TIMEOUT', 180).to_i
+
   class << self
     def provider_key
       'native'
@@ -78,7 +91,28 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
   # --- messages ------------------------------------------------------------------
 
   def send_message(command)
-    model::SendResult.from_h(client.call(command, idempotency_key: "msg:#{command.message_id}"))
+    model::SendResult.from_h(
+      client.call(command, idempotency_key: "msg:#{command.message_id}", timeout: send_timeout(command))
+    )
+  end
+
+  # How long to wait for a send, which for a file is not the same question as for a text.
+  #
+  # Every other RPC answers in milliseconds and the default is right for them. A send with
+  # a file has to cover three transfers before the connector can answer, and under the
+  # default only a few megabytes fit: past that the send fails on the deadline, is
+  # retried, and fails at the same place -- which is why the documented cap was never
+  # reachable through this client.
+  #
+  # Sized from the length the sender already declared rather than from that cap, so a
+  # small file is not given the budget meant for the largest one. Never shorter than the
+  # default, because every other reason to wait is unchanged.
+  def send_timeout(command)
+    size = command.content.try(:size).to_i
+    return Whatsapp::Connector::Client::RPC_TIMEOUT if size <= 0
+
+    budget = Whatsapp::Connector::Client::RPC_TIMEOUT + (size.to_f / MEDIA_SEND_RATE).ceil
+    budget.clamp(Whatsapp::Connector::Client::RPC_TIMEOUT, MEDIA_SEND_MAX_TIMEOUT)
   end
 
   def edit_message(command)

--- a/spec/services/whatsapp/session/backends/connector/backend_spec.rb
+++ b/spec/services/whatsapp/session/backends/connector/backend_spec.rb
@@ -78,7 +78,9 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
   end
 
   it 'sends a message under an idempotency key built from its reserved id' do
-    expect(client).to receive(:call).with(anything, idempotency_key: 'msg:3EB0AAAA').and_return(results['message.send'])
+    expect(client).to receive(:call)
+      .with(anything, idempotency_key: 'msg:3EB0AAAA', timeout: Whatsapp::Connector::Client::RPC_TIMEOUT)
+      .and_return(results['message.send'])
 
     result = backend.send_message(
       model::Commands::MessageSend.new(message_id: '3EB0AAAA', to: model::Address.phone('5541999990000'),
@@ -86,6 +88,39 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
     )
 
     expect(result.message_id).to eq('3EB0AAAA')
+  end
+
+  # The connector has to fetch the file from this app's storage, encrypt it and upload it
+  # to WhatsApp before it can answer, and the default wait covers only a few megabytes of
+  # that. A file past it failed on the deadline, was retried, and failed at the same
+  # place, which is why the documented cap was never reachable through this client.
+  it 'gives a send carrying a file a wait sized from the length the sender declared' do
+    expect(client).to receive(:call)
+      .with(anything, idempotency_key: 'msg:3EB0BBBB', timeout: Whatsapp::Connector::Client::RPC_TIMEOUT + 25)
+      .and_return(results['message.send'])
+
+    backend.send_message(media_send('3EB0BBBB', 25.megabytes))
+  end
+
+  # Every other reason to wait is unchanged, so a small file never shortens the wait a
+  # text would have had.
+  it 'never gives a send less than the default wait' do
+    expect(client).to receive(:call)
+      .with(anything, idempotency_key: 'msg:3EB0CCCC', timeout: Whatsapp::Connector::Client::RPC_TIMEOUT + 1)
+      .and_return(results['message.send'])
+
+    backend.send_message(media_send('3EB0CCCC', 1))
+  end
+
+  # A wait this long holds a Redis connection out of the pool and the worker that called
+  # it, so a file too big to move inside the ceiling is one this deployment does not send.
+  it 'bounds the wait however large the file says it is' do
+    expect(client).to receive(:call)
+      .with(anything, idempotency_key: 'msg:3EB0DDDD',
+                      timeout: described_class::MEDIA_SEND_MAX_TIMEOUT)
+      .and_return(results['message.send'])
+
+    backend.send_message(media_send('3EB0DDDD', 10.gigabytes))
   end
 
   it 'reads the account limits off the session status' do
@@ -152,6 +187,17 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
 
     expect(client).to have_received(:call).once
     expect(Down).to have_received(:download).with('https://connector.test/media/abc', anything)
+  end
+
+  def media_send(message_id, size)
+    model::Commands::MessageSend.new(
+      message_id: message_id, to: model::Address.phone('5541999990000'),
+      content: model::Content::Media.new(
+        kind: 'document', mime: 'application/pdf', filename: 'contrato.pdf', size: size,
+        ref: model::MediaRef.url('http://rails:3000/rails/active_storage/blobs/proxy/abc', mime: 'application/pdf',
+                                                                                           size: size)
+      )
+    )
   end
 
   def download_command(ref)


### PR DESCRIPTION
Passo 1 da fazer-ai/whatsapp-connector#29. O connector documenta 100 MiB como o maior arquivo que envia, e por este cliente nenhum arquivo perto disso passava.

## O que acontecia

`Backend#send_message` chamava `client.call` sem `timeout:`, então todo `message.send` levava `RPC_TIMEOUT` (20s) e saía com `deadline = agora + 18s`. O connector honra esse deadline, como deve, e dentro dele tem que caber a busca do arquivo no storage desta aplicação, a passagem de cifragem para um arquivo temporário e o upload para a WhatsApp. Alguns megabytes cabem. Vinte e cinco não cabem em link nenhum que não seja de datacentre. Cem é impossível.

O envio falhava no deadline, era retentado, e falhava no mesmo lugar.

## A correção

O `send_message` passa a dimensionar o timeout a partir do tamanho que o remetente já declara no conteúdo: `RPC_TIMEOUT` mais um segundo por `WHATSAPP_MEDIA_SEND_RATE_BYTES` (1 MiB por padrão), com teto em `WHATSAPP_MEDIA_SEND_MAX_TIMEOUT` (180s).

Derivado do tamanho declarado e não do cap, para um arquivo pequeno não receber o orçamento do maior. Nunca menor que o padrão, porque todos os outros motivos de espera continuam iguais.

## O que verifiquei antes de escolher esse desenho

A conexão do pool é criada com `timeout: RPC_TIMEOUT + 5`, e eu esperava que um `blpop` mais longo estourasse no socket antes de estourar no comando. Não estoura: o redis-client usa `timeout + config.read_timeout` como read timeout de um comando bloqueante (`connection_mixin.rb:85`), justamente para não ficar racy. Medido no `redis-client` 0.26.4 que está no `Gemfile.lock`, não assumido.

## O custo, que é real

Uma espera dessas segura uma conexão fora do pool e o worker que chamou. O pool já é dimensionado como uma conexão por thread que pode estar enviando, então a razão não muda, mas encompridar a espera aproxima o `CHECKOUT_TIMEOUT` de 5s de um envio concorrente. É o motivo de o teto existir e de o padrão ser pessimista.

## Provas

Três exemplos novos: o tamanho declarado vira orçamento, o piso é o padrão e o teto é respeitado. Remover o `timeout:` do `send_message` derruba os quatro (os três novos e o que já existia).

`spec/services/whatsapp/` verde: 1628 exemplos, 0 falhas. `rubocop` sem ofensas.

## O que não está aqui

Os passos 2 e 3 da issue: reconciliar o número no README do connector, e o connector recusar de antemão um tamanho que não cabe no deadline recebido. O passo 3 só faz sentido agora que este passo definiu qual é o orçamento de verdade, e vai para o repositório do connector.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/479)
<!-- Reviewable:end -->
