### PR TITLE
fix(whatsapp): terminar o que a recuperação do placeholder deixa pra trás

### DIFF
--- a/app/services/whatsapp/session/inbound/contact_card.rb
+++ b/app/services/whatsapp/session/inbound/contact_card.rb
@@ -1,0 +1,27 @@
+# Reading one card out of a shared-contact payload.
+#
+# Pure text handling with nothing of the writer's state in it, which is why it is here
+# rather than in `MessageWriter`: the same card is read on the writing path and on the
+# recovery path, and both want the same answer.
+module Whatsapp::Session::Inbound::ContactCard
+  module_function
+
+  # The WhatsApp vCard TEL line is `...;waid=<digits>:<formatted phone>`, so the formatted
+  # number is preferred and the waid digits are the fallback. Same reading the Baileys
+  # layer does, kept so a card with nothing else still lands.
+  def phone_in(vcard)
+    vcard = vcard.to_s
+    vcard[/waid=\d+:\s*([^\r\n]+)/, 1]&.strip.presence || vcard[/waid=(\d+)/, 1].presence
+  end
+
+  def name_in(vcard)
+    vcard.to_s[/^FN[^:]*:\s*([^\r\n]+)/, 1]&.strip.presence
+  end
+
+  def line(name, phone)
+    return name if phone.blank?
+    return phone if name.blank? || name.start_with?('+')
+
+    "#{name} - #{phone}"
+  end
+end

--- a/app/services/whatsapp/session/inbound/handlers/message_edited.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_edited.rb
@@ -27,17 +27,19 @@ class Whatsapp::Session::Inbound::Handlers::MessageEdited < Whatsapp::Session::I
       # The first edit is what the reader wants to compare against, so a second edit
       # does not overwrite the original.
       previous = target.is_edited ? target.previous_content : target.content
-      target.content_attributes = target.content_attributes.except('is_unsupported', 'unsupported_reason') if
-        placeholder?(target)
+      target.content_attributes = target.content_attributes.except('is_unsupported') if placeholder?(target)
       target.update!(content: content, is_edited: true, previous_content: previous)
     end
   end
 
   # An edit is the first readable body a placeholder's row has had, so that row is no
   # longer a message nothing could read: leaving the flag on renders the edit as the
-  # unsupported bubble, which shows none of it. It also settles what a delayed recovery
-  # does afterwards -- the original body is stale next to an edit of it, and the marker
-  # is what says the row is still waiting for one.
+  # unsupported bubble, which shows none of it.
+  #
+  # The recovery marker stays, though, and the two say different things now: the row has a
+  # body and is still missing everything the message carried around it. The delayed
+  # recovery reads that and contributes the rest without touching the body an edit of it
+  # already settled.
   #
   # Only a placeholder, though. `is_unsupported` also marks media that never arrived, and
   # a new caption is no answer to bytes that are not coming.

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -56,12 +56,7 @@ class Whatsapp::Session::Inbound::MessageWriter
     message.with_lock do
       next unless reconcilable?(message)
 
-      message.content = message_content
-      message.content_attributes = message.content_attributes.merge(content_attributes.stringify_keys)
-                                          .except('is_unsupported', 'unsupported_reason')
-      attach_location(message)
-      message.save!
-      written = true
+      written = content_type == 'contacts' ? reconcile_as_a_share(message) : reconcile_in_place(message)
     end
     return false unless written
 
@@ -69,6 +64,72 @@ class Whatsapp::Session::Inbound::MessageWriter
     # save that raised would have it fetch bytes for content nobody stored.
     enqueue_media_fetch(message)
     true
