### PR TITLE
fix(whatsapp): escrever as frases das oito razões de desconexão que faltavam

### DIFF
--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -30,7 +30,7 @@ class Whatsapp::Session::ConnectionStateWriter
   PAIRING_KEYS = %w[phone_number lid].freeze
 
   # The two ways a pairing really ends. Everything else is a connection that may come back.
-  PAIRING_ENDED = [WRONG_PHONE_ERROR, 'logged_out'].freeze
+  PAIRING_ENDED = [WRONG_PHONE_ERROR, 'logged_out', 'logged_out_by_request'].freeze
 
   # Quarantined: the connection belongs to somebody else's WhatsApp account.
   def self.disowned?(channel)

--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -164,7 +164,17 @@ class Whatsapp::Session::ConnectionStateWriter
   # event, and the live update would then overwrite a correctly localized REST value with
   # it. This matches what the Baileys handler has always done.
   def translate(key)
-    I18n.t("errors.inboxes.channel.provider_connection.#{key}", default: key.to_s.humanize)
+    scoped = "errors.inboxes.channel.provider_connection.#{key}"
+    return I18n.t(scoped) if I18n.exists?(scoped, :en)
+
+    # A reason nobody wrote a sentence for. The humanized key keeps the dashboard from
+    # showing a blank, and it is English in every locale, so it can only ever be a
+    # placeholder. Silent, it stays one: `pairing_timeout` reached an operator as
+    # "Pairing timeout" for as long as the key existed, in a codebase that already had a
+    # sentence written for exactly that failure under a name nothing sends. The log line
+    # is what turns the next one into something somebody finds.
+    Rails.logger.warn("[WHATSAPP] no sentence written for provider connection reason #{key.inspect}")
+    key.to_s.humanize
   end
 
   def carry_pairing(payload, persisted)

--- a/app/services/whatsapp/session/inbound/group_resolver.rb
+++ b/app/services/whatsapp/session/inbound/group_resolver.rb
@@ -10,6 +10,10 @@ class Whatsapp::Session::Inbound::GroupResolver
   # What a group message handler needs to write the message.
   Result = Data.define(:group_contact_inbox, :group_contact, :sender_contact)
 
+  # Long enough for the caller to have written its message and opened the thread. Matches
+  # what the Baileys layer waits before the same job.
+  SYNC_DELAY = 5.seconds
+
   attr_reader :inbox, :group, :sender, :subject
 
   def initialize(inbox:, group:, sender: nil, subject: nil)
@@ -86,12 +90,20 @@ class Whatsapp::Session::Inbound::GroupResolver
   #
   # Once, not per message: the job's own 15 minute cooldown covers a burst, and this
   # guard covers the rest, so a busy group does not queue a roster read per message.
+  #
+  # Delayed, and not as a precaution: `Contacts::SyncGroupService` needs a conversation to
+  # drive the roster read through and creates one when it finds none. This runs before the
+  # caller has written the message, so an immediate job finds a group contact with no
+  # thread yet and opens a second one, which then stays empty in the chat list next to the
+  # real thread. The wait is the same one the Baileys layer uses on the same job, and it
+  # also lets a `group.joined` arriving alongside the first message fill the name first,
+  # which the job's cooldown then reads as work already done.
   def sync_unless_known(group_contact)
     return if group_contact.additional_attributes&.dig('group_last_synced_at').present?
     return unless inbox.channel.respond_to?(:session_capabilities)
     return unless inbox.channel.session_capabilities.include?('group_management')
 
-    Contacts::SyncGroupJob.perform_later(group_contact, channel: inbox.channel)
+    Contacts::SyncGroupJob.set(wait: SYNC_DELAY).perform_later(group_contact, channel: inbox.channel)
   end
 
   def resolve_sender

--- a/app/services/whatsapp/session/inbound/group_resolver.rb
+++ b/app/services/whatsapp/session/inbound/group_resolver.rb
@@ -23,6 +23,7 @@ class Whatsapp::Session::Inbound::GroupResolver
     group_contact_inbox, group_contact = find_or_create_group_contact
     sender_contact = resolve_sender
     track_membership(group_contact, sender_contact) if sender_contact
+    sync_unless_known(group_contact)
 
     Result.new(group_contact_inbox: group_contact_inbox, group_contact: group_contact, sender_contact: sender_contact)
   end
