### PR TITLE
fix(whatsapp): gravar quem a WhatsApp diz que escreveu, e apagar por isso

### DIFF
--- a/app/services/whatsapp/session/inbound/contact_card.rb
+++ b/app/services/whatsapp/session/inbound/contact_card.rb
@@ -18,6 +18,15 @@ module Whatsapp::Session::Inbound::ContactCard
     vcard.to_s[/^FN[^:]*:\s*([^\r\n]+)/, 1]&.strip.presence
   end
 
+  # Whether a card says anything a row could show. A card that says nothing takes no row
+  # on the writing path, so it does not make a share of one into a share of several.
+  def readable?(card)
+    card = card.to_h.stringify_keys
+
+    card['phone'].presence || card['display_name'].presence ||
+      phone_in(card['vcard']) || name_in(card['vcard'])
+  end
+
   def line(name, phone)
     return name if phone.blank?
     return phone if name.blank? || name.start_with?('+')

--- a/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
+++ b/app/services/whatsapp/session/inbound/handlers/message_revoked.rb
@@ -46,9 +46,44 @@ class Whatsapp::Session::Inbound::Handlers::MessageRevoked < Whatsapp::Session::
   # contact would refuse every deletion of a message Chatwoot itself sent.
   def claims_the_author_of?(target)
     return true if payload.message_author.blank?
+
+    # What the row itself recorded about who wrote it, which is the only answer that does
+    # not move: an agent editing the contact's phone, or a merge rewriting it, changes
+    # what the contact answers to without changing who wrote the message.
+    stored = target.content_attributes['external_author']
+    if stored.present?
+      return true if same_party?(stored, payload.message_author)
+      # A snapshot answers only in the namespaces it holds, and the contract lets an event
+      # carry just one: a message that arrived naming its author by LID alone cannot say
+      # anything about a claim that names them by phone alone. Unanswered, not refused,
+      # or a valid deletion would be turned down by a snapshot that never knew.
+      return false if answerable?(stored, payload.message_author)
+    end
+
+    # Rows written before this was recorded, or a claim the snapshot cannot speak to,
+    # which have only the contact to go on.
     return claims_the_connected_account? unless target.sender.is_a?(::Contact)
 
     answers_to_the_claim?(target.sender)
+  end
+
+  # Whether the snapshot and the claim meet in a namespace both of them name, which is
+  # what makes a mismatch a real answer rather than a gap.
+  def answerable?(stored, claimed)
+    (claimed.lid.present? && stored['lid'].present?) ||
+      (claimed.phone.present? && stored['phone'].present?)
+  end
+
+  # One namespace at a time, for the reason `answers_to_the_claim?` gives: WhatsApp treats
+  # a LID and a phone as different identities even when their digits are equal, and the
+  # claim is written by whoever sent the deletion.
+  def same_party?(stored, claimed)
+    return true if claimed.lid.present? && stored['lid'].to_s == claimed.lid
+
+    numbers = Whatsapp::Session::PhoneMatch.variants(claimed.phone)
+    written = Whatsapp::Session::PhoneMatch.digits(stored['phone'])
+
+    written.present? && numbers.include?(written)
   end
 
   # Asked of the stored author rather than resolved into one. `ContactLookup` picks a

--- a/app/services/whatsapp/session/inbound/message_writer.rb
+++ b/app/services/whatsapp/session/inbound/message_writer.rb
@@ -100,21 +100,13 @@ class Whatsapp::Session::Inbound::MessageWriter
   # A share whose cards say nothing readable is not a recovery either: `perform` stores
   # exactly the unsupported bubble for that, and this row already is one.
   def reconcile_as_a_share(message)
-    cards = Array(content.contacts).select { |card| readable_card?(card) }
+    cards = Array(content.contacts).select { |card| Whatsapp::Session::Inbound::ContactCard.readable?(card) }
     return false unless cards.one?
     return false unless apply_contact_card(message, cards.first)
 
     settle(message)
     message.save!
     true
