### PR TITLE
fix(whatsapp): escrever a mensagem por cima do placeholder que ela deixou

### DIFF
--- a/app/services/whatsapp/session/inbound/conversation_finder.rb
+++ b/app/services/whatsapp/session/inbound/conversation_finder.rb
@@ -17,6 +17,23 @@ class Whatsapp::Session::Inbound::ConversationFinder
     @reaction_target_id = reaction_target_id
   end
 
+  # When the message reuses an existing thread, what conversation_params would have
+  # persisted on create never lands. Backfill only the keys still missing, so a genuine
+  # first touch is never overwritten by a later one.
+  #
+  # Reachable without a lookup because a caller can already hold the thread: a message
+  # written over the placeholder it left behind has its conversation in hand, and must
+  # not come through `perform` to get here -- that would open a second thread whenever
+  # the first one is resolved.
+  def self.backfill_first_touch(conversation, attribution)
+    return conversation if attribution.blank?
+
+    existing = conversation.additional_attributes || {}
+    missing = attribution.reject { |key, _| existing.key?(key) }
+    conversation.update!(additional_attributes: existing.merge(missing)) if missing.present?
+    conversation
+  end
+
   def perform
     conversation = conversation_for_reaction || conversation_by_inbox_config
     return backfill_first_touch(mark_as_group(conversation)) if conversation
@@ -65,15 +82,5 @@ class Whatsapp::Session::Inbound::ConversationFinder
     conversation
   end
 
-  # When the message reuses an existing thread, what conversation_params would have
-  # persisted on create never lands. Backfill only the keys still missing, so a genuine
-  # first touch is never overwritten by a later one.
-  def backfill_first_touch(conversation)
-    return conversation if attribution.blank?
-
-    existing = conversation.additional_attributes || {}
-    missing = attribution.reject { |key, _| existing.key?(key) }
-    conversation.update!(additional_attributes: existing.merge(missing)) if missing.present?
-    conversation
-  end
+  def backfill_first_touch(conversation) = self.class.backfill_first_touch(conversation, attribution)
 end

--- a/app/services/whatsapp/session/inbound/handlers/message_edited.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_edited.rb
@@ -27,8 +27,22 @@ class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::I
       # The first edit is what the reader wants to compare against, so a second edit
       # does not overwrite the original.
       previous = target.is_edited ? target.previous_content : target.content
+      target.content_attributes = target.content_attributes.except('is_unsupported', 'unsupported_reason') if
+        placeholder?(target)
       target.update!(content: content, is_edited: true, previous_content: previous)
     end
+  end
+
+  # An edit is the first readable body a placeholder's row has had, so that row is no
+  # longer a message nothing could read: leaving the flag on renders the edit as the
+  # unsupported bubble, which shows none of it. It also settles what a delayed recovery
+  # does afterwards -- the original body is stale next to an edit of it, and the marker
+  # is what says the row is still waiting for one.
+  #
+  # Only a placeholder, though. `is_unsupported` also marks media that never arrived, and
+  # a new caption is no answer to bytes that are not coming.
+  def placeholder?(target)
+    target.content_attributes['unsupported_reason'].present?
   end
 
   # By wire type, not by class: a class captured before a reload stops matching and the

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -44,10 +44,27 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   # lands here, and the media it meant to fetch would never be asked for again. The
   # writer decides whether there is anything left to queue.
   def duplicate_of(stored)
-    return :handled if writer_for(stored).reconcile(stored)
+    return recovered(stored) if writer_for(stored).reconcile(stored)
 
     inbound::MessageWriter.fetch_media_for(stored, message)
     :duplicate
+  end
+
+  # What the write path does around a message, for a message that took the long way to
+  # the row it was always going to occupy.
+  #
+  # The attribution is the part only the recovery carries: an undecryptable stanza has no
+  # readable context, so a thread opened by one starts with no ad and no entry point, and
+  # the message that finally arrives is the first and only chance to record them.
+  #
+  # The chat list is refreshed for the reason `ChatList` gives: MESSAGE_UPDATED reaches
+  # the open thread and nothing else, so the card in the list would go on showing the
+  # bubble that could not be read.
+  def recovered(stored)
+    conversation = stored.conversation
+    inbound::ConversationFinder.backfill_first_touch(conversation, attribution)
+    inbound::ChatList.refresh(conversation)
+    :handled
   end
 
   # The row already names the conversation and the sender this message belongs to: it was

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -30,14 +30,31 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
 
   def message = payload.message
 
-  # A message that is already stored is normally nothing to do again. The exception is
-  # the work that was queued after it was saved: an attempt that committed the row and
-  # then failed, most often on the job transport, is retried and lands here, and the
-  # media it meant to fetch would never be asked for again. The writer decides whether
-  # there is anything left to queue.
+  # A message that is already stored is normally nothing to do again. Two things are
+  # not.
+  #
+  # The first is the message the stored row is only a placeholder for. A message the
+  # backend could not decrypt in time is published under the real message's id, and the
+  # message itself arrives later under that same id: read as a duplicate, it leaves the
+  # bubble saying it could not be read forever, over a message whose text is in the
+  # payload that was just dropped.
+  #
+  # The second is the work that was queued after the row was saved: an attempt that
+  # committed the row and then failed, most often on the job transport, is retried and
+  # lands here, and the media it meant to fetch would never be asked for again. The
+  # writer decides whether there is anything left to queue.
   def duplicate_of(stored)
