### PR TITLE
fix(whatsapp): ler as linhas que um update de participantes responde

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -129,34 +129,42 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
   # Baileys one answers with the list it was handed: there, everything it did not raise
   # for counts as added, which is what it meant before this.
   def participants_that_landed(phone_numbers, answer)
-    refused = refused_ids(answer)
+    verdicts = verdicts_by_number(answer)
 
-    # The number that comes back is not the one that was sent: a Brazilian or Argentinian
-    # line is written with or without the ninth digit depending on who is spelling it, and
-    # comparing the digits as they arrived calls one participant two people.
-    Array(phone_numbers).reject do |phone|
-      refused.any? { |id| Whatsapp::Session::PhoneMatch.same_number?(id, phone) }
-    end
+    Array(phone_numbers).reject { |phone| refused_outright?(verdicts, phone) }
   end
 
-  def refused_ids(answer)
+  # The number that comes back is not the one that was sent: a Brazilian or Argentinian
+  # line is written with or without the ninth digit depending on who is spelling it, so
+  # the verdicts about a participant are every row naming the same line.
+  #
+  # Refused means refused in all of them. The same line submitted under both spellings
+  # comes back added under one and, WhatsApp having said nothing about the other, refused
+  # under it: dropping it there would leave the roster without a member who is in the
+  # group.
+  def refused_outright?(verdicts, phone)
+    spoken_for = verdicts.select { |number, _| Whatsapp::Session::PhoneMatch.same_number?(number, phone) }
+
+    spoken_for.present? && spoken_for.all? { |_, status| status == 'failed' }
+  end
+
+  def verdicts_by_number(answer)
     Array(answer).filter_map do |row|
       # Only a row is a row. The Baileys path answers with the list it was handed, and a
       # backend that answers nothing at all answers `true`.
       next unless row.is_a?(Hash)
 
       row = row.stringify_keys
-      next unless row['status'].to_s == 'failed'
-
-      refused_phone_in(row['address'])
+      # A row carrying no verdict has not said this participant is in the group, and it
+      # has not said they are out of it either: only `failed` refuses.
+      [phone_in(row['address']), row['status'].to_s]
     end
   end
 
-  # An `add` is asked by phone and answered under the address it was asked with, so a
-  # refusal names a number. A LID is a separate namespace that happens to be written in
-  # digits too, and reading one as a phone number would drop a participant who did land
-  # because somebody else's LID reads like their line.
-  def refused_phone_in(address)
+  # An `add` is asked by phone and answered under the address it was asked with, so a row
+  # names a number. A LID is a separate namespace that happens to be written in digits
+  # too, and reading one as a phone number would speak for a line it says nothing about.
+  def phone_in(address)
     return nil unless address.is_a?(Hash)
 
     address = address.stringify_keys

--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -134,18 +134,29 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     Array(phone_numbers).reject { |phone| refused_outright?(verdicts, phone) }
   end
 
-  # The number that comes back is not the one that was sent: a Brazilian or Argentinian
-  # line is written with or without the ninth digit depending on who is spelling it, so
-  # the verdicts about a participant are every row naming the same line.
-  #
-  # Refused means refused in all of them. The same line submitted under both spellings
-  # comes back added under one and, WhatsApp having said nothing about the other, refused
-  # under it: dropping it there would leave the roster without a member who is in the
-  # group.
+  # Refused means refused in every row that speaks for this submission.
   def refused_outright?(verdicts, phone)
-    spoken_for = verdicts.select { |number, _| Whatsapp::Session::PhoneMatch.same_number?(number, phone) }
+    spoken_for = verdicts_about(verdicts, phone)
 
     spoken_for.present? && spoken_for.all? { |_, status| status == 'failed' }
