### PR TITLE
fix(imap): buscar por UID em vez de reler a janela de datas a cada minuto

### DIFF
--- a/app/services/imap/base_fetch_email_service.rb
+++ b/app/services/imap/base_fetch_email_service.rb
@@ -194,11 +194,16 @@ class Imap::BaseFetchEmailService
     return imap_client.uid_search(['SINCE', since]) if sync_plan[:mode] == :full
 
     from = sync_plan[:from_uid]
-    # `N:*` is not "UIDs at or above N". RFC 3501 makes `*` the highest UID in the
-    # mailbox, and a range whose start is above it still matches that highest one, so an
-    # idle mailbox keeps handing back its last message forever. The filter is what makes
+    # SequenceSet and not the plain string "N:*". net-imap serialises a bare String
+    # argument as a quoted string, and Gmail answers a quoted sequence-set with
+    # "Could not parse command" -- verified against the live server, where the mocked
+    # client in the specs had happily accepted it.
+    #
+    # And `N:*` is not "UIDs at or above N": RFC 3501 makes `*` the highest UID in the
+    # mailbox, so a range starting above it still matches that highest one and an idle
+    # mailbox would keep handing back its last message forever. The filter is what makes
     # the range mean what it reads like.
-    imap_client.uid_search(['UID', "#{from}:*"]).select { |uid| uid >= from }
+    imap_client.uid_search(['UID', Net::IMAP::SequenceSet.new("#{from}:*")]).select { |uid| uid >= from }
   end
 
   def build_imap_client

--- a/app/services/imap/base_fetch_email_service.rb
+++ b/app/services/imap/base_fetch_email_service.rb
@@ -166,35 +166,41 @@ class Imap::BaseFetchEmailService
                       "(#{sync_plan[:mode]} sync)."
 
     collected = { entries: [], inspected_through: nil }
-    uids.each_slice(MAX_MESSAGES_PER_SYNC) do |batch|
-      break if consume_header_batch(batch, collected) == :capped
+    # Sorted before slicing, not only inside each batch: SEARCH is not required to answer in
+    # ascending order, so a cap that stops on the first slice would leave lower UIDs sitting
+    # under the cursor with no run that ever looks at them again. Ascending order is what
+    # makes "inspected through N" a contiguous boundary instead of a mark with holes below it.
+    uids.sort.each_slice(MAX_MESSAGES_PER_SYNC) do |batch|
+      # Checked here too, and not only inside the batch, so a slice that ends exactly on the
+      # cap does not pay for one more FETCH of up to 500 headers nobody will read.
+      break if collected[:entries].length >= MAX_MESSAGES_PER_SYNC
+
+      consume_header_batch(batch, collected)
     end
 
     [collected[:entries], collected[:inspected_through]]
   end
 
-  # Walks one batch of headers, stopping the moment the sync limit is reached. Returns
-  # :capped so the caller knows the remaining UIDs were never looked at, which is exactly
-  # what keeps the cursor from claiming them.
+  # Walks one batch of headers, stopping the moment the sync limit is reached. Whatever is
+  # left in the batch was never looked at, which is exactly what keeps the cursor from
+  # claiming it.
   def consume_header_batch(batch, collected)
     headers = fetch_headers_for(batch)
-    return :empty if headers.blank?
+    return if headers.blank?
 
-    # Sorted so "inspected through UID N" really means every UID up to N was seen: the
-    # server may answer a batch in any order.
+    # Sorted again here because the server may answer a FETCH in any order, regardless of
+    # the order the UIDs were asked in.
     headers.sort_by { |data| data.attr['UID'].to_i }.each do |data|
       if collected[:entries].length >= MAX_MESSAGES_PER_SYNC
         Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Reached MAX_MESSAGES_PER_SYNC=#{MAX_MESSAGES_PER_SYNC} " \
                           "for #{channel.email}, stopping sync."
-        return :capped
+        break
       end
 
       collected[:inspected_through] = data.attr['UID'] || collected[:inspected_through]
       entry = build_message_id_entry(data)
       collected[:entries].push(entry) if entry
     end
-
-    :ok
   end
 
   def fetch_headers_for(batch)

--- a/app/services/imap/base_fetch_email_service.rb
+++ b/app/services/imap/base_fetch_email_service.rb
@@ -53,11 +53,12 @@ class Imap::BaseFetchEmailService
 
   def fetch_mail_for_channel
     uids = fetch_available_mail_uids
-    entries = collect_message_ids(uids)
+    entries, inspected_through = collect_message_ids(uids)
     mails = entries.filter_map { |entry| process_message_id(entry) }
-    # Only after the batch is built. A run that dies halfway leaves the cursor where it
-    # was, so the next one re-reads the same range: wasted bandwidth, never a gap.
-    advance_cursor(uids)
+    # Only after the batch is built, and only through the UID actually looked at. A run
+    # that dies halfway leaves the cursor where it was, so the next one re-reads the same
+    # range: wasted bandwidth, never a gap.
+    advance_cursor(inspected_through)
     mails
   end
 
@@ -71,6 +72,7 @@ class Imap::BaseFetchEmailService
       validity = mailbox_uid_validity
 
       if validity.nil? || cursor.nil? || cursor[:uid_validity] != validity ||
+         cursor[:mailbox] != mailbox_identity ||
          Time.current.to_i - cursor[:swept_at].to_i >= FULL_SWEEP_INTERVAL
         { mode: :full, uid_validity: validity }
       else
@@ -94,18 +96,36 @@ class Imap::BaseFetchEmailService
     @uid_cursor ||= Imap::UidCursor.new(inbox: channel.inbox)
   end
 
-  def advance_cursor(uids)
+  # UIDVALIDITY is scoped to a mailbox, not global: two different mailboxes can report the
+  # same number. Since the host and login of a channel are editable, the cursor also has to
+  # name the mailbox it was built from, or repointing an inbox would silently inherit a
+  # high-water mark from the previous account.
+  def mailbox_identity
+    @mailbox_identity ||= Digest::SHA256.hexdigest(
+      [channel.imap_address, channel.imap_port, channel.imap_login].join(':')
+    )
+  end
+
+  def advance_cursor(inspected_through)
     validity = sync_plan[:uid_validity]
     return if validity.blank?
 
     previous = uid_cursor.read
-    last_uid = [uids.max.to_i, previous&.dig(:last_uid).to_i].max
+    # A cursor from another UIDVALIDITY generation (or another mailbox) describes UIDs that
+    # no longer exist. Carrying its high-water mark forward would park the new generation
+    # above every real UID, and only the hourly sweep would ever see mail again.
+    carried = reusable_cursor?(previous, validity) ? previous[:last_uid].to_i : 0
+    last_uid = [inspected_through.to_i, carried].max
     return if last_uid.zero?
 
     # swept_at only moves on a full sweep: it is the clock for "when did we last look at
     # the whole window", and an incremental run did not.
     swept_at = sync_plan[:mode] == :full ? Time.current : (previous&.dig(:swept_at) || 0)
-    uid_cursor.write(uid_validity: validity, last_uid: last_uid, swept_at: swept_at)
+    uid_cursor.write(uid_validity: validity, last_uid: last_uid, swept_at: swept_at, mailbox: mailbox_identity)
+  end
+
+  def reusable_cursor?(cursor, validity)
+    cursor.present? && cursor[:uid_validity] == validity && cursor[:mailbox] == mailbox_identity
   end
 
   def process_message_id(entry)
@@ -135,42 +155,59 @@ class Imap::BaseFetchEmailService
 
   # Sends a FETCH command to retrieve data associated with a message in the mailbox.
   # You can send batches of UIDs in `.uid_fetch`.
