### PR TITLE
fix(whatsapp): escrever as frases das oito razões de desconexão que faltavam

### DIFF
--- a/app/services/whatsapp/session/connection_state_writer.rb
+++ b/app/services/whatsapp/session/connection_state_writer.rb
@@ -164,7 +164,17 @@ class Whatsapp::Session::ConnectionStateWriter
   # event, and the live update would then overwrite a correctly localized REST value with
   # it. This matches what the Baileys handler has always done.
   def translate(key)
-    I18n.t("errors.inboxes.channel.provider_connection.#{key}", default: key.to_s.humanize)
+    scoped = "errors.inboxes.channel.provider_connection.#{key}"
+    return I18n.t(scoped) if I18n.exists?(scoped, :en)
+
+    # A reason nobody wrote a sentence for. The humanized key keeps the dashboard from
+    # showing a blank, and it is English in every locale, so it can only ever be a
+    # placeholder. Silent, it stays one: `pairing_timeout` reached an operator as
+    # "Pairing timeout" for as long as the key existed, in a codebase that already had a
+    # sentence written for exactly that failure under a name nothing sends. The log line
+    # is what turns the next one into something somebody finds.
+    Rails.logger.warn("[WHATSAPP] no sentence written for provider connection reason #{key.inspect}")
+    key.to_s.humanize
   end
 
   def carry_pairing(payload, persisted)

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -69,6 +69,14 @@ en:
           connector_incompatible: The WhatsApp connector version is incompatible with this Chatwoot version. Update the connector.
           connect_failure: WhatsApp refused the connection. New attempts continue automatically.
           pairing_timed_out: The code expired before the phone finished pairing. Start the connection again to get a new one.
+          pairing_timeout: Nobody scanned the code before it expired. Start the connection again to get a new one.
+          pairing_pair_error: WhatsApp accepted the code but did not finish linking the device. Start the connection again.
+          pairing_err-scanned-without-multidevice: This WhatsApp account has to turn multi-device on before it can be linked.
+          pairing_code_refused: WhatsApp would not send a pairing code to this number. Link the device with the QR code instead.
+          pairing_connect_failed: The connector could not reach WhatsApp to start the pairing. Try again.
+          connect_failed: The connector could not reach WhatsApp. Retries continue automatically.
+          disconnect_requested: 'This connection was closed here. The pairing is still valid: connect again to resume it.'
+          disconnected: The connection to WhatsApp dropped. Retries continue automatically.
   notifications:
     notification_title:
       internal_chat_mention: You have been mentioned in %{name}

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -69,6 +69,14 @@ es:
           connector_incompatible: La versión del conector de WhatsApp es incompatible con esta versión de Chatwoot. Actualice el conector.
           connect_failure: WhatsApp rechazó la conexión. Los nuevos intentos continúan automáticamente.
           pairing_timed_out: El código expiró antes de que el teléfono completara la vinculación. Inicie la conexión de nuevo para obtener uno nuevo.
+          pairing_timeout: Nadie escaneó el código antes de que expirara. Inicie la conexión de nuevo para obtener uno nuevo.
+          pairing_pair_error: WhatsApp aceptó el código pero no terminó de vincular el dispositivo. Inicie la conexión de nuevo.
+          pairing_err-scanned-without-multidevice: Esta cuenta de WhatsApp debe activar el multidispositivo antes de poder vincularse.
+          pairing_code_refused: WhatsApp no quiso enviar un código de vinculación a este número. Vincule el dispositivo con el código QR.
+          pairing_connect_failed: El conector no pudo comunicarse con WhatsApp para iniciar la vinculación. Inténtelo de nuevo.
+          connect_failed: El conector no pudo comunicarse con WhatsApp. Los reintentos continúan automáticamente.
+          disconnect_requested: 'Esta conexión fue cerrada desde aquí. La vinculación sigue válida: conecte de nuevo para retomarla.'
+          disconnected: La conexión con WhatsApp se cayó. Los reintentos continúan automáticamente.
   notifications:
     notification_title:
       internal_chat_mention: Le mencionaron en %{name}

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -69,6 +69,14 @@ pt_BR:
           connector_incompatible: A versão do conector do WhatsApp é incompatível com esta versão do Chatwoot. Atualize o conector.
           connect_failure: O WhatsApp recusou a conexão. Novas tentativas continuam automaticamente.
           pairing_timed_out: O código expirou antes de o telefone concluir o pareamento. Inicie a conexão novamente para obter um novo.
+          pairing_timeout: Ninguém escaneou o código antes de ele expirar. Inicie a conexão novamente para obter um novo.
+          pairing_pair_error: O WhatsApp aceitou o código mas não concluiu a conexão do dispositivo. Inicie a conexão novamente.
+          pairing_err-scanned-without-multidevice: Esta conta do WhatsApp precisa ativar o multidispositivo antes de poder ser conectada.
+          pairing_code_refused: O WhatsApp não quis enviar um código de pareamento para este número. Conecte o dispositivo pelo QR code.
+          pairing_connect_failed: O conector não conseguiu falar com o WhatsApp para iniciar o pareamento. Tente novamente.
+          connect_failed: O conector não conseguiu falar com o WhatsApp. Novas tentativas continuam automaticamente.
+          disconnect_requested: 'Esta conexão foi encerrada aqui. O pareamento continua válido: conecte novamente para retomá-la.'
+          disconnected: A conexão com o WhatsApp caiu. Novas tentativas continuam automaticamente.
   notifications:
     notification_title:
       internal_chat_mention: Você foi mencionado em %{name}

