### PR TITLE
fix(whatsapp): pedir o nome do grupo na primeira vez que ele aparece

### DIFF
--- a/app/services/whatsapp/session/inbound/group_resolver.rb
+++ b/app/services/whatsapp/session/inbound/group_resolver.rb
@@ -10,6 +10,10 @@ class Whatsapp::Session::Inbound::GroupResolver
   # What a group message handler needs to write the message.
   Result = Data.define(:group_contact_inbox, :group_contact, :sender_contact)
 
+  # Long enough for the caller to have written its message and opened the thread. Matches
+  # what the Baileys layer waits before the same job.
+  SYNC_DELAY = 5.seconds
+
   attr_reader :inbox, :group, :sender, :subject
 
   def initialize(inbox:, group:, sender: nil, subject: nil)
@@ -86,12 +90,20 @@ class Whatsapp::Session::Inbound::GroupResolver
   #
   # Once, not per message: the job's own 15 minute cooldown covers a burst, and this
   # guard covers the rest, so a busy group does not queue a roster read per message.
+  #
+  # Delayed, and not as a precaution: `Contacts::SyncGroupService` needs a conversation to
+  # drive the roster read through and creates one when it finds none. This runs before the
+  # caller has written the message, so an immediate job finds a group contact with no
+  # thread yet and opens a second one, which then stays empty in the chat list next to the
+  # real thread. The wait is the same one the Baileys layer uses on the same job, and it
+  # also lets a `group.joined` arriving alongside the first message fill the name first,
+  # which the job's cooldown then reads as work already done.
   def sync_unless_known(group_contact)
     return if group_contact.additional_attributes&.dig('group_last_synced_at').present?
     return unless inbox.channel.respond_to?(:session_capabilities)
     return unless inbox.channel.session_capabilities.include?('group_management')
 
-    Contacts::SyncGroupJob.perform_later(group_contact, channel: inbox.channel)
+    Contacts::SyncGroupJob.set(wait: SYNC_DELAY).perform_later(group_contact, channel: inbox.channel)
   end
 
   def resolve_sender

--- a/app/services/whatsapp/session/inbound/group_resolver.rb
+++ b/app/services/whatsapp/session/inbound/group_resolver.rb
@@ -23,6 +23,7 @@ class Whatsapp::Session::Inbound::GroupResolver
     group_contact_inbox, group_contact = find_or_create_group_contact
     sender_contact = resolve_sender
     track_membership(group_contact, sender_contact) if sender_contact
+    sync_unless_known(group_contact)
 
     Result.new(group_contact_inbox: group_contact_inbox, group_contact: group_contact, sender_contact: sender_contact)
   end
@@ -70,6 +71,27 @@ class Whatsapp::Session::Inbound::GroupResolver
 
     member.update!(is_active: true) unless member.is_active?
     member
+  end
+
+  # A group nobody ever synced is named after its JID, because that is the fallback
+  # `find_or_create_group_contact` uses when no subject was supplied, and a message
+  # carries none: the wire names the chat, not the group. Left alone the thread stays
+  # called `120363...` forever, since the events that do carry a subject only fire when
+  # something happens to the group, and being added to it already happened.
+  #
+  # A group is first seen through a message far more often than through `group.joined`:
+  # an inbox converted from another provider, a session resumed after a deploy, any
+  # downtime at all. The Baileys layer schedules the same sync from its own stub handler,
+  # for the same reason.
+  #
+  # Once, not per message: the job's own 15 minute cooldown covers a burst, and this
+  # guard covers the rest, so a busy group does not queue a roster read per message.
+  def sync_unless_known(group_contact)
+    return if group_contact.additional_attributes&.dig('group_last_synced_at').present?
+    return unless inbox.channel.respond_to?(:session_capabilities)
+    return unless inbox.channel.session_capabilities.include?('group_management')
+
+    Contacts::SyncGroupJob.perform_later(group_contact, channel: inbox.channel)
   end
 
   def resolve_sender

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -172,7 +172,12 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
     # disagree. The Baileys-era name still works, so an existing deployment does not have
     # to change its env on upgrade.
     def groups_enabled?