+  end
+
+  def reconcile_in_place(message)
+    # An edit reached the row before the recovery did, and it is the newer body: the one
+    # this message carries is the text that edit superseded. Everything around the body
+    # is still only here, so the row takes that and keeps what it is showing.
+    unless message.is_edited
+      message.content = message_content
+      attach_location(message)
+    end
+    settle(message)
+    message.save!
+    true
+  end
+
+  # A share of one contact becomes that contact, in the row that is already there.
+  #
+  # A share of several does not, and the reason is that the row is not the only thing a
+  # message leaves behind. Chatwoot already ran this message's arrival when the
+  # placeholder landed: it reopened the conversation, moved `waiting_since`, fired the
+  # automations and the notifications. Writing the extra cards as new inbound rows runs
+  # all of that a second time, so a conversation an agent resolved while the message was
+  # late reopens itself, and the rules fire again on a message from an hour ago.
+  #
+  # Backdating them to the placeholder is what makes the thread read right and is also
+  # what makes them unreachable: `MessageFinder` takes the latest page by `created_at`
+  # and pages backwards by `id < before_id`, so a row with a fresh id and an old
+  # timestamp falls out of both once twenty newer messages exist. Not backdating them
+  # splits one share between its own place in the thread and the bottom of it.
+  #
+  # So the several-card share stays the unsupported bubble it already was, which is what
+  # it was before any of this, and #488 carries what the way out would have to solve.
+  #
+  # A share whose cards say nothing readable is not a recovery either: `perform` stores
+  # exactly the unsupported bubble for that, and this row already is one.
+  def reconcile_as_a_share(message)
+    cards = Array(content.contacts).select { |card| readable_card?(card) }
+    return false unless cards.one?
+    return false unless apply_contact_card(message, cards.first)
+
+    settle(message)
+    message.save!
+    true
+  end
+
+  def readable_card?(card)
+    card = card.to_h.stringify_keys
+
+    card['phone'].presence || card['display_name'].presence ||
+      Whatsapp::Session::Inbound::ContactCard.phone_in(card['vcard']) ||
+      Whatsapp::Session::Inbound::ContactCard.name_in(card['vcard'])
+  end
+
+  # What the recovery settles about the row regardless of shape: the attributes the
+  # message carried, and the marker that said the row was still waiting for one.
+  #
+  # `rich` is left out for a row an edit already settled. It describes the body, and the
+  # body is not this message's to describe any more: a card drawn around text the edit
+  # replaced reads worse than no card. Everything else here is about the message's place
+  # rather than its content, which an edit of the body does not move.
+  def settle(message)
+    recovered = content_attributes.stringify_keys
+    recovered = recovered.except('rich') if message.is_edited
+
+    message.content_attributes = message.content_attributes.merge(recovered)
+                                        .except('is_unsupported', 'unsupported_reason')
   end
 
   def perform
@@ -160,13 +221,9 @@ class Whatsapp::Session::Inbound::MessageWriter
   # It also costs that recovery the metadata only it carries, the quoted link and the
   # rich attributes -- not the attribution, which the caller records either way. #492.
   #
-  # A share of contacts is left out on purpose: it writes one row per card, and turning
-  # one row into several is not a correction of that row. It stays the unsupported bubble
-  # it already was, which is the same outcome as before this method existed, and #488
-  # carries the reasoning and the way out.
   def reconcilable?(message)
     RECOVERABLE.include?(message.content_attributes['unsupported_reason']) &&
-      content.present? && content_type != 'contacts' && !unsupported?
+      content.present? && !unsupported?
   end
 
   # A rich card with no text and no media header renders as an empty bubble, which is
@@ -250,41 +307,31 @@ class Whatsapp::Session::Inbound::MessageWriter
   end
 
   def build_contact_message(card)
-    card = card.stringify_keys
+    message = apply_contact_card(conversation.messages.build(**message_attributes), card)
+    return if message.nil?
+
+    message.save!
+    message
+  end
+
+  # Fills a row, new or already stored, with one card. Answers nil for a card that says
+  # nothing, which is what keeps an empty one from taking a row.
+  def apply_contact_card(message, card)
+    card = card.to_h.stringify_keys
     # `display_name` is what the contract calls it. Reading `name` found nothing, so a
     # card with a phone lost its name and a name-only card was dropped entirely, leaving
     # the conversation that had just been opened with no message in it. Both fields are
     # optional on the wire and a card may arrive as nothing but its vCard, which is why
     # that is read too rather than dropping the share.
-    phone = card['phone'].presence || vcard_phone(card['vcard'])
-    name = card['display_name'].presence || vcard_name(card['vcard'])
+    phone = card['phone'].presence || Whatsapp::Session::Inbound::ContactCard.phone_in(card['vcard'])
+    name = card['display_name'].presence || Whatsapp::Session::Inbound::ContactCard.name_in(card['vcard'])
     return if phone.blank? && name.blank?
 
-    message = conversation.messages.build(content: contact_line(name, phone), **message_attributes)
+    message.content = Whatsapp::Session::Inbound::ContactCard.line(name, phone)
     message.attachments.build(
       account_id: inbox.account_id, file_type: :contact,
       fallback_title: phone || name, meta: { firstName: name }.compact
     )
-    message.save!
     message
-  end
-
-  # The WhatsApp vCard TEL line is `...;waid=<digits>:<formatted phone>`, so the
-  # formatted number is preferred and the waid digits are the fallback. Same reading the
-  # Baileys layer does, kept here so a card with nothing else still lands.
-  def vcard_phone(vcard)
-    vcard = vcard.to_s
-    vcard[/waid=\d+:\s*([^\r\n]+)/, 1]&.strip.presence || vcard[/waid=(\d+)/, 1].presence
-  end
-
-  def vcard_name(vcard)
-    vcard.to_s[/^FN[^:]*:\s*([^\r\n]+)/, 1]&.strip.presence
-  end
-
-  def contact_line(name, phone)
-    return name if phone.blank?
-    return phone if name.blank? || name.start_with?('+')
-
-    "#{name} - #{phone}"
   end
 end

