### PR TITLE
fix(csat): dar uma segunda chance quando a etiqueta chega depois da resolução

### DIFF
--- a/app/jobs/conversations/csat_survey_retry_job.rb
+++ b/app/jobs/conversations/csat_survey_retry_job.rb
@@ -1,0 +1,11 @@
+class Conversations::CsatSurveyRetryJob < ApplicationJob
+  # `default` and not `low`: this runs in every deployment of the fork, and a deployment is free
+  # to start its workers with an explicit `-q` list. The Guiche Web one consumes only critical,
+  # high, medium, default and scheduled_jobs, so a job queued on `low` would sit in Redis
+  # untouched and the retry would silently never happen.
+  queue_as :default
+
+  def perform(conversation)
+    CsatSurveyService.new(conversation: conversation).perform
+  end
+end

--- a/app/listeners/csat_survey_listener.rb
+++ b/app/listeners/csat_survey_listener.rb
@@ -1,10 +1,20 @@
 class CsatSurveyListener < BaseListener
+  # The status flip and the label the survey rule tests are written by two different jobs. An
+  # agent who answers and resolves in the same gesture makes the automation that applies the
+  # label land AFTER this listener has already read `label_list` and decided not to send:
+  # measured on the Guiche Web email inbox, the label arrives 2s late at p50 and 8s at the worst,
+  # and 31 of 87 eligible conversations in one morning lost their survey that way. A single
+  # delayed second pass covers that window, and it is scheduled only when the rules were what
+  # blocked the survey, so an ordinary resolution still costs exactly one attempt.
+  CSAT_RETRY_DELAY = 30.seconds
+
   def conversation_status_changed(event)
     conversation = extract_conversation_and_account(event)[0]
 
     return unless conversation.resolved?
+    return unless CsatSurveyService.new(conversation: conversation).perform == :blocked_by_survey_rules
 
-    CsatSurveyService.new(conversation: conversation).perform
+    Conversations::CsatSurveyRetryJob.set(wait: CSAT_RETRY_DELAY).perform_later(conversation)
   end
 
   def message_updated(event)

--- a/app/services/csat_survey_service.rb
+++ b/app/services/csat_survey_service.rb
@@ -1,9 +1,20 @@
 class CsatSurveyService
   pattr_initialize [:conversation!]
 
+  # Returns why the survey did not go out, so the caller can tell a conversation that was never
+  # eligible from one whose rule may still be waiting on a label another job is about to write.
   def perform
-    return unless should_send_csat_survey?
+    return :not_eligible unless eligible_for_csat?
+    return :blocked_by_survey_rules unless csat_allowed_by_survey_rules?
 
+    deliver_survey
+  end
+
+  private
+
+  delegate :inbox, :contact, to: :conversation
+
+  def deliver_survey
     if whatsapp_channel? && template_available_and_approved?
       send_whatsapp_template_survey
     elsif inbox.twilio_whatsapp? && twilio_template_available_and_approved?
@@ -15,12 +26,8 @@ class CsatSurveyService
     end
   end
 
-  private
-
-  delegate :inbox, :contact, to: :conversation
-
-  def should_send_csat_survey?
-    conversation_allows_csat? && csat_enabled? && !csat_already_sent? && csat_allowed_by_survey_rules?
+  def eligible_for_csat?
+    conversation_allows_csat? && csat_enabled? && !csat_already_sent?
   end
 
   def conversation_allows_csat?
@@ -146,34 +153,19 @@ class CsatSurveyService
     sorted_keys = body_variables.keys.sort_by(&:to_i)
     sorted_keys.map do |key|
       value = body_variables[key]
-      resolved_value = resolve_liquid_variable(value)
+      resolved_value = liquid_resolver.resolve(value)
       { type: 'text', text: resolved_value }
     end
   end
 