+  #
+  # Returns the entries worth downloading AND the highest UID whose header was actually
+  # inspected. Those are different numbers whenever the cap cuts the run short, and the
+  # cursor has to move by the second one: everything past it was never looked at, so
+  # claiming it would hide those messages from every later incremental poll and leave
+  # only the hourly sweep to find them, 500 at a time, until they age out of the window.
   def collect_message_ids(uids)
     Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{channel.email}, found #{uids.length} " \
                       "(#{sync_plan[:mode]} sync)."
 
-    entries = []
-    uids.each_slice(MAX_MESSAGES_PER_SYNC).each do |batch|
-      append_message_ids_for_batch(batch, entries)
-      if entries.length >= MAX_MESSAGES_PER_SYNC
-        Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Reached MAX_MESSAGES_PER_SYNC=#{MAX_MESSAGES_PER_SYNC} for #{channel.email}, stopping sync."
-        break
-      end
+    collected = { entries: [], inspected_through: nil }
+    uids.each_slice(MAX_MESSAGES_PER_SYNC) do |batch|
+      break if consume_header_batch(batch, collected) == :capped
     end
 
-    entries
+    [collected[:entries], collected[:inspected_through]]
   end
 
-  def append_message_ids_for_batch(batch, entries)
+  # Walks one batch of headers, stopping the moment the sync limit is reached. Returns
+  # :capped so the caller knows the remaining UIDs were never looked at, which is exactly
+  # what keeps the cursor from claiming them.
+  def consume_header_batch(batch, collected)
+    headers = fetch_headers_for(batch)
+    return :empty if headers.blank?
+
+    # Sorted so "inspected through UID N" really means every UID up to N was seen: the
+    # server may answer a batch in any order.
+    headers.sort_by { |data| data.attr['UID'].to_i }.each do |data|
+      if collected[:entries].length >= MAX_MESSAGES_PER_SYNC
+        Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Reached MAX_MESSAGES_PER_SYNC=#{MAX_MESSAGES_PER_SYNC} " \
+                          "for #{channel.email}, stopping sync."
+        return :capped
+      end
+
+      collected[:inspected_through] = data.attr['UID'] || collected[:inspected_through]
+      entry = build_message_id_entry(data)
+      collected[:entries].push(entry) if entry
+    end
+
+    :ok
+  end
+
+  def fetch_headers_for(batch)
     # Fetch only message-id only without mail body or contents.
     Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Starting header batch of #{batch.length} for #{channel.email}"
-    batch_message_ids = imap_client.uid_fetch(batch, %w[UID BODY.PEEK[HEADER]])
-    Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetching the batch for #{channel.email}. Found #{batch_message_ids&.length} messages."
+    headers = imap_client.uid_fetch(batch, %w[UID BODY.PEEK[HEADER]])
+    Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetching the batch for #{channel.email}. Found #{headers&.length} messages."
 
-    # .fetch returns an array of Net::IMAP::FetchData or nil
+    # .uid_fetch returns an array of Net::IMAP::FetchData or nil
     # (instead of an empty array) if there is no matching message.
-    if batch_message_ids.blank?
-      Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetching the batch failed for #{channel.email}."
-      return
-    end
+    Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetching the batch failed for #{channel.email}." if headers.blank?
 
-    batch_message_ids.each do |data|
-      entry = build_message_id_entry(data)
-      next if entry.nil?
-
-      entries.push(entry)
-      break if entries.length >= MAX_MESSAGES_PER_SYNC
-    end
+    headers
   end
 
   def build_message_id_entry(data)

--- a/app/services/imap/base_fetch_email_service.rb
+++ b/app/services/imap/base_fetch_email_service.rb
@@ -52,13 +52,12 @@ class Imap::BaseFetchEmailService
   end
 
   def fetch_mail_for_channel
-    uids = fetch_available_mail_uids
-    entries, inspected_through = collect_message_ids(uids)
-    mails = entries.filter_map { |entry| process_message_id(entry) }
+    collected = collect_message_ids(fetch_available_mail_uids)
+    mails = collected[:entries].filter_map { |entry| process_message_id(entry) }
     # Only after the batch is built, and only through the UID actually looked at. A run
     # that dies halfway leaves the cursor where it was, so the next one re-reads the same
     # range: wasted bandwidth, never a gap.
-    advance_cursor(inspected_through)
+    advance_cursor(collected)
     mails
   end
 
@@ -106,22 +105,32 @@ class Imap::BaseFetchEmailService
     )
   end
 
-  def advance_cursor(inspected_through)
+  def advance_cursor(collected)
     validity = sync_plan[:uid_validity]
     return if validity.blank?
 
     previous = uid_cursor.read
     # A cursor from another UIDVALIDITY generation (or another mailbox) describes UIDs that
-    # no longer exist. Carrying its high-water mark forward would park the new generation
-    # above every real UID, and only the hourly sweep would ever see mail again.
-    carried = reusable_cursor?(previous, validity) ? previous[:last_uid].to_i : 0
-    last_uid = [inspected_through.to_i, carried].max
+    # no longer exist. Carrying anything from it forward would park the new generation above
+    # every real UID, and only the hourly sweep would ever see mail again.
+    reusable = reusable_cursor?(previous, validity)
+    last_uid = [collected[:inspected_through].to_i, reusable ? previous[:last_uid].to_i : 0].max
     return if last_uid.zero?
 
-    # swept_at only moves on a full sweep: it is the clock for "when did we last look at
-    # the whole window", and an incremental run did not.
-    swept_at = sync_plan[:mode] == :full ? Time.current : (previous&.dig(:swept_at) || 0)
-    uid_cursor.write(uid_validity: validity, last_uid: last_uid, swept_at: swept_at, mailbox: mailbox_identity)
+    uid_cursor.write(uid_validity: validity, last_uid: last_uid, mailbox: mailbox_identity,
+                     swept_at: next_swept_at(collected, previous, reusable))
+  end
+
+  # swept_at is the clock for "when did we last look at the whole window", so only a full
+  # sweep that actually reached the end of that window may move it. A sweep cut short by
+  # the message cap did not, and stamping it anyway is what turns a backlog into a one-hour
+  # drip: the cursor can sit above the pending UIDs (it never moves backwards), so the
+  # incremental polls in between cannot see them, and a large enough backlog ages out of
+  # the SINCE window before the sweeps get to it.
+  def next_swept_at(collected, previous, reusable)
+    return Time.current if sync_plan[:mode] == :full && collected[:exhausted]
+
+    reusable ? previous[:swept_at].to_i : 0
   end
 
   def reusable_cursor?(cursor, validity)
@@ -156,11 +165,12 @@ class Imap::BaseFetchEmailService
   # Sends a FETCH command to retrieve data associated with a message in the mailbox.
   # You can send batches of UIDs in `.uid_fetch`.
   #
-  # Returns the entries worth downloading AND the highest UID whose header was actually
-  # inspected. Those are different numbers whenever the cap cuts the run short, and the
-  # cursor has to move by the second one: everything past it was never looked at, so
-  # claiming it would hide those messages from every later incremental poll and leave
-  # only the hourly sweep to find them, 500 at a time, until they age out of the window.
+  # Returns the entries worth downloading, the highest UID whose header was actually
+  # inspected, and whether the run reached the end of what it searched. The first two are
+  # different numbers whenever the cap cuts the run short, and the cursor has to move by
+  # the second one: everything past it was never looked at, so claiming it would hide those
+  # messages from every later incremental poll and leave only the hourly sweep to find
+  # them, 500 at a time, until they age out of the window.
   def collect_message_ids(uids)
     Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{channel.email}, found #{uids.length} " \
                       "(#{sync_plan[:mode]} sync)."
@@ -178,7 +188,9 @@ class Imap::BaseFetchEmailService
       consume_header_batch(batch, collected)
     end
 
-    [collected[:entries], collected[:inspected_through]]
+    # Exactly at the cap counts as "not exhausted": the run cannot tell whether the next UID
+    # existed, and the cost of being wrong is one extra sweep, against a stalled backlog.
+    collected.merge(exhausted: collected[:entries].length < MAX_MESSAGES_PER_SYNC)
   end
 
   # Walks one batch of headers, stopping the moment the sync limit is reached. Whatever is