+    return :handled if writer_for(stored).reconcile(stored)
+
     inbound::MessageWriter.fetch_media_for(stored, message)
     :duplicate
+  end
+
+  # The row already names the conversation and the sender this message belongs to: it was
+  # resolved when the placeholder was stored, from the same chat and the same author, and
+  # only the content was ever missing.
+  def writer_for(stored)
+    inbound::MessageWriter.new(conversation: stored.conversation, inbound: message, sender: stored.sender)
   end
 
   def actionable?

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -44,9 +44,8 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   # lands here, and the media it meant to fetch would never be asked for again. The
   # writer decides whether there is anything left to queue.
   def duplicate_of(stored)
-    writer = writer_for(stored)
-    record_first_touch(stored) if writer.reconcilable?(stored)
-    return recovered(stored) if writer.reconcile(stored)
+    record_first_touch(stored)
+    return recovered(stored) if writer_for(stored).reconcile(stored)
 
     inbound::MessageWriter.fetch_media_for(stored, message)
     :duplicate
@@ -56,11 +55,17 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   # readable context, so a thread opened by one starts with no ad and no entry point, and
   # the message that finally arrives is the first and only chance to record them.
   #
-  # Before the content is written, and that ordering is the whole point. Writing the
-  # content is what takes the recovery marker off the row, so a failure after it would
-  # find the redelivery no longer eligible and lose the attribution for good. Failing
-  # here leaves the marker where it is and the redelivery does all of it again, and
-  # re-running this costs nothing: it only fills keys that are still missing.
+  # Asked of every duplicate rather than only of the ones about to be written over, for
+  # two reasons. It is about the conversation and not about the row, so nothing that
+  # happened to the row disqualifies it -- an edit that reached the placeholder first
+  # settles the body and takes the marker off, and the attribution would go down with it.
+  # And it costs nothing to ask: it returns on the spot when the message carries no
+  # attribution, and otherwise fills only the keys that are still missing.
+  #
+  # Before the write, and that ordering is the point. Writing the content is what takes
+  # the recovery marker off the row, so a failure after it would find the redelivery no
+  # longer eligible and lose the attribution for good; failing here leaves the marker
+  # where it is and the redelivery does all of it again.
   def record_first_touch(stored)
     inbound::ConversationFinder.backfill_first_touch(stored.conversation, attribution)
   end

--- a/app/services/whatsapp/session/inbound/handlers/message_received.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_received.rb
@@ -44,26 +44,39 @@ class Whatsapp::Session::Inbound::Handlers::MessageReceived < Whatsapp::Session:
   # lands here, and the media it meant to fetch would never be asked for again. The
   # writer decides whether there is anything left to queue.
   def duplicate_of(stored)
-    return recovered(stored) if writer_for(stored).reconcile(stored)
+    writer = writer_for(stored)
+    record_first_touch(stored) if writer.reconcilable?(stored)
+    return recovered(stored) if writer.reconcile(stored)
 
     inbound::MessageWriter.fetch_media_for(stored, message)
     :duplicate
   end
 
-  # What the write path does around a message, for a message that took the long way to
-  # the row it was always going to occupy.
-  #
   # The attribution is the part only the recovery carries: an undecryptable stanza has no
   # readable context, so a thread opened by one starts with no ad and no entry point, and
   # the message that finally arrives is the first and only chance to record them.
   #
-  # The chat list is refreshed for the reason `ChatList` gives: MESSAGE_UPDATED reaches
-  # the open thread and nothing else, so the card in the list would go on showing the
-  # bubble that could not be read.
+  # Before the content is written, and that ordering is the whole point. Writing the
+  # content is what takes the recovery marker off the row, so a failure after it would
+  # find the redelivery no longer eligible and lose the attribution for good. Failing
+  # here leaves the marker where it is and the redelivery does all of it again, and
+  # re-running this costs nothing: it only fills keys that are still missing.
+  def record_first_touch(stored)
+    inbound::ConversationFinder.backfill_first_touch(stored.conversation, attribution)
+  end
+
+  # MESSAGE_UPDATED reaches the open thread and nothing else, so the card in the list
+  # would go on showing the bubble that could not be read. It reaches no automation
+  # either, and re-firing `message_created` here is not the answer: every rule that does
+  # not filter on content already matched the placeholder and already ran. That is #491.
+  #
+  # After the write rather than before it, unlike the attribution, because losing it
+  # costs a stale preview until the next event touches that conversation rather than a
+  # fact nothing else records. The media enqueue behind `reconcile` is in the same
+  # position and is not lost either way: a redelivery that finds the row already written
+  # queues it through `fetch_media_for`, which is the path that exists for exactly this.
   def recovered(stored)
-    conversation = stored.conversation
-    inbound::ConversationFinder.backfill_first_touch(conversation, attribution)
-    inbound::ChatList.refresh(conversation)
+    inbound::ChatList.refresh(stored.conversation)
     :handled
   end
 

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -36,40 +36,6 @@ class Whatsapp::Session::Inbound::MessageWriter
     Whatsapp::Session::MediaFetchJob.perform_later(message, media.to_h, inbound.chat&.to_h)
   end
 