-      value = ENV.fetch('WHATSAPP_GROUPS_ENABLED', nil) || ENV.fetch('BAILEYS_WHATSAPP_GROUPS_ENABLED', 'false')
+      # `.presence`, not just the nil check: a compose file that lists the variable with
+      # no value, or a panel field left blank, sets it to the empty string, and an empty
+      # string is truthy here. Read as a value it takes the fallback away, so a
+      # deployment that never migrated off the Baileys-era name loses every group
+      # capability on upgrade -- which is the one thing this fallback exists to prevent.
+      value = ENV.fetch('WHATSAPP_GROUPS_ENABLED', nil).presence || ENV.fetch('BAILEYS_WHATSAPP_GROUPS_ENABLED', 'false')
       value == 'true'
     end
 

--- a/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
+++ b/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe Whatsapp::Session::Inbound::GroupResolver do
     end
   end
 
+  # The sync drives the roster read through a conversation and opens one when it finds
+  # none. This runs before the caller writes the message, so an immediate job opens a
+  # second thread that then sits empty in the chat list beside the real one.
+  it 'waits for the caller to have opened the thread' do
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      expect { described_class.new(inbox: inbox, group: group, sender: sender).perform }
+        .to have_enqueued_job(Contacts::SyncGroupJob).at(a_value > Time.zone.now)
+    end
+  end
+
   # The job carries its own 15 minute cooldown, which covers a burst and not a busy group
   # a day later. Asking once per message would queue a roster read per message.
   it 'does not ask again for a group it already knows' do

--- a/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
+++ b/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
@@ -31,6 +31,37 @@ RSpec.describe Whatsapp::Session::Inbound::GroupResolver do
     expect(GroupMember.find_by(group_contact: result.group_contact, contact: result.sender_contact).role).to eq('admin')
   end
 
+  # A message names the chat, never the group, so the contact is created named after the
+  # JID. Nothing else fills that in: the events that carry a subject fire when something
+  # happens to the group, and being added to it already happened. Without this the thread
+  # is called `120363...` for as long as the group stays quiet.
+  it 'asks for the roster of a group it has never synced' do
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      expect { described_class.new(inbox: inbox, group: group, sender: sender).perform }
+        .to have_enqueued_job(Contacts::SyncGroupJob)
+    end
+  end
+
+  # The job carries its own 15 minute cooldown, which covers a burst and not a busy group
+  # a day later. Asking once per message would queue a roster read per message.
+  it 'does not ask again for a group it already knows' do
+    resolve.group_contact.update!(additional_attributes: { 'group_last_synced_at' => Time.zone.now.to_i })
+
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      expect { described_class.new(inbox: inbox, group: group, sender: sender).perform }
+        .not_to have_enqueued_job(Contacts::SyncGroupJob)
+    end
+  end
+
+  # The sync reads the roster through the session. A provider with no group management
+  # answers nothing, and the job would spend a queue slot to find that out per group.
+  it 'does not ask a provider that cannot read a roster' do
+    allow(channel).to receive(:session_capabilities).and_return(%w[qr_pairing groups])
+
+    expect { described_class.new(inbox: inbox, group: group, sender: sender).perform }
+      .not_to have_enqueued_job(Contacts::SyncGroupJob)
+  end
+
   it 'reactivates a member who had left and came back' do
     first = resolve
     GroupMember.find_by(group_contact: first.group_contact, contact: first.sender_contact)

--- a/spec/services/whatsapp/session/registry_spec.rb
+++ b/spec/services/whatsapp/session/registry_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe Whatsapp::Session::Registry do
       end
     end
 