--- a/app/services/imap/base_fetch_email_service.rb
+++ b/app/services/imap/base_fetch_email_service.rb
@@ -2,6 +2,11 @@ require 'net/imap'
 
 class Imap::BaseFetchEmailService
   MAX_MESSAGES_PER_SYNC = 500
+  # How often the cheap incremental sync gives way to the full date sweep. The sweep is
+  # what catches anything the cursor could have stepped over: a message that failed to
+  # process and got skipped, a UID the server reported out of band, a cursor written by
+  # an older build. One hour bounds that exposure without giving back the savings.
+  FULL_SWEEP_INTERVAL = 1.hour.to_i
 
   pattr_initialize [:channel!, :interval]
 
@@ -30,11 +35,11 @@ class Imap::BaseFetchEmailService
     @imap_client ||= build_imap_client
   end
 
-  def mail_info_logger(inbound_mail, seq_no)
+  def mail_info_logger(inbound_mail, uid)
     return if Rails.env.test?
 
     Rails.logger.info("
-      #{channel.provider} Email id: #{inbound_mail.from} - message_source_id: #{inbound_mail.message_id} - sequence id: #{seq_no}")
+      #{channel.provider} Email id: #{inbound_mail.from} - message_source_id: #{inbound_mail.message_id} - uid: #{uid}")
   end
 
   def email_already_present?(channel, message_id)
@@ -47,25 +52,76 @@ class Imap::BaseFetchEmailService
   end
 
   def fetch_mail_for_channel
-    message_ids_with_seq = fetch_message_ids_with_sequence
-    message_ids_with_seq.filter_map do |message_id_with_seq|
-      process_message_id(message_id_with_seq)
+    uids = fetch_available_mail_uids
+    entries = collect_message_ids(uids)
+    mails = entries.filter_map { |entry| process_message_id(entry) }
+    # Only after the batch is built. A run that dies halfway leaves the cursor where it
+    # was, so the next one re-reads the same range: wasted bandwidth, never a gap.
+    advance_cursor(uids)
+    mails
+  end
+
+  # The cursor turns "list everything since yesterday" (thousands of headers, every
+  # minute, to find a handful of new mails) into "list everything after UID N". The date
+  # sweep still runs on FULL_SWEEP_INTERVAL, and every branch that cannot prove the
+  # cursor still describes this mailbox falls back to it.
+  def sync_plan
+    @sync_plan ||= begin
+      cursor = uid_cursor.read
+      validity = mailbox_uid_validity
+
+      if validity.nil? || cursor.nil? || cursor[:uid_validity] != validity ||
+         Time.current.to_i - cursor[:swept_at].to_i >= FULL_SWEEP_INTERVAL
+        { mode: :full, uid_validity: validity }
+      else
+        { mode: :incremental, uid_validity: validity, from_uid: cursor[:last_uid].to_i + 1 }
+      end
     end
   end
 
-  def process_message_id(message_id_with_seq)
-    seq_no, message_id = message_id_with_seq
+  # UIDVALIDITY is the server's promise that UIDs still mean what they meant last time.
+  # When it changes (or cannot be read at all) every stored UID is meaningless, so the
+  # only safe reading is "no cursor".
+  def mailbox_uid_validity
+    imap_client # selects INBOX
+    @mailbox_uid_validity ||= imap_client.responses('UIDVALIDITY') { |values| values&.last }
+  rescue StandardError => e
+    Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Could not read UIDVALIDITY for #{channel.email}: #{e.message}"
+    nil
+  end
+
+  def uid_cursor
+    @uid_cursor ||= Imap::UidCursor.new(inbox: channel.inbox)
+  end
+
+  def advance_cursor(uids)
+    validity = sync_plan[:uid_validity]
+    return if validity.blank?
+
+    previous = uid_cursor.read
+    last_uid = [uids.max.to_i, previous&.dig(:last_uid).to_i].max
+    return if last_uid.zero?
+
+    # swept_at only moves on a full sweep: it is the clock for "when did we last look at
+    # the whole window", and an incremental run did not.
+    swept_at = sync_plan[:mode] == :full ? Time.current : (previous&.dig(:swept_at) || 0)
+    uid_cursor.write(uid_validity: validity, last_uid: last_uid, swept_at: swept_at)
+  end
+
+  def process_message_id(entry)
+    uid, message_id = entry
 
     if message_id.blank?
-      Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Empty message id for #{channel.email} with seq no. <#{seq_no}>."
+      Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Empty message id for #{channel.email} with uid <#{uid}>."
       return
     end
 
     return if email_already_present?(channel, message_id)
 
-    # Fetch the original mail content using the sequence no.
+    # Fetch the original mail content by UID, which is stable across the connection
+    # unlike the sequence number.
     # BODY.PEEK[] avoids RFC822 parser failures seen with some IMAP servers.
-    mail_str = imap_client.fetch(seq_no, 'BODY.PEEK[]')[0].attr['BODY[]']
+    mail_str = imap_client.uid_fetch(uid, 'BODY.PEEK[]')&.first&.attr&.dig('BODY[]')
 
     if mail_str.blank?
       Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetch failed for #{channel.email} with message-id <#{message_id}>."
@@ -73,33 +129,32 @@ class Imap::BaseFetchEmailService
     end
 
     inbound_mail = build_mail_from_string(mail_str)
-    mail_info_logger(inbound_mail, seq_no)
+    mail_info_logger(inbound_mail, uid)
     inbound_mail
   end
 
   # Sends a FETCH command to retrieve data associated with a message in the mailbox.
-  # You can send batches of message sequence number in `.fetch` method.
-  def fetch_message_ids_with_sequence
-    seq_nums = fetch_available_mail_sequence_numbers
+  # You can send batches of UIDs in `.uid_fetch`.
+  def collect_message_ids(uids)
+    Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{channel.email}, found #{uids.length} " \
+                      "(#{sync_plan[:mode]} sync)."
 
-    Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{channel.email}, found #{seq_nums.length}."
-
-    message_ids_with_seq = []
-    seq_nums.each_slice(MAX_MESSAGES_PER_SYNC).each do |batch|
-      append_message_ids_for_batch(batch, message_ids_with_seq)
-      if message_ids_with_seq.length >= MAX_MESSAGES_PER_SYNC
+    entries = []
+    uids.each_slice(MAX_MESSAGES_PER_SYNC).each do |batch|
+      append_message_ids_for_batch(batch, entries)
+      if entries.length >= MAX_MESSAGES_PER_SYNC
         Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Reached MAX_MESSAGES_PER_SYNC=#{MAX_MESSAGES_PER_SYNC} for #{channel.email}, stopping sync."
         break
       end
     end
 
-    message_ids_with_seq
+    entries
   end
 
-  def append_message_ids_for_batch(batch, message_ids_with_seq)
+  def append_message_ids_for_batch(batch, entries)
     # Fetch only message-id only without mail body or contents.
     Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Starting header batch of #{batch.length} for #{channel.email}"
-    batch_message_ids = imap_client.fetch(batch, 'BODY.PEEK[HEADER]')
+    batch_message_ids = imap_client.uid_fetch(batch, %w[UID BODY.PEEK[HEADER]])
     Rails.logger.info "[IMAP::FETCH_EMAIL_SERVICE] Fetching the batch for #{channel.email}. Found #{batch_message_ids&.length} messages."
 
     # .fetch returns an array of Net::IMAP::FetchData or nil
@@ -113,12 +168,15 @@ class Imap::BaseFetchEmailService
       entry = build_message_id_entry(data)
       next if entry.nil?
 
-      message_ids_with_seq.push(entry)
-      break if message_ids_with_seq.length >= MAX_MESSAGES_PER_SYNC
+      entries.push(entry)
+      break if entries.length >= MAX_MESSAGES_PER_SYNC
     end
   end
 
   def build_message_id_entry(data)
+    uid = data.attr['UID']
+    return nil if uid.blank?
+
     mail = build_mail_from_string(data.attr['BODY[HEADER]'])
     return nil if MailPresenter.new(mail, channel.account).notification_email_from_chatwoot?
 
@@ -126,14 +184,21 @@ class Imap::BaseFetchEmailService
     return nil if message_id.blank?
     return nil if email_already_present?(channel, message_id)
 
-    [data.seqno, message_id]
+    [uid, message_id]
   end
 
-  # Sends a SEARCH command to search the mailbox for messages that were
-  # created between yesterday (or given date) and today and returns message sequence numbers.
-  # Return <message set>
-  def fetch_available_mail_sequence_numbers
-    imap_client.search(['SINCE', since])
+  # Returns the UIDs worth looking at. The incremental branch is the whole point of the
+  # cursor: asking for a UID range costs one small response, while the date branch makes
+  # the server list every message in the window on every run.
+  def fetch_available_mail_uids
+    return imap_client.uid_search(['SINCE', since]) if sync_plan[:mode] == :full
+
+    from = sync_plan[:from_uid]
+    # `N:*` is not "UIDs at or above N". RFC 3501 makes `*` the highest UID in the
+    # mailbox, and a range whose start is above it still matches that highest one, so an
+    # idle mailbox keeps handing back its last message forever. The filter is what makes
+    # the range mean what it reads like.
+    imap_client.uid_search(['UID', "#{from}:*"]).select { |uid| uid >= from }
   end
 
   def build_imap_client

--- a/app/services/imap/uid_cursor.rb
+++ b/app/services/imap/uid_cursor.rb
@@ -18,6 +18,9 @@ class Imap::UidCursor
 
     parsed = JSON.parse(raw).symbolize_keys
     return unless parsed[:uid_validity].present? && parsed[:last_uid].present?
+    # A cursor written before the mailbox fingerprint existed cannot prove which mailbox
+    # it came from, and unprovable is the same as absent here.
+    return if parsed[:mailbox].blank?
 
     parsed
   rescue JSON::ParserError
@@ -26,10 +29,10 @@ class Imap::UidCursor
     nil
   end
 
-  def write(uid_validity:, last_uid:, swept_at:)
+  def write(uid_validity:, last_uid:, swept_at:, mailbox:)
     Redis::Alfred.set(
       key,
-      { uid_validity: uid_validity, last_uid: last_uid, swept_at: swept_at.to_i }.to_json,
+      { uid_validity: uid_validity, last_uid: last_uid, swept_at: swept_at.to_i, mailbox: mailbox }.to_json,
       ex: TTL
     )
   end

--- a/app/services/imap/uid_cursor.rb
+++ b/app/services/imap/uid_cursor.rb
@@ -1,0 +1,46 @@
+# Remembers how far an inbox's mailbox has already been swept, so the next fetch can
+# ask the server for "everything after UID N" instead of re-listing the whole window.
+#
+# This is deliberately a cache and not a column. Losing it costs one expensive sweep,
+# never a message: the date-based sweep it optimises away still runs on a schedule, and
+# `email_already_present?` remains the final net. That asymmetry is what makes the
+# optimisation safe to fail.
+class Imap::UidCursor
+  # A week is long enough that a quiet inbox keeps its cursor across a Redis restart,
+  # and short enough that a channel deleted from Chatwoot does not leak a key forever.
+  TTL = 7.days.to_i
+
+  pattr_initialize [:inbox!]
+
+  def read
+    raw = Redis::Alfred.get(key)
+    return if raw.blank?
+
+    parsed = JSON.parse(raw).symbolize_keys
+    return unless parsed[:uid_validity].present? && parsed[:last_uid].present?
+
+    parsed
+  rescue JSON::ParserError
+    # A malformed cursor is indistinguishable from no cursor, and both mean the same
+    # thing: fall back to the date sweep.
+    nil
+  end
+
+  def write(uid_validity:, last_uid:, swept_at:)
+    Redis::Alfred.set(
+      key,
+      { uid_validity: uid_validity, last_uid: last_uid, swept_at: swept_at.to_i }.to_json,
+      ex: TTL
+    )
+  end
+
+  def clear
+    Redis::Alfred.delete(key)
+  end
+
+  private
+
+  def key
+    format(Redis::RedisKeys::IMAP_UID_CURSOR, inbox_id: inbox.id)
+  end
+end

--- a/lib/redis/redis_keys.rb
+++ b/lib/redis/redis_keys.rb
@@ -4,6 +4,9 @@ module Redis::RedisKeys
   ROUND_ROBIN_AGENTS = 'ROUND_ROBIN_AGENTS:%<inbox_id>d'.freeze
   # Track recently deleted IMAP messages to prevent them from being synced again
   IMAP_DELETED_MESSAGE = 'IMAP_DELETED_MESSAGE::%<inbox_id>d::%<message_id_digest>s'.freeze
+  # How far the mailbox has already been swept, by IMAP UID. A cache, not state:
+  # losing it costs one expensive sweep, never a message.
+  IMAP_UID_CURSOR = 'IMAP_UID_CURSOR::%<inbox_id>d'.freeze
 
   ## Conversation keys
   # Detect whether to send an email reply to the conversation

--- a/spec/services/imap/fetch_email_service_spec.rb
+++ b/spec/services/imap/fetch_email_service_spec.rb
@@ -281,6 +281,31 @@ RSpec.describe Imap::FetchEmailService do
         end
       end
 
+      # The cursor never moves backwards, so a capped sweep can leave pending UIDs below it,
+      # invisible to every incremental poll. Closing the sweep window anyway turns the
+      # backlog into 500 messages an hour, and a big enough one ages out of the SINCE window.
+      it 'does not close the sweep window when the cap cut the full sweep short' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          max = Imap::BaseFetchEmailService::MAX_MESSAGES_PER_SYNC
+          varrido_em = 2.hours.ago.to_i
+          cursor.write(uid_validity: uid_validity, last_uid: 9_999, swept_at: varrido_em, mailbox: mailbox)
+
+          baixos = (1..max).to_a
+          headers = baixos.map do |uid|
+            Net::IMAP::FetchData.new(uid, 'UID' => uid, 'BODY[HEADER]' => eml_content_with_message_id)
+          end
+
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return(baixos + [max + 1, max + 2])
+          allow(imap).to receive(:uid_fetch).with(baixos, %w[UID BODY.PEEK[HEADER]]).and_return(headers)
+          allow(imap).to receive(:uid_fetch).with(anything, 'BODY.PEEK[]').and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(cursor.read[:swept_at]).to eq varrido_em
+        end
+      end
+
       # RFC 3501 does not require SEARCH to answer in ascending order. Slicing the reply as
       # it came would put high UIDs in the first batch, hit the cap there, and park the
       # cursor above UIDs no run ever inspected.

--- a/spec/services/imap/fetch_email_service_spec.rb
+++ b/spec/services/imap/fetch_email_service_spec.rb
@@ -176,12 +176,17 @@ RSpec.describe Imap::FetchEmailService do
 
     context 'when a UID cursor is already recorded' do
       let(:cursor) { Imap::UidCursor.new(inbox: imap_email_channel.inbox) }
+      let(:mailbox) do
+        Digest::SHA256.hexdigest(
+          [imap_email_channel.imap_address, imap_email_channel.imap_port, imap_email_channel.imap_login].join(':')
+        )
+      end
 
       after { cursor.clear }
 
       it 'asks only for UIDs above the cursor instead of re-listing the window' do
         travel_to '26.10.2020 10:00'.to_datetime do
-          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current)
+          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current, mailbox: mailbox)
 
           allow(imap).to receive(:uid_search).with(['UID', Net::IMAP::SequenceSet.new('42:*')]).and_return([])
           allow(imap).to receive(:logout)