-  def resolve_liquid_variable(value)
-    return value if value.blank?
-
-    template = Liquid::Template.parse(value)
-    result = template.render(liquid_drops)
-    result.presence || value
-  rescue Liquid::Error
-    value
-  end
-
-  def liquid_drops
-    @liquid_drops ||= {
-      'contact' => ContactDrop.new(conversation.contact),
-      'conversation' => ConversationDrop.new(conversation),
-      'inbox' => InboxDrop.new(inbox),
-      'account' => AccountDrop.new(conversation.account)
-    }
+  def liquid_resolver
+    @liquid_resolver ||= CsatSurveys::LiquidResolver.new(conversation: conversation)
   end
 
   def build_csat_message
     content = inbox.csat_config&.dig('message') || 'Please rate this conversation'
     body_variables = inbox.csat_config&.dig('template', 'body_variables')
-    body_variables&.each { |key, value| content = content.gsub("{{#{key}}}", resolve_liquid_variable(value)) }
+    body_variables&.each { |key, value| content = content.gsub("{{#{key}}}", liquid_resolver.resolve(value)) }
 
     conversation.messages.build(
       account: conversation.account,

--- a/app/services/csat_surveys/liquid_resolver.rb
+++ b/app/services/csat_surveys/liquid_resolver.rb
@@ -1,0 +1,26 @@
+# Renders an admin-authored `csat_config` value as Liquid against this conversation's drops.
+# It sits outside CsatSurveyService because both the WhatsApp template payload and the message
+# body need it, and a value that fails to parse must degrade to its literal text rather than
+# take the survey down.
+class CsatSurveys::LiquidResolver
+  pattr_initialize [:conversation!]
+
+  def resolve(value)
+    return value if value.blank?
+
+    Liquid::Template.parse(value).render(drops).presence || value
+  rescue Liquid::Error
+    value
+  end
+
+  private
+
+  def drops
+    @drops ||= {
+      'contact' => ContactDrop.new(conversation.contact),
+      'conversation' => ConversationDrop.new(conversation),
+      'inbox' => InboxDrop.new(conversation.inbox),
+      'account' => AccountDrop.new(conversation.account)
+    }
+  end
+end

--- a/spec/jobs/conversations/csat_survey_retry_job_spec.rb
+++ b/spec/jobs/conversations/csat_survey_retry_job_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Conversations::CsatSurveyRetryJob do
+  subject(:job) { described_class.perform_later(conversation) }
+
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account, csat_survey_enabled: true) }
+  let(:conversation) { create(:conversation, account: account, inbox: inbox, status: :resolved) }
+
+  # `low` has no worker in every deployment of this fork, so a job queued there would never run.
+  it 'enqueues on a queue every deployment consumes' do
+    expect { job }.to have_enqueued_job(described_class).on_queue('default')
+  end
+
+  it 'runs the survey service for the conversation' do
+    service = instance_double(CsatSurveyService, perform: nil)
+    allow(CsatSurveyService).to receive(:new).with(conversation: conversation).and_return(service)
+
+    described_class.perform_now(conversation)
+
+    expect(service).to have_received(:perform)
+  end
+end

--- a/spec/listeners/csat_survey_listener_spec.rb
+++ b/spec/listeners/csat_survey_listener_spec.rb
@@ -52,6 +52,43 @@ describe CsatSurveyListener do
 
         listener.conversation_status_changed(event)
       end