-  # The reasons a message may still arrive under the id its placeholder was published
-  # with. `unknown_type` and `masked` are not among them: the first is a body that did
-  # arrive and this build has no arm for, and the second is one WhatsApp withholds from
-  # every linked device on purpose.
-  #
-  # `unavailable` is here because it is the one that recovers on its own: WhatsApp answers
-  # a companion device that way for a view-once photo and asks the primary phone to
-  # forward it. It is also not in `Content::Unsupported::REASONS`, which is a dead
-  # constant the connector has moved past -- #490 carries the sync.
-  RECOVERABLE = %w[undecryptable unavailable].freeze
-
-  # Whether `reconcile` would write this message over that row. Asked before the write by
-  # a caller with work of its own to do first; `reconcile` asks it again under the lock,
-  # because a write landing in between is one that could have changed the answer.
-  #
-  # Only a placeholder is replaced, and only by something that is not one.
-  #
-  # Read from the reason and not from `is_unsupported`, because that flag answers a
-  # different question: `MediaFetchJob#give_up`, `MediaDownloadFailed` and the outbound
-  # sender all raise it on messages that arrived intact, and writing content over one of
-  # those would clear a failure the agent is looking at and ask for the bytes again.
-  #
-  # An edit that landed first takes the marker off the row (`MessageEdited#apply`), which
-  # is what stops a delayed recovery from writing the original body over an edit of it.
-  #
-  # A share of contacts is left out on purpose: it writes one row per card, and turning
-  # one row into several is not a correction of that row. It stays the unsupported bubble
-  # it already was, which is the same outcome as before this method existed, and #488
-  # carries the reasoning and the way out.
-  def reconcilable?(message)
-    RECOVERABLE.include?(message.content_attributes['unsupported_reason']) &&
-      content.present? && content_type != 'contacts' && !unsupported?
-  end
-
   # Replaces the placeholder a message left behind with the message itself.
   #
   # A message the backend could not decrypt in time is published as an unsupported
@@ -169,6 +135,38 @@ class Whatsapp::Session::Inbound::MessageWriter
       unsupported_reason: (content.reason if content_type == 'unsupported'),
       rich: (content.to_content_attribute if content_type == 'rich')
     }.compact
+  end
+
+  # The reasons a message may still arrive under the id its placeholder was published
+  # with. `unknown_type` and `masked` are not among them: the first is a body that did
+  # arrive and this build has no arm for, and the second is one WhatsApp withholds from
+  # every linked device on purpose.
+  #
+  # `unavailable` is here because it is the one that recovers on its own: WhatsApp answers
+  # a companion device that way for a view-once photo and asks the primary phone to
+  # forward it. It is also not in `Content::Unsupported::REASONS`, which is a dead
+  # constant the connector has moved past -- #490 carries the sync.
+  RECOVERABLE = %w[undecryptable unavailable].freeze
+
+  # Only a placeholder is replaced, and only by something that is not one.
+  #
+  # Read from the reason and not from `is_unsupported`, because that flag answers a
+  # different question: `MediaFetchJob#give_up`, `MediaDownloadFailed` and the outbound
+  # sender all raise it on messages that arrived intact, and writing content over one of
+  # those would clear a failure the agent is looking at and ask for the bytes again.
+  #
+  # An edit that landed first takes the marker off the row (`MessageEdited#apply`), which
+  # is what stops a delayed recovery from writing the original body over an edit of it.
+  # It also costs that recovery the metadata only it carries, the quoted link and the
+  # rich attributes -- not the attribution, which the caller records either way. #492.
+  #
+  # A share of contacts is left out on purpose: it writes one row per card, and turning
+  # one row into several is not a correction of that row. It stays the unsupported bubble
+  # it already was, which is the same outcome as before this method existed, and #488
+  # carries the reasoning and the way out.
+  def reconcilable?(message)
+    RECOVERABLE.include?(message.content_attributes['unsupported_reason']) &&
+      content.present? && content_type != 'contacts' && !unsupported?
   end
 
   # A rich card with no text and no media header renders as an empty bubble, which is

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -36,6 +36,30 @@ class Whatsapp::Session::Inbound::MessageWriter
     Whatsapp::Session::MediaFetchJob.perform_later(message, media.to_h, inbound.chat&.to_h)
   end
 
+  # Replaces the placeholder a message left behind with the message itself.
+  #
+  # A message the backend could not decrypt in time is published as an unsupported
+  # placeholder carrying the real message's id, and the message that finally arrives
+  # carries that same id -- so it reaches Chatwoot as a duplicate of its own placeholder.
+  # The content is the part that was missing, so the content is what is written over, in
+  # the row that is already there: the bubble the agent is looking at becomes the message,
+  # keeping its id, its place in the thread, and anything that quotes it.
+  #
+  # Answers whether it did, because a caller it says no to still has a duplicate to report.
+  def reconcile(message)
+    return false unless replaces_a_placeholder?(message)
+
+    message.content = message_content
+    message.content_attributes = message.content_attributes.merge(content_attributes.stringify_keys)
+                                        .except('is_unsupported')
+    attach_location(message)
+    message.save!
+    # After the save, as on the writing path: the job takes the row by reference and a
+    # save that raised would have it fetch bytes for content nobody stored.
+    enqueue_media_fetch(message)
+    true
+  end
+
   def perform
     return build_contact_messages if content_type == 'contacts'
 
@@ -96,6 +120,17 @@ class Whatsapp::Session::Inbound::MessageWriter
       is_unsupported: (true if unsupported?),
       rich: (content.to_content_attribute if content_type == 'rich')
     }.compact
