### PR TITLE
fix(whatsapp): um QR que expirou não é um erro para reportar

### DIFF
--- a/app/services/whatsapp/session/inbound/handlers/connection_state.rb
+++ b/app/services/whatsapp/session/inbound/handlers/connection_state.rb
@@ -31,9 +31,14 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
     'session.stream_replaced' => 'stream_replaced',
     'session.temporary_ban' => 'temporary_ban',
     'session.client_outdated' => 'client_outdated',
-    'session.connect_failure' => 'connect_failure',
-    'pairing.error' => 'connect_failure'
+    'session.connect_failure' => 'connect_failure'
   }.freeze
+
+  # A pairing nobody completed in time. It is the way most pairings that go nowhere end,
+  # and there is nothing to report: the code ran out because nobody scanned it, which the
+  # person looking at the screen is the one who knows. Reported, it reads as a failure of
+  # the connection, and the operator goes looking for one.
+  PAIRING_EXPIRED = %w[timeout pairing_timeout].freeze
 
   # A logout this installation asked for, told apart from an unlink done on the phone.
   # The connector already separates them and says which, and both arrive as
@@ -41,18 +46,28 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
   # to go look at a phone that did nothing.
   LOGOUT_REQUESTED = 'logout_requested'.freeze
 
+  # The events that carry a pairing along, keyed by wire type for the same reason
+  # CLOSING_ERRORS is: a constant holding a class is the generation this file was loaded
+  # in, and after a reload the lookup misses without saying so.
+  PAIRING_STEPS = {
+    'pairing.error' => :pairing_failure,
+    'pairing.qr' => :pairing_qr,
+    'pairing.code' => :pairing_code,
+    'pairing.success' => :pairing_success
+  }.freeze
+
   def build_state
     type = payload&.wire_type
     error = closing_error(type)
     return closed(error, ban: payload.try(:ban)) if error
+    return session_state if type == 'session.state'
 
-    case type
-    when 'session.state' then session_state
-    when 'pairing.qr' then connecting(qr_data_url: payload.png_data_url)
-    when 'pairing.code' then connecting(pairing_code: payload.code)
-    when 'pairing.success' then pairing_success
-    end
+    step = PAIRING_STEPS[type]
+    send(step) if step
   end
+
+  def pairing_qr = connecting(qr_data_url: payload.png_data_url)
+  def pairing_code = connecting(pairing_code: payload.code)
 
   # Which sentence the dashboard ends up rendering, for the events that end a connection.
   def closing_error(type)
@@ -62,11 +77,22 @@ class Whatsapp::Session::Inbound::Handlers::ConnectionState < Whatsapp::Session:
     'logged_out_by_request'
   end
 
+  # A pairing that ended without one. Named after what went wrong rather than reported as
+  # a refused connection, because they are different things and only one of them is worth
+  # an operator's attention: WhatsApp would not send a code to that number, or the account
+  # has not turned multi-device on, are both things they can act on.
+  def pairing_failure
+    return closed(nil) if payload.reason.to_s.in?(PAIRING_EXPIRED)
+
+    closed("pairing_#{payload.reason}")
+  end
+
   # Whose account this is, is not decided here: the writer refuses any state that names
   # the wrong number, or that names none while the inbox is quarantined, because the poll
   # and the connect answer write states without ever passing through a handler.
   def session_state