-  end
-
-  def readable_card?(card)
-    card = card.to_h.stringify_keys
-
-    card['phone'].presence || card['display_name'].presence ||
-      Whatsapp::Session::Inbound::ContactCard.phone_in(card['vcard']) ||
-      Whatsapp::Session::Inbound::ContactCard.name_in(card['vcard'])
   end
 
   # What the recovery settles about the row regardless of shape: the attributes the
@@ -127,9 +119,21 @@ class Whatsapp::Session::Inbound::MessageWriter
   def settle(message)
     recovered = content_attributes.stringify_keys
     recovered = recovered.except('rich') if message.is_edited
+    recovered['external_author'] = every_alias_seen(message, recovered['external_author'])
 
-    message.content_attributes = message.content_attributes.merge(recovered)
+    message.content_attributes = message.content_attributes.merge(recovered.compact)
                                         .except('is_unsupported', 'unsupported_reason')
+  end
+
+  # The union of what the placeholder was told and what the message itself carries. The
+  # contract lets each of them name the author by one alias, and they need not be the
+  # same one, so a plain merge of the two hashes would drop whichever the recovery did
+  # not repeat -- and a later deletion naming that one would be back to asking the
+  # contact, which is the question this field exists to stop asking.
+  def every_alias_seen(message, recovered)
+    seen = message.content_attributes['external_author'].to_h.merge(recovered.to_h)
+
+    seen.compact.presence
   end
 
   def perform
@@ -187,6 +191,12 @@ class Whatsapp::Session::Inbound::MessageWriter
       # itself sent was matched by its reserved id and never reaches this writer.
       external_echo: (true unless incoming?),
       external_sender_name: ('WhatsApp' unless incoming?),
+      # Who WhatsApp says wrote this, kept as WhatsApp names them rather than as whichever
+      # contact row happens to hold them today. A deletion's key names an author and the
+      # comparison has to survive an agent editing the contact's phone or a merge
+      # rewriting it, both of which move what the contact answers to without moving who
+      # wrote the message.
+      external_author: author_identity,
       in_reply_to_external_id: inbound.quoted_id.presence,
       referral: inbound.referral.presence,
       is_unsupported: (true if unsupported?),
@@ -224,6 +234,17 @@ class Whatsapp::Session::Inbound::MessageWriter
   def reconcilable?(message)
     RECOVERABLE.include?(message.content_attributes['unsupported_reason']) &&
       content.present? && !unsupported?
+  end
+
+  # Both namespaces, because WhatsApp names the same person by phone in one event and by
+  # LID in the next, and a reader has to be able to answer in whichever the question
+  # arrives in. Absent when the event named nobody, which a direct chat's own message can
+  # be: there the chat is the author and nothing else has to say so.
+  def author_identity
+    party = inbound.sender
+    return if party.blank?
+
+    { 'phone' => party.phone, 'lid' => party.lid }.compact.presence
   end
 
   # A rich card with no text and no media header renders as an empty bubble, which is

--- a/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_received_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
     )
   end
 
+  # A deletion's key names an author, and the comparison has to survive an agent editing
+  # the contact's phone or a merge rewriting it: both move what the contact answers to
+  # without moving who wrote the message.
+  it 'records who WhatsApp says wrote the message' do
+    dispatch
+
+    stored = inbox.messages.find_by(source_id: '3EB0AAAA0001').content_attributes['external_author']
+    expect(stored).to eq('phone' => '5541999990000', 'lid' => '182736451928374')
+  end
+
   it 'creates the contact behind the message' do
     dispatch
 
@@ -576,6 +586,26 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageReceived do
 
         expect(placeholder.is_unsupported).to be(true)
       end