+  end
+
+  # Only a placeholder is replaced, and only by something that is not one.
+  #
+  # A share of contacts is left out on purpose: it writes one row per card, and turning
+  # one row into several is not a correction of that row. It stays the unsupported bubble
+  # it already was, which is the same outcome as before this method existed, and #488
+  # carries the reasoning and the way out.
+  def replaces_a_placeholder?(message)
+    message.content_attributes['is_unsupported'].present? &&
+      content.present? && content_type != 'contacts' && !unsupported?
   end
 
   # A rich card with no text and no media header renders as an empty bubble, which is

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -36,6 +36,37 @@ class Whatsapp::Session::Inbound::MessageWriter
     Whatsapp::Session::MediaFetchJob.perform_later(message, media.to_h, inbound.chat&.to_h)
   end
 
+  # The reasons a message may still arrive under the id its placeholder was published
+  # with. `unknown_type` and `masked` are not among them: the first is a body that did
+  # arrive and this build has no arm for, and the second is one WhatsApp withholds from
+  # every linked device on purpose.
+  #
+  # `unavailable` is here because it is the one that recovers on its own: WhatsApp answers
+  # a companion device that way for a view-once photo and asks the primary phone to
+  # forward it. It is also not in `Content::Unsupported::REASONS`, which is a dead
+  # constant the connector has moved past -- #490 carries the sync.
+  RECOVERABLE = %w[undecryptable unavailable].freeze
+
+  # Whether `reconcile` would write this message over that row. Asked before the write by
+  # a caller with work of its own to do first; `reconcile` asks it again under the lock,
+  # because a write landing in between is one that could have changed the answer.
+  #
+  # Only a placeholder is replaced, and only by something that is not one.
+  #
+  # Read from the reason and not from `is_unsupported`, because that flag answers a
+  # different question: `MediaFetchJob#give_up`, `MediaDownloadFailed` and the outbound
+  # sender all raise it on messages that arrived intact, and writing content over one of
+  # those would clear a failure the agent is looking at and ask for the bytes again.
+  #
+  # A share of contacts is left out on purpose: it writes one row per card, and turning
+  # one row into several is not a correction of that row. It stays the unsupported bubble
+  # it already was, which is the same outcome as before this method existed, and #488
+  # carries the reasoning and the way out.
+  def reconcilable?(message)
+    RECOVERABLE.include?(message.content_attributes['unsupported_reason']) &&
+      content.present? && content_type != 'contacts' && !unsupported?
+  end
+
   # Replaces the placeholder a message left behind with the message itself.
   #
   # A message the backend could not decrypt in time is published as an unsupported
@@ -54,7 +85,7 @@ class Whatsapp::Session::Inbound::MessageWriter
     # would be written away by a merge computed off the stale hash, and the eligibility
     # that was true a moment ago is exactly what such a write would have changed.
     message.with_lock do
-      next unless replaces_a_placeholder?(message)
+      next unless reconcilable?(message)
 
       message.content = message_content
       message.content_attributes = message.content_attributes.merge(content_attributes.stringify_keys)
@@ -135,33 +166,6 @@ class Whatsapp::Session::Inbound::MessageWriter
       unsupported_reason: (content.reason if content_type == 'unsupported'),
       rich: (content.to_content_attribute if content_type == 'rich')
     }.compact
-  end
-
-  # The reasons a message may still arrive under the id its placeholder was published
-  # with. `unknown_type` and `masked` are not among them: the first is a body that did
-  # arrive and this build has no arm for, and the second is one WhatsApp withholds from
-  # every linked device on purpose.
-  #
-  # `unavailable` is here because it is the one that recovers on its own: WhatsApp answers
-  # a companion device that way for a view-once photo and asks the primary phone to
-  # forward it. It is also not in `Content::Unsupported::REASONS`, which is a dead
-  # constant the connector has moved past -- #490 carries the sync.
-  RECOVERABLE = %w[undecryptable unavailable].freeze
-
-  # Only a placeholder is replaced, and only by something that is not one.
-  #
-  # Read from the reason and not from `is_unsupported`, because that flag answers a
-  # different question: `MediaFetchJob#give_up`, `MediaDownloadFailed` and the outbound
-  # sender all raise it on messages that arrived intact, and writing content over one of
-  # those would clear a failure the agent is looking at and ask for the bytes again.
-  #
-  # A share of contacts is left out on purpose: it writes one row per card, and turning
-  # one row into several is not a correction of that row. It stays the unsupported bubble
-  # it already was, which is the same outcome as before this method existed, and #488
-  # carries the reasoning and the way out.
-  def replaces_a_placeholder?(message)
-    RECOVERABLE.include?(message.content_attributes['unsupported_reason']) &&
-      content.present? && content_type != 'contacts' && !unsupported?
   end
 
   # A rich card with no text and no media header renders as an empty bubble, which is

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -47,13 +47,24 @@ class Whatsapp::Session::Inbound::MessageWriter
   #
   # Answers whether it did, because a caller it says no to still has a duplicate to report.
   def reconcile(message)
-    return false unless replaces_a_placeholder?(message)
+    written = false
+    # Under the row lock and off the row the lock reloads, which is what every other
+    # writer of this flag does (`Message#update_under_lock!`). `content_attributes` is
+    # one JSON column: a revoke or a media failure landing between the read and the save
+    # would be written away by a merge computed off the stale hash, and the eligibility
+    # that was true a moment ago is exactly what such a write would have changed.
+    message.with_lock do
+      next unless replaces_a_placeholder?(message)
 