+  end
+
+  # A row naming the number exactly as it was submitted is the verdict on that
+  # submission: the provider answers one row per participant asked, under the address it
+  # was asked with. Submitting a line under both of its spellings therefore gets a verdict
+  # each, and reading them together would write the refused spelling to the roster on the
+  # strength of the other one.
+  #
+  # Only where no row spells it the way it was submitted do the other spellings speak for
+  # it: a Brazilian or Argentinian line is written with or without the ninth digit
+  # depending on who is spelling it, and a provider that answers under its own spelling
+  # has still answered about this participant.
+  def verdicts_about(verdicts, phone)
+    as_submitted = Whatsapp::Session::PhoneMatch.digits(phone)
+    named = verdicts.select { |number, _| number == as_submitted }
+    return named if named.present?
+
+    verdicts.select { |number, _| Whatsapp::Session::PhoneMatch.same_number?(number, phone) }
   end
 
   def verdicts_by_number(answer)

--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -29,8 +29,8 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     participants = create_params[:participants]
     return render json: { error: 'participants_required' }, status: :unprocessable_entity if participants.blank?
 
-    channel.update_group_participants(@contact.identifier, format_participants(participants), 'add')
-    add_group_members(participants)
+    answer = channel.update_group_participants(@contact.identifier, format_participants(participants), 'add')
+    add_group_members(participants_that_landed(participants, answer))
     head :ok
   rescue Whatsapp::Session::Errors::Error => e
     render json: { error: e.message }, status: :unprocessable_entity
@@ -118,6 +118,35 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     raise Whatsapp::Session::Errors::InvalidPayload, 'group member has no WhatsApp address' if address.nil?
 
     address.to_jid
+  end
+
+  # WhatsApp refuses participants one at a time and answers with a row each, so an `add`
+  # of several can come back having added some of them. Writing all of them to the roster
+  # shows the operator members who are not in the group, until the next scheduled sync
+  # takes them out again.
+  #
+  # A provider that does not answer in rows has told us nothing to filter on, and the
+  # Baileys one answers with the list it was handed: there, everything it did not raise
+  # for counts as added, which is what it meant before this.
+  def participants_that_landed(phone_numbers, answer)
+    refused = refused_ids(answer)
+    return phone_numbers if refused.empty?
+
+    Array(phone_numbers).reject { |phone| refused.include?(Whatsapp::Session::PhoneMatch.digits(phone)) }
+  end
+
+  def refused_ids(answer)
+    Array(answer).filter_map do |row|
+      # Only a row is a row. The Baileys path answers with the list it was handed, and a
+      # backend that answers nothing at all answers `true`.
+      next unless row.is_a?(Hash)
+
+      row = row.stringify_keys
+      next unless row['status'].to_s == 'failed'
+
+      address = row['address']
+      Whatsapp::Session::PhoneMatch.digits((address.is_a?(Hash) ? address.stringify_keys : {})['id'])
+    end
   end
 
   def add_group_members(phone_numbers)

--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -130,9 +130,13 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
   # for counts as added, which is what it meant before this.
   def participants_that_landed(phone_numbers, answer)
     refused = refused_ids(answer)
-    return phone_numbers if refused.empty?
 
-    Array(phone_numbers).reject { |phone| refused.include?(Whatsapp::Session::PhoneMatch.digits(phone)) }
+    # The number that comes back is not the one that was sent: a Brazilian or Argentinian
+    # line is written with or without the ninth digit depending on who is spelling it, and
+    # comparing the digits as they arrived calls one participant two people.
+    Array(phone_numbers).reject do |phone|
+      refused.any? { |id| Whatsapp::Session::PhoneMatch.same_number?(id, phone) }
+    end
   end
 
   def refused_ids(answer)
@@ -144,9 +148,21 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
       row = row.stringify_keys
       next unless row['status'].to_s == 'failed'
 
-      address = row['address']
-      Whatsapp::Session::PhoneMatch.digits((address.is_a?(Hash) ? address.stringify_keys : {})['id'])
+      refused_phone_in(row['address'])
     end