+    end
+
+    # The contract lets the placeholder and the message name the author by one alias each,
+    # and they need not be the same one. Whatever the recovery did not repeat would be
+    # dropped, and a deletion naming that alias would be back to asking the contact.
+    it 'keeps every alias either half of the message named the author by' do
+      placeholder.update!(content_attributes: placeholder.content_attributes.merge(
+        'external_author' => { 'lid' => '182736451928374' }
+      ))
+
+      Whatsapp::Session::Inbound::Dispatcher.dispatch(
+        channel,
+        model::Event.build(model::Events::MessageReceived.new(
+                             message: inbound.with(content: recovered,
+                                                   sender: model::Party.new(phone: '5541999990000'))
+                           ))
+      )
+
+      expect(placeholder.content_attributes['external_author'])
+        .to eq('lid' => '182736451928374', 'phone' => '5541999990000')
     end
 
     # The contract requires content on a message, and nothing checks the contract at

--- a/spec/services/whatsapp/session/inbound/handlers/message_revoked_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/message_revoked_spec.rb
@@ -210,6 +210,121 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::MessageRevoked do
       end
     end
 
+    # What the row recorded about who wrote it, which is the only answer that does not
+    # move. A contact is what the person is called here today; the identity is what
+    # WhatsApp called them when the message arrived.
+    context 'when the row recorded who wrote it' do
+      let(:writer) do
+        contact = create(:contact, account: channel.account, phone_number: '+5541988887777',
+                                   identifier: '998877665544332@lid')
+        create(:contact_inbox, contact: contact, inbox: inbox, source_id: '998877665544332')
+        contact
+      end
+      let(:message) do
+        create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                         content: 'mensagem original', source_id: '3EB0AAAA0001',
+                         message_type: :incoming, sender: writer,
+                         content_attributes: { 'external_author' => { 'phone' => '5541988887777',
+                                                                      'lid' => '998877665544332' } })
+      end
+
+      it 'applies the deletion after an agent edited the contact out of recognition' do
+        writer.update!(phone_number: '+5541900000000', identifier: nil)
+
+        expect(dispatch).to eq(:handled)
+
+        expect(message.reload.deleted_by_contact).to be(true)
+      end
+
+      # The recorded identity wins, or it would only ever be a second chance to match and
+      # never a correction of the first.
+      it 'refuses a claim the row does not name, whatever the contact answers to now' do
+        writer.update!(phone_number: '+5541977776666', identifier: '111222333444555@lid')
+
+        Whatsapp::Session::Inbound::Dispatcher.dispatch(
+          channel,
+          model::Event.build(model::Events::MessageRevoked.new(
+                               chat: model::Address.group('120363041234567890'), message_id: message.source_id,
+                               message_author: model::Party.new(phone: '5541977776666', lid: '111222333444555'),
+                               by: 'contact'
+                             ))
+        )
+
+        expect(message.reload.deleted_by_contact).to be_nil
+      end
+
+      # The contract lets an event carry just one of the two, so a snapshot can hold a
+      # namespace the claim does not use. It answers in the ones it holds and stays out of
+      # the way in the others, or a valid deletion would be turned down by a record that
+      # never knew.
+      context 'when the claim names an alias the row never recorded' do
+        let(:message) do
+          create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                           content: 'mensagem original', source_id: '3EB0AAAA0001',
+                           message_type: :incoming, sender: writer,
+                           content_attributes: { 'external_author' => { 'lid' => '998877665544332' } })
+        end
+        let(:claimed) { model::Party.new(phone: '5541988887777') }
+
+        it 'falls back to the contact rather than refusing' do
+          expect(dispatch).to eq(:handled)
+
+          expect(message.reload.deleted_by_contact).to be(true)
+        end
+      end
+
+      # The fallback the snapshot steps aside for is the namespaced one, so the digits of
+      # a LID are still not a phone number there either.
+      context 'when the claim wears the recorded LID as a phone the row never saw' do
+        let(:writer) { create(:contact, account: channel.account, identifier: '998877665544332@lid') }
+        let(:message) do
+          create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                           content: 'mensagem original', source_id: '3EB0AAAA0001',
+                           message_type: :incoming, sender: writer,
+                           content_attributes: { 'external_author' => { 'lid' => '998877665544332' } })
+        end
+        let(:claimed) { model::Party.new(phone: '998877665544332') }
+
+        it 'leaves the message alone' do
+          expect(dispatch).to eq(:ignored)
+
+          expect(message.reload.deleted_by_contact).to be_nil
+        end
+      end
+
+      # The phone half of that decides on its own: a snapshot holding only a number still
+      # answers a claim that names only a number, and answering is the whole point when
+      # the contact has since been edited into agreeing with the claim.
+      context 'when the row recorded only a number and the claim names another' do
+        let(:writer) { create(:contact, account: channel.account, phone_number: '+5541988887777') }
+        let(:message) do
+          create(:message, conversation: conversation, inbox: inbox, account: channel.account,
+                           content: 'mensagem original', source_id: '3EB0AAAA0001',
+                           message_type: :incoming, sender: writer,
+                           content_attributes: { 'external_author' => { 'phone' => '5541988887777' } })
+        end
+        let(:claimed) { model::Party.new(phone: '5541977776666') }
+
+        it 'refuses it even once the contact answers to that number' do
+          writer.update!(phone_number: '+5541977776666')
+
+          expect(dispatch).to eq(:ignored)
+
+          expect(message.reload.deleted_by_contact).to be_nil
+        end
+      end
+
+      context 'when the claim names a phone whose digits are the recorded LID' do
+        let(:claimed) { model::Party.new(phone: '998877665544332') }
+
+        it 'leaves the message alone' do
+          expect(dispatch).to eq(:ignored)
+
+          expect(message.reload.deleted_by_contact).to be_nil
+        end
+      end
+    end
+
     # A blank claim is what a direct chat sends, and what a producer that predates the
     # field sends for everything: it has to go on meaning today's behaviour.
     context 'when the key named nobody' do