+    # A compose file listing the variable with no value, or a blank field in a panel,
+    # sets it to the empty string. Read as a value it takes the fallback away and the
+    # deployment loses every group capability on upgrade, silently.
+    it 'reads the new name left blank as not set at all' do
+      with_modified_env WHATSAPP_GROUPS_ENABLED: '', BAILEYS_WHATSAPP_GROUPS_ENABLED: 'true' do
+        expect(described_class.groups_enabled?).to be(true)
+      end
+    end
+
     # Two readers of one switch is how an inbox ends up advertising `groups` in its
     # capabilities while refusing to create one.
     it 'is the same answer the legacy service gives' do


### PR DESCRIPTION
Encontrado na bateria ao vivo do canal nativo: mandei uma mensagem de um grupo recém-criado e a conversa apareceu chamada `120363432460358614`.

## O que acontece

Uma mensagem de grupo nomeia a conversa, não o grupo. O evento traz `chat: {kind: "group", id: "120363432460358614"}` e nada mais, então `GroupResolver#extract_group_name` devolve `nil` e `find_or_create_group_contact` cai no fallback: `name: extract_group_name || extract_group_source_id`.

Nada preenche isso depois. Os eventos que carregam o assunto (`group.joined`, `group.updated`, `group.activity`, `group.picture_changed`) só disparam quando algo acontece com o grupo, e ser adicionado a ele já aconteceu. Não há sync periódico. Sobra clicar em sincronizar na mão, no contato, um por um.

Confirmei que o dado está lá: rodando `Groups::Syncer` na mão nesse mesmo contato, o nome virou "novo grupo", com dono, membros e as quatro configurações.

## Por que não é caso de borda

Um grupo é visto pela primeira vez por uma mensagem com muito mais frequência do que por `group.joined`:

- uma inbox convertida de outro provedor, onde todos os grupos já existem
- uma sessão retomada depois de um deploy
- qualquer indisponibilidade do conector, que é como eu caí nisso

`group.joined` só cobre o caso de a conta ser adicionada a um grupo enquanto a sessão está de pé.

A camada Baileys já agenda esse mesmo sync a partir do handler de stub dela (`group_stub_message_handler.rb:69`), pelo mesmo motivo. O caminho nativo não tinha equivalente.

## A correção

`GroupResolver#perform` agenda `Contacts::SyncGroupJob` quando o contato do grupo nunca foi sincronizado. Uma vez por grupo, não por mensagem: o cooldown de 15 minutos do próprio job cobre uma rajada e a guarda de `group_last_synced_at` cobre o resto, senão um grupo movimentado enfileira uma leitura de roster por mensagem.

Fica atrás da capacidade `group_management`, porque a leitura passa pela sessão e um provedor que não a tem gastaria um slot de fila por grupo para descobrir isso.

## A segunda correção, que apareceu no caminho

`WHATSAPP_GROUPS_ENABLED` presente e vazio é o que um compose que lista a variável sem valor, ou um campo em branco num painel, produz. String vazia é truthy em Ruby, então

```ruby
ENV.fetch('WHATSAPP_GROUPS_ENABLED', nil) || ENV.fetch('BAILEYS_WHATSAPP_GROUPS_ENABLED', 'false')
```

tomava o valor vazio e o fallback para o nome da era Baileys nunca rodava. A instalação que nunca migrou de nome perde toda capacidade de grupo no upgrade, calada, que é exatamente o que esse fallback existe para evitar. Agora usa `.presence`.

## Validação

`spec/services/whatsapp/session/` inteiro: 639 exemplos, 0 falhas.

Cinco falhas que eu vi antes de começar eram do meu `.env` local, não da branch: ele liga `WHATSAPP_GROUPS_ENABLED` e `WHATSAPP_CONNECTOR_ENABLED`, e os specs de "é ignorado enquanto a capacidade está desligada" rodavam com a capacidade ligada. Isolei no `.env.test`, que não é versionado.

Falta a confirmação ao vivo com um grupo novo, que depende de outra pessoa criar um.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/512)
<!-- Reviewable:end -->