-    message.content = message_content
-    message.content_attributes = message.content_attributes.merge(content_attributes.stringify_keys)
-                                        .except('is_unsupported')
-    attach_location(message)
-    message.save!
+      message.content = message_content
+      message.content_attributes = message.content_attributes.merge(content_attributes.stringify_keys)
+                                          .except('is_unsupported', 'unsupported_reason')
+      attach_location(message)
+      message.save!
+      written = true
+    end
+    return false unless written
+
     # After the save, as on the writing path: the job takes the row by reference and a
     # save that raised would have it fetch bytes for content nobody stored.
     enqueue_media_fetch(message)
@@ -118,18 +129,38 @@ class Whatsapp::Session::Inbound::MessageWriter
       in_reply_to_external_id: inbound.quoted_id.presence,
       referral: inbound.referral.presence,
       is_unsupported: (true if unsupported?),
+      # Why there is no body, which is what says whether the message can still turn up.
+      # `is_unsupported` cannot: a media download that gave up raises the same flag on a
+      # message that arrived perfectly well.
+      unsupported_reason: (content.reason if content_type == 'unsupported'),
       rich: (content.to_content_attribute if content_type == 'rich')
     }.compact
   end
 
+  # The reasons a message may still arrive under the id its placeholder was published
+  # with. `unknown_type` and `masked` are not among them: the first is a body that did
+  # arrive and this build has no arm for, and the second is one WhatsApp withholds from
+  # every linked device on purpose.
+  #
+  # `unavailable` is here because it is the one that recovers on its own: WhatsApp answers
+  # a companion device that way for a view-once photo and asks the primary phone to
+  # forward it. It is also not in `Content::Unsupported::REASONS`, which is a dead
+  # constant the connector has moved past -- #490 carries the sync.
+  RECOVERABLE = %w[undecryptable unavailable].freeze
+
   # Only a placeholder is replaced, and only by something that is not one.
+  #
+  # Read from the reason and not from `is_unsupported`, because that flag answers a
+  # different question: `MediaFetchJob#give_up`, `MediaDownloadFailed` and the outbound
+  # sender all raise it on messages that arrived intact, and writing content over one of
+  # those would clear a failure the agent is looking at and ask for the bytes again.
   #
   # A share of contacts is left out on purpose: it writes one row per card, and turning
   # one row into several is not a correction of that row. It stays the unsupported bubble
   # it already was, which is the same outcome as before this method existed, and #488
   # carries the reasoning and the way out.
   def replaces_a_placeholder?(message)
-    message.content_attributes['is_unsupported'].present? &&
+    RECOVERABLE.include?(message.content_attributes['unsupported_reason']) &&
       content.present? && content_type != 'contacts' && !unsupported?
   end
 

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -58,6 +58,9 @@ class Whatsapp::Session::Inbound::MessageWriter
   # sender all raise it on messages that arrived intact, and writing content over one of
   # those would clear a failure the agent is looking at and ask for the bytes again.
   #
+  # An edit that landed first takes the marker off the row (`MessageEdited#apply`), which
+  # is what stops a delayed recovery from writing the original body over an edit of it.
+  #
   # A share of contacts is left out on purpose: it writes one row per card, and turning
   # one row into several is not a correction of that row. It stays the unsupported bubble
   # it already was, which is the same outcome as before this method existed, and #488

--- a/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
@@ -28,6 +28,30 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageEdited do
     expect(message.previous_content).to eq('oi')
   end
 