+
+      it 'does not schedule a retry when the survey was not blocked by the rules' do
+        event = Events::Base.new(event_name, Time.zone.now, conversation: resolved_conversation)
+        allow(csat_service).to receive(:perform).and_return(:not_eligible)
+        allow(CsatSurveyService).to receive(:new).and_return(csat_service)
+
+        expect { listener.conversation_status_changed(event) }.not_to have_enqueued_job(Conversations::CsatSurveyRetryJob)
+      end
+
+      it 'schedules one delayed retry when the survey rules blocked the survey' do
+        event = Events::Base.new(event_name, Time.zone.now, conversation: resolved_conversation)
+        allow(csat_service).to receive(:perform).and_return(:blocked_by_survey_rules)
+        allow(CsatSurveyService).to receive(:new).and_return(csat_service)
+
+        expect { listener.conversation_status_changed(event) }
+          .to have_enqueued_job(Conversations::CsatSurveyRetryJob)
+          .with(resolved_conversation)
+          .at(a_value_within(5.seconds).of(described_class::CSAT_RETRY_DELAY.from_now))
+      end
+
+      # The whole point of the retry: the automation that applies the label the rule tests runs in
+      # another job, and on a resolve-right-after-replying it commits a couple of seconds late.
+      it 'sends the survey on the retry when the label only arrives after the resolution' do
+        csat_enabled_inbox.update!(csat_config: { 'survey_rules' => { 'operator' => 'contains', 'values' => ['humano'] } })
+        event = Events::Base.new(event_name, Time.zone.now, conversation: resolved_conversation)
+
+        # The block form of `perform_enqueued_jobs` runs each job the moment it is enqueued, which
+        # would land the retry before the label and prove nothing. Enqueue, let the label arrive,
+        # then drain: that is the real sequence.
+        listener.conversation_status_changed(event)
+        expect(resolved_conversation.messages.where(content_type: :input_csat)).to be_empty
+
+        resolved_conversation.add_labels(['humano'])
+        perform_enqueued_jobs(only: Conversations::CsatSurveyRetryJob)
+
+        expect(resolved_conversation.reload.messages.where(content_type: :input_csat).count).to eq 1
+      end
     end
 
     context 'when conversation is not resolved' do

--- a/spec/services/csat_survey_service_spec.rb
+++ b/spec/services/csat_survey_service_spec.rb
@@ -8,6 +8,50 @@ describe CsatSurveyService do
   let(:conversation) { create(:conversation, contact_inbox: contact_inbox, inbox: inbox, account: account, status: :resolved) }
   let(:service) { described_class.new(conversation: conversation) }
 
+  describe '#perform return value' do
+    let(:rules) { { 'survey_rules' => { 'operator' => 'contains', 'values' => ['humano'] } } }
+
+    it 'reports the rules when they are the only thing in the way' do
+      inbox.update!(csat_config: rules)
+
+      expect(service.perform).to eq :blocked_by_survey_rules
+    end
+
+    it 'does not report the rules once the label the rule asks for is there' do
+      inbox.update!(csat_config: rules)
+      conversation.update!(label_list: ['humano'])
+
+      expect(service.perform).not_to eq :blocked_by_survey_rules
+    end
+
+    it 'is not blocked when no rules are configured' do
+      expect(service.perform).not_to eq :blocked_by_survey_rules
+    end
+
+    # Each of these makes the conversation ineligible on its own, and a retry would never change
+    # that: the caller must not schedule one, or every resolution in the install pays for a job.
+    it 'reports ineligible when the conversation is not resolved' do
+      inbox.update!(csat_config: rules)
+      conversation.update!(status: :open)
+
+      expect(service.perform).to eq :not_eligible
+    end
+
+    it 'reports ineligible when CSAT is disabled on the inbox' do
+      inbox.update!(csat_config: rules, csat_survey_enabled: false)
+
+      expect(service.perform).to eq :not_eligible
+    end
+
+    it 'reports ineligible when the survey was already sent' do
+      inbox.update!(csat_config: rules)
+      create(:message, account: account, inbox: inbox, conversation: conversation,
+                       message_type: :outgoing, content_type: :input_csat)
+
+      expect(service.perform).to eq :not_eligible
+    end
+  end
+
   describe '#perform' do
     let(:csat_template) { instance_double(MessageTemplates::Template::CsatSurvey) }
 

