### PR TITLE
feat(whatsapp): split the groups capability into receiving and managing

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -307,9 +307,12 @@ export default {
     groupMembersFetchTarget() {
       if (!this.groupContactId || !this.isGroupConversation) return null;
 
-      // The roster is a provider group read, so this asks for the command surface and
-      // not for group conversations arriving.
-      return this.hasInboxCapability(CAPABILITIES.GROUP_MANAGEMENT)
+      // `groups` and not `group_management`: this fetch reads the GroupMember rows the
+      // inbound path already filed, through Chatwoot's own API, and never reaches the
+      // provider. Asking for the command surface here would leave a receive-only inbox
+      // without `is_inbox_admin`, and an announcement-only group would look replyable
+      // until the server refused the message.
+      return this.hasInboxCapability(CAPABILITIES.GROUPS)
         ? this.groupContactId
         : null;
     },

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -307,7 +307,9 @@ export default {
     groupMembersFetchTarget() {
       if (!this.groupContactId || !this.isGroupConversation) return null;
 
-      return this.hasInboxCapability(CAPABILITIES.GROUPS)
+      // The roster is a provider group read, so this asks for the command surface and
+      // not for group conversations arriving.
+      return this.hasInboxCapability(CAPABILITIES.GROUP_MANAGEMENT)
         ? this.groupContactId
         : null;
     },

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -193,7 +193,9 @@ export default {
     groupMembersFetchTarget() {
       if (!this.groupContactId || !this.isGroupConversation) return null;
 
-      return this.hasInboxCapability(CAPABILITIES.GROUPS)
+      // The roster is a provider group read, so this asks for the command surface and
+      // not for group conversations arriving.
+      return this.hasInboxCapability(CAPABILITIES.GROUP_MANAGEMENT)
         ? this.groupContactId
         : null;
     },

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -193,9 +193,12 @@ export default {
     groupMembersFetchTarget() {
       if (!this.groupContactId || !this.isGroupConversation) return null;
 
-      // The roster is a provider group read, so this asks for the command surface and
-      // not for group conversations arriving.
-      return this.hasInboxCapability(CAPABILITIES.GROUP_MANAGEMENT)
+      // `groups` and not `group_management`: this fetch reads the GroupMember rows the
+      // inbound path already filed, through Chatwoot's own API, and never reaches the
+      // provider. Asking for the command surface here would leave a receive-only inbox
+      // without `is_inbox_admin`, and an announcement-only group would look replyable
+      // until the server refused the message.
+      return this.hasInboxCapability(CAPABILITIES.GROUPS)
         ? this.groupContactId
         : null;
     },

--- a/app/javascript/dashboard/helper/whatsappSession.js
+++ b/app/javascript/dashboard/helper/whatsappSession.js
@@ -32,6 +32,7 @@ export const CAPABILITIES = {
   CHECK_NUMBER: 'check_number',
   PROFILE_PICTURE: 'profile_picture',
   GROUPS: 'groups',
+  GROUP_MANAGEMENT: 'group_management',
   GROUP_ADMIN: 'group_admin',
   GROUP_INVITES: 'group_invites',
   GROUP_JOIN_REQUESTS: 'group_join_requests',

--- a/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/ContactPanel.vue
@@ -104,7 +104,12 @@ const isGroupConversation = computed(
 // the synthetic group contact. What the capability governs is inside the panel: the member
 // sync below, and the write actions in GroupContactInfo.
 const showGroupInfo = isGroupConversation;
-const supportsGroups = computed(() => hasInboxCapability(CAPABILITIES.GROUPS));
+// Everything this gates is a command against the provider -- syncing the roster, leaving,
+// the settings panel -- so it asks for `group_management`, not for group conversations
+// reaching the inbox.
+const supportsGroups = computed(() =>
+  hasInboxCapability(CAPABILITIES.GROUP_MANAGEMENT)
+);
 const sidebarTitle = computed(() =>
   isGroupConversation.value
     ? 'GROUP.SIDEBAR_TITLE'

--- a/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
+++ b/app/javascript/dashboard/routes/dashboard/conversation/contact/GroupContactInfo.vue
@@ -189,7 +189,12 @@ const canHandleJoinRequests = computed(
 // The panel itself renders for any group thread, because being a group is identity and
 // not a capability. Everything that WRITES still has to ask: `Facade#group` refuses every
 // group call without this one.
-const supportsGroups = computed(() => hasInboxCapability(CAPABILITIES.GROUPS));
+// Everything this gates is a command against the provider -- syncing the roster, leaving,
+// the settings panel -- so it asks for `group_management`, not for group conversations
+// reaching the inbox.
+const supportsGroups = computed(() =>
+  hasInboxCapability(CAPABILITIES.GROUP_MANAGEMENT)
+);
 
 const startEditName = () => {
   if (isGroupLeft.value || !canEditGroup.value) return;

--- a/app/models/concerns/account_inbox_payload_fingerprint.rb
+++ b/app/models/concerns/account_inbox_payload_fingerprint.rb
@@ -12,8 +12,13 @@
 module AccountInboxPayloadFingerprint
   extend ActiveSupport::Concern
 
-  # Bump on any change to the shape of `api/v1/models/_inbox.json.jbuilder`.
-  PAYLOAD_VERSION = 2
+  # Bump on any change to what that partial serializes -- its shape, and equally the
+  # values it derives from code rather than from the record. A capability added to a
+  # descriptor is the second kind and looks like nothing here: the field already existed,
+  # no inbox was written, and every warm cache keeps serving the list from before the
+  # deploy. The dashboard then hides the controls the new capability was added to unlock,
+  # until something happens to write the inbox row.
+  PAYLOAD_VERSION = 3
 
   def cache_keys
     keys = super

--- a/app/services/contacts/sync_group_service.rb
+++ b/app/services/contacts/sync_group_service.rb
@@ -5,7 +5,7 @@ class Contacts::SyncGroupService
     validate_group_contact!
 
     channel = self.channel || contact.group_channel
-    raise ActionController::BadRequest, I18n.t('contacts.sync_group.no_supported_inbox') if channel.blank? || !channel.respond_to?(:sync_group)
+    raise ActionController::BadRequest, I18n.t('contacts.sync_group.no_supported_inbox') unless syncable?(channel)
 
     conversation = find_or_create_sync_conversation(channel)
     raise ActionController::BadRequest, I18n.t('contacts.sync_group.no_supported_inbox') if conversation.blank?
@@ -18,6 +18,26 @@ class Contacts::SyncGroupService
   end
 
   private
+
+  # Answering the method is not the same as being able to carry it out. An inbox on the
+  # session layer that takes group conversations and answers no group commands responds
+  # to `sync_group` and then returns without syncing, so without this the endpoint would
+  # build a conversation, dispatch CONTACT_GROUP_SYNCED and report success over a roster
+  # nobody read.
+  #
+  # Reported as the inbox not supporting group sync, which is what it is, and which is
+  # what this refusal already says for a channel that has no such method at all.
+  #
+  # Asked only of the providers the split applies to. A legacy provider's own service
+  # decides for itself whether it can sync, and reading the descriptor's capability list
+  # for one would newly refuse this endpoint whenever the installation-wide groups switch
+  # is off -- a reach this change has no business extending.
+  def syncable?(channel)
+    return false if channel.blank? || !channel.respond_to?(:sync_group)
+    return true unless Whatsapp::Session::Registry.session_backed?(channel)
+
+    Whatsapp::Session::Registry.capabilities_for(channel).include?('group_management')
+  end
 
   def find_or_create_sync_conversation(channel)
     contact_inbox = sync_contact_inbox(channel)

--- a/app/services/whatsapp/session/capabilities.rb
+++ b/app/services/whatsapp/session/capabilities.rb
@@ -18,6 +18,7 @@ module Whatsapp::Session::Capabilities
     check_number
     profile_picture
     groups
+    group_management
     group_admin
     group_invites
     group_join_requests
@@ -47,13 +48,30 @@ module Whatsapp::Session::Capabilities
     'profile_picture' => :profile_picture_url,
     'account_limits' => :fetch_account_limits,
     'media_download' => :download_media,
-    'groups' => :group_info,
+    'group_management' => :group_info,
     'group_admin' => :update_group_participants,
     'group_invites' => :group_invite_code,
     'group_join_requests' => :group_join_requests
   }.freeze
 
-  GROUP_CAPABILITIES = %w[groups group_admin group_invites group_join_requests].freeze
+  # `groups` and `group_management` are two questions, and a provider can answer one
+  # without the other.
+  #
+  # `groups` is whether group conversations reach this inbox at all: it is what the connect
+  # request carries to the connector, and what the six inbound handlers ask before letting
+  # a group message, reaction, join, rename or picture change through. It unlocks no method,
+  # the way `echo_by_reserved_id` and `calls` unlock none -- it describes what arrives.
+  #
+  # `group_management` is whether this provider can be asked about a group and told to
+  # change one: reading it, creating it, renaming it, its description and photo, its
+  # settings, and leaving it. `group_admin`, `group_invites` and `group_join_requests` are
+  # narrower powers on top of it, each its own capability because a provider can do groups
+  # without them -- Uazapi does groups and cannot serve invite links.
+  #
+  # Splitting them is what lets an installation take group conversations into Chatwoot
+  # without handing agents the group's admin surface, and lets a provider that only
+  # delivers group messages declare exactly that instead of promising commands it refuses.
+  GROUP_CAPABILITIES = %w[groups group_management group_admin group_invites group_join_requests].freeze
 
   def self.validate!(capabilities)
     unknown = capabilities.map(&:to_s) - ALL

--- a/app/services/whatsapp/session/facade/groups.rb
+++ b/app/services/whatsapp/session/facade/groups.rb
@@ -8,11 +8,11 @@ module Whatsapp::Session::Facade::Groups
   # --- groups --------------------------------------------------------------------
 
   def allow_group_creation?
-    capability?('groups')
+    capability?('group_management')
   end
 
   def create_group(subject, participants)
-    raise Whatsapp::Session::Errors::NotSupported, 'groups are disabled on this installation' unless capability?('groups')
+    refuse_group_management unless capability?('group_management')
 
     info = backend.create_group(model::Commands::GroupCreate.new(subject: subject, participants: addresses(participants)))
     # Groups::CreateService reads :id from this, the same key the Baileys response had.
@@ -84,8 +84,12 @@ module Whatsapp::Session::Facade::Groups
     update_group_setting(group_jid, 'member_add_mode', mode.to_s == 'all_member_add')
   end
 
+  # Guarded on `group_management` and not on `groups`: the roster comes from the provider's
+  # own group read, so an inbox that takes group conversations without the command surface
+  # has nothing to sync from. There is no group conversation to reach here without
+  # `groups` anyway.
   def sync_group(conversation, soft: false)
-    return unless capability?('groups')
+    return unless capability?('group_management')
 
     Whatsapp::Session::Groups::Syncer.new(channel: channel, group_contact: conversation.contact, soft: soft).perform
   end
@@ -93,12 +97,31 @@ module Whatsapp::Session::Facade::Groups
   private
 
   # `WHATSAPP_GROUPS_ENABLED=false` takes every group capability away from the descriptor,
-  # and the dashboard hides the group panel accordingly. The API endpoints behind that
-  # panel are still routable, though, so the switch has to be enforced where the calls
-  # land: gating only creation left participants, metadata, invites, settings, leaving and
-  # syncing reaching the provider on an installation that turned groups off.
+  # `group_management` included, and the dashboard hides the group panel accordingly. The
+  # API endpoints behind that panel are still routable, though, so the switch has to be
+  # enforced where the calls land: gating only creation left participants, metadata,
+  # invites, settings, leaving and syncing reaching the provider on an installation that
+  # turned groups off.
+  #
+  # Now also the gate for an inbox whose provider takes group conversations and answers no
+  # group commands, which the switch being on does not make possible.
+  # Two refusals wearing one capability, and an agent reading the reply has to be able to
+  # tell them apart. The installation turned groups off entirely, and nothing about groups
+  # works; or this inbox takes group conversations and its provider answers no group
+  # commands, in which case the threads in the sidebar are real and only this button is
+  # not. Saying "groups are disabled" for the second sends whoever reads it looking for a
+  # switch that is already on.
+  def refuse_group_management
+    raise Whatsapp::Session::Errors::NotSupported,
+          if Whatsapp::Session::Registry.groups_enabled?
+            'this inbox receives group conversations but cannot manage groups'
+          else
+            'groups are disabled on this installation'
+          end
+  end
+
   def group(group_jid)
-    raise Whatsapp::Session::Errors::NotSupported, 'groups are disabled on this installation' unless capability?('groups')
+    refuse_group_management unless capability?('group_management')
 
     parsed = model::Address.parse(group_jid)
     raise Whatsapp::Session::Errors::InvalidPayload, "not a group: #{group_jid}" unless parsed&.group?

--- a/app/services/whatsapp/session/inbound/handlers/group_activity.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_activity.rb
@@ -19,7 +19,11 @@ class Whatsapp::Session::Inbound::Handlers::GroupActivity < Whatsapp::Session::I
       result = resolver.perform
       conversation = resolver.conversation_for(result.group_contact_inbox)
 
-      Contacts::SyncGroupJob.perform_later(result.group_contact, soft: true, channel: channel)
+      # Only where the sync can actually run. The job's own 15 minute cooldown reads
+      # `group_last_synced_at`, which the syncer writes and a refused sync never reaches,
+      # so on a receive-only inbox the cooldown would never engage and every reported
+      # activity would enqueue another job that does nothing.
+      Contacts::SyncGroupJob.perform_later(result.group_contact, soft: true, channel: channel) if capability?(:group_management)
       conversation.update_columns(last_activity_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
       conversation.dispatch_conversation_updated_event
     end

--- a/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
+++ b/app/services/whatsapp/session/inbound/handlers/group_picture_changed.rb
@@ -19,10 +19,17 @@ class Whatsapp::Session::Inbound::Handlers::GroupPictureChanged < Whatsapp::Sess
 
   # A removal has nothing to refetch, and the job returns before purging when the group
   # reports no photo, so asking it to refresh would leave the old image attached for
-  # good.
+  # good. It is also the half that needs nothing from the provider, which is why the
+  # capability is asked about after this branch and not before it: the event is still
+  # worth handling on an inbox that cannot fetch, it just cannot fetch.
+  #
+  # The refetch calls `group_info`, so without `group_management` the job would go out,
+  # be refused, log a warning and leave the old picture -- once per photo change, for
+  # every group, forever.
   def refresh_avatar(group_contact)
-    return Whatsapp::Session::UpdateGroupAvatarJob.perform_later(group_contact, force: true, channel: channel) unless payload.removed
+    return group_contact.avatar.purge if payload.removed && group_contact.avatar.attached?
+    return if payload.removed || !capability?(:group_management)
 
-    group_contact.avatar.purge if group_contact.avatar.attached?
+    Whatsapp::Session::UpdateGroupAvatarJob.perform_later(group_contact, force: true, channel: channel)
   end
 end

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -94,6 +94,14 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
       Whatsapp::Session::PROVIDERS.include?(provider.to_s)
     end
 
+    # Whether this inbox's commands run through the session layer's own backend, which is
+    # what makes the capability list the authority on what it can carry out. A legacy
+    # provider is in the session family and is not this: its own service decides.
+    def session_backed?(channel)
+      descriptor = descriptor(channel.provider)
+      descriptor.present? && descriptor.session? && !descriptor.legacy?
+    end
+
     # The QR/pairing family, legacy providers included. What sets it apart from the cloud
     # family is behavioral: a paired session is a real WhatsApp client, so there is no
     # 24-hour messaging window and no template requirement.

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -25,8 +25,8 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
       # which rides on the pairing commands.
       capabilities: %w[
         qr_pairing code_pairing echo_by_reserved_id edit revoke reactions typing presence
-        presence_subscribe read_receipts mark_unread check_number profile_picture groups group_admin
-        group_invites group_join_requests account_limits media_download
+        presence_subscribe read_receipts mark_unread check_number profile_picture groups
+        group_management group_admin group_invites group_join_requests account_limits media_download
       ],
       fields: [MARK_AS_READ, PRESENCE_SUBSCRIBE]
     ),
@@ -41,7 +41,7 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
       # face, so it is not declared.
       capabilities: %w[
         qr_pairing code_pairing edit revoke reactions typing presence read_receipts check_number
-        profile_picture groups group_admin account_limits media_download
+        profile_picture groups group_management group_admin account_limits media_download
       ],
       fields: [
         Field.new(name: 'base_url', type: 'url', required: true),
@@ -61,8 +61,8 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
       pairing_modes: %w[qr],
       capabilities: %w[
         qr_pairing session_import echo_by_reserved_id edit revoke reactions typing presence presence_subscribe
-        read_receipts mark_unread check_number profile_picture groups group_admin group_invites
-        group_join_requests account_limits media_download
+        read_receipts mark_unread check_number profile_picture groups group_management group_admin
+        group_invites group_join_requests account_limits media_download
       ]
     ),
     Descriptor.new(

--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -165,11 +165,17 @@ namespace :whatsapp do
 
         channel = WhatsappProviderConversion.channel_for(args[:inbox_id])
         # The capability, not the family: `zapi` pairs with a phone and so is session
-        # family, but it declares no `groups` and its frozen service has no `sync_group`,
-        # so every job this enqueued for one would die on NoMethodError. Reading the
-        # capability also honours the instance-wide groups kill switch for free.
-        unless Whatsapp::Session::Registry.capabilities_for(channel).include?('groups')
-          abort "inbox #{args[:inbox_id]} is on #{channel.provider}, which cannot answer for groups"
+        # family, but it declares no group capability and its frozen service has no
+        # `sync_group`, so every job this enqueued for one would die on NoMethodError.
+        # Reading the capability also honours the instance-wide groups kill switch for
+        # free.
+        #
+        # `group_management` and not `groups`: what this enqueues is a roster sync, which
+        # reads the group from the provider. An inbox that takes group conversations and
+        # answers no group commands would pass a `groups` check, enqueue a job per group
+        # contact, have every one of them return without syncing, and report success.
+        unless Whatsapp::Session::Registry.capabilities_for(channel).include?('group_management')
+          abort "inbox #{args[:inbox_id]} is on #{channel.provider}, which cannot be asked about groups"
         end
 
         inbox = channel.inbox

--- a/spec/models/concerns/account_inbox_payload_fingerprint_spec.rb
+++ b/spec/models/concerns/account_inbox_payload_fingerprint_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe AccountInboxPayloadFingerprint do
     end
   end
 
+  # The version is what covers the third case, and it is the one with no runtime signal at
+  # all: a capability added to a descriptor changes what the payload carries while the
+  # record, the env and the payload's shape all stay put. Nothing here can detect that the
+  # bump was forgotten, so this asserts the only thing it can -- that the version is part
+  # of the key, and that moving it moves the key.
+  it 'changes when the payload version is bumped' do
+    before_bump = inbox_key
+
+    stub_const('AccountInboxPayloadFingerprint::PAYLOAD_VERSION',
+               AccountInboxPayloadFingerprint::PAYLOAD_VERSION + 1)
+
+    expect(inbox_key).not_to eq(before_bump)
+  end
+
   # Not a capability, and older than this concern: the same gap applies to anything in the
   # payload that comes from configuration rather than from the record.
   it 'changes when the inbound email domain is configured' do

--- a/spec/services/contacts/sync_group_service_spec.rb
+++ b/spec/services/contacts/sync_group_service_spec.rb
@@ -68,5 +68,34 @@ RSpec.describe Contacts::SyncGroupService do
 
       described_class.new(contact: contact).perform
     end
+
+    # Answering `sync_group` is not the same as being able to carry it out: an inbox on
+    # the session layer that takes group conversations and answers no group commands
+    # returns without syncing, and this endpoint would otherwise report success over a
+    # roster nobody read.
+    it 'refuses a session inbox that cannot manage groups' do
+      channel = create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false)
+      contact = create(:contact, account: channel.account, group_type: :group, identifier: 'group@g.us')
+      create(:contact_inbox, contact: contact, inbox: channel.inbox)
+      allow(Whatsapp::Session::Registry).to receive(:capabilities_for).and_return(%w[groups])
+
+      expect { described_class.new(contact: contact, channel: channel).perform }
+        .to raise_error(ActionController::BadRequest)
+    end
+
+    # And the guard reaches only the providers the split applies to. A legacy provider's
+    # own service decides whether it can sync, and asking the descriptor for one would
+    # newly refuse this endpoint whenever the installation-wide switch is off.
+    it 'leaves a legacy provider to its own service' do
+      channel = create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false)
+      contact = create(:contact, account: channel.account, group_type: :group, identifier: 'group@g.us')
+      contact_inbox = create(:contact_inbox, contact: contact, inbox: channel.inbox)
+      create(:conversation, account: channel.account, inbox: channel.inbox, contact: contact, contact_inbox: contact_inbox)
+      allow(channel).to receive(:sync_group).and_return(true)
+
+      described_class.new(contact: contact, channel: channel).perform
+
+      expect(channel).to have_received(:sync_group)
+    end
   end
 end

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -316,6 +316,47 @@ RSpec.describe Whatsapp::Session::Facade do
       expect(backend.commands).to be_empty
     end
 
+    # The other way the same capability is missing, and it is not the same situation: the
+    # switch is on, group threads are in the sidebar and being answered, and only the
+    # management surface is absent. An agent told "groups are disabled" here goes looking
+    # for a switch that is already on.
+    it 'says groups are receivable but unmanageable when only the command surface is missing' do
+      allow(Whatsapp::Session::Registry).to receive(:capabilities_for).and_return(%w[groups])
+
+      with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+        expect { channel.provider_service.group_leave(group_jid) }
+          .to raise_error(Whatsapp::Session::Errors::NotSupported, /cannot manage groups/)
+      end
+
+      expect(backend.commands).to be_empty
+    end
+
+    # And nothing reaches the provider on the way to that refusal, including the reads the
+    # dashboard fires on its own: the panel is gone, and a stale one still mounted must not
+    # turn into calls the inbox cannot make.
+    it 'reaches the provider for nothing while only the command surface is missing' do
+      allow(Whatsapp::Session::Registry).to receive(:capabilities_for).and_return(%w[groups])
+      # Named rather than inferred from `backend.commands`: the syncer talks to the
+      # provider through its own path, so an empty command list says nothing about whether
+      # it ran.
+      expect(Whatsapp::Session::Groups::Syncer).not_to receive(:new)
+
+      expect(facade.allow_group_creation?).to be(false)
+      facade.sync_group(conversation)
+
+      expect(backend.commands).to be_empty
+    end
+
+    # And the guard is on the command surface and not on the switch: an inbox that has both
+    # still syncs, or the check above would pass by never syncing at all.
+    it 'syncs a group while the command surface is there' do
+      expect(Whatsapp::Session::Groups::Syncer).to receive(:new).and_return(instance_double(
+                                                                              Whatsapp::Session::Groups::Syncer, perform: nil
+                                                                            ))
+
+      facade.sync_group(conversation)
+    end
+
     it 'answers group creation in the shape Groups::CreateService reads' do
       result = facade.create_group('Equipe de Vendas', ['5541999990000@s.whatsapp.net'])
 

--- a/spec/services/whatsapp/session/inbound/handlers/group_activity_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_activity_spec.rb
@@ -36,4 +36,16 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupActivity do
 
     expect(Contacts::SyncGroupJob).to have_been_enqueued.with(anything, soft: true, channel: channel)
   end
+
+  # The job's 15 minute cooldown reads `group_last_synced_at`, which the syncer writes and
+  # a refused sync never reaches. Without this gate the cooldown would never engage on a
+  # receive-only inbox, and every reported activity would enqueue another job that does
+  # nothing -- for as long as the group is active.
+  it 'does not enqueue a roster sync that cannot run' do
+    allow(Whatsapp::Session::Registry).to receive(:capabilities_for).and_return(%w[groups])
+
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      expect { dispatch }.not_to have_enqueued_job(Contacts::SyncGroupJob)
+    end
+  end
 end

--- a/spec/services/whatsapp/session/inbound/handlers/group_picture_changed_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/group_picture_changed_spec.rb
@@ -44,4 +44,15 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::GroupPictureChanged do
       expect(Whatsapp::Session::UpdateGroupAvatarJob).not_to have_been_enqueued
     end
   end
+
+  # The refetch is a provider `group_info`, so on an inbox that takes group conversations
+  # and answers no group commands the job would go out, be refused, log a warning and
+  # leave the old picture -- once per photo change, for every group, forever.
+  it 'does not go looking for the new photo without the group command surface' do
+    allow(Whatsapp::Session::Registry).to receive(:capabilities_for).and_return(%w[groups])
+
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      expect { dispatch }.not_to have_enqueued_job(Whatsapp::Session::UpdateGroupAvatarJob)
+    end
+  end
 end

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -483,6 +483,20 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       expect(inbox.messages).to be_empty
     end
 
+    # `groups` and `group_management` are two questions. This is the half that decides
+    # whether the thread exists at all, and an inbox whose provider answers no group
+    # commands still takes the conversation -- otherwise the split would be a way to lose
+    # messages rather than a way to withhold a panel.
+    it 'opens the group conversation without the group command surface' do
+      allow(Whatsapp::Session::Registry).to receive(:capabilities_for).and_return(%w[groups])
+
+      with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+        expect(dispatch).to eq(:handled)
+      end
+
+      expect(inbox.contacts.find_by(identifier: '120363041234567890@g.us')).to be_present
+    end
+
     it 'opens the group conversation and files the sender as a member' do
       with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
         expect(dispatch).to eq(:handled)


### PR DESCRIPTION
`groups` respondia duas perguntas ao mesmo tempo, e um provider pode responder uma sem a outra.

Ela decidia **se conversas de grupo chegam à caixa** (o flag `groups:` do connect request e os seis handlers de entrada) e também **se o provider pode ser perguntado sobre um grupo e mandado mudar um** (ler, criar, renomear, descrição, foto, settings, sair).

Consequência: uma instalação que quer threads de grupo no Chatwoot sem entregar aos agentes a superfície de administração não tinha como dizer isso, e um provider que só entrega mensagem de grupo tinha que declarar uma capability prometendo comandos que ia recusar.

## A separação

- `groups` = a primeira pergunta. Não destrava método nenhum, como `echo_by_reserved_id` e `calls` também não: descreve o que chega.
- `group_management` = a segunda. `group_admin`, `group_invites` e `group_join_requests` continuam sendo poderes mais estreitos em cima dela, inalterados.
- `WHATSAPP_GROUPS_ENABLED=false` continua tirando todas de uma vez.

## A recusa também separou

As duas formas de faltar essa capability não são a mesma situação:

- **switch desligado**: nada de grupo funciona → "groups are disabled on this installation"
- **superfície de comando ausente**: as threads na sidebar são reais e estão sendo respondidas, só o painel não existe → "this inbox receives group conversations but cannot manage groups"

Um agente que ouve "groups are disabled" no segundo caso vai procurar um switch que já está ligado.

## Dashboard

Os quatro pontos que disparam chamada ao provider passaram a pedir `group_management`: o roster de membros nas duas visões de conversa, o sync no `ContactPanel`, o sair e o acordeão de settings no `GroupContactInfo`. Os dois banners de "grupos desligados" continuam pedindo `groups`, que é o que eles querem dizer.

## Verificação

500 exemplos Ruby passando, e **cada guard preso por mutação**: reverter qualquer um deles para `groups` derruba um teste. Inclui o `sync_group`, cujo primeiro teste que escrevi era vazio (afirmava sobre `backend.commands`, que o Syncer não alimenta) e agora afirma sobre o próprio Syncer.

**Não rodei localmente** as duas specs JS que citam a capability. Elas afirmam sobre `groups`, que isto não muda, e nenhuma spec cobre os quatro componentes editados. A worktree não resolve os `setupFiles` do vitest através de um `node_modules` symlinkado, e a única árvore que resolve está na branch de outra sessão.

Contexto: sai da separação que o `whatsapp-connector` pediu ao implementar os comandos de grupo de verdade (fazer-ai/whatsapp-connector#121 a #124).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/485)
<!-- Reviewable:end -->