+  # An edit is the first readable body a placeholder's row has had, so leaving the flag on
+  # renders the edit as the unsupported bubble, which shows none of it.
+  it 'stops calling a placeholder unreadable once the edit gives it a body' do
+    message.update!(content: nil, content_attributes: { 'is_unsupported' => true,
+                                                        'unsupported_reason' => 'undecryptable' })
+
+    expect(dispatch).to eq(:handled)
+
+    expect(message.reload.content).to eq('oi, corrigido')
+    expect(message.content_attributes).not_to include('is_unsupported', 'unsupported_reason')
+  end
+
+  # `is_unsupported` also marks media that never arrived, and a new caption is no answer
+  # to bytes that are not coming: the bubble has to go on saying the attachment is not
+  # coming, or the agent is left waiting for one.
+  it 'leaves a media failure saying the attachment is not coming' do
+    message.update_under_lock!(is_unsupported: true)
+
+    expect(dispatch).to eq(:handled)
+
+    expect(message.reload.content).to eq('oi, corrigido')
+    expect(message.is_unsupported).to be(true)
+  end
+
   it 'keeps the first version across a second edit' do
     dispatch
     described_class.new(

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -466,6 +466,155 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
     end
   end
 
+  # A message the backend could not decrypt in time is published as an unsupported
+  # placeholder carrying the real message's id, and the message itself arrives later under
+  # that same id. Read as a plain duplicate it is dropped, and the bubble saying it could
+  # not be read stays over a message whose text was in the payload that was just dropped.
+  context 'when the message a placeholder stood in for finally arrives' do
+    subject(:recovery) do
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(
+        channel, model::Event.build(model::Events::MessageReceived.new(message: inbound.with(content: recovered)))
+      )
+    end
+
+    let(:content) { model::Content::Unsupported.new(reason: 'undecryptable') }
+    let(:recovered) { model::Content::Text.new(body: 'oi, tudo bem?') }
+
+    before { dispatch }
+
+    def placeholder = inbox.messages.find_by(source_id: '3EB0AAAA0001')
+
+    it 'stores the placeholder under the id of the message it stands in for' do
+      expect(placeholder.is_unsupported).to be(true)
+      expect(placeholder.content).to be_nil
+    end
+
+    # In the row that is already there, so the bubble the agent is looking at becomes the
+    # message and anything quoting it still points at something.
+    it 'writes the message over the placeholder instead of reporting a duplicate' do
+      was = placeholder.id
+
+      expect { expect(recovery).to eq(:handled) }.not_to change(inbox.messages, :count)
+
+      expect(placeholder.id).to eq(was)
+      expect(placeholder.content).to eq('oi, tudo bem?')
+      expect(placeholder.content_attributes).not_to have_key('is_unsupported')
+    end
+
+    # The recovery is the first time the quote is readable: an undecryptable stanza
+    # carries no context to take it from.
+    it 'links the message it quotes, which only the recovery names' do
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(
+        channel,
+        model::Event.build(model::Events::MessageReceived.new(
+                             message: inbound.with(id: '3EB0AAAA0009', content: model::Content::Text.new(body: 'antes'))
+                           ))
+      )
+      quoted = inbox.messages.find_by(source_id: '3EB0AAAA0009')
+
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(
+        channel,
+        model::Event.build(model::Events::MessageReceived.new(
+                             message: inbound.with(content: recovered, quoted_id: '3EB0AAAA0009')
+                           ))
+      )
+
+      expect(placeholder.content_attributes['in_reply_to']).to eq(quoted.id)
+    end
+
+    context 'when what arrives carries media' do
+      let(:recovered) do
+        model::Content::Media.new(
+          kind: 'image', mime: 'image/jpeg', caption: 'olha isso', filename: 'foto.jpg',
+          ref: model::MediaRef.url('https://connector.test/media/abc')
+        )
+      end
+
+      # The fetch stands down for a row marked unsupported, which is what a placeholder
+      # is: without clearing the flag first the bytes would never be asked for.
+      it 'asks for the bytes the placeholder could not carry' do
+        expect(recovery).to eq(:handled)
+
+        expect(placeholder.content).to eq('olha isso')
+        expect(Whatsapp::Session::MediaFetchJob).to have_been_enqueued
+          .with(placeholder, hash_including('kind' => 'image'), hash_including('kind' => 'phone'))
+      end
+
+      # The job takes the row by reference, so a save that raised would have it fetch
+      # bytes for content nobody stored.
+      it 'asks for nothing when the row cannot be written' do
+        allow_any_instance_of(Message).to receive(:save!).and_raise(ActiveRecord::RecordInvalid) # rubocop:disable RSpec/AnyInstance
+
+        expect { recovery }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(Whatsapp::Session::MediaFetchJob).not_to have_been_enqueued
+      end
+    end
+
+    context 'when what arrives is a location' do
+      let(:recovered) { model::Content::Location.new(latitude: -25.42, longitude: -49.27, name: 'Curitiba') }
+
+      it 'attaches the coordinates the bubble renders' do
+        expect(recovery).to eq(:handled)
+
+        attachment = placeholder.attachments.last
+        expect(attachment.file_type).to eq('location')
+        expect(attachment.coordinates_lat).to eq(-25.42)
+      end
+    end
+
+    # The redelivery of the placeholder itself is a duplicate like any other. Replacing a
+    # placeholder with a placeholder would clear the flag and leave an empty bubble.
+    context 'when the redelivery is the placeholder again' do
+      let(:recovered) { model::Content::Unsupported.new(reason: 'undecryptable') }
+
+      it 'leaves it alone' do
+        expect(recovery).to eq(:duplicate)
+
+        expect(placeholder.is_unsupported).to be(true)
+      end
+    end
+
+    # The contract requires content on a message, and nothing checks the contract at
+    # runtime. Written over by nothing, the placeholder would lose its flag and become an
+    # empty bubble, which says less than the one that says it could not be read.
+    context 'when what arrives carries no content at all' do
+      let(:recovered) { nil }
+
+      it 'leaves the placeholder standing' do
+        expect(recovery).to eq(:duplicate)
+
+        expect(placeholder.is_unsupported).to be(true)
+      end
+    end
+
+    # One row cannot become the several a share writes, so this stays the unsupported
+    # bubble it already was. Recorded as #488 rather than silently accepted.
+    context 'when what arrives is a share of contacts' do
+      let(:recovered) { model::Content::Contacts.new(contacts: [{ 'display_name' => 'Carlos Dias' }]) }
+
+      it 'reports a duplicate rather than turning one row into several' do
+        expect(recovery).to eq(:duplicate)
+
+        expect(placeholder.is_unsupported).to be(true)
+        expect(inbox.messages.count).to eq(1)
+      end
+    end
+  end
+
+  # Only a placeholder is written over. A message that is already the message is a
+  # duplicate, and rewriting it would undo whatever has happened to the row since.
+  context 'when a message that was never a placeholder is redelivered' do
+    it 'reports a duplicate and leaves the stored content alone' do
+      expect(dispatch).to eq(:handled)
+      inbox.messages.find_by(source_id: '3EB0AAAA0001').update!(content: 'editada por alguém')
+
+      expect(Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, event)).to eq(:duplicate)
+
+      expect(inbox.messages.find_by(source_id: '3EB0AAAA0001').content).to eq('editada por alguém')
+    end
+  end
+
   context 'with a chat Chatwoot has no place for' do
     let(:chat) { model::Address.new(kind: 'status', id: 'status') }
 

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -679,6 +679,19 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       end
     end
 