@@ -70,6 +71,27 @@ class Whatsapp::Session::Inbound::GroupResolver
 
     member.update!(is_active: true) unless member.is_active?
     member
+  end
+
+  # A group nobody ever synced is named after its JID, because that is the fallback
+  # `find_or_create_group_contact` uses when no subject was supplied, and a message
+  # carries none: the wire names the chat, not the group. Left alone the thread stays
+  # called `120363...` forever, since the events that do carry a subject only fire when
+  # something happens to the group, and being added to it already happened.
+  #
+  # A group is first seen through a message far more often than through `group.joined`:
+  # an inbox converted from another provider, a session resumed after a deploy, any
+  # downtime at all. The Baileys layer schedules the same sync from its own stub handler,
+  # for the same reason.
+  #
+  # Once, not per message: the job's own 15 minute cooldown covers a burst, and this
+  # guard covers the rest, so a busy group does not queue a roster read per message.
+  def sync_unless_known(group_contact)
+    return if group_contact.additional_attributes&.dig('group_last_synced_at').present?
+    return unless inbox.channel.respond_to?(:session_capabilities)
+    return unless inbox.channel.session_capabilities.include?('group_management')
+
+    Contacts::SyncGroupJob.perform_later(group_contact, channel: inbox.channel)
   end
 
   def resolve_sender

--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -35,9 +35,15 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
     'pairing.error' => 'connect_failure'
   }.freeze
 
+  # A logout this installation asked for, told apart from an unlink done on the phone.
+  # The connector already separates them and says which, and both arrive as
+  # `session.logged_out`: collapsing the two sends an agent who just clicked disconnect
+  # to go look at a phone that did nothing.
+  LOGOUT_REQUESTED = 'logout_requested'.freeze
+
   def build_state
     type = payload&.wire_type
-    error = CLOSING_ERRORS[type]
+    error = closing_error(type)
     return closed(error, ban: payload.try(:ban)) if error
 
     case type
@@ -46,6 +52,14 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
     when 'pairing.code' then connecting(pairing_code: payload.code)
     when 'pairing.success' then pairing_success
     end
+  end
+
+  # Which sentence the dashboard ends up rendering, for the events that end a connection.
+  def closing_error(type)
+    error = CLOSING_ERRORS[type]
+    return error unless error == 'logged_out' && payload.try(:reason) == LOGOUT_REQUESTED
+
+    'logged_out_by_request'
   end
 
   # Whose account this is, is not decided here: the writer refuses any state that names

--- a/app/services/whatsapp/session/registry.rb
+++ b/app/services/whatsapp/session/registry.rb
@@ -172,7 +172,12 @@ module Whatsapp::Session::Registry # rubocop:disable Metrics/ModuleLength
     # disagree. The Baileys-era name still works, so an existing deployment does not have
     # to change its env on upgrade.
     def groups_enabled?
-      value = ENV.fetch('WHATSAPP_GROUPS_ENABLED', nil) || ENV.fetch('BAILEYS_WHATSAPP_GROUPS_ENABLED', 'false')
+      # `.presence`, not just the nil check: a compose file that lists the variable with
+      # no value, or a panel field left blank, sets it to the empty string, and an empty
+      # string is truthy here. Read as a value it takes the fallback away, so a
+      # deployment that never migrated off the Baileys-era name loses every group
+      # capability on upgrade -- which is the one thing this fallback exists to prevent.
+      value = ENV.fetch('WHATSAPP_GROUPS_ENABLED', nil).presence || ENV.fetch('BAILEYS_WHATSAPP_GROUPS_ENABLED', 'false')
       value == 'true'
     end
 

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -69,6 +69,14 @@ en:
           connector_incompatible: The WhatsApp connector version is incompatible with this Chatwoot version. Update the connector.
           connect_failure: WhatsApp refused the connection. New attempts continue automatically.
           pairing_timed_out: The code expired before the phone finished pairing. Start the connection again to get a new one.