--- a/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_edited_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageEdited do
   end
 
   # An edit is the first readable body a placeholder's row has had, so leaving the flag on
-  # renders the edit as the unsupported bubble, which shows none of it.
+  # renders the edit as the unsupported bubble, which shows none of it. The recovery
+  # marker stays: the row has a body now and is still missing what the message carried
+  # around it, which only the delayed recovery has.
   it 'stops calling a placeholder unreadable once the edit gives it a body' do
     message.update!(content: nil, content_attributes: { 'is_unsupported' => true,
                                                         'unsupported_reason' => 'undecryptable' })
@@ -37,7 +39,8 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageEdited do
     expect(dispatch).to eq(:handled)
 
     expect(message.reload.content).to eq('oi, corrigido')
-    expect(message.content_attributes).not_to include('is_unsupported', 'unsupported_reason')
+    expect(message.content_attributes).not_to have_key('is_unsupported')
+    expect(message.content_attributes['unsupported_reason']).to eq('undecryptable')
   end
 
   # `is_unsupported` also marks media that never arrived, and a new caption is no answer

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -482,7 +482,10 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
 
     before { dispatch }
 
-    def placeholder = inbox.messages.find_by(source_id: '3EB0AAAA0001')
+    # By id, and `reorder` rather than `order`: `Message` carries a `created_at` default
+    # scope, and a recovered share gives its cards the placeholder's own timestamp, so
+    # ordering by that alone leaves which row comes back up to the database.
+    def placeholder = inbox.messages.where(source_id: '3EB0AAAA0001').reorder(:id).first
 
     it 'stores the placeholder under the id of the message it stands in for' do
       expect(placeholder.is_unsupported).to be(true)
@@ -712,9 +715,48 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       end
 
       it 'does not let the recovery write the original body over the edit' do
-        expect(recovery).to eq(:duplicate)
+        expect(recovery).to eq(:handled)
 
         expect(placeholder.content).to eq('oi, tudo bem mesmo?')
+      end
+
+      # Everything around the body is still only on the recovery: an undecryptable stanza
+      # carries no context, so the quote is unreadable until the message itself arrives.
+      it 'still takes what the recovery carries around the body' do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(
+          channel,
+          model::Event.build(model::Events::MessageReceived.new(
+                               message: inbound.with(id: '3EB0AAAA0009', content: model::Content::Text.new(body: 'antes'))
+                             ))
+        )
+        quoted = inbox.messages.find_by(source_id: '3EB0AAAA0009')
+
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(
+          channel,
+          model::Event.build(model::Events::MessageReceived.new(
+                               message: inbound.with(content: recovered, quoted_id: '3EB0AAAA0009')
+                             ))
+        )
+
+        expect(placeholder.content).to eq('oi, tudo bem mesmo?')
+        expect(placeholder.content_attributes['in_reply_to']).to eq(quoted.id)
+        expect(placeholder.content_attributes).not_to have_key('unsupported_reason')
+      end
+
+      # `rich` describes the body, and the body is not this message's to describe any
+      # more: a card drawn around text the edit replaced reads worse than no card.
+      it 'leaves the rich card out, because the body it describes is gone' do
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(
+          channel,
+          model::Event.build(model::Events::MessageReceived.new(
+                               message: inbound.with(content: model::Content::Rich.new(
+                                 kind: 'button', title: 'Pedido #4312', body: 'Seu pedido saiu para entrega'
+                               ))
+                             ))
+        )
+
+        expect(placeholder.content).to eq('oi, tudo bem mesmo?')
+        expect(placeholder.content_attributes).not_to have_key('rich')
       end
 
       # The edit settles the body and takes the recovery marker off the row. The
@@ -731,12 +773,59 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
       end
     end
 
-    # One row cannot become the several a share writes, so this stays the unsupported
-    # bubble it already was. Recorded as #488 rather than silently accepted.
-    context 'when what arrives is a share of contacts' do
-      let(:recovered) { model::Content::Contacts.new(contacts: [{ 'display_name' => 'Carlos Dias' }]) }
+    # A share of one contact becomes that contact, in the row that is already there.
+    context 'when what arrives is a share of one contact' do
+      let(:recovered) do
+        model::Content::Contacts.new(contacts: [{ 'display_name' => 'Carlos Dias', 'phone' => '+5541988881111' }])
+      end
 
