### PR TITLE
fix(whatsapp): não culpar o celular por uma desconexão pedida daqui

### DIFF
--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -30,7 +30,7 @@ class Whatsapp::Session::ConnectionStateWriter
   PAIRING_KEYS = %w[phone_number lid].freeze
 
   # The two ways a pairing really ends. Everything else is a connection that may come back.
-  PAIRING_ENDED = [WRONG_PHONE_ERROR, 'logged_out'].freeze
+  PAIRING_ENDED = [WRONG_PHONE_ERROR, 'logged_out', 'logged_out_by_request'].freeze
 
   # Quarantined: the connection belongs to somebody else's WhatsApp account.
   def self.disowned?(channel)

--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -35,9 +35,15 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
     'pairing.error' => 'connect_failure'
   }.freeze
 
+  # A logout this installation asked for, told apart from an unlink done on the phone.
+  # The connector already separates them and says which, and both arrive as
+  # `session.logged_out`: collapsing the two sends an agent who just clicked disconnect
+  # to go look at a phone that did nothing.
+  LOGOUT_REQUESTED = 'logout_requested'.freeze
+
   def build_state
     type = payload&.wire_type
-    error = CLOSING_ERRORS[type]
+    error = closing_error(type)
     return closed(error, ban: payload.try(:ban)) if error
 
     case type
@@ -46,6 +52,14 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
     when 'pairing.code' then connecting(pairing_code: payload.code)
     when 'pairing.success' then pairing_success
     end
+  end
+
+  # Which sentence the dashboard ends up rendering, for the events that end a connection.
+  def closing_error(type)
+    error = CLOSING_ERRORS[type]
+    return error unless error == 'logged_out' && payload.try(:reason) == LOGOUT_REQUESTED
+
+    'logged_out_by_request'
   end
 
   # Whose account this is, is not decided here: the writer refuses any state that names

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -60,6 +60,7 @@ en:
           send_stall_detected: This connection is receiving messages but cannot send them. If it does not clear on its own within a few minutes, disconnect the inbox and connect again by scanning a new QR code.
           invalid_credentials: The provider rejected the credentials for this inbox. Check the address and the token and try again.
           logged_out: This device was disconnected from WhatsApp on the phone. Pair it again to keep receiving messages.
+          logged_out_by_request: This inbox was disconnected from WhatsApp here. Pair it again to keep receiving messages.
           stream_replaced: This session was replaced by another connection to the same WhatsApp account. Pair it again to use it here.
           temporary_ban: WhatsApp temporarily blocked this number. Wait until the block expires before pairing again.
           client_outdated: The WhatsApp connector is out of date and can no longer connect. Update it to restore the connection.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -60,6 +60,7 @@ es:
           send_stall_detected: Esta conexión está recibiendo mensajes pero no puede enviarlos. Si no se resuelve por sí sola en unos minutos, desconecte la bandeja de entrada y conéctela de nuevo escaneando un nuevo código QR.
           invalid_credentials: El proveedor rechazó las credenciales de esta bandeja de entrada. Verifique la dirección y el token e inténtelo de nuevo.
           logged_out: Este dispositivo fue desconectado de WhatsApp desde el teléfono. Vuelva a vincularlo para seguir recibiendo mensajes.
+          logged_out_by_request: Esta bandeja fue desconectada de WhatsApp desde aquí. Vuelva a vincularla para seguir recibiendo mensajes.
           stream_replaced: Esta sesión fue reemplazada por otra conexión de la misma cuenta de WhatsApp. Vuelva a vincularla para usarla aquí.
           temporary_ban: WhatsApp bloqueó temporalmente este número. Espere a que termine el bloqueo antes de volver a vincularlo.
           client_outdated: El conector de WhatsApp está desactualizado y ya no puede conectarse. Actualícelo para restablecer la conexión.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -60,6 +60,7 @@ pt_BR:
           send_stall_detected: Esta conexão está recebendo mensagens, mas não consegue enviá-las. Se não se resolver sozinha em alguns minutos, desconecte a caixa de entrada e conecte novamente escaneando um novo QR code.
           invalid_credentials: O provedor recusou as credenciais desta caixa de entrada. Confira o endereço e o token e tente novamente.
           logged_out: Este dispositivo foi desconectado do WhatsApp pelo celular. Conecte novamente para continuar recebendo mensagens.