### PR DESCRIPTION
Fecha a #494.

## O problema

A checagem de autor do #493 compara a reivindicação da chave do apagamento contra o **contato** que a mensagem aponta. Isso responde outra pergunta: contato é como a pessoa se chama nesta caixa **hoje**. Um agente editando o telefone, ou uma mesclagem reescrevendo, move isso sem mover quem escreveu a mensagem, e o revoke legítimo era recusado.

A #494 registrava as duas saídas. Esta é a segunda: guardar a identidade na própria mensagem, imune a edição e mesclagem por construção.

## O que muda

O `MessageWriter` grava `external_author` junto de toda mensagem que a camada de sessão armazena, com os **dois namespaces**, porque a WhatsApp nomeia a mesma pessoa por telefone num evento e por LID no seguinte e a pergunta pode chegar em qualquer um dos dois.

O `MessageRevoked` passa a comparar contra isso quando existe. A identidade gravada **ganha** do contato, senão ela seria só uma segunda chance de casar e nunca uma correção da primeira. Linhas escritas antes disso continuam comparando contra o contato, que é o que elas têm.

Os namespaces continuam separados aqui também, pelo motivo que a comparação por contato já dava: a WhatsApp trata LID e telefone como identidades diferentes mesmo com dígitos iguais, e quem escreve a reivindicação é quem mandou a deleção.

## Por que não a outra saída

A #494 também listava pôr namespace na `contact_inboxes.source_id`. Ela resolveria este caso e mexe numa tabela que todo canal usa, com migração de dados. Esta cabe na camada de sessão e descreve o que o campo significa: quem escreveu **aquela** mensagem, não quem o contato é agora.

## Testes

166 exemplos nos handlers, 1511 na suíte de WhatsApp, 0 falhas, com seeds fixos além do aleatório.

Quatro mutações, todas morrem:

| mutação | falhas |
|---|---|
| writer não grava a identidade | 1 |
| handler ignora a identidade gravada | 2 |
| `same_party?` achata os namespaces | 1 |
| fallback pro contato some | 8 |

O caso que fixa a intenção: a mensagem é apagada mesmo depois de o agente ter editado o contato até ele não responder mais a nada da reivindicação, e uma reivindicação que a linha **não** nomeia é recusada mesmo quando o contato de hoje casaria com ela.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/496)
<!-- Reviewable:end -->