-    state(payload.state, error: payload.reason, phone_number: payload.phone, lid: payload.lid,
+    reason = payload.reason.to_s.in?(PAIRING_EXPIRED) ? nil : payload.reason
+    state(payload.state, error: reason, phone_number: payload.phone, lid: payload.lid,
                          quarantine: payload.quarantine, ban: payload.ban)
   end
 

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -69,7 +69,6 @@ en:
           connector_incompatible: The WhatsApp connector version is incompatible with this Chatwoot version. Update the connector.
           connect_failure: WhatsApp refused the connection. New attempts continue automatically.
           pairing_timed_out: The code expired before the phone finished pairing. Start the connection again to get a new one.
-          pairing_timeout: Nobody scanned the code before it expired. Start the connection again to get a new one.
           pairing_pair_error: WhatsApp accepted the code but did not finish linking the device. Start the connection again.
           pairing_err-scanned-without-multidevice: This WhatsApp account has to turn multi-device on before it can be linked.
           pairing_code_refused: WhatsApp would not send a pairing code to this number. Link the device with the QR code instead.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -69,7 +69,6 @@ es:
           connector_incompatible: La versión del conector de WhatsApp es incompatible con esta versión de Chatwoot. Actualice el conector.
           connect_failure: WhatsApp rechazó la conexión. Los nuevos intentos continúan automáticamente.
           pairing_timed_out: El código expiró antes de que el teléfono completara la vinculación. Inicie la conexión de nuevo para obtener uno nuevo.
-          pairing_timeout: Nadie escaneó el código antes de que expirara. Inicie la conexión de nuevo para obtener uno nuevo.
           pairing_pair_error: WhatsApp aceptó el código pero no terminó de vincular el dispositivo. Inicie la conexión de nuevo.
           pairing_err-scanned-without-multidevice: Esta cuenta de WhatsApp debe activar el multidispositivo antes de poder vincularse.
           pairing_code_refused: WhatsApp no quiso enviar un código de vinculación a este número. Vincule el dispositivo con el código QR.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -69,7 +69,6 @@ pt_BR:
           connector_incompatible: A versão do conector do WhatsApp é incompatível com esta versão do Chatwoot. Atualize o conector.
           connect_failure: O WhatsApp recusou a conexão. Novas tentativas continuam automaticamente.
           pairing_timed_out: O código expirou antes de o telefone concluir o pareamento. Inicie a conexão novamente para obter um novo.
-          pairing_timeout: Ninguém escaneou o código antes de ele expirar. Inicie a conexão novamente para obter um novo.
           pairing_pair_error: O WhatsApp aceitou o código mas não concluiu a conexão do dispositivo. Inicie a conexão novamente.
           pairing_err-scanned-without-multidevice: Esta conta do WhatsApp precisa ativar o multidispositivo antes de poder ser conectada.
           pairing_code_refused: O WhatsApp não quis enviar um código de pareamento para este número. Conecte o dispositivo pelo QR code.

--- a/spec/services/whatsapp/session/connection_state_writer_spec.rb
+++ b/spec/services/whatsapp/session/connection_state_writer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Whatsapp::Session::ConnectionStateWriter do
   # `pairing_timed_out`, which nothing sends.
   %w[
     connect_failed disconnect_requested disconnected
-    pairing_timeout pairing_pair_error pairing_err-scanned-without-multidevice
+    pairing_pair_error pairing_err-scanned-without-multidevice
     pairing_code_refused pairing_connect_failed
   ].each do |reason|
     it "has a sentence written for #{reason}" do

--- a/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
+++ b/spec/services/whatsapp/session/inbound/handlers/connection_state_spec.rb
@@ -63,6 +63,39 @@ RSpec.describe Whatsapp::Session::Inbound::Handlers::ConnectionState do
     expect(channel.reload.provider_connection).not_to include('phone_number')
   end
 
+  # Most pairings that go nowhere end this way, and it is not a failure of anything: the
+  # code ran out because nobody scanned it, which the person looking at the screen is the
+  # one who knows. Reported in red it reads as a broken connection, and the operator goes
+  # looking for one. Closed with no sentence, the QR goes away and the button comes back.
+  it 'closes without a word when nobody completed the pairing in time' do
+    event = model::Event.build(model::Events::PairingError.new(reason: 'timeout', message: 'ran out'), epoch: 3)
+    described_class.new(channel: channel, event: event).perform
+
+    expect(channel.reload.provider_connection).to include('connection' => 'close')
+    expect(channel.provider_connection).not_to have_key('error')
+  end
+
+  it 'closes without a word on the closing state that follows it' do
+    event = model::Event.build(model::Events::SessionState.new(state: 'close', reason: 'pairing_timeout'), epoch: 3)
+    described_class.new(channel: channel, event: event).perform
+
+    expect(channel.reload.provider_connection).not_to have_key('error')
+  end
+
+  # These the operator can act on, and could not before: every pairing failure was
+  # reported as `connect_failure`, which says WhatsApp refused the connection and that
+  # retries continue on their own. Neither is true of a number WhatsApp will not send a
+  # code to, and there is nothing to act on in the sentence either.
+  it 'names what actually went wrong when a pairing fails' do
+    event = model::Event.build(model::Events::PairingError.new(reason: 'code_refused', message: 'refused'), epoch: 3)
+    described_class.new(channel: channel, event: event).perform
+
+    expect(channel.reload.provider_connection).to include(
+      'connection' => 'close', 'error_code' => 'pairing_code_refused',
+      'error' => I18n.t('errors.inboxes.channel.provider_connection.pairing_code_refused')
+    )
+  end
+
   # The dispatcher looks before the handler runs, and this lands in between: the operator
   # saved new credentials while the event was on its way to the write. The instance travels
   # with the event so the writer can compare it inside the row lock, which is the only place


### PR DESCRIPTION
Empilhada na #514. Rebasear depois do squash dela.

## O que você via

Deixe um QR expirar sem escanear e a inbox ficava com isto em vermelho:

> O WhatsApp recusou a conexão. Novas tentativas continuam automaticamente.

Nenhuma das duas frases é verdade. O WhatsApp não recusou nada, e não há tentativa nenhuma acontecendo. É simplesmente o desfecho de ninguém ter escaneado.

## Duas coisas erradas, uma dentro da outra

**A razão era descartada.** Todo `pairing.error` virava `connect_failure`, qualquer que fosse o motivo. O evento carrega `reason`, e ninguém lia.

**E o desfecho mais comum não é um erro.** A maioria dos pareamentos que não vão a lugar nenhum termina assim, e quem está olhando a tela é justamente quem sabe que não escaneou. Reportado em vermelho, lê-se como conexão quebrada e manda o operador procurar um defeito que não existe.

## O que muda

Um pareamento que expirou fecha **sem frase nenhuma**: o QR some, o botão de conectar volta. É o que a camada Baileys sempre fez. Vale para os dois eventos que carregam esse desfecho, o `pairing.error` de razão `timeout` e o `session.state` de fechamento que vem atrás com `pairing_timeout`.

As outras falhas de pareamento passam a ser nomeadas pela razão, o que torna alcançáveis as frases que a #514 escreveu e que até agora nada podia usar:

| razão do conector | o que aparece agora |
|---|---|
| `timeout` | nada, o botão volta |
| `code_refused` | o WhatsApp não quis mandar código para esse número, use o QR |
| `err-scanned-without-multidevice` | essa conta precisa ativar o multidispositivo |
| `pair_error` | o WhatsApp aceitou o código mas não concluiu |
| `connect_failed` | o conector não conseguiu falar com o WhatsApp |

A frase de `pairing_timeout` sai dos três idiomas, porque nada mais a traduz.

## Validação

`spec/services/whatsapp/session/`: 653 exemplos, 0 falhas. Três casos novos: o `pairing.error` de timeout, o `session.state` que vem atrás dele, e uma falha de verdade sendo nomeada pelo que aconteceu.

Encontrado ao vivo, pareando de novo depois do teste de logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/515)
<!-- Reviewable:end -->
