### PR TITLE
fix(i18n): say what the native provider does instead of naming its plumbing

### DIFF
--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -9,7 +9,7 @@
           "ZAPI": "Z-API",
           "ZAPI_DESC": "Connect via non-official API Z-API",
           "NATIVE": "WhatsApp (native)",
-          "NATIVE_DESC": "Connect through an unofficial API, using the connector that ships with this installation",
+          "NATIVE_DESC": "Connect through an unofficial API, pairing as with WhatsApp Web, with no outside provider",
           "UAZAPI": "Uazapi",
           "UAZAPI_DESC": "Connect through the unofficial Uazapi API, on your own instance"
         },

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -9,7 +9,7 @@
           "ZAPI": "Z-API",
           "ZAPI_DESC": "Conectar mediante la API no oficial Z-API",
           "NATIVE": "WhatsApp (nativo)",
-          "NATIVE_DESC": "Conectar mediante una API no oficial, con el conector que ya viene en esta instalación",
+          "NATIVE_DESC": "Conectar mediante una API no oficial, vinculando como en WhatsApp Web, sin proveedor externo",
           "UAZAPI": "Uazapi",
           "UAZAPI_DESC": "Conectar mediante la API no oficial de Uazapi, en tu propia instancia"
         },

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -5,13 +5,13 @@
         "PROVIDERS": {
           "360_DIALOG_DESC": "Conectar através de credenciais 360Dialog",
           "BAILEYS": "Baileys",
-          "BAILEYS_DESC": "Conectar via API não-oficial Baileys",
+          "BAILEYS_DESC": "Conectar via API não oficial Baileys",
           "ZAPI": "Z-API",
-          "ZAPI_DESC": "Conectar via API não-oficial Z-API",
+          "ZAPI_DESC": "Conectar via API não oficial Z-API",
           "NATIVE": "WhatsApp (nativo)",
-          "NATIVE_DESC": "Conectar via API não-oficial, pelo conector que já vem nesta instalação",
+          "NATIVE_DESC": "Conectar via API não oficial, pareando como no WhatsApp Web, sem provedor externo",
           "UAZAPI": "Uazapi",
-          "UAZAPI_DESC": "Conectar via API não-oficial Uazapi, na sua própria instância"
+          "UAZAPI_DESC": "Conectar via API não oficial Uazapi, na sua própria instância"
         },
         "PROVIDER_URL": {
           "LABEL": "URL do provedor",


### PR DESCRIPTION
## O que muda

A linha do card **WhatsApp (nativo)** na tela de nova caixa de entrada dizia `Conectar via API não-oficial, pelo conector que já vem nesta instalação`. "O conector" é o nome de um componente interno: quem está escolhendo o provedor nunca ouviu falar dele, e a frase não diz nem como a conexão acontece nem o que o operador ganha em relação aos vizinhos da lista.

A nova linha diz as duas coisas que importam na hora da escolha: como conecta (pareando, como no WhatsApp Web) e o que a diferencia de Baileys, Z-API e Uazapi (nada passa por provedor externo), sem esconder que continua sendo API não oficial.

| | antes | depois |
|---|---|---|
| pt_BR | Conectar via API não-oficial, pelo conector que já vem nesta instalação | Conectar via API não oficial, pareando como no WhatsApp Web, sem provedor externo |
| en | Connect through an unofficial API, using the connector that ships with this installation | Connect through an unofficial API, pairing as with WhatsApp Web, with no outside provider |
| es | Conectar mediante una API no oficial, con el conector que ya viene en esta instalación | Conectar mediante una API no oficial, vinculando como en WhatsApp Web, sin proveedor externo |

## Hífen

De quebra, `não-oficial` vira `não oficial` nas quatro linhas pt-BR (Baileys, Z-API, Uazapi e nativo). O advérbio "não" só recebe hífen antes de palavra iniciada pela mesma letra ou por h; em "não oficial" é locução, sem hífen. As linhas en e es já estavam corretas.

## Por que na `main` e não na branch de integração

A string é idêntica nas duas branches, e `main` é o caminho curto para o hífen chegar em produção. A próxima sincronização traz a correção para `feat/whatsapp-session` de graça, agora que a ancestralidade está reparada.

## Testes

Mudança só de conteúdo de string: os três arquivos continuam JSON válido (`json.load` nos três) e a formatação não foi tocada. Sem código para exercitar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/506)
<!-- Reviewable:end -->
