### PR TITLE
feat(csat): vestir a pesquisa pública com a marca da conta

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -161,3 +161,4 @@ app/javascript/dashboard/routes/dashboard/settings/automation/constants.js: Pres
 # this conversation" is a per-conversation authorization scheme bots do not have today, for
 # every account bot (Captain included), and belongs to its own issue.
 app/controllers/api/v1/accounts/inboxes/agent_bot_observers_controller.rb: Enforce the observer role on bot API mutations  # PR#453
+app/views/survey/responses/show.html.erb: Use the project's Tailwind theming mechanism  # PR#482

--- a/CUSTOM_BRANDING.md
+++ b/CUSTOM_BRANDING.md
@@ -29,7 +29,7 @@ bundle exec rails branding:update
 | `PRIVACY_URL`        | `https://www.chatwoot.com/privacy-policy`   | The privacy policy URL displayed in the app.                          |
 | `DISPLAY_MANIFEST`   | `true`                                      | Display default Chatwoot metadata like favicons and upgrade warnings. |
 
-## Per-account branding for email
+## Per-account branding
 
 The configuration above is installation-wide, which is what a single-tenant install wants. An installation that hosts several companies usually wants the opposite: an account's emails should carry that account's brand, not the installation owner's.
 
@@ -46,8 +46,21 @@ The fallback is field by field, so an account that sets only a colour keeps the 
 
 The email logo is uploaded rather than referenced by URL, and is served by this installation, so the link inside an email does not expire the way a signed storage URL would. PNG, JPG and GIF only, up to 2 MB: no mail client renders SVG.
 
+### On the CSAT survey page
+
+The public survey page a contact opens from a CSAT request wears the same brand, resolved from the conversation:
+
+| Field         | Where it shows                                                            |
+| :------------ | :------------------------------------------------------------------------ |
+| Brand name    | The browser tab, and the "Powered by" line in the footer                  |
+| Brand website | Where that footer line links                                              |
+| Brand color   | The confirm and submit buttons, the selected rating, and the focus rings  |
+| Email logo    | The footer mark, and the top of the page when the inbox has no avatar     |
+
+Enable `disable_branding` on the account to drop the footer line entirely, the same way the widget and the help center portal already honour it.
+
 > [!NOTE]
-> This covers email only. The dashboard, the login page, the favicon, the PWA manifest and the widget are the installation's own surfaces and always use the installation branding.
+> This covers what a customer of the account sees: their email, and the public survey page. The dashboard, the login page, the favicon, the PWA manifest and the widget are the installation's own surfaces and always use the installation branding.
 
 ## Favicon and other assets
 

--- a/app/controllers/survey/responses_controller.rb
+++ b/app/controllers/survey/responses_controller.rb
@@ -1,10 +1,30 @@
 class Survey::ResponsesController < ActionController::Base
+  before_action :set_conversation
   before_action :set_global_config
+
   def show; end
 
   private
 
+  # find_by, not find_by!: the page has to render for a uuid it does not know, so the Vue app
+  # can ask the public endpoint and show the error that comes back. Raising here would put a
+  # Rails error page in front of a customer who only mistyped a link.
+  #
+  # `uuid` is a Postgres uuid column, so a string that is not one casts to nil and the query
+  # becomes `WHERE uuid IS NULL` -- no exception to rescue.
+  def set_conversation
+    @conversation = Conversation.find_by(uuid: params[:id])
+  end
+
+  # The contact opening this page is a customer of the account, not of the installation, so
+  # the page wears the account's brand. Without a conversation to resolve -- an unknown uuid
+  # -- Brand falls back to the installation on its own.
   def set_global_config