@@ -198,7 +203,7 @@ RSpec.describe Imap::FetchEmailService do
       # every run and re-fetch its header forever.
       it 'discards the trailing UID the server returns below the requested range' do
         travel_to '26.10.2020 10:00'.to_datetime do
-          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current)
+          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current, mailbox: mailbox)
 
           allow(imap).to receive(:uid_search).with(['UID', Net::IMAP::SequenceSet.new('42:*')]).and_return([41])
           # Stubbed so the negative expectation below can be asserted at all; the point
@@ -215,7 +220,7 @@ RSpec.describe Imap::FetchEmailService do
 
       it 'falls back to the date sweep when the mailbox reports a new UIDVALIDITY' do
         travel_to '26.10.2020 10:00'.to_datetime do
-          cursor.write(uid_validity: uid_validity - 1, last_uid: 41, swept_at: Time.current)
+          cursor.write(uid_validity: uid_validity - 1, last_uid: 41, swept_at: Time.current, mailbox: mailbox)
 
           allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([])
           allow(imap).to receive(:logout)
@@ -228,7 +233,7 @@ RSpec.describe Imap::FetchEmailService do
 
       it 'falls back to the date sweep once the full sweep interval has elapsed' do
         travel_to '26.10.2020 10:00'.to_datetime do