+    # Off the wire and not off a hand-built model. Every other example here constructs
+    # `Content::Unsupported` directly, so a reason that arrived under a different key
+    # would leave the marker unwritten, the recovery dead in production, and all of them
+    # green.
+    it 'reads the reason out of the frame the connector actually sends' do
+      frame = Whatsapp::SessionContract.fixture('events', 'message_received_unsupported')
+
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(channel, model::Event.from_frame(frame))
+
+      stored = inbox.messages.find_by(source_id: frame.dig('payload', 'message', 'id'))
+      expect(stored.content_attributes['unsupported_reason']).to eq('undecryptable')
+    end
+
     # An edit can decrypt while the message it edits does not, so it lands on the
     # placeholder and is the first readable body that row has. The original body arriving
     # afterwards is stale next to an edit of it.

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -588,6 +588,72 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       end
     end
 
+    # MESSAGE_UPDATED reaches the open thread and nothing else, so the card in the list
+    # would go on showing the bubble that could not be read until something else touched
+    # that conversation.
+    it 'refreshes the card in the chat list' do
+      conversation = placeholder.conversation
+      conversation.update_columns(updated_at: 1.hour.ago) # rubocop:disable Rails/SkipsModelValidations
+
+      expect { recovery }.to(change { conversation.reload.updated_at })
+    end
+
+    # An undecryptable stanza carries no readable context, so a thread opened by one
+    # starts with no ad and no entry point: the message that finally arrives is the first
+    # and only chance to record them.
+    it 'records the attribution only the recovery carries' do
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(
+        channel,
+        model::Event.build(model::Events::MessageReceived.new(
+                             message: inbound.with(content: recovered, entry_point: 'ad',
+                                                   referral: { 'source_type' => 'ad', 'title' => 'Promo' })
+                           ))
+      )
+
+      attributes = placeholder.conversation.additional_attributes
+      expect(attributes['entry_point']).to eq('ad')
+      expect(attributes['referral']).to include('title' => 'Promo')
+    end
+
+    # `content_attributes` is one JSON column. A revoke or a media failure landing between
+    # the read and the save is written away by a merge computed off the hash that was read
+    # first, which is why every other writer of this column goes under the row lock.
+    it 'keeps what landed on the row while the recovery was on its way' do
+      # A revoke, written the way the revoke handler writes it, landing after the handler
+      # has already read the row.
+      allow(Whatsapp::Session::Inbound::MessageWriter).to receive(:new).and_wrap_original do |original, **kwargs|
+        Message.find(placeholder.id).update_under_lock!(deleted: true)
+        original.call(**kwargs)
+      end
+
+      expect(recovery).to eq(:handled)
+
+      expect(placeholder.content).to eq('oi, tudo bem?')
+      expect(placeholder.content_attributes['deleted']).to be(true)
+    end
+
+    # `is_unsupported` answers a different question: MediaFetchJob#give_up and
+    # MediaDownloadFailed raise it on messages that arrived intact. Writing content over
+    # one of those clears a failure the agent is looking at and asks for the bytes again.
+    context 'when the stored row is a media failure rather than a placeholder' do
+      let(:content) do
+        model::Content::Media.new(kind: 'image', mime: 'image/jpeg', caption: 'olha isso',
+                                  ref: model::MediaRef.url('https://connector.test/media/abc'))
+      end
+      let(:recovered) { content }
+
+      before { placeholder.update_under_lock!(is_unsupported: true) }
+
+      it 'leaves the failure alone' do
+        ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+
+        expect(recovery).to eq(:duplicate)
+
+        expect(placeholder.is_unsupported).to be(true)
+        expect(Whatsapp::Session::MediaFetchJob).not_to have_been_enqueued
+      end
+    end
+
     # One row cannot become the several a share writes, so this stays the unsupported
     # bubble it already was. Recorded as #488 rather than silently accepted.
     context 'when what arrives is a share of contacts' do

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -615,6 +615,31 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       expect(attributes['referral']).to include('title' => 'Promo')
     end
 
+    # Writing the content takes the recovery marker off the row, so anything recorded
+    # only after it is lost for good when the step in between raises: the redelivery
+    # finds the row no longer eligible and never comes back here. The job transport is
+    # its own Redis and goes down on its own schedule, which is that step.
+    it 'records the attribution even when the work after the write raises' do
+      allow(Whatsapp::Session::MediaFetchJob).to receive(:perform_later).and_raise(Redis::CannotConnectError)
+
+      expect do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(
+          channel,
+          model::Event.build(model::Events::MessageReceived.new(
+                               message: inbound.with(
+                                 entry_point: 'ad', referral: { 'source_type' => 'ad', 'title' => 'Promo' },
+                                 content: model::Content::Media.new(
+                                   kind: 'image', mime: 'image/jpeg',
+                                   ref: model::MediaRef.url('https://connector.test/media/abc')
+                                 )
+                               )
+                             ))
+        )
+      end.to raise_error(Redis::CannotConnectError)
+
+      expect(placeholder.conversation.additional_attributes['entry_point']).to eq('ad')
+    end
+
     # `content_attributes` is one JSON column. A revoke or a media failure landing between
     # the read and the save is written away by a merge computed off the hash that was read
     # first, which is why every other writer of this column goes under the row lock.

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -716,6 +716,19 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
 
         expect(placeholder.content).to eq('oi, tudo bem mesmo?')
       end