+  end
+
+  # An `add` is asked by phone and answered under the address it was asked with, so a
+  # refusal names a number. A LID is a separate namespace that happens to be written in
+  # digits too, and reading one as a phone number would drop a participant who did land
+  # because somebody else's LID reads like their line.
+  def refused_phone_in(address)
+    return nil unless address.is_a?(Hash)
+
+    address = address.stringify_keys
+    return nil if address['kind'].present? && address['kind'].to_s != 'phone'
+
+    Whatsapp::Session::PhoneMatch.digits(address['id'])
   end
 
   def add_group_members(phone_numbers)

--- a/app/services/whatsapp/session/backends/connector/backend.rb
+++ b/app/services/whatsapp/session/backends/connector/backend.rb
@@ -171,8 +171,20 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
     true
   end
 
+  # WhatsApp refuses participants one at a time -- a privacy setting, the group's
+  # creator, somebody who left recently -- so the answer is a row each and `ok` says only
+  # that the command ran. The connector fails the command when nothing was carried out,
+  # and this reaches the same verdict from the rows: a caller told `ok` and handed a
+  # refusal for every participant it named has had nothing done, which both controllers
+  # already turn into the message an operator reads.
+  #
+  # A partial refusal is not an error. Reporting the participants that were added as not
+  # added is a worse answer, and the caller reads the rows to find out which is which.
   def update_group_participants(command)
-    Array(client.call(command))
+    rows = Array(client.call(command))
+    raise Whatsapp::Session::Errors::GroupParticipantNotAllowed if wholly_refused?(rows)
+
+    rows
   end
 
   def update_group_name(command)
@@ -209,6 +221,13 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
   end
 
   private
+
+  def wholly_refused?(rows)
+    rows.present? && rows.all? do |row|
+      row.is_a?(Hash) &&
+        row.stringify_keys['code'].to_s == Whatsapp::Session::Errors::GroupParticipantNotAllowed::CODE
+    end
+  end
 
   def refresh(command)
     model::MediaRef.from_h(client.call(command))

--- a/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
@@ -157,6 +157,63 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
           .to contain_exactly('+5511999990001')
       end
 
+      # The refusal comes back written the way WhatsApp spells the line, which for a
+      # Brazilian or Argentinian number is not necessarily the way the operator typed it.
+      it 'matches a refusal written in the other ninth-digit form' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+        allow(baileys_service).to receive(:update_group_participants).and_return(
+          [{ 'address' => { 'kind' => 'phone', 'id' => '5511999990001' }, 'status' => 'success', 'code' => nil },
+           { 'address' => { 'kind' => 'phone', 'id' => '551199990002' }, 'status' => 'failed',
+             'code' => 'group_participant_not_allowed' }]
+        )
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990001', '+5511999990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to contain_exactly('+5511999990001')
+      end
+
+      # A LID and a phone number are separate namespaces written in the same digits, so a
+      # refusal naming a LID says nothing about the line that happens to read like it.
+      it 'keeps a participant whose number reads like a refused lid' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+        allow(baileys_service).to receive(:update_group_participants).and_return(
+          [{ 'address' => { 'kind' => 'lid', 'id' => '5511999990002' }, 'status' => 'failed',
+             'code' => 'group_participant_not_allowed' }]
+        )
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to contain_exactly('+5511999990002')
+      end
+
+      # A row is only readable where it names an address the way the contract does. A
+      # provider that writes the participant as a bare JID has not been refused any less,
+      # but it has not said whom in a shape this can act on either, and answering the
+      # operator with a 500 helps nobody.
+      it 'adds the participant when the refusal names no address it can read' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+        allow(baileys_service).to receive(:update_group_participants).and_return(
+          [{ 'address' => '5511999990002@s.whatsapp.net', 'status' => 'failed',
+             'code' => 'group_participant_not_allowed' }]
+        )
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to contain_exactly('+5511999990002')
+      end
+
       # A provider that does not answer in rows has told us nothing to filter on, and the
       # Baileys one answers with whatever `each` returned.
       it 'adds every participant when the provider answers in no rows at all' do

--- a/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
@@ -194,6 +194,44 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
           .to contain_exactly('+5511999990002')
       end
 