-          cursor.write(uid_validity: uid_validity, last_uid: 41,
+          cursor.write(uid_validity: uid_validity, last_uid: 41, mailbox: mailbox,
                        swept_at: Time.current - Imap::BaseFetchEmailService::FULL_SWEEP_INTERVAL - 1)
 
           allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([])
@@ -242,7 +247,7 @@ RSpec.describe Imap::FetchEmailService do
 
       it 'keeps the cursor when a run finds nothing, so the next run resumes from it' do
         travel_to '26.10.2020 10:00'.to_datetime do
-          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current)
+          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current, mailbox: mailbox)
 
           allow(imap).to receive(:uid_search).with(['UID', Net::IMAP::SequenceSet.new('42:*')]).and_return([])
           allow(imap).to receive(:logout)
@@ -250,6 +255,61 @@ RSpec.describe Imap::FetchEmailService do
           described_class.new(channel: imap_email_channel).perform
 
           expect(cursor.read).to include(uid_validity: uid_validity, last_uid: 41)
+        end
+      end
+
+      # A cursor that claims UIDs the run never looked at hides them from every later
+      # incremental poll, and only the hourly sweep would find them, 500 at a time.
+      it 'does not advance the cursor past UIDs the sync limit left uninspected' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          max = Imap::BaseFetchEmailService::MAX_MESSAGES_PER_SYNC
+          seen = (1..max).to_a
+          unseen = [max + 1, max + 2]
+          headers = seen.map do |uid|
+            Net::IMAP::FetchData.new(uid, 'UID' => uid, 'BODY[HEADER]' => eml_content_with_message_id)
+          end
+
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return(seen + unseen)
+          allow(imap).to receive(:uid_fetch).with(seen, %w[UID BODY.PEEK[HEADER]]).and_return(headers)
+          allow(imap).to receive(:uid_fetch).with(unseen, %w[UID BODY.PEEK[HEADER]]).and_return([])
+          allow(imap).to receive(:uid_fetch).with(anything, 'BODY.PEEK[]').and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(cursor.read[:last_uid]).to eq max
+        end
+      end
+
+      it 'drops the previous high-water mark when UIDVALIDITY changed' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          cursor.write(uid_validity: uid_validity - 1, last_uid: 9_999, swept_at: Time.current, mailbox: mailbox)
+
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([7])
+          allow(imap).to receive(:uid_fetch).with([7], %w[UID BODY.PEEK[HEADER]])
+                                            .and_return([Net::IMAP::FetchData.new(7, 'UID' => 7,
+                                                                                     'BODY[HEADER]' => eml_content_with_message_id)])
+          allow(imap).to receive(:uid_fetch).with(7, 'BODY.PEEK[]').and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(cursor.read).to include(uid_validity: uid_validity, last_uid: 7)
+        end
+      end
+
+      # UIDVALIDITY is per mailbox, not global, so it cannot tell two accounts apart on
+      # its own. Repointing the channel must not inherit the old account's position.
+      it 'ignores a cursor recorded against a different mailbox' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current, mailbox: 'outra-caixa')
+
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(imap).to have_received(:uid_search).with(%w[SINCE 25-Oct-2020])
         end
       end
     end

--- a/spec/services/imap/fetch_email_service_spec.rb
+++ b/spec/services/imap/fetch_email_service_spec.rb
@@ -281,6 +281,52 @@ RSpec.describe Imap::FetchEmailService do
         end
       end
 
+      # RFC 3501 does not require SEARCH to answer in ascending order. Slicing the reply as
+      # it came would put high UIDs in the first batch, hit the cap there, and park the
+      # cursor above UIDs no run ever inspected.
+      it 'inspects the lowest UIDs first when SEARCH answers out of order' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          max = Imap::BaseFetchEmailService::MAX_MESSAGES_PER_SYNC
+          baixos = (1..max).to_a
+          altos = [max + 1, max + 2]
+          headers = baixos.map do |uid|
+            Net::IMAP::FetchData.new(uid, 'UID' => uid, 'BODY[HEADER]' => eml_content_with_message_id)
+          end
+
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return(altos + baixos)
+          allow(imap).to receive(:uid_fetch).with(baixos, %w[UID BODY.PEEK[HEADER]]).and_return(headers)
+          allow(imap).to receive(:uid_fetch).with(anything, 'BODY.PEEK[]').and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(cursor.read[:last_uid]).to eq max
+          expect(imap).not_to have_received(:uid_fetch).with(altos, %w[UID BODY.PEEK[HEADER]])
+        end
+      end
+
+      # A slice that ends exactly on the cap used to cost one more header FETCH of up to
+      # 500 UIDs that the run had already decided not to read.
+      it 'does not fetch another header batch once the sync limit is already reached' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          max = Imap::BaseFetchEmailService::MAX_MESSAGES_PER_SYNC
+          primeiro = (1..max).to_a
+          segundo = [max + 1]
+          headers = primeiro.map do |uid|
+            Net::IMAP::FetchData.new(uid, 'UID' => uid, 'BODY[HEADER]' => eml_content_with_message_id)
+          end
+
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return(primeiro + segundo)
+          allow(imap).to receive(:uid_fetch).with(primeiro, %w[UID BODY.PEEK[HEADER]]).and_return(headers)
+          allow(imap).to receive(:uid_fetch).with(anything, 'BODY.PEEK[]').and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(imap).not_to have_received(:uid_fetch).with(segundo, %w[UID BODY.PEEK[HEADER]])
+        end
+      end
+
       it 'drops the previous high-water mark when UIDVALIDITY changed' do
         travel_to '26.10.2020 10:00'.to_datetime do
           cursor.write(uid_validity: uid_validity - 1, last_uid: 9_999, swept_at: Time.current, mailbox: mailbox)

--- a/spec/services/imap/fetch_email_service_spec.rb
+++ b/spec/services/imap/fetch_email_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Imap::FetchEmailService do
   let(:imap) { instance_double(Net::IMAP) }
   let(:eml_content_with_message_id) { Rails.root.join('spec/fixtures/files/only_text.eml').read }
   let(:eml_content_without_message_id) { eml_content_with_message_id.sub(/^Message-ID:.*\n/, '') }
+  let(:uid_validity) { 987_654 }
 
   describe '#perform' do
     before do
@@ -19,6 +20,7 @@ RSpec.describe Imap::FetchEmailService do
         'plain', imap_email_channel.imap_login, imap_email_channel.imap_password
       )
       allow(imap).to receive(:select).with('INBOX')
+      allow(imap).to receive(:responses).with('UIDVALIDITY').and_yield([uid_validity])
     end
 
     context 'when using CRAM-MD5 authentication' do