+
+      # The edit settles the body and takes the recovery marker off the row. The
+      # attribution is not about the row, though, and nothing else ever records it.
+      it 'still records the attribution the recovery carries' do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(
+          channel,
+          model::Event.build(model::Events::MessageReceived.new(
+                               message: inbound.with(content: recovered, entry_point: 'ad')
+                             ))
+        )
+
+        expect(placeholder.conversation.additional_attributes['entry_point']).to eq('ad')
+      end
     end
 
     # One row cannot become the several a share writes, so this stays the unsupported

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -679,6 +679,32 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       end
     end
 
+    # An edit can decrypt while the message it edits does not, so it lands on the
+    # placeholder and is the first readable body that row has. The original body arriving
+    # afterwards is stale next to an edit of it.
+    context 'when an edit landed on the placeholder first' do
+      before do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(
+          channel,
+          model::Event.build(model::Events::MessageEdited.new(
+                               chat: chat, message_id: inbound.id,
+                               content: model::Content::Text.new(body: 'oi, tudo bem mesmo?')
+                             ))
+        )
+      end
+
+      it 'shows the edit rather than the unsupported bubble' do
+        expect(placeholder.content).to eq('oi, tudo bem mesmo?')
+        expect(placeholder.is_unsupported).to be_nil
+      end
+
+      it 'does not let the recovery write the original body over the edit' do
+        expect(recovery).to eq(:duplicate)
+
+        expect(placeholder.content).to eq('oi, tudo bem mesmo?')
+      end
+    end
+
     # One row cannot become the several a share writes, so this stays the unsupported
     # bubble it already was. Recorded as #488 rather than silently accepted.
     context 'when what arrives is a share of contacts' do


### PR DESCRIPTION
Fecha a #484.

## O que acontecia

Uma mensagem que o conector não consegue decifrar dentro da janela de rerequest vira um placeholder `unsupported`, publicado **com o id da mensagem real**. Quando a mensagem finalmente chega, ela chega sob esse mesmo id.

O `MessageReceived` achava a linha e respondia `:duplicate`, e o `duplicate_of` só re-enfileirava mídia:

```ruby
def duplicate_of(stored)
  inbound::MessageWriter.fetch_media_for(stored, message)
  :duplicate
end
```

Resultado: a bolha "não foi possível ler" ficava para sempre, sobre uma mensagem cujo texto estava no payload que acabou de ser descartado.

## Revalidado no HEAD do conector

A premissa não foi assumida da issue. No `internal/engine/whatsmeow/message.go`, uma recuperação **dentro** da janela cancela o placeholder em vez de publicá-lo, com este comentário:

> the placeholder waiting for it is called off rather than published and corrected, because **a client that deduplicates on the id would keep the placeholder and discard this**

Fora da janela, `arrived` devolve `held=true, inTime=false`, o hold é largado e o fluxo **segue** para `s.deliver(protocol.EventMessageReceived, ...)` com o mesmo id. Ou seja: o conector já antecipou exatamente este bug, e o caso tardio é o que ficou descoberto do lado do cliente.

## O conserto

`MessageWriter#reconcile` escreve o conteúdo por cima da linha que já existe. Mesmo id, mesmo lugar na thread, e quem cita continua apontando para algo. A citação faz parte do que é recuperado: um stanza indecifrável não carrega contexto de onde lê-la.

Só um placeholder é sobrescrito, e só por algo que não seja um:

| o que chega | resultado | por quê |
|---|---|---|
| texto, mídia, localização, rich | escrito por cima | é o que faltava |
| o próprio placeholder de novo | `:duplicate` | limpar a flag deixaria bolha vazia |
| share de contatos | `:duplicate` | uma linha não vira várias sem mexer em id que outra linha aponta (#488) |
| sem conteúdo nenhum | `:duplicate` | o contrato exige conteúdo e nada checa o contrato em runtime |
| linha que nunca foi placeholder | `:duplicate` | reescrever desfaria o que aconteceu com a linha desde então |

A ordem `save!` antes de `enqueue_media_fetch` é a mesma do caminho de escrita, e por um motivo: o job pega a linha por referência, então um save que levantou faria ele buscar bytes de um conteúdo que ninguém guardou. Tem teste.

## Testes

43 exemplos no arquivo, 0 falhas. Bateria de mutação de 9 pontos, todas morrem:

| mutação | falhas |
|---|---|
| sem o gancho de `reconcile` | 5 |
| sem checar `is_unsupported` no armazenado | 4 |
| sem `!unsupported?` | 1 |
| sem excluir `contacts` | 1 |
| sem `.except('is_unsupported')` | 2 |
| `enqueue_media_fetch` antes do `save!` | 1 |
| sem `attach_location` | 1 |
| conteúdo não substituído | 2 |
| sem o guarda de conteúdo nulo | 1 |

As 17 falhas em `spec/models/message_spec.rb` (liquidable) e a 1 no backend uazapi são pré-existentes: rodei a base com `git stash` e dão as mesmas 17.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/489)
<!-- Reviewable:end -->