+      # The same line can be submitted under both of its spellings, and the answer names
+      # one row per participant asked: WhatsApp adds it under one and says nothing about
+      # the other, which the provider reports as a refusal. A line it added is in the
+      # group whatever the row for the other spelling says.
+      it 'keeps a number a row added even when another row refused the same line' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+        allow(baileys_service).to receive(:update_group_participants).and_return(
+          [{ 'address' => { 'kind' => 'phone', 'id' => '5511999990002' }, 'status' => 'success', 'code' => nil },
+           { 'address' => { 'kind' => 'phone', 'id' => '551199990002' }, 'status' => 'failed',
+             'code' => 'group_participant_not_allowed' }]
+        )
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to contain_exactly('+5511999990002')
+      end
+
+      # A row that carries no verdict at all has not said the participant is in the group,
+      # and it has not said they are out of it either.
+      it 'adds the participant when the only row about them carries no verdict' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+        allow(baileys_service).to receive(:update_group_participants).and_return(
+          [{ 'address' => { 'kind' => 'phone', 'id' => '5511999990002' }, 'status' => 'pending', 'code' => nil }]
+        )
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to contain_exactly('+5511999990002')
+      end
+
       # A row is only readable where it names an address the way the contract does. A
       # provider that writes the participant as a bare JID has not been refused any less,
       # but it has not said whom in a shape this can act on either, and answering the

--- a/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
@@ -232,6 +232,49 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
           .to contain_exactly('+5511999990002')
       end
 
+      # Submitted under both of its spellings, the line gets a verdict each, and the
+      # roster is written from the number as submitted: writing the refused spelling too
+      # would put the same person on it twice, once as somebody WhatsApp turned down.
+      it 'writes only the spelling whose own row landed' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+        allow(baileys_service).to receive(:update_group_participants).and_return(
+          [{ 'address' => { 'kind' => 'phone', 'id' => '5511999990002' }, 'status' => 'success', 'code' => nil },
+           { 'address' => { 'kind' => 'phone', 'id' => '551199990002' }, 'status' => 'failed',
+             'code' => 'group_participant_not_allowed' }]
+        )
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990002', '+551199990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to contain_exactly('+5511999990002')
+      end
+
+      # A provider that normalizes the number answers every row under its own spelling, so
+      # a line submitted twice comes back as two rows nobody's submission spells exactly.
+      # Both speak for both submissions, and a line WhatsApp added is in the group: the
+      # refusal on the other attempt does not take it off the roster. That both spellings
+      # are then written as two members is #498, which is about the roster reading a
+      # number literally and is not what the provider said here.
+      it 'keeps a line one row added when the rows are written in a spelling nobody sent' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+        allow(baileys_service).to receive(:update_group_participants).and_return(
+          [{ 'address' => { 'kind' => 'phone', 'id' => '551199990002' }, 'status' => 'success', 'code' => nil },
+           { 'address' => { 'kind' => 'phone', 'id' => '551199990002' }, 'status' => 'failed',
+             'code' => 'group_participant_not_allowed' }]
+        )
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to include('+5511999990002')
+      end
+
       # A row is only readable where it names an address the way the contract does. A
       # provider that writes the participant as a bare JID has not been refused any less,
       # but it has not said whom in a shape this can act on either, and answering the

--- a/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
@@ -137,6 +137,40 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
         expect(response).to have_http_status(:ok)
       end
 