@@ -36,7 +38,7 @@ RSpec.describe Imap::FetchEmailService do
 
       it 'uses CRAM-MD5 authentication' do
         travel_to '26.10.2020 10:00'.to_datetime do
-          allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return([])
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([])
           allow(imap).to receive(:logout)
 
           described_class.new(channel: cram_md5_channel).perform
@@ -63,7 +65,7 @@ RSpec.describe Imap::FetchEmailService do
 
       it 'uses LOGIN authentication' do
         travel_to '26.10.2020 10:00'.to_datetime do
-          allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return([])
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([])
           allow(imap).to receive(:logout)
 
           described_class.new(channel: login_channel).perform
@@ -79,22 +81,23 @@ RSpec.describe Imap::FetchEmailService do
       it 'fetches the emails and returns the emails that are not present in the db' do
         travel_to '26.10.2020 10:00'.to_datetime do
           email_object = create_inbound_email_from_fixture('only_text.eml')
-          email_header = Net::IMAP::FetchData.new(1, 'BODY[HEADER]' => eml_content_with_message_id)
+          email_header = Net::IMAP::FetchData.new(1, 'UID' => 1, 'BODY[HEADER]' => eml_content_with_message_id)
           imap_fetch_mail = Net::IMAP::FetchData.new(1, 'BODY[]' => eml_content_with_message_id)
 
-          allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return([1])
-          allow(imap).to receive(:fetch).with([1], 'BODY.PEEK[HEADER]').and_return([email_header])
-          allow(imap).to receive(:fetch).with(1, 'BODY.PEEK[]').and_return([imap_fetch_mail])
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([1])
+          allow(imap).to receive(:uid_fetch).with([1], %w[UID BODY.PEEK[HEADER]]).and_return([email_header])
+          allow(imap).to receive(:uid_fetch).with(1, 'BODY.PEEK[]').and_return([imap_fetch_mail])
           allow(imap).to receive(:logout)
 
           result = described_class.new(channel: imap_email_channel).perform
 
           expect(result.length).to eq 1
           expect(result[0].message_id).to eq email_object.message_id
-          expect(imap).to have_received(:search).with(%w[SINCE 25-Oct-2020])
-          expect(imap).to have_received(:fetch).with([1], 'BODY.PEEK[HEADER]')
-          expect(imap).to have_received(:fetch).with(1, 'BODY.PEEK[]')
-          expect(logger).to have_received(:info).with("[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{imap_email_channel.email}, found 1.")
+          expect(imap).to have_received(:uid_search).with(%w[SINCE 25-Oct-2020])
+          expect(imap).to have_received(:uid_fetch).with([1], %w[UID BODY.PEEK[HEADER]])
+          expect(imap).to have_received(:uid_fetch).with(1, 'BODY.PEEK[]')
+          expect(logger).to have_received(:info)
+            .with("[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{imap_email_channel.email}, found 1 (full sync).")
           expect(imap).to have_received(:logout)
         end
       end
@@ -104,38 +107,38 @@ RSpec.describe Imap::FetchEmailService do
           email_object = create_inbound_email_from_fixture('only_text.eml')
           create(:message, source_id: email_object.message_id, account: account, inbox: imap_email_channel.inbox)
 
-          email_header = Net::IMAP::FetchData.new(1, 'BODY[HEADER]' => eml_content_with_message_id)
+          email_header = Net::IMAP::FetchData.new(1, 'UID' => 1, 'BODY[HEADER]' => eml_content_with_message_id)
 
-          allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return([1])
-          allow(imap).to receive(:fetch).with([1], 'BODY.PEEK[HEADER]').and_return([email_header])
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([1])
+          allow(imap).to receive(:uid_fetch).with([1], %w[UID BODY.PEEK[HEADER]]).and_return([email_header])
           allow(imap).to receive(:logout)
 
           result = described_class.new(channel: imap_email_channel).perform
 
           expect(result.length).to eq 0
-          expect(imap).to have_received(:search).with(%w[SINCE 25-Oct-2020])
-          expect(imap).to have_received(:fetch).with([1], 'BODY.PEEK[HEADER]')
-          expect(imap).not_to have_received(:fetch).with(1, 'BODY.PEEK[]')
+          expect(imap).to have_received(:uid_search).with(%w[SINCE 25-Oct-2020])
+          expect(imap).to have_received(:uid_fetch).with([1], %w[UID BODY.PEEK[HEADER]])
+          expect(imap).not_to have_received(:uid_fetch).with(1, 'BODY.PEEK[]')
         end
       end
 
       it 'does not return recently deleted emails' do
         travel_to '26.10.2020 10:00'.to_datetime do
           email_object = create_inbound_email_from_fixture('only_text.eml')
-          email_header = Net::IMAP::FetchData.new(1, 'BODY[HEADER]' => eml_content_with_message_id)
+          email_header = Net::IMAP::FetchData.new(1, 'UID' => 1, 'BODY[HEADER]' => eml_content_with_message_id)
           redis_key = format(Redis::RedisKeys::IMAP_DELETED_MESSAGE,
                              inbox_id: imap_email_channel.inbox.id,
                              message_id_digest: Digest::SHA256.hexdigest(email_object.message_id))
 
           Imap::DeletedMessageTracker.new(inbox: imap_email_channel.inbox).record([email_object.message_id])
-          allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return([1])
-          allow(imap).to receive(:fetch).with([1], 'BODY.PEEK[HEADER]').and_return([email_header])
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([1])
+          allow(imap).to receive(:uid_fetch).with([1], %w[UID BODY.PEEK[HEADER]]).and_return([email_header])
           allow(imap).to receive(:logout)
 
           result = described_class.new(channel: imap_email_channel).perform
 
           expect(result).to be_empty
-          expect(imap).not_to have_received(:fetch).with(1, 'RFC822')
+          expect(imap).not_to have_received(:uid_fetch).with(1, 'RFC822')
         ensure
           Redis::Alfred.delete(redis_key) if redis_key
         end
@@ -148,24 +151,118 @@ RSpec.describe Imap::FetchEmailService do
           empty_message_id_seq_nums = (1..max_messages_per_sync).to_a
           valid_message_seq_num = max_messages_per_sync + 1
           empty_message_id_headers = empty_message_id_seq_nums.map do |seq_num|
-            Net::IMAP::FetchData.new(seq_num, 'BODY[HEADER]' => eml_content_without_message_id)
+            Net::IMAP::FetchData.new(seq_num, 'UID' => seq_num, 'BODY[HEADER]' => eml_content_without_message_id)
           end
-          valid_email_header = Net::IMAP::FetchData.new(valid_message_seq_num, 'BODY[HEADER]' => eml_content_with_message_id)
+          valid_email_header = Net::IMAP::FetchData.new(valid_message_seq_num, 'UID' => valid_message_seq_num,
+                                                                               'BODY[HEADER]' => eml_content_with_message_id)
           imap_fetch_mail = Net::IMAP::FetchData.new(valid_message_seq_num, 'BODY[]' => eml_content_with_message_id)
 
-          allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return(empty_message_id_seq_nums + [valid_message_seq_num])
-          allow(imap).to receive(:fetch).with(empty_message_id_seq_nums, 'BODY.PEEK[HEADER]').and_return(empty_message_id_headers)
-          allow(imap).to receive(:fetch).with([valid_message_seq_num], 'BODY.PEEK[HEADER]').and_return([valid_email_header])
-          allow(imap).to receive(:fetch).with(valid_message_seq_num, 'BODY.PEEK[]').and_return([imap_fetch_mail])
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return(empty_message_id_seq_nums + [valid_message_seq_num])
+          allow(imap).to receive(:uid_fetch).with(empty_message_id_seq_nums, %w[UID BODY.PEEK[HEADER]]).and_return(empty_message_id_headers)
+          allow(imap).to receive(:uid_fetch).with([valid_message_seq_num], %w[UID BODY.PEEK[HEADER]]).and_return([valid_email_header])
+          allow(imap).to receive(:uid_fetch).with(valid_message_seq_num, 'BODY.PEEK[]').and_return([imap_fetch_mail])
           allow(imap).to receive(:logout)
 
           result = described_class.new(channel: imap_email_channel).perform
 
           expect(result.length).to eq 1
           expect(result[0].message_id).to eq email_object.message_id