--- a/spec/services/csat_surveys/liquid_resolver_spec.rb
+++ b/spec/services/csat_surveys/liquid_resolver_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe CsatSurveys::LiquidResolver do
+  subject(:resolver) { described_class.new(conversation: conversation) }
+
+  let(:account) { create(:account) }
+  let(:inbox) { create(:inbox, account: account) }
+  let(:contact) { create(:contact, account: account, name: 'Joana') }
+  let(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox) }
+  let(:conversation) { create(:conversation, contact: contact, contact_inbox: contact_inbox, inbox: inbox, account: account) }
+
+  it 'renders a drop against the conversation' do
+    expect(resolver.resolve('{{contact.name}}')).to eq 'Joana'
+  end
+
+  it 'returns a blank value untouched' do
+    expect(resolver.resolve('')).to eq ''
+  end
+
+  it 'keeps the literal when the template renders to nothing' do
+    expect(resolver.resolve('{{contact.nonexistent}}')).to eq '{{contact.nonexistent}}'
+  end
+
+  # A broken value is admin copy, not a reason to lose the survey.
+  it 'keeps the literal when the template does not parse' do
+    expect(resolver.resolve('{% if %}')).to eq '{% if %}'
+  end
+end


### PR DESCRIPTION
## O problema

O `CsatSurveyListener` decide sobre a pesquisa no instante em que o status vira resolvido, mas a etiqueta que a regra testa (`survey_rules`) é escrita por uma automação que roda em outro job. Quando o atendente responde e resolve no mesmo gesto, a etiqueta chega depois e a pesquisa é descartada em silêncio, para sempre.

## A medição

Caixa de e-mail de SAC de um cliente, manhã de 09/09, das 198 conversas resolvidas:

| | |
|---|---|
| com a etiqueta `respondido-por-humano` | 87 |
| dessas, **com** pesquisa | 56 |
| dessas, **sem** pesquisa | 31 |

O corte é binário: as 31 sem pesquisa receberam a etiqueta 2s depois da resolução (p50; p90 3s, máx 8s), e as 56 com pesquisa receberam de 27min a 23h antes. Nenhuma perdeu tendo a etiqueta antes, nenhuma ganhou tendo só depois.

## A correção

`CsatSurveyService#perform` passa a devolver o motivo de não ter enviado (`:not_eligible`, `:blocked_by_survey_rules`). Só quando a regra foi o que barrou, o listener agenda `Conversations::CsatSurveyRetryJob` para 30s depois. Resolução comum segue custando uma tentativa só, e o `csat_already_sent?` que já existia torna a repetição inócua.

## Duas decisões que valem revisão

**Fila `default`, não `low`.** Cada instalação sobe os workers com uma lista explícita de `-q`; a do cliente medido consome `critical, high, medium, default` e `scheduled_jobs`. Um job em `low` ficaria parado no Redis sem nunca rodar.

**`CsatSurveys::LiquidResolver`.** O `Metrics/ClassLength` estourou por 3 linhas. Em vez de silenciar o cop, extraí a renderização Liquid do `csat_config`, que tinha dois consumidores dentro da classe.

## Alternativas descartadas

- **Inverter para `does_not_contain [resolvido-pela-ia]`**: das 111 resolvidas sem etiqueta no dia, zero têm `resolvido-pela-ia` (a Gi não etiqueta no e-mail) e 78 não tiveram resposta nenhuma. Mandaria pesquisa para conversa que ninguém atendeu.
- **Etiquetar na atribuição ao humano**: 53 das 150 atribuídas a um humano nunca tiveram resposta humana. 35% de falso positivo, pior que a perda atual.
- **Varredura externa pela API**: funciona (a API aceita `content_type` em `POST /messages`), mas move para fora do produto uma decisão que é do produto.
- **Resolver por macro**: o `Macros::ExecutionService` roda as ações em sequência no mesmo processo, então mataria a corrida sem código, mas depende de o atendente não usar o botão Resolver que está do lado.

## Teste

490 exemplos passando em `spec/services/csat_survey_service_spec.rb`, `spec/services/csat_surveys`, `spec/listeners`, `spec/jobs/conversations`, `spec/services/message_templates` e `spec/models/conversation_spec.rb`. Rubocop limpo em `app/`.

O spec do listener cobre a sequência real: resolve sem a etiqueta, confirma que nada foi enviado, a etiqueta chega, o job drena e a pesquisa sai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/501)
<!-- Reviewable:end -->