+          pairing_timeout: Nobody scanned the code before it expired. Start the connection again to get a new one.
+          pairing_pair_error: WhatsApp accepted the code but did not finish linking the device. Start the connection again.
+          pairing_err-scanned-without-multidevice: This WhatsApp account has to turn multi-device on before it can be linked.
+          pairing_code_refused: WhatsApp would not send a pairing code to this number. Link the device with the QR code instead.
+          pairing_connect_failed: The connector could not reach WhatsApp to start the pairing. Try again.
+          connect_failed: The connector could not reach WhatsApp. Retries continue automatically.
+          disconnect_requested: 'This connection was closed here. The pairing is still valid: connect again to resume it.'
+          disconnected: The connection to WhatsApp dropped. Retries continue automatically.
   notifications:
     notification_title:
       internal_chat_mention: You have been mentioned in %{name}

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -60,6 +60,7 @@ en:
           send_stall_detected: This connection is receiving messages but cannot send them. If it does not clear on its own within a few minutes, disconnect the inbox and connect again by scanning a new QR code.
           invalid_credentials: The provider rejected the credentials for this inbox. Check the address and the token and try again.
           logged_out: This device was disconnected from WhatsApp on the phone. Pair it again to keep receiving messages.
+          logged_out_by_request: This inbox was disconnected from WhatsApp here. Pair it again to keep receiving messages.
           stream_replaced: This session was replaced by another connection to the same WhatsApp account. Pair it again to use it here.
           temporary_ban: WhatsApp temporarily blocked this number. Wait until the block expires before pairing again.
           client_outdated: The WhatsApp connector is out of date and can no longer connect. Update it to restore the connection.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -60,6 +60,7 @@ es:
           send_stall_detected: Esta conexión está recibiendo mensajes pero no puede enviarlos. Si no se resuelve por sí sola en unos minutos, desconecte la bandeja de entrada y conéctela de nuevo escaneando un nuevo código QR.
           invalid_credentials: El proveedor rechazó las credenciales de esta bandeja de entrada. Verifique la dirección y el token e inténtelo de nuevo.
           logged_out: Este dispositivo fue desconectado de WhatsApp desde el teléfono. Vuelva a vincularlo para seguir recibiendo mensajes.
+          logged_out_by_request: Esta bandeja fue desconectada de WhatsApp desde aquí. Vuelva a vincularla para seguir recibiendo mensajes.
           stream_replaced: Esta sesión fue reemplazada por otra conexión de la misma cuenta de WhatsApp. Vuelva a vincularla para usarla aquí.
           temporary_ban: WhatsApp bloqueó temporalmente este número. Espere a que termine el bloqueo antes de volver a vincularlo.
           client_outdated: El conector de WhatsApp está desactualizado y ya no puede conectarse. Actualícelo para restablecer la conexión.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -69,6 +69,14 @@ es:
           connector_incompatible: La versión del conector de WhatsApp es incompatible con esta versión de Chatwoot. Actualice el conector.
           connect_failure: WhatsApp rechazó la conexión. Los nuevos intentos continúan automáticamente.
           pairing_timed_out: El código expiró antes de que el teléfono completara la vinculación. Inicie la conexión de nuevo para obtener uno nuevo.
+          pairing_timeout: Nadie escaneó el código antes de que expirara. Inicie la conexión de nuevo para obtener uno nuevo.
+          pairing_pair_error: WhatsApp aceptó el código pero no terminó de vincular el dispositivo. Inicie la conexión de nuevo.
+          pairing_err-scanned-without-multidevice: Esta cuenta de WhatsApp debe activar el multidispositivo antes de poder vincularse.
+          pairing_code_refused: WhatsApp no quiso enviar un código de vinculación a este número. Vincule el dispositivo con el código QR.
+          pairing_connect_failed: El conector no pudo comunicarse con WhatsApp para iniciar la vinculación. Inténtelo de nuevo.
+          connect_failed: El conector no pudo comunicarse con WhatsApp. Los reintentos continúan automáticamente.
+          disconnect_requested: 'Esta conexión fue cerrada desde aquí. La vinculación sigue válida: conecte de nuevo para retomarla.'
+          disconnected: La conexión con WhatsApp se cayó. Los reintentos continúan automáticamente.
   notifications:
     notification_title:
       internal_chat_mention: Le mencionaron en %{name}

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -69,6 +69,14 @@ pt_BR:
           connector_incompatible: A versão do conector do WhatsApp é incompatível com esta versão do Chatwoot. Atualize o conector.
           connect_failure: O WhatsApp recusou a conexão. Novas tentativas continuam automaticamente.
           pairing_timed_out: O código expirou antes de o telefone concluir o pareamento. Inicie a conexão novamente para obter um novo.