+      # WhatsApp refuses participants one at a time -- a privacy setting, somebody who
+      # left recently -- and answers `ok` with a row each. Writing all of them to the
+      # roster shows the operator members who are not in the group.
+      it 'adds only the participants the provider did not refuse' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+        allow(baileys_service).to receive(:update_group_participants).and_return(
+          [{ 'address' => { 'kind' => 'phone', 'id' => '5511999990001' }, 'status' => 'success', 'code' => nil },
+           { 'address' => { 'kind' => 'phone', 'id' => '5511999990002' }, 'status' => 'failed',
+             'code' => 'group_participant_not_allowed' }]
+        )
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990001', '+5511999990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to contain_exactly('+5511999990001')
+      end
+
+      # A provider that does not answer in rows has told us nothing to filter on, and the
+      # Baileys one answers with whatever `each` returned.
+      it 'adds every participant when the provider answers in no rows at all' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990001', '+5511999990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to contain_exactly('+5511999990001', '+5511999990002')
+      end
+
       it 'returns 422 when provider is unavailable' do
         allow(baileys_service).to receive(:update_group_participants)
           .and_raise(Whatsapp::Providers::WhatsappBaileysService::ProviderUnavailableError, 'Offline')

--- a/spec/services/whatsapp/session/backends/connector/backend_spec.rb
+++ b/spec/services/whatsapp/session/backends/connector/backend_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
       expect(backend.update_group_participants(command)).to eq(rows)
     end
 
+    # An answer with no rows in it refused nobody. Reading it as a refusal for everyone
+    # named would fail a command the provider carried out.
+    it 'treats an answer with no rows as nothing refused' do
+      results['group.participants.update'] = []
+
+      expect { backend.update_group_participants(command) }.not_to raise_error
+    end
+
     # Any other refusal is the connector's to name: it fails the command itself when the
     # code is one it maps, and a code this build does not know must not be read as the
     # one it happens to rescue.

--- a/spec/services/whatsapp/session/backends/connector/backend_spec.rb
+++ b/spec/services/whatsapp/session/backends/connector/backend_spec.rb
@@ -51,6 +51,53 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
 
   it_behaves_like 'a whatsapp session backend'
 
+  # The connector fails the command when nothing was carried out. This reaches the same
+  # verdict from the rows, so a caller told `ok` and handed a refusal for every
+  # participant it named gets the error both controllers already turn into a message an
+  # operator reads, rather than a silent success.
+  describe 'a participants update the provider refused' do
+    let(:command) do
+      model::Commands::GroupParticipantsUpdate.new(
+        group: model::Address.group('120363040000000001'),
+        participants: [model::Address.phone('5541999990000')], action: 'remove'
+      )
+    end
+
+    it 'raises when every participant was refused' do
+      results['group.participants.update'] = [
+        { 'address' => { 'kind' => 'phone', 'id' => '5541999990000' }, 'status' => 'failed',
+          'code' => 'group_participant_not_allowed' }
+      ]
+
+      expect { backend.update_group_participants(command) }
+        .to raise_error(Whatsapp::Session::Errors::GroupParticipantNotAllowed)
+    end
+
+    # Reporting the participants that were added as not added is a worse answer, and the
+    # caller reads the rows to find out which is which.
+    it 'hands back a partial refusal rather than failing the command' do
+      rows = [
+        { 'address' => { 'kind' => 'phone', 'id' => '5541999990000' }, 'status' => 'success', 'code' => nil },
+        { 'address' => { 'kind' => 'phone', 'id' => '5541988887777' }, 'status' => 'failed',
+          'code' => 'group_participant_not_allowed' }
+      ]
+      results['group.participants.update'] = rows
+
+      expect(backend.update_group_participants(command)).to eq(rows)
+    end
+
+    # Any other refusal is the connector's to name: it fails the command itself when the
+    # code is one it maps, and a code this build does not know must not be read as the
+    # one it happens to rescue.
+    it 'leaves a refusal it does not recognise alone' do
+      results['group.participants.update'] = [
+        { 'address' => { 'kind' => 'phone', 'id' => '5541999990000' }, 'status' => 'failed', 'code' => 'internal' }
+      ]
+
+      expect { backend.update_group_participants(command) }.not_to raise_error
+    end
+  end
+
   it 'declares exactly what the registry advertises for the provider' do
     expect(described_class.capabilities).to eq(Whatsapp::Session::Registry.descriptor('native').capabilities)
   end