-    @global_config = GlobalConfig.get('LOGO_THUMBNAIL', 'BRAND_NAME', 'WIDGET_BRAND_URL', 'INSTALLATION_NAME')
+    account = @conversation&.account
+
+    @global_config = Brand.for(account: account, inbox: @conversation&.inbox).web_config.merge(
+      # Kept out of Brand: this is a plan entitlement, not part of what the brand looks like.
+      'DISABLE_BRANDING' => account.present? && account.feature_enabled?('disable_branding')
+    )
   end
 end

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/generalSettings.json
@@ -4,7 +4,7 @@
     "FORM": {
       "EMAIL_BRANDING": {
         "TITLE": "Email branding",
-        "NOTE": "How this account's emails look. Anything left empty uses the installation's own branding. This applies to email only — the dashboard, the favicon and the widget keep the installation's brand.",
+        "NOTE": "How this account's emails and CSAT survey page look. Anything left empty uses the installation's own branding. This applies to what your customers see — the dashboard, the favicon and the widget keep the installation's brand.",
         "NAME": {
           "LABEL": "Brand name",
           "PLACEHOLDER": "Your company",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/generalSettings.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/generalSettings.json
@@ -4,7 +4,7 @@
     "FORM": {
       "EMAIL_BRANDING": {
         "TITLE": "Marca de los correos",
-        "NOTE": "Cómo se ven los correos de esta cuenta. Lo que quede vacío usa la identidad de la instalación. Aplica solo al correo: el panel, el favicon y el widget mantienen la marca de la instalación.",
+        "NOTE": "Cómo se ven los correos y la página de encuesta CSAT de esta cuenta. Lo que quede vacío usa la identidad de la instalación. Aplica a lo que ven tus clientes: el panel, el favicon y el widget mantienen la marca de la instalación.",
         "NAME": {
           "LABEL": "Nombre de la marca",
           "PLACEHOLDER": "Tu empresa",

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/generalSettings.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/generalSettings.json
@@ -4,7 +4,7 @@
     "FORM": {
       "EMAIL_BRANDING": {
         "TITLE": "Marca dos e-mails",
-        "NOTE": "Como os e-mails desta conta aparecem. O que ficar em branco usa a identidade da instalação. Vale só para e-mail: o painel, o favicon e o widget continuam com a marca da instalação.",
+        "NOTE": "Como os e-mails e a página de pesquisa de satisfação desta conta aparecem. O que ficar em branco usa a identidade da instalação. Vale para o que o seu cliente vê: o painel, o favicon e o widget continuam com a marca da instalação.",
         "NAME": {
           "LABEL": "Nome da marca",
           "PLACEHOLDER": "Sua empresa",

--- a/app/javascript/entrypoints/survey.js
+++ b/app/javascript/entrypoints/survey.js
@@ -9,6 +9,9 @@ import { domPurifyConfig } from '../shared/helpers/HTMLSanitizer';
 const app = createApp(App);
 const i18n = createI18n({
   locale: 'en',
+  // Only a few languages carry the fork's own strings, so without this a survey served in any
+  // other locale renders the raw key -- inside an aria-label, in the case of the rating scale.
+  fallbackLocale: 'en',
   messages: i18nMessages,
 });
 

--- a/app/javascript/shared/components/Branding.vue
+++ b/app/javascript/shared/components/Branding.vue
@@ -101,9 +101,15 @@ export default {
            mark of whoever owns it is not a badge, so that one keeps its colour.
            max-w rather than a square box: an account's mark is a wide email header logo, and
            squeezing it into 12x12 leaves an illegible smudge. A square installation thumbnail
-           still renders exactly as before. -->
+           still renders exactly as before.
+
+           Height, not just width, is what has to give for a wide mark: a 391x121 logo capped at
+           12px tall comes out 39px wide, so max-w-16 never engages and the wordmark inside is
+           unreadable. Only the own-logo case is raised -- the vendor badge stays the size it
+           has always been. -->
       <img
-        class="ltr:mr-1 rtl:ml-1 max-h-3 w-auto max-w-16 object-contain"
+        class="ltr:mr-1 rtl:ml-1 w-auto object-contain"
+        :class="ownLogo ? 'max-h-5 max-w-24' : 'max-h-3 max-w-16'"
         :alt="displayedBrandName"
         :src="globalConfig.logoThumbnail"
       />

--- a/app/javascript/shared/components/Branding.vue
+++ b/app/javascript/shared/components/Branding.vue
@@ -13,6 +13,18 @@ export default {
       type: Boolean,
       default: false,
     },
+    // Pages served on behalf of a single account pass that account's brand. Everything else
+    // omits it and keeps the installation's, so the widget is untouched.
+    brandName: {
+      type: String,
+      default: '',
+    },
+    // Whether the thumbnail is the mark of whoever this page belongs to, rather than a vendor
+    // badge. Only that case drops the greyscale.
+    ownLogo: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup() {
     const { replaceInstallationName } = useBranding();
@@ -30,6 +42,9 @@ export default {
     };
   },
   computed: {
+    displayedBrandName() {
+      return this.brandName || this.globalConfig.brandName;
+    },
     brandRedirectURL() {
       try {
         const referrerHost = this.$store.getters['appConfig/getReferrerHost'];
@@ -53,22 +68,28 @@ export default {
 
 <template>
   <div
-    v-if="globalConfig.brandName && !disableBranding"
+    v-if="displayedBrandName && !disableBranding"
     class="px-0 py-3 flex justify-center"
   >
     <a
       :href="brandRedirectURL"
       rel="noreferrer noopener nofollow"
       target="_blank"
-      class="branding--link text-n-slate-11 hover:text-n-slate-12 cursor-pointer text-xs inline-flex grayscale-[1] hover:grayscale-0 hover:opacity-100 opacity-90 no-underline justify-center items-center leading-3"
+      class="branding--link text-n-slate-11 hover:text-n-slate-12 cursor-pointer text-xs inline-flex hover:opacity-100 opacity-90 no-underline justify-center items-center leading-3"
+      :class="{ 'grayscale-[1] hover:grayscale-0': !ownLogo }"
     >
+      <!-- Greyscale suits a vendor badge, which is what this is by default. A page carrying the
+           mark of whoever owns it is not a badge, so that one keeps its colour.
+           max-w rather than a square box: an account's mark is a wide email header logo, and
+           squeezing it into 12x12 leaves an illegible smudge. A square installation thumbnail
+           still renders exactly as before. -->
       <img
-        class="ltr:mr-1 rtl:ml-1 max-w-3 max-h-3"
-        :alt="globalConfig.brandName"
+        class="ltr:mr-1 rtl:ml-1 max-h-3 w-auto max-w-16 object-contain"
+        :alt="displayedBrandName"
         :src="globalConfig.logoThumbnail"
       />
       <span>
-        {{ replaceInstallationName($t('POWERED_BY')) }}
+        {{ replaceInstallationName($t('POWERED_BY'), brandName) }}
       </span>
     </a>
   </div>

--- a/app/javascript/shared/components/Branding.vue
+++ b/app/javascript/shared/components/Branding.vue
@@ -45,6 +45,22 @@ export default {
     displayedBrandName() {
       return this.brandName || this.globalConfig.brandName;
     },
+    // Substitution first, interpolation only as a fallback, because the two differ in what they
+    // preserve. POWERED_BY is translated into every language upstream ships; POWERED_BY_BRAND is
+    // ours and exists in three, falling back to English everywhere else. So substituting into
+    // the localized sentence keeps a French survey French, and the fork key is reached only
+    // where substitution has nothing to match -- Persian and Tamil spell the vendor
+    // transliterated, so the Latin name never appears. An English sentence around the right
+    // brand beats a French sentence around the wrong one, and only those locales pay it.
+    poweredByText() {
+      const template = this.$t('POWERED_BY');
+      if (!this.brandName) return this.replaceInstallationName(template);
+
+      const substituted = template.replace(/chatwoot/gi, this.brandName);
+      return substituted === template
+        ? this.$t('POWERED_BY_BRAND', { brandName: this.brandName })
+        : substituted;
+    },
     brandRedirectURL() {
       try {
         const referrerHost = this.$store.getters['appConfig/getReferrerHost'];
@@ -88,17 +104,8 @@ export default {
         :alt="displayedBrandName"
         :src="globalConfig.logoThumbnail"
       />
-      <!-- Interpolated rather than run through replaceInstallationName: POWERED_BY is
-           translated per locale, and in Persian and Tamil it carries a transliterated name
-           instead of the Latin "Chatwoot", so the replace matches nothing and the footer would
-           credit the vendor on a page already wearing the account's brand. Callers that pass
-           brandName must ship POWERED_BY_BRAND in their bundle; the survey does. -->
       <span>
-        {{
-          brandName
-            ? $t('POWERED_BY_BRAND', { brandName })
-            : replaceInstallationName($t('POWERED_BY'))
-        }}
+        {{ poweredByText }}
       </span>
     </a>
   </div>

--- a/app/javascript/shared/components/Branding.vue
+++ b/app/javascript/shared/components/Branding.vue
@@ -56,7 +56,10 @@ export default {
       const template = this.$t('POWERED_BY');
       if (!this.brandName) return this.replaceInstallationName(template);
 
-      const substituted = template.replace(/chatwoot/gi, this.brandName);
+      // Callback, not a string: in a replacement string `$$`, `$&` and `$1` are syntax, and
+      // brand_name only rejects `<>`, so a brand of "ACME $$" would render "ACME $" and one of
+      // "$&" would put "Chatwoot" back. A function inserts whatever it returns, verbatim.
+      const substituted = template.replace(/chatwoot/gi, () => this.brandName);
       return substituted === template
         ? this.$t('POWERED_BY_BRAND', { brandName: this.brandName })
         : substituted;

--- a/app/javascript/shared/components/Branding.vue
+++ b/app/javascript/shared/components/Branding.vue
@@ -88,8 +88,17 @@ export default {
         :alt="displayedBrandName"
         :src="globalConfig.logoThumbnail"
       />
+      <!-- Interpolated rather than run through replaceInstallationName: POWERED_BY is
+           translated per locale, and in Persian and Tamil it carries a transliterated name
+           instead of the Latin "Chatwoot", so the replace matches nothing and the footer would
+           credit the vendor on a page already wearing the account's brand. Callers that pass
+           brandName must ship POWERED_BY_BRAND in their bundle; the survey does. -->
       <span>
-        {{ replaceInstallationName($t('POWERED_BY'), brandName) }}
+        {{
+          brandName
+            ? $t('POWERED_BY_BRAND', { brandName })
+            : replaceInstallationName($t('POWERED_BY'))
+        }}
       </span>
     </a>
   </div>

--- a/app/javascript/shared/components/StarRating.vue
+++ b/app/javascript/shared/components/StarRating.vue
@@ -34,8 +34,11 @@ const getStarClass = value => {
       hoveredRating.value >= value) ||
     props.selectedRating >= value;
 
+  // A cor sai de --survey-brand quando a pagina define a variavel (so a survey define), e
+  // cai no token do design system em qualquer outro lugar. Sem prop nova, e o widget que
+  // compartilha este componente nao muda.
   const starTypeClass = isStarActive
-    ? 'i-ri-star-fill text-n-amber-9'
+    ? 'i-ri-star-fill text-[color:var(--survey-brand,rgb(var(--amber-9)))]'
     : 'i-ri-star-line text-n-slate-10';
 
   return starTypeClass;
@@ -48,7 +51,7 @@ const getStarClass = value => {
       v-for="value in starRatings"
       :key="value"
       type="button"
-      class="rounded-full p-1 transition-all duration-200 focus:enabled:scale-[1.2] focus-within:enabled:scale-[1.2] hover:enabled:scale-[1.2] focus:outline-none focus-visible:ring-2 focus-visible:ring-n-slate-9 flex items-center flex-shrink-0"
+      class="rounded-full p-1 transition-all duration-200 focus:enabled:scale-[1.2] focus-within:enabled:scale-[1.2] hover:enabled:scale-[1.2] focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--survey-brand,rgb(var(--slate-9)))] flex items-center flex-shrink-0"
       :class="{ 'cursor-not-allowed opacity-50': isDisabled }"
       :disabled="isDisabled"
       :aria-label="'Star ' + value"

--- a/app/javascript/shared/components/StarRating.vue
+++ b/app/javascript/shared/components/StarRating.vue
@@ -48,7 +48,7 @@ const getStarClass = value => {
       v-for="value in starRatings"
       :key="value"
       type="button"
-      class="rounded-full p-1 transition-all duration-200 focus:enabled:scale-[1.2] focus-within:enabled:scale-[1.2] hover:enabled:scale-[1.2] focus:outline-none flex items-center flex-shrink-0"
+      class="rounded-full p-1 transition-all duration-200 focus:enabled:scale-[1.2] focus-within:enabled:scale-[1.2] hover:enabled:scale-[1.2] focus:outline-none focus-visible:ring-2 focus-visible:ring-n-slate-9 flex items-center flex-shrink-0"
       :class="{ 'cursor-not-allowed opacity-50': isDisabled }"
       :disabled="isDisabled"
       :aria-label="'Star ' + value"

--- a/app/javascript/shared/components/TextArea.vue
+++ b/app/javascript/shared/components/TextArea.vue
@@ -55,7 +55,7 @@ export default {
     <textarea
       :id="id"
       v-model="computedModel"
-      class="w-full px-3 py-2 leading-tight border rounded outline-none resize-none text-n-gray-12"
+      class="w-full px-4 py-3 leading-relaxed border rounded-xl outline-none resize-none text-n-gray-12"
       :class="{
         'border-n-weak hover:border-n-slate-8 focus:border-n-slate-9 focus:ring-1 focus:ring-n-slate-9':
           !error,

--- a/app/javascript/shared/components/TextArea.vue
+++ b/app/javascript/shared/components/TextArea.vue
@@ -17,6 +17,12 @@ export default {
       type: String,
       default: '',
     },
+    // So a caller can label the field with its own <label for>, which is what a screen reader
+    // needs when the visible label lives outside this component.
+    id: {
+      type: String,
+      default: '',
+    },
   },
   emits: ['update:modelValue'],
   computed: {
@@ -44,12 +50,17 @@ export default {
     >
       {{ label }}
     </div>
+    <!-- The focus border used to be the same colour as the resting one, which is a focus
+         state nobody can see. -->
     <textarea
+      :id="id"
       v-model="computedModel"
       class="w-full px-3 py-2 leading-tight border rounded outline-none resize-none text-n-gray-12"
       :class="{
-        'border-n-weak hover:border-n-weak focus:border-n-weak': !error,
-        'border-n-ruby-9 hover:border-n-ruby-9 focus:border-n-ruby-9': error,
+        'border-n-weak hover:border-n-slate-8 focus:border-n-slate-9 focus:ring-1 focus:ring-n-slate-9':
+          !error,
+        'border-n-ruby-9 hover:border-n-ruby-9 focus:border-n-ruby-9 focus:ring-1 focus:ring-n-ruby-9':
+          error,
       }"
       :placeholder="placeholder"
     />

--- a/app/javascript/shared/components/TextArea.vue
+++ b/app/javascript/shared/components/TextArea.vue
@@ -51,13 +51,14 @@ export default {
       {{ label }}
     </div>
     <!-- The focus border used to be the same colour as the resting one, which is a focus
-         state nobody can see. -->
+         state nobody can see. It takes --survey-brand where the page defines it, so the
+         survey's primary control carries the account's colour like every other one. -->
     <textarea
       :id="id"
       v-model="computedModel"
       class="w-full px-4 py-3 leading-relaxed border rounded-xl outline-none resize-none text-n-gray-12"
       :class="{
-        'border-n-weak hover:border-n-slate-8 focus:border-n-slate-9 focus:ring-1 focus:ring-n-slate-9':
+        'border-n-weak hover:border-n-slate-8 focus:border-[color:var(--survey-brand,rgb(var(--slate-9)))] focus:ring-1 focus:ring-[color:var(--survey-brand,rgb(var(--slate-9)))]':
           !error,
         'border-n-ruby-9 hover:border-n-ruby-9 focus:border-n-ruby-9 focus:ring-1 focus:ring-n-ruby-9':
           error,

--- a/app/javascript/shared/components/specs/Branding.spec.js
+++ b/app/javascript/shared/components/specs/Branding.spec.js
@@ -1,0 +1,51 @@
+import { shallowMount } from '@vue/test-utils';
+
+const mockGlobalConfig = { value: { installationName: 'Chatwoot fazer.ai' } };
+
+vi.mock('dashboard/composables/store.js', () => ({
+  useMapGetter: () => mockGlobalConfig,
+}));
+
+// Read at module scope by the component, so it has to exist before the import below.
+window.globalConfig = {
+  BRAND_NAME: 'Chatwoot fazer.ai',
+  LOGO_THUMBNAIL: '/brand-assets/logo_thumbnail.svg',
+  WIDGET_BRAND_URL: 'https://www.chatwoot.com',
+};
+
+const Branding = (await import('../Branding.vue')).default;
+
+const mountBranding = (props = {}) =>
+  shallowMount(Branding, {
+    props,
+    global: {
+      mocks: {
+        $t: key => (key === 'POWERED_BY' ? 'Powered by Chatwoot' : key),
+        $store: { getters: { 'appConfig/getReferrerHost': '' } },
+      },
+    },
+  });
+
+describe('Branding', () => {
+  it('names the installation when no brand name is given', () => {
+    const wrapper = mountBranding();
+
+    expect(wrapper.text()).toContain('Powered by Chatwoot fazer.ai');
+  });
+
+  it('names the account when a brand name is given', () => {
+    const wrapper = mountBranding({ brandName: 'Guichê Live' });
+
+    expect(wrapper.text()).toContain('Powered by Guichê Live');
+    expect(wrapper.find('img').attributes('alt')).toBe('Guichê Live');
+  });
+
+  it('renders nothing when branding is disabled', () => {
+    const wrapper = mountBranding({
+      brandName: 'Guichê Live',
+      disableBranding: true,
+    });
+
+    expect(wrapper.find('a').exists()).toBe(false);
+  });
+});

--- a/app/javascript/shared/components/specs/Branding.spec.js
+++ b/app/javascript/shared/components/specs/Branding.spec.js
@@ -62,6 +62,17 @@ describe('Branding', () => {
     expect(wrapper.text()).toContain('Propulsé par Guichê Live');
   });
 
+  // brand_name only rejects `<>`, so `$` reaches here. As a replacement string those are
+  // syntax: "ACME $$" would render "ACME $", and "$&" would put the vendor's name back.
+  it('inserts a brand containing replacement syntax literally', () => {
+    expect(mountBranding({ brandName: 'ACME $$' }).text()).toContain(
+      'Powered by ACME $$'
+    );
+    expect(mountBranding({ brandName: '$&' }).text()).toContain(
+      'Powered by $&'
+    );
+  });
+
   it('falls back to the interpolated key where there is no Latin name to substitute', () => {
     const wrapper = mountBranding(
       { brandName: 'Guichê Live' },

--- a/app/javascript/shared/components/specs/Branding.spec.js
+++ b/app/javascript/shared/components/specs/Branding.spec.js
@@ -15,12 +15,20 @@ window.globalConfig = {
 
 const Branding = (await import('../Branding.vue')).default;
 
-const mountBranding = (props = {}) =>
+// poweredBy stands in for the locale's own POWERED_BY. The default carries the Latin
+// "Chatwoot" that replaceInstallationName depends on; a test can pass a transliterated one to
+// stand for Persian or Tamil.
+const mountBranding = (props = {}, poweredBy = 'Powered by Chatwoot') =>
   shallowMount(Branding, {
     props,
     global: {
       mocks: {
-        $t: key => (key === 'POWERED_BY' ? 'Powered by Chatwoot' : key),
+        $t: (key, params) => {
+          if (key === 'POWERED_BY') return poweredBy;
+          if (key === 'POWERED_BY_BRAND')
+            return `Powered by ${params.brandName}`;
+          return key;
+        },
         $store: { getters: { 'appConfig/getReferrerHost': '' } },
       },
     },
@@ -38,6 +46,20 @@ describe('Branding', () => {
 
     expect(wrapper.text()).toContain('Powered by Guichê Live');
     expect(wrapper.find('img').attributes('alt')).toBe('Guichê Live');
+  });
+
+  // The reason the account name is interpolated instead of substituted into POWERED_BY: in
+  // Persian and Tamil that string carries a transliterated name, so a replace of the Latin
+  // "Chatwoot" matches nothing and the footer would credit the vendor on a page already
+  // wearing the account's brand.
+  it('names the account even in a locale that never spells Chatwoot in Latin script', () => {
+    const wrapper = mountBranding(
+      { brandName: 'Guichê Live' },
+      'قدرت گرفته از چت ووت'
+    );
+
+    expect(wrapper.text()).toContain('Powered by Guichê Live');
+    expect(wrapper.text()).not.toContain('چت ووت');
   });
 
   it('renders nothing when branding is disabled', () => {

--- a/app/javascript/shared/components/specs/Branding.spec.js
+++ b/app/javascript/shared/components/specs/Branding.spec.js
@@ -48,11 +48,21 @@ describe('Branding', () => {
     expect(wrapper.find('img').attributes('alt')).toBe('Guichê Live');
   });
 
-  // The reason the account name is interpolated instead of substituted into POWERED_BY: in
-  // Persian and Tamil that string carries a transliterated name, so a replace of the Latin
-  // "Chatwoot" matches nothing and the footer would credit the vendor on a page already
-  // wearing the account's brand.
-  it('names the account even in a locale that never spells Chatwoot in Latin script', () => {
+  // The only case the fork key is for: Persian and Tamil spell the vendor transliterated, so
+  // there is no Latin "Chatwoot" to substitute.
+  // Regression: an earlier fix sent every survey through the fork key, which exists in three
+  // languages and falls back to English. A French survey then read "Powered by Chatwoot"
+  // where it used to read "Propulsé par Chatwoot".
+  it('keeps the sentence in the locale of the survey when substituting the brand', () => {
+    const wrapper = mountBranding(
+      { brandName: 'Guichê Live' },
+      'Propulsé par Chatwoot'
+    );
+
+    expect(wrapper.text()).toContain('Propulsé par Guichê Live');
+  });
+
+  it('falls back to the interpolated key where there is no Latin name to substitute', () => {
     const wrapper = mountBranding(
       { brandName: 'Guichê Live' },
       'قدرت گرفته از چت ووت'

--- a/app/javascript/shared/composables/specs/useBranding.spec.js
+++ b/app/javascript/shared/composables/specs/useBranding.spec.js
@@ -92,5 +92,14 @@ describe('useBranding', () => {
 
       expect(result).toBe('Welcome to My-Company & Co.');
     });
+    it('inserts an installation name containing replacement syntax literally', () => {
+      mockGlobalConfig.value = { installationName: 'ACME $$' };
+
+      const { replaceInstallationName } = useBranding();
+
+      expect(replaceInstallationName('Powered by Chatwoot')).toBe(
+        'Powered by ACME $$'
+      );
+    });
   });
 });

--- a/app/javascript/shared/composables/specs/useBranding.spec.js
+++ b/app/javascript/shared/composables/specs/useBranding.spec.js
@@ -92,26 +92,5 @@ describe('useBranding', () => {
 
       expect(result).toBe('Welcome to My-Company & Co.');
     });
-    it('prefers an explicit brand name over the installation name', () => {
-      mockGlobalConfig.value = { installationName: 'MyCompany' };
-
-      const { replaceInstallationName } = useBranding();
-      const result = replaceInstallationName(
-        'Powered by Chatwoot',
-        'Guiche Live'
-      );
-
-      expect(result).toBe('Powered by Guiche Live');
-    });
-
-    it('keeps the installation name when no brand name is given', () => {
-      mockGlobalConfig.value = { installationName: 'MyCompany' };
-
-      const { replaceInstallationName } = useBranding();
-
-      expect(replaceInstallationName('Powered by Chatwoot', '')).toBe(
-        'Powered by MyCompany'
-      );
-    });
   });
 });

--- a/app/javascript/shared/composables/specs/useBranding.spec.js
+++ b/app/javascript/shared/composables/specs/useBranding.spec.js
@@ -92,5 +92,26 @@ describe('useBranding', () => {
 
       expect(result).toBe('Welcome to My-Company & Co.');
     });
+    it('prefers an explicit brand name over the installation name', () => {
+      mockGlobalConfig.value = { installationName: 'MyCompany' };
+
+      const { replaceInstallationName } = useBranding();
+      const result = replaceInstallationName(
+        'Powered by Chatwoot',
+        'Guiche Live'
+      );
+
+      expect(result).toBe('Powered by Guiche Live');
+    });
+
+    it('keeps the installation name when no brand name is given', () => {
+      mockGlobalConfig.value = { installationName: 'MyCompany' };
+
+      const { replaceInstallationName } = useBranding();
+
+      expect(replaceInstallationName('Powered by Chatwoot', '')).toBe(
+        'Powered by MyCompany'
+      );
+    });
   });
 });

--- a/app/javascript/shared/composables/useBranding.js
+++ b/app/javascript/shared/composables/useBranding.js
@@ -18,7 +18,9 @@ export function useBranding() {
     const installationName = globalConfig.value?.installationName;
     if (!installationName) return text;
 
-    return text.replace(/chatwoot/gi, installationName);
+    // Callback, not a string: `$$`, `$&` and `$1` are replacement syntax, so an installation
+    // named "ACME $$" would render "ACME $".
+    return text.replace(/chatwoot/gi, () => installationName);
   };
 
   return {

--- a/app/javascript/shared/composables/useBranding.js
+++ b/app/javascript/shared/composables/useBranding.js
@@ -7,18 +7,25 @@ import { useMapGetter } from 'dashboard/composables/store.js';
 export function useBranding() {
   const globalConfig = useMapGetter('globalConfig/get');
   /**
-   * Replaces "Chatwoot" (any casing) in text with the installation name from
-   * global config
+   * Replaces "Chatwoot" (any casing) in text with a brand name.
+   *
+   * The replace is what covers all 40-odd locales: only a handful of the strings are
+   * translated in this fork, and interpolating a name into them would leave the rest saying
+   * "Chatwoot" literally.
+   *
    * @param {string} text - The text to process
-   * @returns {string} - Text with "Chatwoot" replaced by installation name
+   * @param {string} [brandName] - Name to use instead of the installation's. Pages served on
+   *   behalf of one account pass the brand of that account; everything else omits it and
+   *   keeps the installation name.
+   * @returns {string} - Text with "Chatwoot" replaced
    */
-  const replaceInstallationName = text => {
+  const replaceInstallationName = (text, brandName) => {
     if (!text) return text;
 
-    const installationName = globalConfig.value?.installationName;
-    if (!installationName) return text;
+    const name = brandName || globalConfig.value?.installationName;
+    if (!name) return text;
 
-    return text.replace(/chatwoot/gi, installationName);
+    return text.replace(/chatwoot/gi, name);
   };
 
   return {

--- a/app/javascript/shared/composables/useBranding.js
+++ b/app/javascript/shared/composables/useBranding.js
@@ -7,25 +7,18 @@ import { useMapGetter } from 'dashboard/composables/store.js';
 export function useBranding() {
   const globalConfig = useMapGetter('globalConfig/get');
   /**
-   * Replaces "Chatwoot" (any casing) in text with a brand name.
-   *
-   * The replace is what covers all 40-odd locales: only a handful of the strings are
-   * translated in this fork, and interpolating a name into them would leave the rest saying
-   * "Chatwoot" literally.
-   *
+   * Replaces "Chatwoot" (any casing) in text with the installation name from
+   * global config
    * @param {string} text - The text to process
-   * @param {string} [brandName] - Name to use instead of the installation's. Pages served on
-   *   behalf of one account pass the brand of that account; everything else omits it and
-   *   keeps the installation name.
-   * @returns {string} - Text with "Chatwoot" replaced
+   * @returns {string} - Text with "Chatwoot" replaced by installation name
    */
-  const replaceInstallationName = (text, brandName) => {
+  const replaceInstallationName = text => {
     if (!text) return text;
 
-    const name = brandName || globalConfig.value?.installationName;
-    if (!name) return text;
+    const installationName = globalConfig.value?.installationName;
+    if (!installationName) return text;
 
-    return text.replace(/chatwoot/gi, name);
+    return text.replace(/chatwoot/gi, installationName);
   };
 
   return {

--- a/app/javascript/survey/components/Banner.vue
+++ b/app/javascript/survey/components/Banner.vue
@@ -18,14 +18,19 @@ export default {
 </script>
 
 <template>
-  <div class="flex items-center">
-    <i
+  <!-- The rating and the feedback both land here after a write, and neither moves focus, so
+       without a live region a screen reader never learns the submission went through. -->
+  <div class="flex items-center gap-1" role="status" aria-live="polite">
+    <span
       v-if="showSuccess"
-      class="ion-checkmark-circled text-3xl text-green-500 mr-1"
+      class="i-ri-checkbox-circle-fill text-2xl text-n-teal-10"
     />
-    <i v-if="showError" class="ion-android-alert text-3xl text-red-600 mr-1" />
-    <label class="text-base font-medium text-n-slate-12 mt-4 mb-4">
+    <span
+      v-if="showError"
+      class="i-ri-error-warning-fill text-2xl text-n-ruby-10"
+    />
+    <p class="text-base font-medium text-n-slate-12 my-4">
       {{ message }}
-    </label>
+    </p>
   </div>
 </template>

--- a/app/javascript/survey/components/Feedback.vue
+++ b/app/javascript/survey/components/Feedback.vue
@@ -47,8 +47,11 @@ export default {
 </script>
 
 <template>
-  <div class="mt-6">
-    <label for="survey-feedback" class="text-base font-medium text-n-slate-12">
+  <div class="mt-8 border-t border-n-weak pt-6">
+    <label
+      for="survey-feedback"
+      class="text-base font-medium leading-snug text-n-slate-12"
+    >
       {{ $t('SURVEY.FEEDBACK.LABEL') }}
     </label>
     <TextArea
@@ -57,11 +60,13 @@ export default {
       class="my-5"
       :placeholder="$t('SURVEY.FEEDBACK.PLACEHOLDER')"
     />
-    <div class="flex justify-end font-medium">
+    <div
+      class="flex flex-col items-stretch font-medium sm:flex-row sm:justify-end"
+    >
       <CustomButton
         :disabled="isSubmitDisabled"
         bg-color="var(--survey-brand)"
-        class="w-full sm:w-auto hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)]"
+        class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
         @click="onClick"
       >
         <Spinner v-if="isUpdating" class="p-0" />

--- a/app/javascript/survey/components/Feedback.vue
+++ b/app/javascript/survey/components/Feedback.vue
@@ -60,7 +60,7 @@ export default {
     <div class="flex justify-end font-medium">
       <CustomButton
         :disabled="isSubmitDisabled"
-        bg-color="var(--survey-brand-strong)"
+        bg-color="var(--survey-brand)"
         class="w-full sm:w-auto hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)]"
         @click="onClick"
       >

--- a/app/javascript/survey/components/Feedback.vue
+++ b/app/javascript/survey/components/Feedback.vue
@@ -48,16 +48,22 @@ export default {
 
 <template>
   <div class="mt-6">
-    <label class="text-base font-medium text-n-slate-12">
+    <label for="survey-feedback" class="text-base font-medium text-n-slate-12">
       {{ $t('SURVEY.FEEDBACK.LABEL') }}
     </label>
     <TextArea
+      id="survey-feedback"
       v-model="feedback"
       class="my-5"
       :placeholder="$t('SURVEY.FEEDBACK.PLACEHOLDER')"
     />
-    <div class="flex items-center float-right font-medium">
-      <CustomButton :disabled="isSubmitDisabled" @click="onClick">
+    <div class="flex justify-end font-medium">
+      <CustomButton
+        :disabled="isSubmitDisabled"
+        bg-color="var(--survey-brand-strong)"
+        class="w-full sm:w-auto hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)]"
+        @click="onClick"
+      >
         <Spinner v-if="isUpdating" class="p-0" />
         {{ $t('SURVEY.FEEDBACK.BUTTON_TEXT') }}
       </CustomButton>

--- a/app/javascript/survey/components/Feedback.vue
+++ b/app/javascript/survey/components/Feedback.vue
@@ -63,13 +63,17 @@ export default {
     <div
       class="flex flex-col items-stretch font-medium sm:flex-row sm:justify-end"
     >
-      <!-- Escurece no hover, nao clareia: --survey-brand ja vem de BrandColor.on_light, que
-           para exatamente em 4.5:1 contra o branco. Clarear o fundo 10% derruba o rotulo
-           branco para 3,9-4,2:1 em toda marca medida, inclusive na cor padrao. -->
+      <!-- O hover escurece o FUNDO, e so ele. --survey-brand vem de BrandColor.on_light, que
+           para exatamente em 4.5:1 contra o branco, entao o hover nao tem folga para gastar:
+           `brightness-110` clareia o fundo e derruba o rotulo para 3,9-4,2:1, e `brightness-90`
+           filtra o botao inteiro, escurecendo o proprio rotulo para #E6E6E6 e ficando em
+           4,41-4,70:1. Um veu preto como background-image nao encosta no texto (sao
+           propriedades diferentes, e o background-color continua vindo do style inline) e
+           leva as mesmas marcas para 5,6-6,0:1. -->
       <CustomButton
         :disabled="isSubmitDisabled"
         bg-color="var(--survey-brand)"
-        class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:brightness-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
+        class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:bg-[image:linear-gradient(rgb(0_0_0/12%),rgb(0_0_0/12%))] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
         @click="onClick"
       >
         <Spinner v-if="isUpdating" class="p-0" />

--- a/app/javascript/survey/components/Feedback.vue
+++ b/app/javascript/survey/components/Feedback.vue
@@ -63,10 +63,13 @@ export default {
     <div
       class="flex flex-col items-stretch font-medium sm:flex-row sm:justify-end"
     >
+      <!-- Escurece no hover, nao clareia: --survey-brand ja vem de BrandColor.on_light, que
+           para exatamente em 4.5:1 contra o branco. Clarear o fundo 10% derruba o rotulo
+           branco para 3,9-4,2:1 em toda marca medida, inclusive na cor padrao. -->
       <CustomButton
         :disabled="isSubmitDisabled"
         bg-color="var(--survey-brand)"
-        class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
+        class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:brightness-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
         @click="onClick"
       >
         <Spinner v-if="isUpdating" class="p-0" />

--- a/app/javascript/survey/components/Rating.vue
+++ b/app/javascript/survey/components/Rating.vue
@@ -1,72 +1,51 @@
-<script>
+<script setup>
 import { CSAT_RATINGS } from 'shared/constants/messages';
 
-export default {
-  props: {
-    selectedRating: {
-      type: Number,
-      default: null,
-    },
-    isDisabled: {
-      type: Boolean,
-      default: false,
-    },
+const props = defineProps({
+  selectedRating: {
+    type: Number,
+    default: null,
   },
-  emits: ['selectRating'],
-  data() {
-    return {
-      ratings: CSAT_RATINGS,
-    };
+  isDisabled: {
+    type: Boolean,
+    default: false,
   },
+});
 
-  methods: {
-    buttonClass(rating) {
-      return [
-        { selected: rating.value === this.selectedRating },
-        { disabled: this.isDisabled },
-        { hover: this.isDisabled },
-        'emoji-button shadow-none text-3xl lg:text-4xl outline-none mr-8',
-      ];
-    },
-    onClick(rating) {
-      if (this.isDisabled) return;
-      this.$emit('selectRating', rating.value);
-    },
-  },
-};
+const emit = defineEmits(['selectRating']);
+
+const ratings = CSAT_RATINGS;
+
+// No scale on hover. A touch device keeps :hover on the last element touched, so an
+// unselected face would stay enlarged and coloured, lying about the state. Selection alone
+// carries the emphasis now.
+const buttonClass = rating => [
+  'flex h-12 w-12 items-center justify-center rounded-full text-3xl transition',
+  'sm:h-14 sm:w-14 sm:text-4xl',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+  'focus-visible:ring-[color:var(--survey-brand)]',
+  'disabled:cursor-default disabled:opacity-50',
+  rating.value === props.selectedRating
+    ? 'grayscale-0 bg-n-slate-3 ring-2 ring-[color:var(--survey-brand)]'
+    : 'grayscale enabled:hover:grayscale-0',
+];
 </script>
 
 <template>
-  <div class="customer-satisfcation mb-2">
-    <div class="ratings flex py-5 px-0">
-      <button
-        v-for="rating in ratings"
-        :key="rating.key"
-        :class="buttonClass(rating)"
-        @click="onClick(rating)"
-      >
-        {{ rating.emoji }}
-      </button>
-    </div>
+  <div class="flex flex-wrap gap-2 py-4 sm:gap-3">
+    <button
+      v-for="rating in ratings"
+      :key="rating.key"
+      type="button"
+      :disabled="isDisabled"
+      :aria-label="$t(rating.translationKey)"
+      :aria-pressed="rating.value === selectedRating"
+      :class="buttonClass(rating)"
+      @click="emit('selectRating', rating.value)"
+    >
+      <!-- The label above already says "Good"; without this a screen reader would read the
+           glyph name on top of it. -->
+      <span aria-hidden="true">{{ rating.emoji }}</span>
+    </button>
   </div>
 </template>
-
-<style lang="scss" scoped>
-.emoji-button {
-  filter: grayscale(100%);
-  &.selected,
-  &:hover,
-  &:focus,
-  &:active {
-    filter: grayscale(0%);
-    transform: scale(1.32);
-    transition: transform 300ms;
-  }
-
-  &.disabled {
-    cursor: default;
-    opacity: 0.5;
-    pointer-events: none;
-  }
-}
-</style>

--- a/app/javascript/survey/components/Rating.vue
+++ b/app/javascript/survey/components/Rating.vue
@@ -16,23 +16,26 @@ const emit = defineEmits(['selectRating']);
 
 const ratings = CSAT_RATINGS;
 
-// No scale on hover. A touch device keeps :hover on the last element touched, so an
-// unselected face would stay enlarged and coloured, lying about the state. Selection alone
-// carries the emphasis now.
+// Hover effects are gated behind `(hover: hover)`. A touch device keeps :hover on the last
+// element tapped, so an unselected face would sit there enlarged and coloured, lying about the
+// state -- the reason the old always-on hover scale had to go.
 const buttonClass = rating => [
-  'flex h-12 w-12 items-center justify-center rounded-full text-3xl transition',
-  'sm:h-14 sm:w-14 sm:text-4xl',
+  'flex h-14 w-14 items-center justify-center rounded-full text-4xl',
+  'transition-all duration-200 ease-out sm:h-16 sm:w-16 sm:text-5xl',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
   'focus-visible:ring-[color:var(--survey-brand)]',
-  'disabled:cursor-default disabled:opacity-50',
+  'disabled:cursor-default disabled:opacity-40',
+  '[@media(hover:hover)]:hover:enabled:scale-110',
+  '[@media(hover:hover)]:hover:enabled:opacity-100',
+  '[@media(hover:hover)]:hover:enabled:saturate-100',
   rating.value === props.selectedRating
-    ? 'grayscale-0 bg-n-slate-3 ring-2 ring-[color:var(--survey-brand)]'
-    : 'grayscale enabled:hover:grayscale-0',
+    ? 'scale-110 opacity-100 saturate-100 bg-[color-mix(in_srgb,var(--survey-brand)_14%,transparent)]'
+    : 'opacity-60 saturate-50',
 ];
 </script>
 
 <template>
-  <div class="flex flex-wrap gap-2 py-4 sm:gap-3">
+  <div class="flex flex-wrap gap-1 pb-2 sm:gap-2">
     <button
       v-for="rating in ratings"
       :key="rating.key"

--- a/app/javascript/survey/components/specs/Rating.spec.js
+++ b/app/javascript/survey/components/specs/Rating.spec.js
@@ -1,0 +1,62 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import Rating from '../Rating.vue';
+
+const mountRating = (props = {}) =>
+  mount(Rating, {
+    props,
+    global: { mocks: { $t: key => key } },
+  });
+
+describe('Rating', () => {
+  it('labels every face, so a screen reader announces the rating and not the glyph', () => {
+    const buttons = mountRating().findAll('button');
+
+    expect(buttons).toHaveLength(5);
+    expect(buttons.map(b => b.attributes('aria-label'))).toEqual([
+      'CSAT.RATINGS.POOR',
+      'CSAT.RATINGS.FAIR',
+      'CSAT.RATINGS.AVERAGE',
+      'CSAT.RATINGS.GOOD',
+      'CSAT.RATINGS.EXCELLENT',
+    ]);
+    expect(buttons[0].find('span').attributes('aria-hidden')).toBe('true');
+  });
+
+  it('emits the value that was clicked', async () => {
+    const wrapper = mountRating();
+
+    await wrapper.findAll('button')[3].trigger('click');
+
+    expect(wrapper.emitted('selectRating')).toEqual([[4]]);
+  });
+
+  it('marks only the selected face as pressed', () => {
+    const buttons = mountRating({ selectedRating: 2 }).findAll('button');
+
+    expect(buttons.map(b => b.attributes('aria-pressed'))).toEqual([
+      'false',
+      'true',
+      'false',
+      'false',
+      'false',
+    ]);
+  });
+
+  // Disabled on the element itself, not pointer-events: none, so the buttons also leave the
+  // tab order instead of being focusable but inert.
+  it('disables the buttons rather than swallowing their clicks', async () => {
+    const wrapper = mountRating({ isDisabled: true });
+    const button = wrapper.findAll('button')[0];
+
+    expect(button.attributes('disabled')).toBeDefined();
+
+    await button.trigger('click');
+
+    expect(wrapper.emitted('selectRating')).toBeUndefined();
+  });
+
+  it('is a real button, so it never submits a form it happens to sit in', () => {
+    expect(mountRating().find('button').attributes('type')).toBe('button');
+  });
+});

--- a/app/javascript/survey/i18n/fazer-ai/locale/en.json
+++ b/app/javascript/survey/i18n/fazer-ai/locale/en.json
@@ -14,5 +14,6 @@
       "GOOD": "Good",
       "EXCELLENT": "Excellent"
     }
-  }
+  },
+  "POWERED_BY_BRAND": "Powered by {brandName}"
 }

--- a/app/javascript/survey/i18n/fazer-ai/locale/en.json
+++ b/app/javascript/survey/i18n/fazer-ai/locale/en.json
@@ -2,7 +2,17 @@
   "SURVEY": {
     "RATING": {
       "CONFIRM_LABEL": "Confirm the rating you picked to send it.",
-      "CONFIRM_BUTTON": "Confirm rating"
+      "CONFIRM_BUTTON": "Confirm rating",
+      "SELECTED": "Your rating: {rating}"
+    }
+  },
+  "CSAT": {
+    "RATINGS": {
+      "POOR": "Poor",
+      "FAIR": "Fair",
+      "AVERAGE": "Average",
+      "GOOD": "Good",
+      "EXCELLENT": "Excellent"
     }
   }
 }

--- a/app/javascript/survey/i18n/fazer-ai/locale/es.json
+++ b/app/javascript/survey/i18n/fazer-ai/locale/es.json
@@ -2,7 +2,17 @@
   "SURVEY": {
     "RATING": {
       "CONFIRM_LABEL": "Confirma la puntuación que elegiste para enviarla.",
-      "CONFIRM_BUTTON": "Confirmar puntuación"
+      "CONFIRM_BUTTON": "Confirmar puntuación",
+      "SELECTED": "Tu puntuación: {rating}"
+    }
+  },
+  "CSAT": {
+    "RATINGS": {
+      "POOR": "Mala",
+      "FAIR": "Regular",
+      "AVERAGE": "Normal",
+      "GOOD": "Buena",
+      "EXCELLENT": "Excelente"
     }
   }
 }

--- a/app/javascript/survey/i18n/fazer-ai/locale/es.json
+++ b/app/javascript/survey/i18n/fazer-ai/locale/es.json
@@ -14,5 +14,6 @@
       "GOOD": "Buena",
       "EXCELLENT": "Excelente"
     }
-  }
+  },
+  "POWERED_BY_BRAND": "Desarrollado por {brandName}"
 }

--- a/app/javascript/survey/i18n/fazer-ai/locale/pt_BR.json
+++ b/app/javascript/survey/i18n/fazer-ai/locale/pt_BR.json
@@ -2,7 +2,17 @@
   "SURVEY": {
     "RATING": {
       "CONFIRM_LABEL": "Confirme a nota que você escolheu para enviá-la.",
-      "CONFIRM_BUTTON": "Confirmar nota"
+      "CONFIRM_BUTTON": "Confirmar nota",
+      "SELECTED": "Sua nota: {rating}"
+    }
+  },
+  "CSAT": {
+    "RATINGS": {
+      "POOR": "Ruim",
+      "FAIR": "Fraco",
+      "AVERAGE": "Regular",
+      "GOOD": "Bom",
+      "EXCELLENT": "Excelente"
     }
   }
 }

--- a/app/javascript/survey/i18n/fazer-ai/locale/pt_BR.json
+++ b/app/javascript/survey/i18n/fazer-ai/locale/pt_BR.json
@@ -14,5 +14,6 @@
       "GOOD": "Bom",
       "EXCELLENT": "Excelente"
     }
-  }
+  },
+  "POWERED_BY_BRAND": "Desenvolvido por {brandName}"
 }

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -49,8 +49,13 @@ export default {
     pageConfig() {
       return window.globalConfig || {};
     },
+    // Only the account's own name. Left empty for an account without a brand, so the footer
+    // keeps the exact wording it had before -- Branding falls back to the installation name in
+    // the locale's own translation, which is what the ~39 languages we do not ship rely on.
     brandName() {
-      return this.pageConfig.BRAND_NAME || '';
+      return this.pageConfig.BRAND_FROM_ACCOUNT
+        ? this.pageConfig.BRAND_NAME || ''
+        : '';
     },
     brandLogo() {
       return this.pageConfig.BRAND_LOGO_URL || '';

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -315,7 +315,7 @@ export default {
           <CustomButton
             :disabled="isUpdating"
             bg-color="var(--survey-brand)"
-            class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
+            class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:brightness-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
             @click="confirmRating"
           >
             <Spinner v-if="isUpdating" class="p-0" />

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -315,7 +315,7 @@ export default {
           <CustomButton
             :disabled="isUpdating"
             bg-color="var(--survey-brand)"
-            class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:brightness-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
+            class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:bg-[image:linear-gradient(rgb(0_0_0/12%),rgb(0_0_0/12%))] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
             @click="confirmRating"
           >
             <Spinner v-if="isUpdating" class="p-0" />

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -246,24 +246,30 @@ export default {
   >
     <Spinner size="" />
   </div>
+  <!-- The ground is a wash of the brand rather than a flat grey, so the page reads as the
+       account's before a single word is. color-mix keeps it in a utility instead of a second
+       server-rendered variable. -->
   <div
     v-else
-    class="flex items-center justify-center w-full h-full min-h-[100dvh] overflow-auto bg-n-background"
+    class="flex items-start justify-center w-full min-h-[100dvh] overflow-auto px-0 py-0 sm:items-center sm:px-6 sm:py-10 bg-[color-mix(in_srgb,var(--survey-brand)_6%,white)]"
   >
     <div
-      class="flex flex-col w-full h-full bg-n-solid-1 border border-solid border-n-weak sm:h-auto sm:w-full sm:max-w-xl sm:rounded-lg sm:shadow-md"
+      class="flex flex-col w-full min-h-[100dvh] overflow-hidden bg-n-solid-1 sm:min-h-0 sm:max-w-lg sm:rounded-2xl sm:shadow-[0_20px_50px_-20px_rgba(15,23,42,0.25)]"
     >
-      <div class="w-full px-6 py-8 m-auto my-0 sm:px-10 sm:pt-10 sm:pb-6">
+      <!-- Identity before content: a hairline of the brand across the top says whose page this
+           is even for an inbox with no avatar to show. -->
+      <div class="h-1.5 shrink-0 bg-[color:var(--survey-brand)]" />
+      <div class="w-full px-6 pt-8 pb-6 sm:px-10 sm:pt-10">
         <img
           v-if="logo"
           :src="logo"
           :alt="inboxName || brandName"
-          class="mb-6 max-h-12 w-auto object-contain"
+          class="mb-8 max-h-10 w-auto object-contain"
         />
         <div
           v-if="!isRatingSubmitted"
           v-dompurify-html="formattedMessageContent"
-          class="mb-8 text-lg leading-relaxed text-n-slate-12 prose prose-bubble"
+          class="mb-8 text-2xl font-semibold leading-snug tracking-tight text-balance text-n-slate-12 prose prose-bubble"
         />
         <Banner
           v-if="shouldShowBanner"
@@ -276,7 +282,7 @@ export default {
              unnamed group for a screen reader on the revision flow. -->
         <p
           id="survey-rating-label"
-          class="mb-4 text-base font-medium text-n-slate-11"
+          class="mb-3 text-xs font-semibold uppercase tracking-wider text-n-slate-10"
         >
           {{ ratingLabel }}
         </p>
@@ -299,9 +305,9 @@ export default {
         </div>
         <div
           v-if="isPendingConfirmation"
-          class="mt-6 flex flex-col items-start gap-3"
+          class="mt-8 flex flex-col items-stretch gap-3 sm:items-start"
         >
-          <p class="text-base text-n-slate-11 m-0">
+          <p class="m-0 text-sm text-n-slate-11">
             {{ $t('SURVEY.RATING.CONFIRM_LABEL') }}
           </p>
           <!-- bg-color as a prop, not a bg-* class: with no inline styles the button applies
@@ -309,7 +315,7 @@ export default {
           <CustomButton
             :disabled="isUpdating"
             bg-color="var(--survey-brand)"
-            class="w-full sm:w-auto hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)]"
+            class="w-full !rounded-xl !py-3.5 text-base font-semibold transition-all duration-200 hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)] sm:w-auto sm:!px-8"
             @click="confirmRating"
           >
             <Spinner v-if="isUpdating" class="p-0" />
@@ -324,7 +330,7 @@ export default {
           @send-feedback="sendFeedback"
         />
       </div>
-      <div class="mb-3">
+      <div class="mt-auto pb-5 pt-2 sm:mt-0">
         <Branding
           :brand-name="brandName"
           :own-logo="Boolean(brandLogo)"

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -61,6 +61,14 @@ export default {
     selectedRatingDetails() {
       return CSAT_RATINGS.find(({ value }) => value === this.selectedRating);
     },
+    ratingLabel() {
+      if (this.isRatingSubmitted && this.selectedRatingDetails) {
+        return this.$t('SURVEY.RATING.SELECTED', {
+          rating: this.$t(this.selectedRatingDetails.translationKey),
+        });
+      }
+      return this.$t('SURVEY.RATING.LABEL');
+    },
     surveyId() {
       // Read the path, not the href: the rating links in the survey email carry a
       // query string, which would otherwise be taken as part of the uuid.
@@ -258,22 +266,14 @@ export default {
           :show-error="shouldShowErrorMessage"
           :message="message"
         />
+        <!-- Always rendered, never behind a v-if: the group below takes its accessible name
+             from this id, so removing the element once the rating is saved would leave an
+             unnamed group for a screen reader on the revision flow. -->
         <p
-          v-if="!isRatingSubmitted"
           id="survey-rating-label"
           class="mb-4 text-base font-medium text-n-slate-11"
         >
-          {{ $t('SURVEY.RATING.LABEL') }}
-        </p>
-        <p
-          v-else-if="selectedRatingDetails"
-          class="mb-4 text-base text-n-slate-11"
-        >
-          {{
-            $t('SURVEY.RATING.SELECTED', {
-              rating: $t(selectedRatingDetails.translationKey),
-            })
-          }}
+          {{ ratingLabel }}
         </p>
         <!-- group, not radiogroup: the latter promises arrow-key navigation, which would mean
              managing roving focus for five buttons that already tab fine. -->
@@ -303,7 +303,7 @@ export default {
                bg-n-brand itself, and the two would fight over source order. -->
           <CustomButton
             :disabled="isUpdating"
-            bg-color="var(--survey-brand-strong)"
+            bg-color="var(--survey-brand)"
             class="w-full sm:w-auto hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)]"
             @click="confirmRating"
           >

--- a/app/javascript/survey/views/Response.vue
+++ b/app/javascript/survey/views/Response.vue
@@ -44,6 +44,23 @@ export default {
     };
   },
   computed: {
+    // Read here rather than destructured at module scope: the spec mounts without setting the
+    // global, and a module-level read would freeze whatever existed at import time.
+    pageConfig() {
+      return window.globalConfig || {};
+    },
+    brandName() {
+      return this.pageConfig.BRAND_NAME || '';
+    },
+    brandLogo() {
+      return this.pageConfig.BRAND_LOGO_URL || '';
+    },
+    disableBranding() {
+      return Boolean(this.pageConfig.DISABLE_BRANDING);
+    },
+    selectedRatingDetails() {
+      return CSAT_RATINGS.find(({ value }) => value === this.selectedRating);
+    },
     surveyId() {
       // Read the path, not the href: the rating links in the survey email carry a
       // query string, which would otherwise be taken as part of the uuid.
@@ -143,7 +160,9 @@ export default {
       this.isLoading = true;
       try {
         const result = await getSurveyDetails({ uuid: this.surveyId });
-        this.logo = result.data.inbox_avatar_url;
+        // The inbox avatar is optional, and an inbox without one used to leave the page with
+        // no mark at all. The account's own logo is the right thing to fall back to.
+        this.logo = result.data.inbox_avatar_url || this.brandLogo;
         this.inboxName = result.data.inbox_name;
         this.surveyDetails = result?.data?.csat_survey_response;
         this.selectedRating = this.surveyDetails?.rating;
@@ -210,19 +229,24 @@ export default {
 <template>
   <div
     v-if="isLoading"
-    class="flex items-center justify-center flex-1 h-full min-h-screen bg-n-background"
+    class="flex items-center justify-center flex-1 h-full min-h-[100dvh] bg-n-background"
   >
     <Spinner size="" />
   </div>
   <div
     v-else
-    class="flex items-center justify-center w-full h-full min-h-screen overflow-auto bg-n-background"
+    class="flex items-center justify-center w-full h-full min-h-[100dvh] overflow-auto bg-n-background"
   >
     <div
-      class="flex flex-col w-full h-full bg-n-solid-1 rounded-lg border border-solid border-n-weak shadow-md lg:w-2/5 lg:h-auto"
+      class="flex flex-col w-full h-full bg-n-solid-1 border border-solid border-n-weak sm:h-auto sm:w-full sm:max-w-xl sm:rounded-lg sm:shadow-md"
     >
-      <div class="w-full px-12 pt-12 pb-6 m-auto my-0">
-        <img v-if="logo" :src="logo" alt="Chatwoot logo" class="mb-6 logo" />
+      <div class="w-full px-6 py-8 m-auto my-0 sm:px-10 sm:pt-10 sm:pb-6">
+        <img
+          v-if="logo"
+          :src="logo"
+          :alt="inboxName || brandName"
+          class="mb-6 max-h-12 w-auto object-contain"
+        />
         <div
           v-if="!isRatingSubmitted"
           v-dompurify-html="formattedMessageContent"
@@ -234,25 +258,40 @@ export default {
           :show-error="shouldShowErrorMessage"
           :message="message"
         />
-        <label
+        <p
           v-if="!isRatingSubmitted"
+          id="survey-rating-label"
           class="mb-4 text-base font-medium text-n-slate-11"
         >
           {{ $t('SURVEY.RATING.LABEL') }}
-        </label>
-        <Rating
-          v-if="isEmojiType"
-          :selected-rating="selectedRating"
-          :is-disabled="isFeedbackSubmitted || isUpdating"
-          @select-rating="selectRating"
-        />
-        <StarRating
-          v-if="isStarType"
-          :selected-rating="selectedRating"
-          :is-disabled="isFeedbackSubmitted || isUpdating"
-          class="[&>button>span]:text-4xl !justify-start !px-0"
-          @select-rating="selectRating"
-        />
+        </p>
+        <p
+          v-else-if="selectedRatingDetails"
+          class="mb-4 text-base text-n-slate-11"
+        >
+          {{
+            $t('SURVEY.RATING.SELECTED', {
+              rating: $t(selectedRatingDetails.translationKey),
+            })
+          }}
+        </p>
+        <!-- group, not radiogroup: the latter promises arrow-key navigation, which would mean
+             managing roving focus for five buttons that already tab fine. -->
+        <div role="group" aria-labelledby="survey-rating-label">
+          <Rating
+            v-if="isEmojiType"
+            :selected-rating="selectedRating"
+            :is-disabled="isFeedbackSubmitted || isUpdating"
+            @select-rating="selectRating"
+          />
+          <StarRating
+            v-if="isStarType"
+            :selected-rating="selectedRating"
+            :is-disabled="isFeedbackSubmitted || isUpdating"
+            class="[&>button>span]:text-4xl !justify-start !px-0"
+            @select-rating="selectRating"
+          />
+        </div>
         <div
           v-if="isPendingConfirmation"
           class="mt-6 flex flex-col items-start gap-3"
@@ -260,7 +299,14 @@ export default {
           <p class="text-base text-n-slate-11 m-0">
             {{ $t('SURVEY.RATING.CONFIRM_LABEL') }}
           </p>
-          <CustomButton :disabled="isUpdating" @click="confirmRating">
+          <!-- bg-color as a prop, not a bg-* class: with no inline styles the button applies
+               bg-n-brand itself, and the two would fight over source order. -->
+          <CustomButton
+            :disabled="isUpdating"
+            bg-color="var(--survey-brand-strong)"
+            class="w-full sm:w-auto hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--survey-brand)]"
+            @click="confirmRating"
+          >
             <Spinner v-if="isUpdating" class="p-0" />
             {{ $t('SURVEY.RATING.CONFIRM_BUTTON') }}
           </CustomButton>
@@ -274,14 +320,12 @@ export default {
         />
       </div>
       <div class="mb-3">
-        <Branding />
+        <Branding
+          :brand-name="brandName"
+          :own-logo="Boolean(brandLogo)"
+          :disable-branding="disableBranding"
+        />
       </div>
     </div>
   </div>
 </template>
-
-<style scoped lang="scss">
-.logo {
-  max-height: 3rem;
-}
-</style>

--- a/app/javascript/survey/views/specs/Response.spec.js
+++ b/app/javascript/survey/views/specs/Response.spec.js
@@ -205,4 +205,70 @@ describe('Response', () => {
     expect(wrapper.vm.shouldShowSuccessMessage).toBe(false);
     expect(wrapper.vm.enableFeedbackForm).toBe(false);
   });
+  describe('account branding', () => {
+    afterEach(() => {
+      delete window.globalConfig;
+    });
+
+    it('falls back to the account logo when the inbox has no avatar', async () => {
+      window.globalConfig = {
+        BRAND_LOGO_URL: 'https://cdn.example.com/live.png',
+      };
+      getSurveyDetails.mockResolvedValue(surveyPayload());
+      setUrl('');
+      const wrapper = buildWrapper();
+      await flushPromises();
+
+      expect(wrapper.vm.logo).toBe('https://cdn.example.com/live.png');
+    });
+
+    it('prefers the inbox avatar when there is one', async () => {
+      window.globalConfig = {
+        BRAND_LOGO_URL: 'https://cdn.example.com/live.png',
+      };
+      const payload = surveyPayload();
+      payload.data.inbox_avatar_url = 'https://cdn.example.com/inbox.png';
+      getSurveyDetails.mockResolvedValue(payload);
+      setUrl('');
+      const wrapper = buildWrapper();
+      await flushPromises();
+
+      expect(wrapper.vm.logo).toBe('https://cdn.example.com/inbox.png');
+    });
+
+    it('shows no logo when neither the inbox nor the account has one', async () => {
+      getSurveyDetails.mockResolvedValue(surveyPayload());
+      setUrl('');
+      const wrapper = buildWrapper();
+      await flushPromises();
+
+      expect(wrapper.vm.logo).toBe('');
+    });
+
+    it('hands the account brand and the branding entitlement to the footer', async () => {
+      window.globalConfig = {
+        BRAND_NAME: 'Guichê Live',
+        DISABLE_BRANDING: true,
+      };
+      getSurveyDetails.mockResolvedValue(surveyPayload());
+      setUrl('');
+      const wrapper = buildWrapper();
+      await flushPromises();
+
+      const branding = wrapper.findComponent({ name: 'Branding' });
+      expect(branding.props('brandName')).toBe('Guichê Live');
+      expect(branding.props('disableBranding')).toBe(true);
+    });
+
+    it('names the rating that was submitted', async () => {
+      getSurveyDetails.mockResolvedValue(surveyPayload({ rating: 4 }));
+      setUrl('');
+      const wrapper = buildWrapper();
+      await flushPromises();
+
+      expect(wrapper.vm.selectedRatingDetails.translationKey).toBe(
+        'CSAT.RATINGS.GOOD'
+      );
+    });
+  });
 });

--- a/app/javascript/survey/views/specs/Response.spec.js
+++ b/app/javascript/survey/views/specs/Response.spec.js
@@ -245,9 +245,28 @@ describe('Response', () => {
       expect(wrapper.vm.logo).toBe('');
     });
 
+    // The footer only takes a name when it is the account's own. Handing it the installation's
+    // would push every survey down the fork-key path, which is translated in three languages
+    // and falls back to English in the rest.
+    it('withholds the brand name when it is the installation falling back', async () => {
+      window.globalConfig = {
+        BRAND_NAME: 'Chatwoot',
+        BRAND_FROM_ACCOUNT: false,
+      };
+      getSurveyDetails.mockResolvedValue(surveyPayload());
+      setUrl('');
+      const wrapper = buildWrapper();
+      await flushPromises();
+
+      expect(
+        wrapper.findComponent({ name: 'Branding' }).props('brandName')
+      ).toBe('');
+    });
+
     it('hands the account brand and the branding entitlement to the footer', async () => {
       window.globalConfig = {
         BRAND_NAME: 'Guichê Live',
+        BRAND_FROM_ACCOUNT: true,
         DISABLE_BRANDING: true,
       };
       getSurveyDetails.mockResolvedValue(surveyPayload());

--- a/app/services/message_templates/template/csat_survey.rb
+++ b/app/services/message_templates/template/csat_survey.rb
@@ -12,9 +12,21 @@ class MessageTemplates::Template::CsatSurvey
   delegate :contact, :account, :inbox, to: :conversation
 
   def message_content
-    return I18n.t('conversations.templates.csat_input_message_body') if csat_config.blank? || csat_config['message'].blank?
+    return csat_config['message'] if csat_config['message'].present?
 
-    csat_config['message']
+    # The fallback is translated here and stored in `content`, so whatever locale is current
+    # when this runs is the locale the customer reads forever. This runs inside the job that
+    # resolves the conversation, where I18n.locale is the process default (:en) rather than
+    # the account's -- so without this the survey goes out in English to accounts configured
+    # in another language, and the wrong text is frozen in the column.
+    I18n.with_locale(account_locale) { I18n.t('conversations.templates.csat_input_message_body') }
+  end
+
+  # I18n.with_locale raises InvalidLocale on a locale the installation never loaded, and a
+  # raise here would take down the resolution that triggered the survey. Same guard, and the
+  # same reason, as ApplicationMailer#locale_from_account.
+  def account_locale
+    I18n.available_locales.map(&:to_s).include?(account.locale) ? account.locale : I18n.default_locale
   end
 
   def csat_survey_message_params

--- a/app/views/survey/responses/show.html.erb
+++ b/app/views/survey/responses/show.html.erb
@@ -4,15 +4,23 @@
     <title><%= @global_config['BRAND_NAME'] %></title>
     <%= csrf_meta_tags %>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
-    <%# Rendered server side so the brand is painted on the first frame. Reaching these
-        through window.globalConfig would show the Chatwoot blue and then swap it, on a page
-        the customer opens exactly once. Both values come out of BrandColor, which returns
-        either its default or a validated hex, so nothing account-controlled lands in CSS. %>
+    <%# Rendered server side so the brand is painted on the first frame. Reaching this through
+        window.globalConfig would show the Chatwoot blue and then swap it, on a page the
+        customer opens exactly once.
+
+        It carries BRAND_COLOR_STRONG, not the brand colour as configured: every use on this
+        page is something that has to be *seen* against the white card -- a focus ring, the
+        selected rating, a button carrying white text -- and a pale brand (#FFF is a valid one)
+        would render each of them invisible. BrandColor.on_light darkens to 4.5:1 against
+        white, and contrast is symmetric, so the same value serves both readings. Exposing the
+        faithful colour as a second token would only offer a wrong choice at the call site.
+
+        The value comes out of BrandColor, which returns either its default or a validated hex,
+        so nothing account-controlled lands in CSS. %>
     <style>
       :root {
         color-scheme: light;
-        --survey-brand: <%= @global_config['BRAND_COLOR'] %>;
-        --survey-brand-strong: <%= @global_config['BRAND_COLOR_STRONG'] %>;
+        --survey-brand: <%= @global_config['BRAND_COLOR_STRONG'] %>;
       }
     </style>
     <script>

--- a/app/views/survey/responses/show.html.erb
+++ b/app/views/survey/responses/show.html.erb
@@ -1,9 +1,20 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= @conversation&.account&.locale&.tr('_', '-') || 'en' %>">
   <head>
-    <title><%= @global_config['INSTALLATION_NAME'] %></title>
+    <title><%= @global_config['BRAND_NAME'] %></title>
     <%= csrf_meta_tags %>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
+    <%# Rendered server side so the brand is painted on the first frame. Reaching these
+        through window.globalConfig would show the Chatwoot blue and then swap it, on a page
+        the customer opens exactly once. Both values come out of BrandColor, which returns
+        either its default or a validated hex, so nothing account-controlled lands in CSS. %>
+    <style>
+      :root {
+        color-scheme: light;
+        --survey-brand: <%= @global_config['BRAND_COLOR'] %>;
+        --survey-brand-strong: <%= @global_config['BRAND_COLOR_STRONG'] %>;
+      }
+    </style>
     <script>
       window.globalConfig = <%= raw @global_config.to_json %>
     </script>

--- a/app/views/survey/responses/show.html.erb
+++ b/app/views/survey/responses/show.html.erb
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html lang="<%= @conversation&.account&.locale&.tr('_', '-') || 'en' %>">
   <head>
-    <title><%= @global_config['BRAND_NAME'] %></title>
+    <%# The account's name only when the account actually set one. Falling back to BRAND_NAME
+        would rename the tab of every unbranded survey -- and of an unknown uuid -- from the
+        installation's own title to its public brand, which are allowed to differ. %>
+    <title><%= @global_config['BRAND_FROM_ACCOUNT'] ? @global_config['BRAND_NAME'] : @global_config['INSTALLATION_NAME'] %></title>
     <%= csrf_meta_tags %>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
     <%# Rendered server side so the brand is painted on the first frame. Reaching this through

--- a/lib/brand.rb
+++ b/lib/brand.rb
@@ -9,10 +9,19 @@
 # by field -- setting only a colour keeps the installation's name and logo -- so an install
 # that configures nothing behaves exactly as it did before.
 #
-# The scope is email. The dashboard, the favicon, the PWA manifest and the widget are the
-# installation's own surfaces and stay global; see CUSTOM_BRANDING.md.
+# The scope is what the customer sees: email, and the public pages a contact of that account
+# opens. #config serves the mail layouts, #web_config serves those pages. The dashboard, the
+# login page, the favicon, the PWA manifest and the widget are the installation's own
+# surfaces and stay global; see CUSTOM_BRANDING.md.
 class Brand
+  # Published contract: layouts that customers already stored in email_templates read this
+  # hash as `global_config`, so adding a key here changes what those layouts see. Keys the
+  # mail layouts have no use for belong in WEB_KEYS instead.
   INSTALLATION_KEYS = %w[BRAND_NAME BRAND_URL BRAND_COLOR LOGO_EMAIL LOGO].freeze
+
+  # The public pages want a different set: a small thumbnail for the footer, the widget's
+  # brand URL, and a logo that may be a vector, since a browser renders what email cannot.
+  WEB_KEYS = %w[BRAND_NAME BRAND_COLOR WIDGET_BRAND_URL LOGO_THUMBNAIL].freeze
 
   # Email clients render none of the vector formats, so a logo that is not one of these puts a
   # broken image at the top of every email, which reads worse than the no-logo layout.
@@ -59,12 +68,37 @@ class Brand
     account_logo_url || absolute_url(installation_logo)
   end
 
+  # Keyed like the installation config, same as #config, so the page reads one shape whether
+  # the brand came from the account or from the installation.
+  def web_config
+    web_installation.merge(
+      'BRAND_NAME' => name,
+      # The account's own brand_url, but falling back to WIDGET_BRAND_URL rather than to
+      # BRAND_URL: that is the link this page already carries, and an install that points the
+      # two at different places meant the difference.
+      'WIDGET_BRAND_URL' => override(:brand_url) || web_installation['WIDGET_BRAND_URL'],
+      'LOGO_THUMBNAIL' => account_logo_url || web_installation['LOGO_THUMBNAIL'],
+      # Only ever the account's own logo. Falling back to the installation's would put one
+      # company's mark on top of another company's page, and today the page simply shows no
+      # logo in that case, which is the honest thing to keep doing.
+      'BRAND_LOGO_URL' => account_logo_url.to_s,
+      'BRAND_COLOR' => BrandColor.surface(color),
+      # Darkened to 4.5:1 against white. Contrast is symmetric, so the same value is also what
+      # makes white label text on top of it legible -- no second colour to compute.
+      'BRAND_COLOR_STRONG' => BrandColor.on_light(color)
+    )
+  end
+
   private
 
   attr_reader :account, :inbox
 
   def installation
     @installation ||= GlobalConfig.get(*INSTALLATION_KEYS)
+  end
+
+  def web_installation
+    @web_installation ||= GlobalConfig.get(*WEB_KEYS)
   end
 
   # Blank falls back rather than meaning "no name", which is what the settings screen promises

--- a/lib/brand.rb
+++ b/lib/brand.rb
@@ -21,7 +21,7 @@ class Brand
 
   # The public pages want a different set: a small thumbnail for the footer, the widget's
   # brand URL, and a logo that may be a vector, since a browser renders what email cannot.
-  WEB_KEYS = %w[BRAND_NAME BRAND_COLOR WIDGET_BRAND_URL LOGO_THUMBNAIL].freeze
+  WEB_KEYS = %w[BRAND_NAME BRAND_COLOR WIDGET_BRAND_URL LOGO_THUMBNAIL INSTALLATION_NAME].freeze
 
   # Email clients render none of the vector formats, so a logo that is not one of these puts a
   # broken image at the top of every email, which reads worse than the no-logo layout.
@@ -85,7 +85,11 @@ class Brand
       'BRAND_COLOR' => BrandColor.surface(color),
       # Darkened to 4.5:1 against white. Contrast is symmetric, so the same value is also what
       # makes white label text on top of it legible -- no second colour to compute.
-      'BRAND_COLOR_STRONG' => BrandColor.on_light(color)
+      'BRAND_COLOR_STRONG' => BrandColor.on_light(color),
+      # Whether the name above is the account's own or the installation's. #name alone cannot
+      # answer that -- it falls back -- and the page needs the difference: an account with no
+      # brand of its own has to keep rendering exactly what it rendered before.
+      'BRAND_FROM_ACCOUNT' => override(:brand_name).present?
     )
   end
 

--- a/spec/controllers/service/responses_controller_spec.rb
+++ b/spec/controllers/service/responses_controller_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
 
 describe '/survey/response', type: :request do
+  def install(values)
+    values.each { |name, value| InstallationConfig.where(name: name).first_or_initialize.update!(value: value) }
+    GlobalConfig.clear_cache
+  end
+
+  before do
+    install(
+      'BRAND_NAME' => 'Chatwoot',
+      'BRAND_COLOR' => '#1F93FF',
+      'WIDGET_BRAND_URL' => 'https://www.chatwoot.com',
+      'LOGO_THUMBNAIL' => '/brand-assets/logo_thumbnail.svg'
+    )
+  end
+
   describe 'GET survey/responses/{uuid}' do
     it 'renders the page correctly when called' do
       conversation = create(:conversation)
@@ -11,6 +25,70 @@ describe '/survey/response', type: :request do
     it 'returns 404 when called with invalid conversation uuid' do
       get survey_response_url(id: '')
       expect(response).to have_http_status(:not_found)
+    end
+
+    # The customer only mistyped a link, or the conversation was deleted. The page renders and
+    # the Vue app surfaces the error from the public endpoint; a Rails error page would not.
+    it 'still renders for a uuid that matches no conversation' do
+      get survey_response_url(id: SecureRandom.uuid)
+
+      expect(response).to be_successful
+      expect(response.body).to include 'Chatwoot'
+    end
+
+    it 'still renders for a uuid that is not even a uuid' do
+      get survey_response_url(id: 'not-a-uuid')
+
+      expect(response).to be_successful
+    end
+
+    context 'when the account configured a brand' do
+      let(:account) { create(:account) }
+      let(:conversation) { create(:conversation, account: account) }
+
+      before do
+        account.enable_features!('branded_email_templates')
+        account.update!(
+          brand_name: 'Guichê Live',
+          brand_url: 'https://www.guichelive.com.br',
+          brand_color: '#F82323'
+        )
+      end
+
+      it 'dresses the page in the brand of that account' do
+        get survey_response_url(id: conversation.uuid)
+
+        expect(response.body).to include 'Guichê Live'
+        expect(response.body).to include 'https://www.guichelive.com.br'
+        expect(response.body).to include BrandColor.surface('#F82323')
+      end
+
+      it 'names the account in the tab, not the installation' do
+        get survey_response_url(id: conversation.uuid)
+
+        expect(response.body).to include '<title>Guichê Live</title>'
+      end
+
+      it 'keeps the installation brand for an account that configured none' do
+        get survey_response_url(id: create(:conversation).uuid)
+
+        expect(response.body).to include 'Chatwoot'
+        expect(response.body).not_to include 'Guichê Live'
+      end
+
+      it 'tells the page to keep the branding footer by default' do
+        get survey_response_url(id: conversation.uuid)
+
+        expect(response.body).to include '"DISABLE_BRANDING":false'
+      end
+
+      it 'tells the page to drop the branding footer when the account may' do
+        account.enable_features!('disable_branding')
+
+        get survey_response_url(id: conversation.uuid)
+
+        expect(response.body).to include '"DISABLE_BRANDING":true'
+      end
     end
   end
 end

--- a/spec/controllers/service/responses_controller_spec.rb
+++ b/spec/controllers/service/responses_controller_spec.rb
@@ -69,6 +69,20 @@ describe '/survey/response', type: :request do
         expect(response.body).to include '<title>Guichê Live</title>'
       end
 
+      # INSTALLATION_NAME and BRAND_NAME are separate settings and are allowed to differ: one
+      # is what the install calls itself, the other what it shows the public. Only an account
+      # that set its own name may take over the tab.
+      it 'keeps the installation title for an account that configured no brand name' do
+        %w[INSTALLATION_NAME BRAND_NAME].zip(['Atendimento Interno', 'Marca Publica']).each do |name, value|
+          InstallationConfig.where(name: name).first_or_initialize.update!(value: value)
+        end
+        GlobalConfig.clear_cache
+
+        get survey_response_url(id: create(:conversation).uuid)
+
+        expect(response.body).to include '<title>Atendimento Interno</title>'
+      end
+
       it 'keeps the installation brand for an account that configured none' do
         get survey_response_url(id: create(:conversation).uuid)
 

--- a/spec/lib/brand_spec.rb
+++ b/spec/lib/brand_spec.rb
@@ -169,6 +169,18 @@ RSpec.describe Brand do
         expect(described_class.for(account: account).web_config['BRAND_NAME']).to eq 'Chatwoot'
       end
 
+      # The page renders a different footer for each, so a name that merely fell back must not
+      # look like one the account chose.
+      it 'says the name came from the account' do
+        expect(described_class.for(account: account).web_config['BRAND_FROM_ACCOUNT']).to be true
+      end
+
+      it 'says it did not when the account named nothing' do
+        account.update!(brand_name: '')
+
+        expect(described_class.for(account: account).web_config['BRAND_FROM_ACCOUNT']).to be false
+      end
+
       it 'gives white text on the strong colour a legible background' do
         config = described_class.for(account: account).web_config
 

--- a/spec/lib/brand_spec.rb
+++ b/spec/lib/brand_spec.rb
@@ -114,4 +114,97 @@ RSpec.describe Brand do
       end
     end
   end
+
+  describe '#web_config' do
+    before do
+      install(
+        'LOGO_THUMBNAIL' => '/brand-assets/logo_thumbnail.svg',
+        'WIDGET_BRAND_URL' => 'https://www.chatwoot.com'
+      )
+    end
+
+    context 'without an account' do
+      it 'is the installation brand' do
+        config = described_class.for.web_config
+
+        expect(config['BRAND_NAME']).to eq 'Chatwoot'
+        expect(config['WIDGET_BRAND_URL']).to eq 'https://www.chatwoot.com'
+        expect(config['LOGO_THUMBNAIL']).to eq '/brand-assets/logo_thumbnail.svg'
+      end
+
+      it 'leaves the hero logo empty rather than lending the installation mark to a page' do
+        expect(described_class.for.web_config['BRAND_LOGO_URL']).to eq ''
+      end
+    end
+
+    context 'when the account configured a brand' do
+      before do
+        account.enable_features!('branded_email_templates')
+        account.update!(
+          brand_name: 'Guichê Live',
+          brand_url: 'https://www.guichelive.com.br',
+          brand_color: '#F82323'
+        )
+      end
+
+      it 'wears the brand of the account' do
+        config = described_class.for(account: account).web_config
+
+        expect(config['BRAND_NAME']).to eq 'Guichê Live'
+        expect(config['WIDGET_BRAND_URL']).to eq 'https://www.guichelive.com.br'
+      end
+
+      it 'falls back field by field to the installation' do
+        account.update!(brand_url: '')
+
+        config = described_class.for(account: account).web_config
+
+        expect(config['BRAND_NAME']).to eq 'Guichê Live'
+        expect(config['WIDGET_BRAND_URL']).to eq 'https://www.chatwoot.com'
+      end
+
+      it 'ignores the account when the feature is off' do
+        account.disable_features!('branded_email_templates')
+
+        expect(described_class.for(account: account).web_config['BRAND_NAME']).to eq 'Chatwoot'
+      end
+
+      it 'gives white text on the strong colour a legible background' do
+        config = described_class.for(account: account).web_config
+
+        expect(config['BRAND_COLOR']).to eq BrandColor.surface('#F82323')
+        expect(config['BRAND_COLOR_STRONG']).to eq BrandColor.on_light('#F82323')
+      end
+
+      context 'with a logo attached' do
+        before do
+          account.brand_logo_email.attach(
+            io: Rails.root.join('spec/assets/avatar.png').open,
+            filename: 'avatar.png',
+            content_type: 'image/png'
+          )
+        end
+
+        it 'uses it for both the footer thumbnail and the hero' do
+          config = described_class.for(account: account).web_config
+
+          expect(config['LOGO_THUMBNAIL']).to start_with 'http://localhost:3000/rails/active_storage/blobs/redirect/'
+          expect(config['BRAND_LOGO_URL']).to eq config['LOGO_THUMBNAIL']
+        end
+      end
+
+      it 'keeps the installation thumbnail when the account attached no logo' do
+        config = described_class.for(account: account).web_config
+
+        expect(config['LOGO_THUMBNAIL']).to eq '/brand-assets/logo_thumbnail.svg'
+        expect(config['BRAND_LOGO_URL']).to eq ''
+      end
+    end
+
+    # The mail layouts customers already stored read #config as `global_config`. Widening it
+    # would quietly change what those layouts see, which is why the web keys live apart.
+    it 'does not widen the hash the stored mail layouts read' do
+      expect(described_class.for.config.keys).to match_array(described_class::INSTALLATION_KEYS)
+    end
+  end
 end

--- a/spec/services/message_templates/template/csat_survey_spec.rb
+++ b/spec/services/message_templates/template/csat_survey_spec.rb
@@ -18,6 +18,32 @@ describe MessageTemplates::Template::CsatSurvey do
       end
     end
 
+    context 'when the inbox has no configured message' do
+      before { inbox.update!(csat_config: {}) }
+
+      # The job that resolves a conversation runs with the process default locale, not the
+      # account's, so this reproduces the Sidekiq condition rather than the request one.
+      it 'translates the fallback into the locale of the account' do
+        account.update!(locale: 'pt_BR')
+
+        I18n.with_locale(:en) { service.perform }
+
+        expect(conversation.messages.template.last.content)
+          .to eq(I18n.t('conversations.templates.csat_input_message_body', locale: :pt_BR))
+      end
+
+      # Account#locale is an enum over LANGUAGES_CONFIG, which is a wider list than the
+      # locale files the installation actually loads. I18n.with_locale raises on the gap.
+      it 'falls back to the default locale when the installation did not load the account language' do
+        account.update!(locale: 'pt_BR')
+        allow(I18n).to receive(:available_locales).and_return([:en])
+
+        expect { service.perform }.not_to raise_error
+        expect(conversation.messages.template.last.content)
+          .to eq(I18n.t('conversations.templates.csat_input_message_body', locale: :en))
+      end
+    end
+
     context 'when csat config is provided' do
       let(:csat_config) do
         {


### PR DESCRIPTION
A página de CSAT é a única superfície pública que ainda usava a marca da instalação. Numa instalação que hospeda várias empresas, o cliente de uma conta abre a pesquisa e vê o nome, o logo e o link de outra: a pesquisa da conta A dizia "Desenvolvido por B" e apontava para o site de B.

## O que muda

**`Brand#web_config`.** Um segundo conjunto de chaves ao lado do que já serve os e-mails. `INSTALLATION_KEYS` fica intocado de propósito: layouts Liquid que clientes já gravaram em `email_templates` leem aquele hash como `global_config`, então ele é contrato publicado. As chaves que só a web usa (`LOGO_THUMBNAIL`, `WIDGET_BRAND_URL`) não têm override por conta, e incluí-las ali faria um layout esperar marca de conta e receber a da instalação. Um spec de regressão trava as chaves de `#config`.

**Cor renderizada pelo servidor, como custom property.** A cor já é conhecida no render; qualquer caminho por JS pintaria o azul do Chatwoot no primeiro frame para trocar depois, numa página que o cliente abre uma vez, no celular. São dois tokens porque um hex não serve para dois papéis: o normalizado para anéis e acentos, e o escurecido a 4.5:1 contra branco para preenchimentos. Contraste é simétrico, então esse mesmo valor é o que deixa o texto branco legível por cima — nenhuma cor nova a calcular.

**A página passa a respeitar `disable_branding`**, que o widget e o portal do help center já honram e só ela ignorava.

**Locale da mensagem da pesquisa.** `MessageTemplates::Template::CsatSurvey` traduzia o texto de fallback com o `I18n.locale` corrente e **gravava o resultado na coluna `content`**. Quem cria a mensagem é o job que resolve a conversa, onde o locale é o default do processo (`:en`), então toda conta configurada em outro idioma cujo inbox não tenha `csat_config['message']` próprio manda a pesquisa em inglês, congelada na coluna. Guarda de disponibilidade espelhando `ApplicationMailer#locale_from_account`, porque o enum de locale da Account cobre mais idiomas do que a instalação carrega.

## Junto, o que a tela devia ter e não tinha

- Rótulo em cada nota. O leitor de tela lia o nome do emoji.
- Foco visível na escala e no textarea (o do textarea era da mesma cor da borda em repouso).
- Área de toque de 48px, e o card se comportando abaixo de 360px.
- Estado final dizendo **qual** nota foi enviada, em vez de só agradecer.
- Sai o `scale(1.32)` no hover: num aparelho de toque ele fica preso na última nota tocada, aumentada e colorida, mentindo sobre o estado.

`DISABLE_BRANDING` fica fora do `Brand` de propósito: é direito de plano, não parte da cara da marca, e colocá-lo ali faria o mailer carregar uma chave que ignora.

## Verificação

- 132 exemplos RSpec, incluindo os dois specs de mailer como regressão do e-mail.
- 44 testes Vitest em 6 arquivos. Os 14 que já existiam no `Response.spec.js` passam **sem edição**.
- Regressão do widget medida, não presumida: rodapé com texto, link e greyscale idênticos, e o logo renderizando 12×12 exatos como antes.
- No browser: conta com marca, conta sem marca, `disable_branding`, escala estrela, mobile 375px sem scroll horizontal, `color-scheme: light` aplicado.

## Fora de escopo

`StarRating.vue` tem `aria-label="Star N"` fixo em inglês. Corrigir exige chave nova num componente que o widget também usa, e misturaria dois assuntos aqui.

Mensagens de CSAT já gravadas continuam em inglês: `content` é coluna, não tradução em tempo de render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/482)
<!-- Reviewable:end -->