### PR TITLE
fix(whatsapp): não prometer limites de conta que o conector não tem como preencher

### DIFF
--- a/app/jobs/whatsapp/session/connection_check_job.rb
+++ b/app/jobs/whatsapp/session/connection_check_job.rb
@@ -44,6 +44,11 @@ class Whatsapp::Session::ConnectionCheckJob < ApplicationJob
   # every state update the new provider sends and shows the agent the old provider's
   # restrictions until the new one happens to report its own.
   def refresh_limits(channel, backend, fence)
+    # A backend that does not declare the limits refuses them, and the refusal would be
+    # logged as a failed read on every cycle: a provider saying it has nothing to report
+    # is not a provider failing to report.
+    return unless backend.supports?('account_limits')
+
     limits = backend.fetch_account_limits || {}
     channel.with_lock do
       next if channel.provider != fence[:provider]

--- a/app/services/whatsapp/session/backends/connector/backend.rb
+++ b/app/services/whatsapp/session/backends/connector/backend.rb
@@ -75,13 +75,6 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
     nil
   end
 
-  # The limits ride along with the session status, which is the only thing that knows
-  # them: they are pushed as events the rest of the time.
-  def fetch_account_limits
-    status = client.call(commands::SessionStatus.new) || {}
-    status.slice('reachout_time_lock', 'new_chat_cap')
-  end
-
   # --- messages ------------------------------------------------------------------
 
   def send_message(command)

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -23,10 +23,18 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
       # consume, and there is no such command in the contract. Its replacement for the
       # same problem (pairing without a QR the operator can scan) is the passkey relay,
       # which rides on the pairing commands.
+      #
+      # No account_limits either. The contract lets a connection state carry
+      # `reachout_time_lock` and `new_chat_cap`, and the connector's `session.status`
+      # answers connection, phone number and LID and nothing else: whatsmeow surfaces no
+      # WhatsApp Business messaging limit for it to fill them with. Nothing asks for them
+      # on this provider today, because a connector session is pushed rather than polled,
+      # so what the declaration bought was a promise on the inbox payload that the next
+      # caller would have read as an answer.
       capabilities: %w[
         qr_pairing code_pairing echo_by_reserved_id edit revoke reactions typing presence
         presence_subscribe read_receipts mark_unread check_number profile_picture groups
-        group_management group_admin group_invites group_join_requests account_limits media_download
+        group_management group_admin group_invites group_join_requests media_download
       ],
       fields: [MARK_AS_READ, PRESENCE_SUBSCRIBE]
     ),

--- a/spec/jobs/whatsapp/session/connection_check_job_spec.rb
+++ b/spec/jobs/whatsapp/session/connection_check_job_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe Whatsapp::Session::ConnectionCheckJob do
     expect(channel).to have_received(:update_provider_connection!).twice
   end
 
+  # A provider that declares no limits has nothing to answer, and asking it would log a
+  # refusal as a failed read on every cycle.
+  it 'does not ask for limits a backend does not report' do
+    allow(Whatsapp::Session::Backends::Uazapi::Backend).to receive(:supports?).and_call_original
+    allow(Whatsapp::Session::Backends::Uazapi::Backend).to receive(:supports?).with('account_limits').and_return(false)
+
+    described_class.perform_now(channel)
+
+    expect(channel.reload.provider_connection['connection']).to eq('open')
+    expect(WebMock).not_to have_requested(:get, "#{base}/instance/wa_messages_limits")
+  end
+
   # A provider that cannot be reached is not a session that closed, and writing `close`
   # over a healthy connection would show the operator an outage that is not there.
   it 'leaves the last known state alone when the provider does not answer' do

--- a/spec/services/whatsapp/session/backends/connector/backend_spec.rb
+++ b/spec/services/whatsapp/session/backends/connector/backend_spec.rb
@@ -143,8 +143,10 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
     expect(result.message_id).to eq('3EB0AAAA')
   end
 
-  it 'reads the account limits off the session status' do
-    expect(backend.fetch_account_limits).to eq({ 'reachout_time_lock' => { 'status' => 'UNLOCKED' } })
+  # The contract lets a connection state carry them and this connector fills neither, so
+  # answering the read would hand back an empty slice dressed as an answer.
+  it 'refuses the account limits rather than answering an empty slice' do
+    expect { backend.fetch_account_limits }.to raise_error(Whatsapp::Session::Errors::NotSupported)
   end
 
   it 'downloads media straight from the URL the event carried' do


### PR DESCRIPTION
Parte da #481, revalidada no HEAD.

## O que a issue dizia e o que sobrou

A #481 foi escrita contra `feat/whatsapp-session-layer` (18/08) e o conector em `3bbfc82`. Conferido agora contra `feat/whatsapp-session` e o conector em `b85f9bb`, quase tudo dela já não vale:

| a issue diz | hoje |
|---|---|
| oito capacidades declaradas que o conector recusa | o conector serve `contact.check`, `contact.profile_picture`, `group.info`, `group.participants.update`, `group.invite.get` e `group.join_requests.*` |
| `groups` faz dois trabalhos diferentes | separado em `groups` e `group_management` no PR #485 |
| sete handlers de entrada para eventos que ninguém produz | `group.joined` e `group.updated` são produzidos pelo tradutor do uazapi; sobram cinco sem produtor |

Sobrou `account_limits` no `native`, que é o que este PR fecha.

## O que acontecia

O contrato deixa um estado de conexão carregar `reachout_time_lock` e `new_chat_cap`, e o `session.status` do conector responde `connection`, `phone_number` e `lid` e mais nada: o whatsmeow não expõe limite de mensagens da conta para preencher os dois.

Ninguém pede esses limites no `native` hoje, porque sessão de conector é empurrada e não consultada (`state_polling?` é falso, e o `ConnectionCheckJob` sai antes). Então o custo não era uma chamada desperdiçada: era a promessa no payload da inbox, que o próximo chamador leria como resposta, mais um `fetch_account_limits` que devolvia `{}` com cara de leitura feita.

## O que muda

Três pontos, e o terceiro é o que evita o mesmo buraco na próxima vez:

1. `native` não declara mais `account_limits`.
2. O `fetch_account_limits` do backend do conector sai. O shared example exige as duas direções, então tirar a capacidade sem tirar o método falharia por "not declared but answered anyway", que é exatamente o alarme certo.
3. O health check pergunta os limites só a quem declara reportá-los. Um backend consultado que não declara a capacidade teria a recusa registrada como leitura falha a cada ciclo, e provedor que não tem o que dizer não é provedor falhando.

## O que continua aberto na #481

Cinco tipos de evento que backend nenhum produz (`contact.picture_changed`, `group.picture_changed`, `group.activity` e os dois `account.*`), e o fato de o shared example checar que o método Ruby existe, não que o outro lado responde. A issue vai ser reescrita para isso.

## Testes

1655 exemplos na suíte de WhatsApp mais os jobs e o modelo do canal, 0 falhas.

Três mutações, todas morrem:

| mutação | falhas |
|---|---|
| `native` volta a declarar `account_limits` | 1 |
| sem o portão de capacidade no job | 1 |
| portão invertido no job | 3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/499)
<!-- Reviewable:end -->