-      it 'reports a duplicate rather than turning one row into several' do
+      it 'turns the placeholder into the card' do
+        expect(recovery).to eq(:handled)
+
+        expect(placeholder.content).to eq('Carlos Dias - +5541988881111')
+        expect(placeholder.content_attributes).not_to have_key('is_unsupported')
+        expect(placeholder.attachments.last.file_type).to eq('contact')
+        expect(inbox.messages.count).to eq(1)
+      end
+
+      # A card that says nothing takes no row on the writing path either, so a share
+      # carrying one real contact next to a malformed one is still a share of one.
+      context 'when the other cards say nothing' do
+        let(:recovered) do
+          model::Content::Contacts.new(contacts: [{ 'vcard' => 'BEGIN:VCARD\\nEND:VCARD' },
+                                                  { 'display_name' => 'Bruno Lima', 'phone' => '+5541977776666' }])
+        end
+
+        it 'takes the card that says something' do
+          expect(recovery).to eq(:handled)
+
+          expect(placeholder.content).to eq('Bruno Lima - +5541977776666')
+          expect(inbox.messages.count).to eq(1)
+        end
+      end
+    end
+
+    # A share of several would have to write rows whose arrival Chatwoot already ran when
+    # the placeholder landed, and backdating them into the thread puts them where
+    # `MessageFinder` cannot page back to. #488 carries both.
+    context 'when what arrives is a share of several contacts' do
+      let(:recovered) do
+        model::Content::Contacts.new(contacts: [{ 'display_name' => 'Carlos Dias', 'phone' => '+5541988881111' },
+                                                { 'display_name' => 'Bruno Lima', 'phone' => '+5541977776666' }])
+      end
+
+      it 'leaves the placeholder standing rather than writing rows beside it' do
+        expect(recovery).to eq(:duplicate)
+
+        expect(placeholder.is_unsupported).to be(true)
+        expect(inbox.messages.count).to eq(1)
+      end
+    end
+
+    context 'when nothing in the recovered share can be read' do
+      let(:recovered) { model::Content::Contacts.new(contacts: [{ 'vcard' => 'BEGIN:VCARD\\nEND:VCARD' }]) }
+
+      it 'leaves the placeholder standing' do
         expect(recovery).to eq(:duplicate)
 
         expect(placeholder.is_unsupported).to be(true)


### PR DESCRIPTION
Fecha a #492. A #488 fica **parcialmente** resolvida e continua aberta, com o porquê registrado lá.

## O share de contatos

Um share **de um contato** vira aquele contato, na linha que já existe. Antes a bolha continuava dizendo que a mensagem não pôde ser lida com o cartão no payload que acabou de ser descartado. Cartão que não diz nada não toma linha no caminho de escrita também, então um share com um contato real ao lado de um malformado ainda é um share de um.

Um share **de vários** continua como estava, e essa é a parte que vale registrar. Minha primeira versão escrevia o placeholder como primeiro cartão e os demais como linhas novas ao lado. A revisão derrubou isso por dois motivos, e os dois são o mesmo mal-entendido: uma linha não é a única coisa que uma mensagem deixa.

- **A chegada já foi processada.** Quando o placeholder caiu, o Chatwoot reabriu a conversa, mexeu no `waiting_since` e disparou automações e notificações. Escrever os cartões extras como mensagem de entrada roda tudo de novo: uma conversa que o agente resolveu enquanto a mensagem estava atrasada se reabre sozinha.
- **E não dá pra colocá-las no lugar certo da thread.** Retrodatar pro `created_at` do placeholder é o que faz a thread ler certo e é o que torna as linhas inalcançáveis: o `MessageFinder` pega a última página por `created_at` e pagina pra trás por `id < before_id`, então id novo com timestamp velho cai fora das duas assim que existirem vinte mensagens mais novas.

A #488 tem as duas saídas possíveis e o custo de cada uma.

## A edição que chega antes (#492)

Uma edição consegue decifrar mesmo quando a mensagem que ela edita não, e ela tirava o marcador de recuperação junto com a flag de unsupported. Isso resolvia o corpo certo e jogava fora tudo em volta: a citação, que um stanza indecifrável não carrega e só a recuperação sabe, e a atribuição de anúncio.

A flag e o marcador agora dizem coisas diferentes: a linha **tem corpo** e **continua faltando o resto**. A edição limpa só a flag, e a recuperação contribui o resto sem tocar no corpo.

O `rich` fica de fora numa linha já editada: ele descreve o corpo, e um card desenhado em volta de um texto que a edição substituiu lê pior que card nenhum.

## De passagem

A leitura de vCard virou `Inbound::ContactCard`. Não tem nada do estado do writer, os dois caminhos querem a mesma resposta, e o `MessageWriter` tinha passado do limite de tamanho de classe.

## Testes

162 exemplos nos handlers, 1507 na suíte de WhatsApp, 0 falhas, com seeds fixos além do aleatório.

Um teste meu saiu flaky e a causa era minha: com os cartões compartilhando `created_at`, um `find_by` sob o default scope de `created_at` deixava a escolha da linha pro banco, e o teste às vezes lia a irmã em vez do placeholder. Reproduzido com `--seed 1001`, agora lê pelo menor id.