-          expect(imap).to have_received(:fetch).with(empty_message_id_seq_nums, 'BODY.PEEK[HEADER]')
-          expect(imap).to have_received(:fetch).with([valid_message_seq_num], 'BODY.PEEK[HEADER]')
-          expect(imap).to have_received(:fetch).with(valid_message_seq_num, 'BODY.PEEK[]')
+          expect(imap).to have_received(:uid_fetch).with(empty_message_id_seq_nums, %w[UID BODY.PEEK[HEADER]])
+          expect(imap).to have_received(:uid_fetch).with([valid_message_seq_num], %w[UID BODY.PEEK[HEADER]])
+          expect(imap).to have_received(:uid_fetch).with(valid_message_seq_num, 'BODY.PEEK[]')
+        end
+      end
+    end
+
+    context 'when a UID cursor is already recorded' do
+      let(:cursor) { Imap::UidCursor.new(inbox: imap_email_channel.inbox) }
+
+      after { cursor.clear }
+
+      it 'asks only for UIDs above the cursor instead of re-listing the window' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current)
+
+          allow(imap).to receive(:uid_search).with(['UID', '42:*']).and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(imap).to have_received(:uid_search).with(['UID', '42:*'])
+          expect(imap).not_to have_received(:uid_search).with(%w[SINCE 25-Oct-2020])
+        end
+      end
+
+      # `N:*` is not "UIDs at or above N": the server answers with its highest UID even
+      # when that UID is below N, so an idle mailbox would hand back the same message on
+      # every run and re-fetch its header forever.
+      it 'discards the trailing UID the server returns below the requested range' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current)
+
+          allow(imap).to receive(:uid_search).with(['UID', '42:*']).and_return([41])
+          # Stubbed so the negative expectation below can be asserted at all; the point
+          # is that the filter keeps it from ever being called.
+          allow(imap).to receive(:uid_fetch)
+          allow(imap).to receive(:logout)
+
+          result = described_class.new(channel: imap_email_channel).perform
+
+          expect(result).to be_empty
+          expect(imap).not_to have_received(:uid_fetch)
+        end
+      end
+
+      it 'falls back to the date sweep when the mailbox reports a new UIDVALIDITY' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          cursor.write(uid_validity: uid_validity - 1, last_uid: 41, swept_at: Time.current)
+
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(imap).to have_received(:uid_search).with(%w[SINCE 25-Oct-2020])
+        end
+      end
+
+      it 'falls back to the date sweep once the full sweep interval has elapsed' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          cursor.write(uid_validity: uid_validity, last_uid: 41,
+                       swept_at: Time.current - Imap::BaseFetchEmailService::FULL_SWEEP_INTERVAL - 1)
+
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(imap).to have_received(:uid_search).with(%w[SINCE 25-Oct-2020])
+        end
+      end
+
+      it 'keeps the cursor when a run finds nothing, so the next run resumes from it' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current)
+
+          allow(imap).to receive(:uid_search).with(['UID', '42:*']).and_return([])
+          allow(imap).to receive(:logout)
+
+          described_class.new(channel: imap_email_channel).perform
+
+          expect(cursor.read).to include(uid_validity: uid_validity, last_uid: 41)
+        end
+      end
+    end
+
+    context 'when the mailbox does not report a UIDVALIDITY' do
+      it 'sweeps by date instead of trusting a cursor it cannot validate' do
+        travel_to '26.10.2020 10:00'.to_datetime do
+          allow(imap).to receive(:responses).with('UIDVALIDITY').and_yield(nil)
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([])
+          allow(imap).to receive(:logout)
+
+          expect { described_class.new(channel: imap_email_channel).perform }.not_to raise_error
+          expect(imap).to have_received(:uid_search).with(%w[SINCE 25-Oct-2020])
         end
       end
     end

--- a/spec/services/imap/fetch_email_service_spec.rb
+++ b/spec/services/imap/fetch_email_service_spec.rb
@@ -183,12 +183,12 @@ RSpec.describe Imap::FetchEmailService do
         travel_to '26.10.2020 10:00'.to_datetime do
           cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current)
 
-          allow(imap).to receive(:uid_search).with(['UID', '42:*']).and_return([])
+          allow(imap).to receive(:uid_search).with(['UID', Net::IMAP::SequenceSet.new('42:*')]).and_return([])
           allow(imap).to receive(:logout)
 
           described_class.new(channel: imap_email_channel).perform
 
-          expect(imap).to have_received(:uid_search).with(['UID', '42:*'])
+          expect(imap).to have_received(:uid_search).with(['UID', Net::IMAP::SequenceSet.new('42:*')])
           expect(imap).not_to have_received(:uid_search).with(%w[SINCE 25-Oct-2020])
         end
       end
@@ -200,7 +200,7 @@ RSpec.describe Imap::FetchEmailService do
         travel_to '26.10.2020 10:00'.to_datetime do
           cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current)
 
-          allow(imap).to receive(:uid_search).with(['UID', '42:*']).and_return([41])
+          allow(imap).to receive(:uid_search).with(['UID', Net::IMAP::SequenceSet.new('42:*')]).and_return([41])
           # Stubbed so the negative expectation below can be asserted at all; the point
           # is that the filter keeps it from ever being called.
           allow(imap).to receive(:uid_fetch)
@@ -244,7 +244,7 @@ RSpec.describe Imap::FetchEmailService do
         travel_to '26.10.2020 10:00'.to_datetime do
           cursor.write(uid_validity: uid_validity, last_uid: 41, swept_at: Time.current)
 
-          allow(imap).to receive(:uid_search).with(['UID', '42:*']).and_return([])
+          allow(imap).to receive(:uid_search).with(['UID', Net::IMAP::SequenceSet.new('42:*')]).and_return([])
           allow(imap).to receive(:logout)
 
           described_class.new(channel: imap_email_channel).perform

--- a/spec/services/imap/microsoft_fetch_email_service_spec.rb
+++ b/spec/services/imap/microsoft_fetch_email_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Imap::MicrosoftFetchEmailService do
         'XOAUTH2', microsoft_channel.imap_login, microsoft_channel.provider_config['access_token']
       )
       allow(imap).to receive(:select).with('INBOX')
+      allow(imap).to receive(:responses).with('UIDVALIDITY').and_yield([987_654])
 
       allow(Microsoft::RefreshOauthTokenService).to receive(:new).and_return(refresh_token_service)
       allow(refresh_token_service).to receive(:access_token).and_return(microsoft_channel.provider_config['access_token'])
@@ -29,12 +30,12 @@ RSpec.describe Imap::MicrosoftFetchEmailService do
       it 'fetches the emails and returns the emails that are not present in the db' do
         travel_to '26.10.2020 10:00'.to_datetime do
           email_object = create_inbound_email_from_fixture('only_text.eml')
-          email_header = Net::IMAP::FetchData.new(1, 'BODY[HEADER]' => eml_content_with_message_id)
+          email_header = Net::IMAP::FetchData.new(1, 'UID' => 1, 'BODY[HEADER]' => eml_content_with_message_id)
           imap_fetch_mail = Net::IMAP::FetchData.new(1, 'BODY[]' => eml_content_with_message_id)
 