### PR DESCRIPTION
Fecha a #483. Premissa revalidada no HEAD: os três pontos que a issue cita continuam iguais, e ela foi escrita contra outra branch.

## O que acontecia

A WhatsApp recusa participante por participante, uma configuração de privacidade, o criador do grupo, alguém que saiu há pouco. O `group.participants.update` responde uma linha por participante e o `ok` diz só que o comando rodou. Nada nesse caminho lia as linhas, e os três controllers escreviam a mudança no roster local de qualquer jeito.

Daí saem duas falhas diferentes.

**Um `add` de vários pode voltar tendo adicionado só alguns**, e o roster levava todos: o operador via membros que não estão no grupo, até a próxima sincronização tirá-los. O `create` agora adiciona só os participantes cuja linha deu certo.

**E um comando recusado para todos não é sucesso.** O conector já falha esse comando por conta dele; o backend agora chega ao mesmo veredito pelas linhas, então quem recebe `ok` com nada além de recusas recebe o erro que os dois controllers já convertem em `group_creator_not_modifiable`, que é a mensagem que o caminho Baileys mostra desde sempre.

## O que de propósito não é erro

Recusa parcial. Reportar como não adicionados os participantes que **foram** adicionados é uma resposta pior, e quem chamou lê as linhas pra saber qual é qual. Foi a decisão que o conector tomou no #122 e ela vale igual aqui.

## Só linha conta como linha

O caminho Baileys responde com a lista que recebeu e um backend stubado responde `true`. Nenhum dos dois disse nada em que filtrar, então ali tudo que não levantou conta como adicionado, que é o que significava antes disto.

## Qual linha fala por qual número

Número brasileiro e argentino tem duas grafias, com e sem o nono dígito, e a que volta na recusa não é necessariamente a que o operador digitou. Comparar os dígitos como chegaram deixava a recusa passar direto.

O provedor responde uma linha por participante pedido, sob o endereço com que foi pedido. Então o veredito de uma submissão é o da linha que soletra o número do jeito que ele foi enviado, e as outras grafias só falam por ele quando nenhuma linha o nomeia, que é o que sobra de um provedor que normaliza. Sem isso, a mesma linha submetida nas duas grafias entrava no roster também pela grafia recusada, na carona da aceita.

Só endereço de tipo `phone` entra nessa conta. LID é outro namespace escrito em dígitos, e lê-lo como telefone derrubaria do roster um participante sobre quem aquela linha não disse nada.

Recusa vale quando **todas** as linhas que falam pela submissão recusam: uma linha que a WhatsApp aceitou põe a pessoa no grupo, qualquer coisa que as outras digam.

## O que fica de fora

Duas grafias **aceitas** ainda viram dois contatos e dois membros para a mesma pessoa. É a busca de contato comparar telefone por igualdade de string, não o que o provedor respondeu, e mexer nisso é mexer em `ContactInboxWithContactBuilder`, caminho compartilhado com todos os canais. Está na #498, com custo e caminho de correção. Não é regressão daqui: antes deste PR as duas grafias entravam sem filtro nenhum.

## Testes

25 exemplos no spec do controller e 26 no do backend, 1588 na suíte de WhatsApp mais os controllers de contato, 0 falhas, com seeds fixos além do aleatório.

Doze mutações, todas morrem:

| mutação | falhas |
|---|---|
| sem a preferência pela grafia submetida | 1 |
| dígitos exatos no lugar de `same_number?` | 1 |
| sem o portão de tipo de endereço | 1 |
| recusa por `any?` no lugar de `all?` | 1 |
| sem o guarda de "alguma linha fala por ele" | 3 |
| sem o guarda de resposta que não é linha | 2 |
| recusa por qualquer coisa que não seja sucesso | 1 |
| status lido da chave errada | 3 |
| backend sem o guarda de resposta vazia | 1 |
| backend levanta também em recusa parcial | 1 |
| backend com `any?` no lugar de `all?` | 1 |
| backend sem a comparação de código | 2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/497)
<!-- Reviewable:end -->