+          pairing_timeout: Ninguém escaneou o código antes de ele expirar. Inicie a conexão novamente para obter um novo.
+          pairing_pair_error: O WhatsApp aceitou o código mas não concluiu a conexão do dispositivo. Inicie a conexão novamente.
+          pairing_err-scanned-without-multidevice: Esta conta do WhatsApp precisa ativar o multidispositivo antes de poder ser conectada.
+          pairing_code_refused: O WhatsApp não quis enviar um código de pareamento para este número. Conecte o dispositivo pelo QR code.
+          pairing_connect_failed: O conector não conseguiu falar com o WhatsApp para iniciar o pareamento. Tente novamente.
+          connect_failed: O conector não conseguiu falar com o WhatsApp. Novas tentativas continuam automaticamente.
+          disconnect_requested: 'Esta conexão foi encerrada aqui. O pareamento continua válido: conecte novamente para retomá-la.'
+          disconnected: A conexão com o WhatsApp caiu. Novas tentativas continuam automaticamente.
   notifications:
     notification_title:
       internal_chat_mention: Você foi mencionado em %{name}

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -60,6 +60,7 @@ pt_BR:
           send_stall_detected: Esta conexão está recebendo mensagens, mas não consegue enviá-las. Se não se resolver sozinha em alguns minutos, desconecte a caixa de entrada e conecte novamente escaneando um novo QR code.
           invalid_credentials: O provedor recusou as credenciais desta caixa de entrada. Confira o endereço e o token e tente novamente.
           logged_out: Este dispositivo foi desconectado do WhatsApp pelo celular. Conecte novamente para continuar recebendo mensagens.
+          logged_out_by_request: Esta caixa de entrada foi desconectada do WhatsApp aqui mesmo. Conecte novamente para continuar recebendo mensagens.
           stream_replaced: Esta sessão foi substituída por outra conexão da mesma conta do WhatsApp. Conecte novamente para usar aqui.
           temporary_ban: O WhatsApp bloqueou temporariamente este número. Aguarde o fim do bloqueio antes de conectar novamente.
           client_outdated: O conector do WhatsApp está desatualizado e não consegue mais conectar. Atualize-o para restabelecer a conexão.

--- a/spec/services/whatsapp/session/connection_state_writer_spec.rb
+++ b/spec/services/whatsapp/session/connection_state_writer_spec.rb
@@ -12,6 +12,35 @@ RSpec.describe Whatsapp::Session::ConnectionStateWriter do
     expect(channel.reload.provider_connection).to include('connection' => 'connecting', 'epoch' => 3)
   end
 
+  # Every reason the connector puts on a closing `session.state`, taken from
+  # `publishPairingFailure` and the `EventSessionState` emits in
+  # `internal/engine/whatsmeow/session.go`. A key that is missing does not fail anywhere:
+  # it renders as the humanized key, in English, in every locale. `pairing_timeout` did
+  # exactly that while a written sentence for the same failure sat under
+  # `pairing_timed_out`, which nothing sends.
+  %w[
+    connect_failed disconnect_requested disconnected
+    pairing_timeout pairing_pair_error pairing_err-scanned-without-multidevice
+    pairing_code_refused pairing_connect_failed
+  ].each do |reason|
+    it "has a sentence written for #{reason}" do
+      writer.apply(state.new(connection: 'close', error: reason, epoch: 3))
+
+      expect(channel.reload.provider_connection['error']).not_to eq(reason.humanize)
+    end
+  end
+
+  # The placeholder still stands, because a blank is worse. What it must not do is stand
+  # in silence: this is the only thing that says a provider started sending something
+  # nobody wrote a sentence for.
+  it 'says out loud when a reason has no sentence' do
+    allow(Rails.logger).to receive(:warn)
+    writer.apply(state.new(connection: 'close', error: 'a_reason_nobody_wrote', epoch: 3))
+
+    expect(Rails.logger).to have_received(:warn).with(/no sentence written.*a_reason_nobody_wrote/)
+    expect(channel.reload.provider_connection['error']).to eq('A reason nobody wrote')
+  end
+
   it 'clears what the new state does not carry' do
     writer.apply(state.new(connection: 'connecting', qr_data_url: 'data:image/png;base64,AAA', epoch: 3))
     writer.apply(state.new(connection: 'open', epoch: 3))