-          allow(imap).to receive(:search).with(%w[SINCE 25-Oct-2020]).and_return([1])
-          allow(imap).to receive(:fetch).with([1], 'BODY.PEEK[HEADER]').and_return([email_header])
-          allow(imap).to receive(:fetch).with(1, 'BODY.PEEK[]').and_return([imap_fetch_mail])
+          allow(imap).to receive(:uid_search).with(%w[SINCE 25-Oct-2020]).and_return([1])
+          allow(imap).to receive(:uid_fetch).with([1], %w[UID BODY.PEEK[HEADER]]).and_return([email_header])
+          allow(imap).to receive(:uid_fetch).with(1, 'BODY.PEEK[]').and_return([imap_fetch_mail])
           allow(imap).to receive(:logout)
 
           result = described_class.new(channel: microsoft_channel).perform
@@ -43,10 +44,11 @@ RSpec.describe Imap::MicrosoftFetchEmailService do
 
           expect(result.length).to eq 1
           expect(result[0].message_id).to eq email_object.message_id
-          expect(imap).to have_received(:search).with(%w[SINCE 25-Oct-2020])
-          expect(imap).to have_received(:fetch).with([1], 'BODY.PEEK[HEADER]')
-          expect(imap).to have_received(:fetch).with(1, 'BODY.PEEK[]')
-          expect(logger).to have_received(:info).with("[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{microsoft_channel.email}, found 1.")
+          expect(imap).to have_received(:uid_search).with(%w[SINCE 25-Oct-2020])
+          expect(imap).to have_received(:uid_fetch).with([1], %w[UID BODY.PEEK[HEADER]])
+          expect(imap).to have_received(:uid_fetch).with(1, 'BODY.PEEK[]')
+          expect(logger).to have_received(:info)
+            .with("[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{microsoft_channel.email}, found 1 (full sync).")
         end
       end
     end
@@ -55,12 +57,12 @@ RSpec.describe Imap::MicrosoftFetchEmailService do
       it 'fetches the emails based on the interval specified in the job' do
         travel_to '26.10.2020 10:00'.to_datetime do
           email_object = create_inbound_email_from_fixture('only_text.eml')
-          email_header = Net::IMAP::FetchData.new(1, 'BODY[HEADER]' => eml_content_with_message_id)
+          email_header = Net::IMAP::FetchData.new(1, 'UID' => 1, 'BODY[HEADER]' => eml_content_with_message_id)
           imap_fetch_mail = Net::IMAP::FetchData.new(1, 'BODY[]' => eml_content_with_message_id)
 
-          allow(imap).to receive(:search).with(%w[SINCE 18-Oct-2020]).and_return([1])
-          allow(imap).to receive(:fetch).with([1], 'BODY.PEEK[HEADER]').and_return([email_header])
-          allow(imap).to receive(:fetch).with(1, 'BODY.PEEK[]').and_return([imap_fetch_mail])
+          allow(imap).to receive(:uid_search).with(%w[SINCE 18-Oct-2020]).and_return([1])
+          allow(imap).to receive(:uid_fetch).with([1], %w[UID BODY.PEEK[HEADER]]).and_return([email_header])
+          allow(imap).to receive(:uid_fetch).with(1, 'BODY.PEEK[]').and_return([imap_fetch_mail])
           allow(imap).to receive(:logout)
 
           result = described_class.new(channel: microsoft_channel, interval: 8).perform
@@ -69,10 +71,11 @@ RSpec.describe Imap::MicrosoftFetchEmailService do
 
           expect(result.length).to eq 1
           expect(result[0].message_id).to eq email_object.message_id
-          expect(imap).to have_received(:search).with(%w[SINCE 18-Oct-2020])
-          expect(imap).to have_received(:fetch).with([1], 'BODY.PEEK[HEADER]')
-          expect(imap).to have_received(:fetch).with(1, 'BODY.PEEK[]')
-          expect(logger).to have_received(:info).with("[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{microsoft_channel.email}, found 1.")
+          expect(imap).to have_received(:uid_search).with(%w[SINCE 18-Oct-2020])
+          expect(imap).to have_received(:uid_fetch).with([1], %w[UID BODY.PEEK[HEADER]])
+          expect(imap).to have_received(:uid_fetch).with(1, 'BODY.PEEK[]')
+          expect(logger).to have_received(:info)
+            .with("[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from #{microsoft_channel.email}, found 1 (full sync).")
         end
       end
     end


### PR DESCRIPTION
## O problema, medido em produção

O poller de e-mail varre `SEARCH SINCE ontem` de minuto em minuto e baixa o cabeçalho de **toda** mensagem da janela antes de descartar as já importadas, porque o `email_already_present?` só age depois que o header chegou.

Medido na caixa de SAC de um cliente:

```
[IMAP::FETCH_EMAIL_SERVICE] Fetching mails from sac@..., found 4917
[IMAP::FETCH_EMAIL_SERVICE] Fetched 5 new emails for inbox 19
```

**4.917 cabeçalhos baixados por passada para encontrar 5 mensagens novas**, a cada minuto. Com o cabeçalho entre 3 e 5 KB, isso dá algo entre 25 e 35 GB por dia, contra o limite de **2,5 GB/dia** do IMAP do Gmail.

A conta estourou e o Gmail passou a recusar. Na última hora antes desta correção: **60 varreduras iniciadas contra 18 concluídas**, todas as demais morrendo em `Account exceeded command or bandwidth limits`. E piorando: 0 erros às 16h, 30 às 17h, 40 às 18h.

Não é regressão nossa. É o algoritmo do upstream encontrando um volume que ele não previa: em 04/09 a janela tinha ~1.400 mensagens, hoje tem 4.900.

## A correção

Um cursor por inbox guarda até onde a caixa já foi lida, e a varredura normal passa a pedir `UID SEARCH UID <último+1>:*`, que custa uma resposta pequena.

**O cursor é cache, não estado, e essa assimetria é o que torna seguro falhar:** perdê-lo custa uma varredura cara, nunca uma mensagem. Por isso mora no Redis e não numa coluna, e por isso toda dúvida cai de volta na varredura por data. São quatro portas de saída: sem cursor, `UIDVALIDITY` diferente, `UIDVALIDITY` ilegível, ou uma hora desde a última varredura completa.

Essa varredura horária é a rede que recupera qualquer mensagem que o cursor tenha passado por cima (uma que falhou no processamento, um UID relatado fora de ordem, um cursor escrito por build anterior), e o `email_already_present?` segue sendo a rede final.

Custo depois da mudança: 24 varreduras completas por dia mais milhares de incrementais baratas, algo em torno de 0,5 GB/dia.

## Duas armadilhas, ambas cobertas por teste

**`N:*` não quer dizer "UIDs a partir de N".** Pela RFC 3501 o `*` é o maior UID da caixa, e um intervalo que começa acima dele ainda casa com esse maior. Sem o filtro, uma caixa parada devolveria a mesma mensagem para sempre e rebaixaria o cabeçalho dela em todo ciclo.

**O cursor só avança depois do lote montado.** Uma execução que morre no meio deixa o cursor onde estava, então a próxima relê o mesmo intervalo: gasta banda, não abre buraco.

## Alcance

Vale para os três provedores. `Imap::GoogleFetchEmailService` e `Imap::MicrosoftFetchEmailService` só trocam a autenticação para XOAUTH2 e herdam a mesma varredura, então trocar de provedor nunca foi saída para esse problema.

## Verificação

- 33 exemplos em `spec/services/imap/` e `spec/jobs/inboxes/`, incluindo 6 novos: incremental em vez de data, descarte do UID abaixo do intervalo, fallback por `UIDVALIDITY` mudado, fallback pelo intervalo de varredura completa, cursor preservado em rodada vazia, e `UIDVALIDITY` ilegível sem exceção.
- `rubocop` limpo.
- **O que os testes não cobrem:** o Gmail de verdade. As semânticas de `uid_search`/`uid_fetch` estão sendo validadas contra a caixa real em paralelo, numa inbox de baixo volume para não consumir a cota da que está limitada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/487)
<!-- Reviewable:end -->