+          logged_out_by_request: Esta caixa de entrada foi desconectada do WhatsApp aqui mesmo. Conecte novamente para continuar recebendo mensagens.
           stream_replaced: Esta sessão foi substituída por outra conexão da mesma conta do WhatsApp. Conecte novamente para usar aqui.
           temporary_ban: O WhatsApp bloqueou temporariamente este número. Aguarde o fim do bloqueio antes de conectar novamente.
           client_outdated: O conector do WhatsApp está desatualizado e não consegue mais conectar. Atualize-o para restabelecer a conexão.

--- a/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
@@ -37,6 +37,32 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ConnectionState do
     )
   end
 
+  # The connector already tells the two apart and says which. Collapsing them sends an
+  # agent who just clicked disconnect to go look at a phone that did nothing, and leaves
+  # an operator who really was unlinked on the phone with no idea where it happened.
+  it 'says the disconnect came from here when it was asked for from here' do
+    event = model::Event.build(model::Events::SessionLoggedOut.new(reason: 'logout_requested'), epoch: 3)
+    described_class.new(channel: channel, event: event).perform
+
+    expect(channel.reload.provider_connection).to include(
+      'connection' => 'close', 'error_code' => 'logged_out_by_request',
+      'error' => I18n.t('errors.inboxes.channel.provider_connection.logged_out_by_request')
+    )
+  end
+
+  # Both are the end of a pairing, not a connection that may come back. Left out of that
+  # list the number stays on the channel, and the next connect tries to resume credentials
+  # WhatsApp has already thrown away instead of asking for a fresh QR.
+  it 'forgets the number a requested logout ended' do
+    model::Event.build(model::Events::SessionState.new(state: 'open', phone: '+5541988887777'), epoch: 3).then do |opened|
+      described_class.new(channel: channel, event: opened).perform
+    end
+    event = model::Event.build(model::Events::SessionLoggedOut.new(reason: 'logout_requested'), epoch: 4)
+    described_class.new(channel: channel, event: event).perform
+
+    expect(channel.reload.provider_connection).not_to include('phone_number')
+  end
+
   # The dispatcher looks before the handler runs, and this lands in between: the operator
   # saved new credentials while the event was on its way to the write. The instance travels
   # with the event so the writer can compare it inside the row lock, which is the only place


### PR DESCRIPTION
Encontrado testando logout ao vivo no canal nativo. Desconectei a sessão pareada pelo Chatwoot e a frase que ficou guardada no canal foi:

> Este dispositivo foi desconectado do WhatsApp **pelo celular**. Conecte novamente para continuar recebendo mensagens.

Nada aconteceu no celular. Fui eu que pedi.

## Por que acontece

O conector já separa as duas coisas e diz qual foi. Os dois eventos chegam como `session.logged_out`, com razões diferentes:

```json
{"reason": "logout_requested"}          // fomos nós que pedimos
{"reason": "device_removed", ...}       // desvinculado no celular, razão do whatsmeow
```

O handler mapeava o tipo do evento direto para um código de erro e descartava a razão, então os dois viravam `logged_out` e a mesma frase.

## O que muda

Um código novo, `logged_out_by_request`, com frase própria em en, es e pt-BR. Quem clica em desconectar lê que a desconexão foi feita aqui, e quem foi desvinculado no celular continua lendo o que já lia.

Ele entra também em `PAIRING_ENDED`. Fora dessa lista o número continuaria no canal e o próximo connect tentaria retomar credenciais que a WhatsApp já jogou fora, em vez de pedir um QR novo. Tem spec para isso separado da frase, porque é a metade que quebra silenciosamente.

## Validação

`spec/services/whatsapp/session/`: 642 exemplos, 0 falhas.

Ao vivo, no canal pareado, despachando o evento pelo caminho real:

```
{"epoch"=>9, "error"=>"This inbox was disconnected from WhatsApp here. Pair it again to keep receiving messages.",
 "connection"=>"close", "error_code"=>"logged_out_by_request"}
```

## Contexto: o logout em si funciona

O que essa PR corrige é só a frase. O resto da desconexão está correto e foi verificado no mesmo teste: o dispositivo saiu do `whatsmeow_device` e do `wac_session_device` (0 linhas nos dois), o telefone e o LID foram limpos do estado, e o conector publicou `session.logged_out` com a razão certa em 7ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/513)
<!-- Reviewable:end -->