--- a/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
+++ b/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe Whatsapp::Session::Inbound::GroupResolver do
     end
   end
 
+  # The sync drives the roster read through a conversation and opens one when it finds
+  # none. This runs before the caller writes the message, so an immediate job opens a
+  # second thread that then sits empty in the chat list beside the real one.
+  it 'waits for the caller to have opened the thread' do
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      expect { described_class.new(inbox: inbox, group: group, sender: sender).perform }
+        .to have_enqueued_job(Contacts::SyncGroupJob).at(a_value > Time.zone.now)
+    end
+  end
+
   # The job carries its own 15 minute cooldown, which covers a burst and not a busy group
   # a day later. Asking once per message would queue a roster read per message.
   it 'does not ask again for a group it already knows' do

--- a/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
+++ b/spec/services/whatsapp/session/inbound/group_resolver_spec.rb
@@ -31,6 +31,37 @@ RSpec.describe Whatsapp::Session::Inbound::GroupResolver do
     expect(GroupMember.find_by(group_contact: result.group_contact, contact: result.sender_contact).role).to eq('admin')
   end
 
+  # A message names the chat, never the group, so the contact is created named after the
+  # JID. Nothing else fills that in: the events that carry a subject fire when something
+  # happens to the group, and being added to it already happened. Without this the thread
+  # is called `120363...` for as long as the group stays quiet.
+  it 'asks for the roster of a group it has never synced' do
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      expect { described_class.new(inbox: inbox, group: group, sender: sender).perform }
+        .to have_enqueued_job(Contacts::SyncGroupJob)
+    end
+  end
+
+  # The job carries its own 15 minute cooldown, which covers a burst and not a busy group
+  # a day later. Asking once per message would queue a roster read per message.
+  it 'does not ask again for a group it already knows' do
+    resolve.group_contact.update!(additional_attributes: { 'group_last_synced_at' => Time.zone.now.to_i })
+
+    with_modified_env WHATSAPP_GROUPS_ENABLED: 'true' do
+      expect { described_class.new(inbox: inbox, group: group, sender: sender).perform }
+        .not_to have_enqueued_job(Contacts::SyncGroupJob)
+    end
+  end
+
+  # The sync reads the roster through the session. A provider with no group management
+  # answers nothing, and the job would spend a queue slot to find that out per group.
+  it 'does not ask a provider that cannot read a roster' do
+    allow(channel).to receive(:session_capabilities).and_return(%w[qr_pairing groups])
+
+    expect { described_class.new(inbox: inbox, group: group, sender: sender).perform }
+      .not_to have_enqueued_job(Contacts::SyncGroupJob)
+  end
+
   it 'reactivates a member who had left and came back' do
     first = resolve
     GroupMember.find_by(group_contact: first.group_contact, contact: first.sender_contact)

--- a/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
@@ -37,6 +37,32 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ConnectionState do
     )
   end
 
+  # The connector already tells the two apart and says which. Collapsing them sends an
+  # agent who just clicked disconnect to go look at a phone that did nothing, and leaves
+  # an operator who really was unlinked on the phone with no idea where it happened.
+  it 'says the disconnect came from here when it was asked for from here' do
+    event = model::Event.build(model::Events::SessionLoggedOut.new(reason: 'logout_requested'), epoch: 3)
+    described_class.new(channel: channel, event: event).perform
+
+    expect(channel.reload.provider_connection).to include(
+      'connection' => 'close', 'error_code' => 'logged_out_by_request',
+      'error' => I18n.t('errors.inboxes.channel.provider_connection.logged_out_by_request')
+    )
+  end
+
+  # Both are the end of a pairing, not a connection that may come back. Left out of that
+  # list the number stays on the channel, and the next connect tries to resume credentials
+  # WhatsApp has already thrown away instead of asking for a fresh QR.
+  it 'forgets the number a requested logout ended' do
+    model::Event.build(model::Events::SessionState.new(state: 'open', phone: '+5541988887777'), epoch: 3).then do |opened|
+      described_class.new(channel: channel, event: opened).perform
+    end
+    event = model::Event.build(model::Events::SessionLoggedOut.new(reason: 'logout_requested'), epoch: 4)
+    described_class.new(channel: channel, event: event).perform
+
+    expect(channel.reload.provider_connection).not_to include('phone_number')
+  end
+
   # The dispatcher looks before the handler runs, and this lands in between: the operator
   # saved new credentials while the event was on its way to the write. The instance travels
   # with the event so the writer can compare it inside the row lock, which is the only place