--- a/spec/services/whatsapp/session/connection_state_writer_spec.rb
+++ b/spec/services/whatsapp/session/connection_state_writer_spec.rb
@@ -12,6 +12,35 @@ RSpec.describe Whatsapp::Session::ConnectionStateWriter do
     expect(channel.reload.provider_connection).to include('connection' => 'connecting', 'epoch' => 3)
   end
 
+  # Every reason the connector puts on a closing `session.state`, taken from
+  # `publishPairingFailure` and the `EventSessionState` emits in
+  # `internal/engine/whatsmeow/session.go`. A key that is missing does not fail anywhere:
+  # it renders as the humanized key, in English, in every locale. `pairing_timeout` did
+  # exactly that while a written sentence for the same failure sat under
+  # `pairing_timed_out`, which nothing sends.
+  %w[
+    connect_failed disconnect_requested disconnected
+    pairing_timeout pairing_pair_error pairing_err-scanned-without-multidevice
+    pairing_code_refused pairing_connect_failed
+  ].each do |reason|
+    it "has a sentence written for #{reason}" do
+      writer.apply(state.new(connection: 'close', error: reason, epoch: 3))
+
+      expect(channel.reload.provider_connection['error']).not_to eq(reason.humanize)
+    end
+  end
+
+  # The placeholder still stands, because a blank is worse. What it must not do is stand
+  # in silence: this is the only thing that says a provider started sending something
+  # nobody wrote a sentence for.
+  it 'says out loud when a reason has no sentence' do
+    allow(Rails.logger).to receive(:warn)
+    writer.apply(state.new(connection: 'close', error: 'a_reason_nobody_wrote', epoch: 3))
+
+    expect(Rails.logger).to have_received(:warn).with(/no sentence written.*a_reason_nobody_wrote/)
+    expect(channel.reload.provider_connection['error']).to eq('A reason nobody wrote')
+  end
+
   it 'clears what the new state does not carry' do
     writer.apply(state.new(connection: 'connecting', qr_data_url: 'data:image/png;base64,AAA', epoch: 3))
     writer.apply(state.new(connection: 'open', epoch: 3))


### PR DESCRIPTION
Empilhada na #513, que toca os mesmos arquivos de tradução. Rebasear depois do squash dela.

## O que acontece

`ConnectionStateWriter#translate` tinha:

```ruby
I18n.t("errors.inboxes.channel.provider_connection.#{key}", default: key.to_s.humanize)
```

Uma chave que falta não falha em lugar nenhum. Vira a própria chave humanizada, em inglês, em qualquer idioma. Oito razões que o conector manda num fechamento de sessão estavam nesse estado.

Visto ao vivo hoje: o QR de uma inbox nova expirou sem ninguém escanear, e o que ficou gravado no canal foi

```
"error" => "Pairing timeout", "error_code" => "pairing_timeout"
```

E o pior detalhe: **existe uma frase escrita para exatamente essa falha**, sob `pairing_timed_out`, usada só pelo caminho de polling da uazapi. O conector diz `pairing_timeout`. As duas chaves nunca se encontraram, e nada apontou isso.

## As oito

Tiradas de `publishPairingFailure` e dos emits de `EventSessionState` em `internal/engine/whatsmeow/session.go`:

| razão | o que o operador lia |
|---|---|
| `pairing_timeout` | Pairing timeout |
| `pairing_pair_error` | Pairing pair error |
| `pairing_err-scanned-without-multidevice` | Pairing err-scanned-without-multidevice |
| `pairing_code_refused` | Pairing code refused |
| `pairing_connect_failed` | Pairing connect failed |
| `connect_failed` | Connect failed |
| `disconnect_requested` | Disconnect requested |
| `disconnected` | Disconnected |

Todas ganham frase em en, es e pt-BR. Onde a frase diz o que fazer, ela diz: `pairing_code_refused` manda usar o QR, `pairing_err-scanned-without-multidevice` manda ativar o multidispositivo, `disconnect_requested` avisa que o pareamento continua válido e basta conectar de novo.

## E o fallback para de ser calado

Ele continua existindo, porque um espaço em branco na tela é pior, mas agora deixa um aviso no log. Sem isso, a próxima razão que um provedor passar a mandar chega ao operador em inglês e nada em lugar nenhum diz que falta tradução, que é literalmente o que aconteceu com a `pairing_timeout`.

## Onde isso aparece

No modal de conectar dispositivo (`WhatsappLinkDeviceModal`), em vermelho, acima do botão de conectar. Ele é aberto das configurações da inbox, do passo final do setup, da página de configuração do canal e da própria tela de conversa quando a inbox cai.

## Validação

`spec/services/whatsapp/session/`: 651 exemplos, 0 falhas. Um exemplo por razão, mais um que fixa o aviso no log.

O teste por razão compara com `reason.humanize` em vez de com a frase: escrito contra a frase, ele passaria a testar a redação, e é a ausência que importa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





---

Substitui a #514, que o GitHub fechou sozinha quando a branch base dela foi apagada no merge da #513. Mesmo commit, rebaseado sobre `feat/whatsapp-session`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/517)
<!-- Reviewable:end -->