--- a/spec/services/whatsapp/session/registry_spec.rb
+++ b/spec/services/whatsapp/session/registry_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe Whatsapp::Session::Registry do
       end
     end
 
+    # A compose file listing the variable with no value, or a blank field in a panel,
+    # sets it to the empty string. Read as a value it takes the fallback away and the
+    # deployment loses every group capability on upgrade, silently.
+    it 'reads the new name left blank as not set at all' do
+      with_modified_env WHATSAPP_GROUPS_ENABLED: '', BAILEYS_WHATSAPP_GROUPS_ENABLED: 'true' do
+        expect(described_class.groups_enabled?).to be(true)
+      end
+    end
+
     # Two readers of one switch is how an inbox ends up advertising `groups` in its
     # capabilities while refusing to create one.
     it 'is the same answer the legacy service gives' do


### PR DESCRIPTION
Empilhada na #513, que toca os mesmos arquivos de tradução. Rebasear depois do squash dela.

## O que acontece

`ConnectionStateWriter#translate` tinha:

```ruby
I18n.t("errors.inboxes.channel.provider_connection.#{key}", default: key.to_s.humanize)
```

Uma chave que falta não falha em lugar nenhum. Vira a própria chave humanizada, em inglês, em qualquer idioma. Oito razões que o conector manda num fechamento de sessão estavam nesse estado.

Visto ao vivo hoje: o QR de uma inbox nova expirou sem ninguém escanear, e o que ficou gravado no canal foi

```
"error" => "Pairing timeout", "error_code" => "pairing_timeout"
```

E o pior detalhe: **existe uma frase escrita para exatamente essa falha**, sob `pairing_timed_out`, usada só pelo caminho de polling da uazapi. O conector diz `pairing_timeout`. As duas chaves nunca se encontraram, e nada apontou isso.

## As oito

Tiradas de `publishPairingFailure` e dos emits de `EventSessionState` em `internal/engine/whatsmeow/session.go`:

| razão | o que o operador lia |
|---|---|
| `pairing_timeout` | Pairing timeout |
| `pairing_pair_error` | Pairing pair error |
| `pairing_err-scanned-without-multidevice` | Pairing err-scanned-without-multidevice |
| `pairing_code_refused` | Pairing code refused |
| `pairing_connect_failed` | Pairing connect failed |
| `connect_failed` | Connect failed |
| `disconnect_requested` | Disconnect requested |
| `disconnected` | Disconnected |

Todas ganham frase em en, es e pt-BR. Onde a frase diz o que fazer, ela diz: `pairing_code_refused` manda usar o QR, `pairing_err-scanned-without-multidevice` manda ativar o multidispositivo, `disconnect_requested` avisa que o pareamento continua válido e basta conectar de novo.

## E o fallback para de ser calado

Ele continua existindo, porque um espaço em branco na tela é pior, mas agora deixa um aviso no log. Sem isso, a próxima razão que um provedor passar a mandar chega ao operador em inglês e nada em lugar nenhum diz que falta tradução, que é literalmente o que aconteceu com a `pairing_timeout`.

## Onde isso aparece

No modal de conectar dispositivo (`WhatsappLinkDeviceModal`), em vermelho, acima do botão de conectar. Ele é aberto das configurações da inbox, do passo final do setup, da página de configuração do canal e da própria tela de conversa quando a inbox cai.

## Validação

`spec/services/whatsapp/session/`: 651 exemplos, 0 falhas. Um exemplo por razão, mais um que fixa o aviso no log.

O teste por razão compara com `reason.humanize` em vez de com a frase: escrito contra a frase, ele passaria a testar a redação, e é a ausência que importa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/514)
<!-- Reviewable:end -->
