### PR TITLE
fix(attachments): refuse a file with no bytes instead of sending it

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -60,9 +60,11 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
       attachment = @message.attachments.build(
         account_id: @message.account_id,
         file: uploaded_attachment,
-        # An agent picked this file, so an empty one is a mistake we can still name to their face
-        # instead of a message that turns red minutes later. Ingestion never comes through here.
-        refuse_empty_file: true
+        # Someone on our side picked this file, so an empty one is a mistake we can still name to
+        # their face instead of a message that turns red minutes later. An API inbox pushes
+        # customer messages through this same builder, and those are ingestion: refusing one would
+        # throw away its text along with the odd attachment.
+        refuse_empty_file: !@message.incoming?
       )
       metadata = process_metadata(uploaded_attachment)
       attachment.meta = metadata if metadata.present?

--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -59,7 +59,10 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
     @attachments.each do |uploaded_attachment|
       attachment = @message.attachments.build(
         account_id: @message.account_id,
-        file: uploaded_attachment
+        file: uploaded_attachment,
+        # An agent picked this file, so an empty one is a mistake we can still name to their face
+        # instead of a message that turns red minutes later. Ingestion never comes through here.
+        refuse_empty_file: true
       )
       metadata = process_metadata(uploaded_attachment)
       attachment.meta = metadata if metadata.present?

--- a/app/javascript/dashboard/composables/spec/useFileUpload.spec.js
+++ b/app/javascript/dashboard/composables/spec/useFileUpload.spec.js
@@ -3,7 +3,7 @@ import { useMapGetter } from 'dashboard/composables/store';
 import { useAlert } from 'dashboard/composables';
 import { useI18n } from 'vue-i18n';
 import { DirectUpload } from 'activestorage';
-import { checkFileSizeLimit } from 'shared/helpers/FileHelper';
+import { checkFileSizeLimit, isFileEmpty } from 'shared/helpers/FileHelper';
 import { getMaxUploadSizeByChannel } from '@chatwoot/utils';
 
 vi.mock('dashboard/composables/store');
@@ -14,6 +14,7 @@ vi.mock('vue-i18n');
 vi.mock('activestorage');
 vi.mock('shared/helpers/FileHelper', () => ({
   checkFileSizeLimit: vi.fn(),
+  isFileEmpty: vi.fn(),
   resolveMaximumFileUploadSize: vi.fn(value => Number(value) || 40),
   DEFAULT_MAXIMUM_FILE_UPLOAD_SIZE: 40,
 }));
@@ -49,7 +50,55 @@ describe('useFileUpload', () => {
 
     useI18n.mockReturnValue({ t: mockTranslate });
     checkFileSizeLimit.mockReturnValue(true);
+    isFileEmpty.mockReturnValue(false);
     getMaxUploadSizeByChannel.mockReturnValue(25); // default max size MB for tests
+  });
+
+  // The server refuses a zero-byte file, and before this the agent saw no reason at all: the
+  // message just turned red minutes later. Say it in the composer, where the size limit is said.
+  describe('an empty file', () => {
+    beforeEach(() => {
+      isFileEmpty.mockReturnValue(true);
+      mockTranslate.mockReturnValue('This file is empty and cannot be sent');
+    });
+
+    it('is refused with a readable reason on the direct upload path', () => {
+      const { onFileUpload } = useFileUpload({
+        inbox,
+        attachFile: mockAttachFile,
+      });
+      onFileUpload(mockFile);
+
+      expect(mockTranslate).toHaveBeenCalledWith('CONVERSATION.FILE_IS_EMPTY');
+      expect(useAlert).toHaveBeenCalledWith(
+        'This file is empty and cannot be sent'
+      );
+      expect(DirectUpload).not.toHaveBeenCalled();
+      expect(mockAttachFile).not.toHaveBeenCalled();
+    });
+
+    it('is refused on the indirect upload path too', () => {
+      useMapGetter.mockImplementation(getter => {
+        const getterMap = {
+          getCurrentAccountId: { value: '123' },
+          getSelectedChat: { value: { id: '456' } },
+          'globalConfig/get': {
+            value: { directUploadsEnabled: false, maximumFileUploadSize: 40 },
+          },
+        };
+        return getterMap[getter];
+      });
+      const { onFileUpload } = useFileUpload({
+        inbox,
+        attachFile: mockAttachFile,
+      });
+      onFileUpload(mockFile);
+
+      expect(useAlert).toHaveBeenCalledWith(
+        'This file is empty and cannot be sent'
+      );
+      expect(mockAttachFile).not.toHaveBeenCalled();
+    });
   });
 
   it('handles direct file upload when direct uploads enabled', () => {

--- a/app/javascript/dashboard/composables/useFileUpload.js
+++ b/app/javascript/dashboard/composables/useFileUpload.js
@@ -3,7 +3,7 @@ import { useAlert } from 'dashboard/composables';
 import { useI18n } from 'vue-i18n';
 import { DirectUpload } from 'activestorage';
 import { setDirectUploadAuthHeaders } from 'dashboard/helper/directUploadsHelper';
-import { checkFileSizeLimit } from 'shared/helpers/FileHelper';
+import { checkFileSizeLimit, isFileEmpty } from 'shared/helpers/FileHelper';
 import { getMaxUploadSizeByChannel } from '@chatwoot/utils';
 import {
   DEFAULT_MAXIMUM_FILE_UPLOAD_SIZE,
@@ -55,6 +55,8 @@ export const useFileUpload = ({ inbox, attachFile, isPrivateNote = false }) => {
     return Math.min(channelLimit, installationLimit);
   };
 
+  const alertEmptyFile = () => useAlert(t('CONVERSATION.FILE_IS_EMPTY'));
+
   const alertOverLimit = maxSizeMB =>
     useAlert(
       t('CONVERSATION.FILE_SIZE_LIMIT', {
@@ -67,6 +69,11 @@ export const useFileUpload = ({ inbox, attachFile, isPrivateNote = false }) => {
 
     const mime = file.file?.type || file.type;
     const maxSizeMB = maxSizeFor(mime);
+
+    if (isFileEmpty(file)) {
+      alertEmptyFile();
+      return;
+    }
 
     if (!checkFileSizeLimit(file, maxSizeMB)) {
       alertOverLimit(maxSizeMB);
@@ -97,6 +104,11 @@ export const useFileUpload = ({ inbox, attachFile, isPrivateNote = false }) => {
 
     const mime = file.file?.type || file.type;
     const maxSizeMB = maxSizeFor(mime);
+
+    if (isFileEmpty(file)) {
+      alertEmptyFile();
+      return;
+    }
 
     if (!checkFileSizeLimit(file, maxSizeMB)) {
       alertOverLimit(maxSizeMB);

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/conversation.json
@@ -94,7 +94,8 @@
       "REQUESTED": "Asked the phone for older messages. They appear here as it sends them.",
       "ERROR": "Could not ask for older messages. Try again in a moment.",
       "EXHAUSTED": "There is nothing older here. The rest of this conversation is only on the phone."
-    }
+    },
+    "FILE_IS_EMPTY": "This file is empty and cannot be sent"
   },
   "CONVERSATION_SIDEBAR": {
     "ACCORDION": {

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/conversation.json
@@ -94,7 +94,8 @@
       "REQUESTED": "Le pedimos al teléfono los mensajes más antiguos. Aparecen aquí a medida que los envía.",
       "ERROR": "No se pudieron pedir los mensajes más antiguos. Inténtalo de nuevo en un momento.",
       "EXHAUSTED": "No hay nada más antiguo aquí. El resto de esta conversación está solo en el teléfono."
-    }
+    },
+    "FILE_IS_EMPTY": "Este archivo está vacío y no se puede enviar"
   },
   "CONVERSATION_SIDEBAR": {
     "ACCORDION": {

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/conversation.json
@@ -94,7 +94,8 @@
       "REQUESTED": "Pedimos as mensagens mais antigas ao celular. Elas aparecem aqui conforme ele envia.",
       "ERROR": "Não foi possível pedir as mensagens mais antigas. Tente de novo em instantes.",
       "EXHAUSTED": "Não há nada mais antigo aqui. O restante desta conversa está apenas no celular."
-    }
+    },
+    "FILE_IS_EMPTY": "Este arquivo está vazio e não pode ser enviado"
   },
   "CONVERSATION_SIDEBAR": {
     "ACCORDION": {

--- a/app/javascript/dashboard/mixins/fileUploadMixin.js
+++ b/app/javascript/dashboard/mixins/fileUploadMixin.js
@@ -1,6 +1,6 @@
 import { mapGetters } from 'vuex';
 import { useAlert } from 'dashboard/composables';
-import { checkFileSizeLimit } from 'shared/helpers/FileHelper';
+import { checkFileSizeLimit, isFileEmpty } from 'shared/helpers/FileHelper';
 import { getMaxUploadSizeByChannel } from '@chatwoot/utils';
 import { DirectUpload } from 'activestorage';
 import { setDirectUploadAuthHeaders } from 'dashboard/helper/directUploadsHelper';
@@ -47,6 +47,9 @@ export default {
 
       return Math.min(channelLimit, this.installationLimit);
     },
+    alertEmptyFile() {
+      useAlert(this.$t('CONVERSATION.FILE_IS_EMPTY'));
+    },
     alertOverLimit(maxSizeMB) {
       useAlert(
         this.$t('CONVERSATION.FILE_SIZE_LIMIT', {
@@ -67,6 +70,11 @@ export default {
 
       const mime = file.file?.type || file.type;
       const maxSizeMB = this.maxSizeFor(mime);
+
+      if (isFileEmpty(file)) {
+        this.alertEmptyFile();
+        return;
+      }
 
       if (!checkFileSizeLimit(file, maxSizeMB)) {
         this.alertOverLimit(maxSizeMB);
@@ -97,6 +105,11 @@ export default {
 
       const mime = file.file?.type || file.type;
       const maxSizeMB = this.maxSizeFor(mime);
+
+      if (isFileEmpty(file)) {
+        this.alertEmptyFile();
+        return;
+      }
 
       if (!checkFileSizeLimit(file, maxSizeMB)) {
         this.alertOverLimit(maxSizeMB);

--- a/app/javascript/dashboard/mixins/specs/fileUploadMixin.spec.js
+++ b/app/javascript/dashboard/mixins/specs/fileUploadMixin.spec.js
@@ -1,11 +1,12 @@
 import { shallowMount } from '@vue/test-utils';
 import { useAlert } from 'dashboard/composables';
 import fileUploadMixin from 'dashboard/mixins/fileUploadMixin';
-import { checkFileSizeLimit } from 'shared/helpers/FileHelper';
+import { checkFileSizeLimit, isFileEmpty } from 'shared/helpers/FileHelper';
 import { reactive } from 'vue';
 
 vi.mock('shared/helpers/FileHelper', () => ({
   checkFileSizeLimit: vi.fn(),
+  isFileEmpty: vi.fn(),
   resolveMaximumFileUploadSize: vi.fn(value => Number(value) || 40),
   DEFAULT_MAXIMUM_FILE_UPLOAD_SIZE: 40,
 }));
@@ -57,6 +58,9 @@ describe('FileUploadMixin', () => {
       },
       template: '<div />',
     });
+
+    checkFileSizeLimit.mockReturnValue(true);
+    isFileEmpty.mockReturnValue(false);
   });
 
   it('should call onDirectFileUpload when direct uploads are enabled', () => {
@@ -70,6 +74,28 @@ describe('FileUploadMixin', () => {
     wrapper.vm.onIndirectFileUpload = vi.fn();
     wrapper.vm.onFileUpload({});
     expect(wrapper.vm.onIndirectFileUpload).toHaveBeenCalledWith({});
+  });
+
+  // Same reason as in the composable: without this the refusal reaches the agent only as a
+  // message that looked sent and failed later.
+  describe('an empty file', () => {
+    beforeEach(() => {
+      isFileEmpty.mockReturnValue(true);
+    });
+
+    it('is refused with a readable reason on the direct upload path', () => {
+      wrapper.vm.onDirectFileUpload({ size: 0 });
+
+      expect(useAlert).toHaveBeenCalledWith('CONVERSATION.FILE_IS_EMPTY');
+      expect(checkFileSizeLimit).not.toHaveBeenCalled();
+    });
+
+    it('is refused on the indirect upload path too', () => {
+      wrapper.vm.onIndirectFileUpload({ size: 0 });
+
+      expect(useAlert).toHaveBeenCalledWith('CONVERSATION.FILE_IS_EMPTY');
+      expect(checkFileSizeLimit).not.toHaveBeenCalled();
+    });
   });
 
   describe('onDirectFileUpload', () => {

--- a/app/javascript/shared/helpers/FileHelper.js
+++ b/app/javascript/shared/helpers/FileHelper.js
@@ -25,6 +25,14 @@ export const checkFileSizeLimit = (file, maximumUploadLimit) => {
   return fileSizeInMB <= maximumUploadLimit;
 };
 
+// A zero-byte file is refused by the server, and on a WhatsApp inbox that refusal used to reach
+// the agent only as a message that looked sent and failed minutes later. Catch it here so the
+// reason is readable, the same way the size limit is.
+export const isFileEmpty = file => {
+  const fileSize = file?.file?.size ?? file?.size;
+  return fileSize === 0;
+};
+
 export const resolveMaximumFileUploadSize = value => {
   const parsedValue = Number(value);
 

--- a/app/javascript/shared/helpers/specs/FileHelper.spec.js
+++ b/app/javascript/shared/helpers/specs/FileHelper.spec.js
@@ -5,6 +5,7 @@ import {
   checkFileSizeLimit,
   resolveMaximumFileUploadSize,
   isFileTypeAllowedForChannel,
+  isFileEmpty,
 } from '../FileHelper';
 
 describe('#File Helpers', () => {
@@ -29,6 +30,23 @@ describe('#File Helpers', () => {
     });
     it('should return 19.07 if 20000000 is passed', () => {
       expect(fileSizeInMegaBytes(20000000)).toBeCloseTo(19.07, 2);
+    });
+  });
+
+  describe('isFileEmpty', () => {
+    it('should return true for a zero-byte file in either shape', () => {
+      expect(isFileEmpty({ file: { size: 0 } })).toBe(true);
+      expect(isFileEmpty({ size: 0 })).toBe(true);
+    });
+    it('should return false for a file that carries bytes', () => {
+      expect(isFileEmpty({ file: { size: 1 } })).toBe(false);
+      expect(isFileEmpty({ size: 199154 })).toBe(false);
+    });
+    // An unknown size is not the same as an empty file, and refusing it would block uploads
+    // whose size the browser never reported.
+    it('should return false when the size is unknown', () => {
+      expect(isFileEmpty({})).toBe(false);
+      expect(isFileEmpty(undefined)).toBe(false);
     });
   });
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -43,7 +43,12 @@ class Attachment < ApplicationRecord
   has_one_attached :file
   before_save :set_extension
   validate :acceptable_file
-  validate :file_is_not_empty
+  # Off by default on purpose. Only the paths where we compose a message and are about to send it
+  # turn this on, because a refusal on an ingested attachment raises inside the provider webhook
+  # and loses the whole message instead of storing an odd one.
+  attr_accessor :refuse_empty_file
+
+  validate :file_is_not_empty, if: :refuse_empty_file
   validates :external_url, length: { maximum: Limits::URL_LENGTH_LIMIT }
   enum file_type: { :image => 0, :audio => 1, :video => 2, :file => 3, :location => 4, :fallback => 5, :share => 6, :story_mention => 7,
                     :contact => 8, :ig_reel => 9, :ig_post => 10, :ig_story => 11, :embed => 12 }
@@ -201,12 +206,8 @@ class Attachment < ApplicationRecord
   # Outgoing only, and that boundary is the point: refusing what an agent uploads hands them the
   # reason while they can still fix it, while refusing what a contact sent would raise inside
   # `Whatsapp::IncomingMessageBaseService#process_messages` and take the inbound webhook down.
-  # Only worth refusing when we are the ones about to send the file. Whatever the provider handed
-  # us is recorded as it arrived, whether incoming or an echo of a message sent from another
-  # client, because refusing it would roll back the whole webhook.
   def file_is_not_empty
     return unless file.attached? && file.byte_size.to_i.zero?
-    return unless %w[outgoing template].include?(message&.message_type) && !message.content_attributes['external_echo']
 
     errors.add(:file, 'is empty')
   end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -196,12 +196,13 @@ class Attachment < ApplicationRecord
     true
   end
 
-  # Separate from `acceptable_file`, which only runs on a web widget inbox: what is an acceptable
-  # *type* is a per-channel policy, but a file with no bytes is useless on every channel. It used
-  # to be accepted, stored and handed to the provider — the agent saw a message that looked sent,
-  # and the refusal came back later as a failed status carrying an error nobody could tie to it.
+  # Separate from `acceptable_file`, which runs only on a web widget inbox: which *types* an inbox
+  # accepts is a per-channel policy, while a file with no bytes is useless on every channel.
+  # Outgoing only, and that boundary is the point: refusing what an agent uploads hands them the
+  # reason while they can still fix it, while refusing what a contact sent would raise inside
+  # `Whatsapp::IncomingMessageBaseService#process_messages` and take the inbound webhook down.
   def file_is_not_empty
-    return unless file.attached?
+    return unless file.attached? && (message&.outgoing? || message&.template?)
     return unless file.byte_size.to_i.zero?
 
     errors.add(:file, 'is empty')

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -201,9 +201,12 @@ class Attachment < ApplicationRecord
   # Outgoing only, and that boundary is the point: refusing what an agent uploads hands them the
   # reason while they can still fix it, while refusing what a contact sent would raise inside
   # `Whatsapp::IncomingMessageBaseService#process_messages` and take the inbound webhook down.
+  # Only worth refusing when we are the ones about to send the file. Whatever the provider handed
+  # us is recorded as it arrived, whether incoming or an echo of a message sent from another
+  # client, because refusing it would roll back the whole webhook.
   def file_is_not_empty
-    return unless file.attached? && (message&.outgoing? || message&.template?)
-    return unless file.byte_size.to_i.zero?
+    return unless file.attached? && file.byte_size.to_i.zero?
+    return unless %w[outgoing template].include?(message&.message_type) && !message.content_attributes['external_echo']
 
     errors.add(:file, 'is empty')
   end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -43,6 +43,7 @@ class Attachment < ApplicationRecord
   has_one_attached :file
   before_save :set_extension
   validate :acceptable_file
+  validate :file_is_not_empty
   validates :external_url, length: { maximum: Limits::URL_LENGTH_LIMIT }
   enum file_type: { :image => 0, :audio => 1, :video => 2, :file => 3, :location => 4, :fallback => 5, :share => 6, :story_mention => 7,
                     :contact => 8, :ig_reel => 9, :ig_post => 10, :ig_story => 11, :embed => 12 }
@@ -193,6 +194,17 @@ class Attachment < ApplicationRecord
     return false unless message.inbox.channel_type == 'Channel::WebWidget'
 
     true
+  end
+
+  # Separate from `acceptable_file`, which only runs on a web widget inbox: what is an acceptable
+  # *type* is a per-channel policy, but a file with no bytes is useless on every channel. It used
+  # to be accepted, stored and handed to the provider — the agent saw a message that looked sent,
+  # and the refusal came back later as a failed status carrying an error nobody could tie to it.
+  def file_is_not_empty
+    return unless file.attached?
+    return unless file.byte_size.to_i.zero?
+
+    errors.add(:file, 'is empty')
   end
 
   def acceptable_file

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -202,10 +202,9 @@ class Attachment < ApplicationRecord
   end
 
   # Separate from `acceptable_file`, which runs only on a web widget inbox: which *types* an inbox
-  # accepts is a per-channel policy, while a file with no bytes is useless on every channel.
-  # Outgoing only, and that boundary is the point: refusing what an agent uploads hands them the
-  # reason while they can still fix it, while refusing what a contact sent would raise inside
-  # `Whatsapp::IncomingMessageBaseService#process_messages` and take the inbound webhook down.
+  # accepts is a per-channel policy, while a file with no bytes is useless on every channel. Who
+  # gets refused is decided by `refuse_empty_file`, not by the message type, and the flag lives in
+  # memory only, so reloading a row that was stored before this existed never refuses it later.
   def file_is_not_empty
     return unless file.attached? && file.byte_size.to_i.zero?
 

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -119,6 +119,18 @@ describe Messages::MessageBuilder do
         message = message_builder
         expect(message.message_type).to eq params[:message_type]
       end
+
+      # An API inbox pushes customer messages through this same builder, so it is ingestion even
+      # though it comes in over HTTP. Refusing an empty attachment here would answer 422 and throw
+      # away the message text with it.
+      it 'keeps an empty attachment on an incoming message instead of refusing the whole message' do
+        params[:attachments] = [Rack::Test::UploadedFile.new('spec/assets/attachment.pdf', 'application/pdf')]
+
+        message = message_builder
+
+        expect(message.attachments.first.refuse_empty_file).to be(false)
+        expect(message.attachments.first.file.byte_size).to eq(0)
+      end
     end
 
     context 'when attachment messages' do

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -134,6 +134,21 @@ describe Messages::MessageBuilder do
         expect(message.attachments.first.file_type).to eq 'image'
       end
 
+      # This builder is the boundary where an agent (or a campaign, macro or automation) composes
+      # a message we are about to send. It is the only place that asks the attachment to refuse an
+      # empty file, so a zero-byte upload is named here instead of failing at the provider later.
+      it 'asks the attachment to refuse an empty file' do
+        message = message_builder
+        expect(message.attachments.first.refuse_empty_file).to be(true)
+      end
+
+      it 'refuses a zero-byte upload instead of storing it' do
+        params[:attachments] = [Rack::Test::UploadedFile.new('spec/assets/attachment.pdf', 'application/pdf')]
+
+        expect { message_builder }.to raise_error(ActiveRecord::RecordInvalid, /file is empty/i)
+        expect(Message.count).to eq(0)
+      end
+
       it 'creates attachment with is_recorded_audio metadata' do
         params[:is_recorded_audio] = true
 

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -98,6 +98,22 @@ RSpec.describe 'Conversation Messages API', type: :request do
         expect(conversation.messages.last.attachments.first.file_type).to eq('image')
       end
 
+      # The agent has to learn now, from the request they made, rather than from a failed status
+      # minutes later carrying a provider error nobody can tie back to an empty file.
+      it 'refuses an empty attachment without creating the message' do
+        empty = Tempfile.new(['voice', '.ogg'])
+        empty.close
+        params = { content: nil, attachments: [Rack::Test::UploadedFile.new(empty.path, 'audio/ogg')] }
+
+        post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: params,
+             headers: agent.create_new_auth_token
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to include('file is empty')
+        expect(conversation.messages.count).to eq(0)
+      end
+
       it 'triggers typing off event for non-private messages' do
         params = { content: 'test-message', private: false }
         allow(Rails.configuration.dispatcher).to receive(:dispatch).and_call_original

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -215,19 +215,21 @@ RSpec.describe Attachment do
   describe 'push_event_data for instagram direct message attachments' do
     let(:account) { create(:account) }
     let(:instagram_inbox) do
-      create(:inbox, account: account,
+      create(:inbox, account: message.account,
                      channel: create(:channel_instagram_fb_page, account: account, instagram_id: 'instagram-dm-test'))
     end
 
     context 'when conversation type is instagram_direct_message' do
       let(:conversation) do
-        create(:conversation, account: account, inbox: instagram_inbox,
+        create(:conversation, account: message.account, inbox: instagram_inbox,
                               additional_attributes: { 'type' => 'instagram_direct_message' })
       end
-      let(:instagram_message) { create(:message, account: account, inbox: instagram_inbox, conversation: conversation, message_type: :incoming) }
+      let(:instagram_message) do
+        create(:message, account: message.account, inbox: instagram_inbox, conversation: conversation, message_type: :incoming)
+      end
 
       it 'uses external_url for data_url and thumb_url' do
-        attachment = instagram_message.attachments.new(account_id: account.id, file_type: :image, external_url: 'https://instagram.com/image.jpg')
+        attachment = instagram_message.attachments.new(account_id: message.account_id, file_type: :image, external_url: 'https://instagram.com/image.jpg')
         attachment.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
         attachment.save!
 
@@ -239,13 +241,15 @@ RSpec.describe Attachment do
 
     context 'when conversation type is not instagram_direct_message' do
       let(:conversation) do
-        create(:conversation, account: account, inbox: instagram_inbox,
+        create(:conversation, account: message.account, inbox: instagram_inbox,
                               additional_attributes: { 'type' => 'other_type' })
       end
-      let(:instagram_message) { create(:message, account: account, inbox: instagram_inbox, conversation: conversation, message_type: :incoming) }
+      let(:instagram_message) do
+        create(:message, account: message.account, inbox: instagram_inbox, conversation: conversation, message_type: :incoming)
+      end
 
       it 'uses file_url for data_url instead of external_url' do
-        attachment = instagram_message.attachments.new(account_id: account.id, file_type: :image, external_url: 'https://instagram.com/image.jpg')
+        attachment = instagram_message.attachments.new(account_id: message.account_id, file_type: :image, external_url: 'https://instagram.com/image.jpg')
         attachment.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
         attachment.save!
 
@@ -256,13 +260,15 @@ RSpec.describe Attachment do
 
     context 'when message is outgoing on instagram DM conversation' do
       let(:conversation) do
-        create(:conversation, account: account, inbox: instagram_inbox,
+        create(:conversation, account: message.account, inbox: instagram_inbox,
                               additional_attributes: { 'type' => 'instagram_direct_message' })
       end
-      let(:outgoing_message) { create(:message, account: account, inbox: instagram_inbox, conversation: conversation, message_type: :outgoing) }
+      let(:outgoing_message) do
+        create(:message, account: message.account, inbox: instagram_inbox, conversation: conversation, message_type: :outgoing)
+      end
 
       it 'does not override data_url with external_url' do
-        attachment = outgoing_message.attachments.new(account_id: account.id, file_type: :image, external_url: 'https://instagram.com/image.jpg')
+        attachment = outgoing_message.attachments.new(account_id: message.account_id, file_type: :image, external_url: 'https://instagram.com/image.jpg')
         attachment.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
         attachment.save!
 
@@ -274,11 +280,11 @@ RSpec.describe Attachment do
     context 'when inbox is Channel::Instagram (direct login)' do
       let(:instagram_channel) { create(:channel_instagram, account: account) }
       let(:direct_inbox) { instagram_channel.inbox }
-      let(:conversation) { create(:conversation, account: account, inbox: direct_inbox) }
-      let(:incoming_message) { create(:message, account: account, inbox: direct_inbox, conversation: conversation, message_type: :incoming) }
+      let(:conversation) { create(:conversation, account: message.account, inbox: direct_inbox) }
+      let(:incoming_message) { create(:message, account: message.account, inbox: direct_inbox, conversation: conversation, message_type: :incoming) }
 
       it 'uses external_url for data_url and thumb_url' do
-        attachment = incoming_message.attachments.new(account_id: account.id, file_type: :image, external_url: 'https://instagram.com/image.jpg')
+        attachment = incoming_message.attachments.new(account_id: message.account_id, file_type: :image, external_url: 'https://instagram.com/image.jpg')
         attachment.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
         attachment.save!
 
@@ -380,6 +386,53 @@ RSpec.describe Attachment do
       attachment.send(:validate_file_size, 6.megabytes)
 
       expect(attachment.errors[:file]).to include('size is too big')
+    end
+
+    # The size validation only runs on a web widget inbox, so nothing was checking a file on a
+    # WhatsApp one. A zero-byte recording was accepted, stored and sent to the provider as a voice
+    # note: the agent saw a message that looked sent, and the rejection arrived later as a failed
+    # status carrying an error nobody could tie back to "the file was empty".
+    describe 'an empty file' do
+      def empty_attachment_on(channel)
+        inbox = create(:inbox, account: message.account, channel: channel)
+        conversation = create(:conversation, account: message.account, inbox: inbox)
+        empty_message = create(:message, account: message.account, conversation: conversation)
+        attachment = empty_message.attachments.new(account_id: message.account_id, file_type: :audio)
+        attachment.file.attach(io: StringIO.new(''), filename: 'voice.ogg', content_type: 'audio/ogg')
+        attachment
+      end
+
+      it 'is rejected on a provider inbox, where nothing used to look' do
+        attachment = empty_attachment_on(create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false))
+
+        expect(attachment).not_to be_valid
+        expect(attachment.errors[:file]).to include('is empty')
+      end
+
+      it 'is rejected on a web widget inbox too' do
+        attachment = empty_attachment_on(create(:channel_widget, account: message.account))
+
+        expect(attachment).not_to be_valid
+        expect(attachment.errors[:file]).to include('is empty')
+      end
+
+      it 'leaves a file with bytes alone' do
+        inbox = create(:inbox, account: message.account, channel: create(:channel_whatsapp, account: message.account,
+                                                                                            validate_provider_config: false, sync_templates: false))
+        conversation = create(:conversation, account: message.account, inbox: inbox)
+        sized_message = create(:message, account: message.account, conversation: conversation)
+        attachment = sized_message.attachments.new(account_id: message.account_id, file_type: :audio)
+        attachment.file.attach(io: Rails.root.join('spec/assets/sample_opus.ogg').open, filename: 'voice.ogg', content_type: 'audio/ogg')
+
+        expect(attachment).to be_valid
+      end
+
+      it 'leaves an attachment that carries no file at all alone' do
+        location = message.attachments.new(account_id: message.account_id, file_type: :location,
+                                           coordinates_lat: 1.0, coordinates_long: 1.0, fallback_title: 'here')
+
+        expect(location).to be_valid
+      end
     end
 
     it 'falls back to default when configured limit is invalid' do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -453,6 +453,21 @@ RSpec.describe Attachment do
         expect(attachment).to be_valid
       end
 
+      # The flag is in-memory only, so a row that already exists is never re-refused when something
+      # saves it again later. Retry does exactly that: it calls `message.update!` on a failed
+      # message, and an attachment stored before this validation existed must not block it.
+      it 'never refuses a row that is already stored, however it is saved again' do
+        attachment = empty_attachment_on(whatsapp_channel, refuse: false)
+        attachment.save!
+        owner = attachment.message
+
+        # A fresh instance, because `reload` keeps the in-memory accessor on the object it is
+        # called on and would hide exactly the thing under test.
+        expect(described_class.find(attachment.id).refuse_empty_file).to be_nil
+        expect { owner.update!(content: 'edited') }.not_to raise_error
+        expect(described_class.find(attachment.id)).to be_valid
+      end
+
       # A fence, not a checklist. There are four provider ingestion paths that build outgoing
       # attachments (baileys, z-api, the session writer, the reaction store), each marking the
       # echo differently, and enumerating them is how the third one got missed. Assert instead

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe Attachment do
       def empty_attachment_on(channel)
         inbox = create(:inbox, account: message.account, channel: channel)
         conversation = create(:conversation, account: message.account, inbox: inbox)
-        empty_message = create(:message, account: message.account, conversation: conversation)
+        empty_message = create(:message, account: message.account, conversation: conversation, message_type: :outgoing)
         attachment = empty_message.attachments.new(account_id: message.account_id, file_type: :audio)
         attachment.file.attach(io: StringIO.new(''), filename: 'voice.ogg', content_type: 'audio/ogg')
         attachment
@@ -420,18 +420,46 @@ RSpec.describe Attachment do
         inbox = create(:inbox, account: message.account, channel: create(:channel_whatsapp, account: message.account,
                                                                                             validate_provider_config: false, sync_templates: false))
         conversation = create(:conversation, account: message.account, inbox: inbox)
-        sized_message = create(:message, account: message.account, conversation: conversation)
+        sized_message = create(:message, account: message.account, conversation: conversation, message_type: :outgoing)
         attachment = sized_message.attachments.new(account_id: message.account_id, file_type: :audio)
         attachment.file.attach(io: Rails.root.join('spec/assets/sample_opus.ogg').open, filename: 'voice.ogg', content_type: 'audio/ogg')
 
         expect(attachment).to be_valid
       end
 
+      # Refusing an inbound empty file would raise inside Whatsapp::IncomingMessageBaseService and
+      # take the whole webhook down, losing the message rather than recording an odd one.
+      it 'leaves an incoming message alone, so the inbound webhook is not brought down' do
+        inbox = create(:inbox, account: message.account,
+                               channel: create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false))
+        conversation = create(:conversation, account: message.account, inbox: inbox)
+        incoming = create(:message, account: message.account, conversation: conversation, message_type: :incoming)
+        attachment = incoming.attachments.new(account_id: message.account_id, file_type: :file)
+        attachment.file.attach(io: StringIO.new(''), filename: 'empty.pdf', content_type: 'application/pdf')
+
+        expect(attachment).to be_valid
+      end
+
+      # On an outgoing message, so the `file.attached?` guard is what keeps this valid rather than
+      # the outgoing check short-circuiting before the file is ever looked at.
       it 'leaves an attachment that carries no file at all alone' do
-        location = message.attachments.new(account_id: message.account_id, file_type: :location,
-                                           coordinates_lat: 1.0, coordinates_long: 1.0, fallback_title: 'here')
+        outgoing = create(:message, account: message.account, conversation: message.conversation, message_type: :outgoing)
+        location = outgoing.attachments.new(account_id: message.account_id, file_type: :location,
+                                            coordinates_lat: 1.0, coordinates_long: 1.0, fallback_title: 'here')
 
         expect(location).to be_valid
+      end
+
+      it 'is rejected on a template message too' do
+        inbox = create(:inbox, account: message.account,
+                               channel: create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false))
+        conversation = create(:conversation, account: message.account, inbox: inbox)
+        template = create(:message, account: message.account, conversation: conversation, message_type: :template)
+        attachment = template.attachments.new(account_id: message.account_id, file_type: :file)
+        attachment.file.attach(io: StringIO.new(''), filename: 'empty.pdf', content_type: 'application/pdf')
+
+        expect(attachment).not_to be_valid
+        expect(attachment.errors[:file]).to include('is empty')
       end
     end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -450,6 +450,21 @@ RSpec.describe Attachment do
         expect(location).to be_valid
       end
 
+      # An echo is a message someone sent from another WhatsApp client; it reaches us through the
+      # same webhook as an incoming one and is only stored as outgoing. We never send it, so
+      # refusing it would roll back the ingestion the same way an incoming refusal would.
+      it 'leaves an outgoing echo alone, because we are not the ones sending it' do
+        inbox = create(:inbox, account: message.account,
+                               channel: create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false))
+        conversation = create(:conversation, account: message.account, inbox: inbox)
+        echo = create(:message, account: message.account, conversation: conversation, message_type: :outgoing,
+                                content_attributes: { external_echo: true })
+        attachment = echo.attachments.new(account_id: message.account_id, file_type: :file)
+        attachment.file.attach(io: StringIO.new(''), filename: 'empty.pdf', content_type: 'application/pdf')
+
+        expect(attachment).to be_valid
+      end
+
       it 'is rejected on a template message too' do
         inbox = create(:inbox, account: message.account,
                                channel: create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false))

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -393,17 +393,21 @@ RSpec.describe Attachment do
     # note: the agent saw a message that looked sent, and the rejection arrived later as a failed
     # status carrying an error nobody could tie back to "the file was empty".
     describe 'an empty file' do
-      def empty_attachment_on(channel)
+      def empty_attachment_on(channel, message_type: :outgoing, refuse: true)
         inbox = create(:inbox, account: message.account, channel: channel)
         conversation = create(:conversation, account: message.account, inbox: inbox)
-        empty_message = create(:message, account: message.account, conversation: conversation, message_type: :outgoing)
-        attachment = empty_message.attachments.new(account_id: message.account_id, file_type: :audio)
+        owner = create(:message, account: message.account, conversation: conversation, message_type: message_type)
+        attachment = owner.attachments.new(account_id: message.account_id, file_type: :audio, refuse_empty_file: refuse)
         attachment.file.attach(io: StringIO.new(''), filename: 'voice.ogg', content_type: 'audio/ogg')
         attachment
       end
 
+      def whatsapp_channel
+        create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false)
+      end
+
       it 'is rejected on a provider inbox, where nothing used to look' do
-        attachment = empty_attachment_on(create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false))
+        attachment = empty_attachment_on(whatsapp_channel)
 
         expect(attachment).not_to be_valid
         expect(attachment.errors[:file]).to include('is empty')
@@ -416,65 +420,61 @@ RSpec.describe Attachment do
         expect(attachment.errors[:file]).to include('is empty')
       end
 
+      it 'is rejected on a template message too' do
+        attachment = empty_attachment_on(whatsapp_channel, message_type: :template)
+
+        expect(attachment).not_to be_valid
+        expect(attachment.errors[:file]).to include('is empty')
+      end
+
       it 'leaves a file with bytes alone' do
-        inbox = create(:inbox, account: message.account, channel: create(:channel_whatsapp, account: message.account,
-                                                                                            validate_provider_config: false, sync_templates: false))
+        inbox = create(:inbox, account: message.account, channel: whatsapp_channel)
         conversation = create(:conversation, account: message.account, inbox: inbox)
         sized_message = create(:message, account: message.account, conversation: conversation, message_type: :outgoing)
-        attachment = sized_message.attachments.new(account_id: message.account_id, file_type: :audio)
+        attachment = sized_message.attachments.new(account_id: message.account_id, file_type: :audio, refuse_empty_file: true)
         attachment.file.attach(io: Rails.root.join('spec/assets/sample_opus.ogg').open, filename: 'voice.ogg', content_type: 'audio/ogg')
 
         expect(attachment).to be_valid
       end
 
-      # Refusing an inbound empty file would raise inside Whatsapp::IncomingMessageBaseService and
-      # take the whole webhook down, losing the message rather than recording an odd one.
-      it 'leaves an incoming message alone, so the inbound webhook is not brought down' do
-        inbox = create(:inbox, account: message.account,
-                               channel: create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false))
-        conversation = create(:conversation, account: message.account, inbox: inbox)
-        incoming = create(:message, account: message.account, conversation: conversation, message_type: :incoming)
-        attachment = incoming.attachments.new(account_id: message.account_id, file_type: :file)
-        attachment.file.attach(io: StringIO.new(''), filename: 'empty.pdf', content_type: 'application/pdf')
+      # The refusal is off unless the caller asks for it. Every provider ingestion path builds
+      # attachments without asking, so an empty download is stored rather than raising inside the
+      # webhook and losing the message. This holds for an incoming message and for an echo alike,
+      # which is why neither needs its own marker here.
+      it 'is accepted by default, because ingestion never asks to refuse' do
+        attachment = empty_attachment_on(whatsapp_channel, refuse: false)
 
         expect(attachment).to be_valid
       end
 
-      # On an outgoing message, so the `file.attached?` guard is what keeps this valid rather than
-      # the outgoing check short-circuiting before the file is ever looked at.
+      it 'is accepted by default on an incoming message too' do
+        attachment = empty_attachment_on(whatsapp_channel, message_type: :incoming, refuse: false)
+
+        expect(attachment).to be_valid
+      end
+
+      # A fence, not a checklist. There are four provider ingestion paths that build outgoing
+      # attachments (baileys, z-api, the session writer, the reaction store), each marking the
+      # echo differently, and enumerating them is how the third one got missed. Assert instead
+      # that composing a message is the only thing in the tree that turns the refusal on.
+      it 'is turned on in exactly one place in the source tree' do
+        roots = %w[app enterprise lib].select { |dir| Rails.root.join(dir).directory? }
+        setters = Dir.glob(Rails.root.join("{#{roots.join(',')}}/**/*.rb")).select do |path|
+          File.read(path).match?(/refuse_empty_file\s*[:=]/)
+        end
+
+        expect(setters.map { |path| Pathname.new(path).relative_path_from(Rails.root).to_s })
+          .to contain_exactly('app/builders/messages/message_builder.rb')
+      end
+
+      # On a message that asked to refuse, so the `file.attached?` guard is what keeps this valid
+      # rather than the flag short-circuiting before the file is ever looked at.
       it 'leaves an attachment that carries no file at all alone' do
         outgoing = create(:message, account: message.account, conversation: message.conversation, message_type: :outgoing)
-        location = outgoing.attachments.new(account_id: message.account_id, file_type: :location,
+        location = outgoing.attachments.new(account_id: message.account_id, file_type: :location, refuse_empty_file: true,
                                             coordinates_lat: 1.0, coordinates_long: 1.0, fallback_title: 'here')
 
         expect(location).to be_valid
-      end
-
-      # An echo is a message someone sent from another WhatsApp client; it reaches us through the
-      # same webhook as an incoming one and is only stored as outgoing. We never send it, so
-      # refusing it would roll back the ingestion the same way an incoming refusal would.
-      it 'leaves an outgoing echo alone, because we are not the ones sending it' do
-        inbox = create(:inbox, account: message.account,
-                               channel: create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false))
-        conversation = create(:conversation, account: message.account, inbox: inbox)
-        echo = create(:message, account: message.account, conversation: conversation, message_type: :outgoing,
-                                content_attributes: { external_echo: true })
-        attachment = echo.attachments.new(account_id: message.account_id, file_type: :file)
-        attachment.file.attach(io: StringIO.new(''), filename: 'empty.pdf', content_type: 'application/pdf')
-
-        expect(attachment).to be_valid
-      end
-
-      it 'is rejected on a template message too' do
-        inbox = create(:inbox, account: message.account,
-                               channel: create(:channel_whatsapp, account: message.account, validate_provider_config: false, sync_templates: false))
-        conversation = create(:conversation, account: message.account, inbox: inbox)
-        template = create(:message, account: message.account, conversation: conversation, message_type: :template)
-        attachment = template.attachments.new(account_id: message.account_id, file_type: :file)
-        attachment.file.attach(io: StringIO.new(''), filename: 'empty.pdf', content_type: 'application/pdf')
-
-        expect(attachment).not_to be_valid
-        expect(attachment.errors[:file]).to include('is empty')
       end
     end
 

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -376,6 +376,52 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
       end
     end
 
+    # An echo of a message the agent sent from the connected phone is stored as outgoing, but it
+    # still arrives through this webhook. A zero-byte download must not raise at `@message.save!`,
+    # or the whole ingestion rolls back and the message is lost instead of merely being odd.
+    context 'when an outgoing echo carries a zero-byte attachment' do
+      let(:echo_params) do
+        {
+          phone_number: whatsapp_channel.phone_number,
+          object: 'whatsapp_business_account',
+          entry: [{
+            changes: [{
+              value: {
+                contacts: [{ profile: { name: 'Sojan Jose' }, wa_id: '2423423243' }],
+                messages: [{
+                  from: whatsapp_channel.phone_number,
+                  to: '2423423243',
+                  id: 'wamid.ECHO_EMPTY',
+                  document: {
+                    id: 'b1c68f38-8734-4ad3-b4a1-ef0c10d683',
+                    mime_type: 'application/pdf',
+                    sha256: '29ed500fa64eb55fc19dc4124acb300e5dcca0f822a301ae99944db',
+                    filename: 'empty.pdf'
+                  },
+                  timestamp: '1664799904', type: 'document'
+                }]
+              }
+            }]
+          }]
+        }.with_indifferent_access
+      end
+
+      it 'still records the message instead of bringing the webhook down' do
+        stub_media_url_request
+        stub_request(:get, 'https://chatwoot-assets.local/sample.png').to_return(
+          status: 200, body: File.read('spec/assets/attachment.pdf'), headers: { 'content-type' => 'application/pdf' }
+        )
+
+        expect do
+          described_class.new(inbox: whatsapp_channel.inbox, params: echo_params, outgoing_echo: true).perform
+        end.to change(Message, :count).by(1)
+
+        message = whatsapp_channel.inbox.messages.last
+        expect(message).to be_outgoing
+        expect(message.content_attributes['external_echo']).to be(true)
+      end
+    end
+
     context 'when dispatching provider events' do
       let(:message_params) do
         {


### PR DESCRIPTION
Fixes #522

## What was broken

An attachment with zero bytes was accepted, stored and sent to the provider. On a WhatsApp inbox the agent saw a message that looked sent, and the rejection came back minutes later as a failed status carrying a provider error nobody could tie back to "the file was empty". Nothing on screen ever said what happened.

Nothing looked, either. `Attachment#should_validate_file?` returns false unless the inbox channel is `Channel::WebWidget`, so on every provider inbox the file validations were skipped entirely.

## What changed

**The composer says it.** A new `isFileEmpty` in `FileHelper.js`, called at the four upload entry points (`useFileUpload.js` and `fileUploadMixin.js`, direct and indirect paths), refuses a zero-byte file before the upload starts and shows the same kind of warning the size limit already showed, in the same container. The string is `CONVERSATION.FILE_IS_EMPTY`, translated in the three languages the fork maintains.

**The server refuses it too**, but only where we are the ones about to send. This took three tries and the shape of the fix is the interesting part.

Scoping the model validation by message type kept catching ingestion. First it caught every incoming message, which raised inside `Whatsapp::IncomingMessageBaseService#process_messages` and took down the whole inbound webhook. Scoping it to outgoing then caught WhatsApp Cloud echoes, which are messages the agent sent from the connected phone and are stored as outgoing. Exempting `external_echo` then still caught the baileys and z-api echoes, which mark themselves with `external_sender_name` instead. Three ingestion paths, three different markers, and enumerating them is what let the third one through.

So the default is inverted. `Attachment#refuse_empty_file` is off unless the caller asks for it, and the only caller that asks is `Messages::MessageBuilder`, which every composed message goes through: the dashboard, the public API, campaigns, macros, automation rules and scheduled messages. Provider ingestion never touches that builder, so it is exempt by construction rather than by a list somebody has to keep current. A spec fences it: it scans `app`, `enterprise` and `lib` and fails if anything but the builder turns the flag on.

One exception inside the builder itself: an Api inbox pushes customer messages through it with `message_type: incoming`. That is ingestion arriving over HTTP, so the flag stays off there, or a 422 would throw the message text away along with the odd attachment.

## Validation scope

Proven by test:

- 38 model examples, including the fence and both ingestion defaults.
- 40 builder examples, including the flag being set for a composed message, a zero-byte upload raising instead of persisting, and an incoming API message keeping its empty attachment.
- A service-level regression on `Whatsapp::IncomingMessageWhatsappCloudService`: an outgoing echo carrying a zero-byte download still records the message instead of rolling back the webhook. It fails with `ActiveRecord::RecordInvalid` without the exemption.
- 48 frontend examples across `FileHelper`, `useFileUpload` and `fileUploadMixin`.
- A property test pinning the refusal to the moment of composition: the flag lives in memory, so a row stored before this validation existed is never refused when something saves it again later. Retry does exactly that on a failed message. Written with `reload` first, which keeps the accessor on the object it is called on and would have passed for the wrong reason; it uses a fresh instance instead.
- Mutation batteries on both sides: 8 mutations on the Ruby guard and 8 on the frontend guard, all killed, controls clean at 152 and 48 examples. The fence was mutated too, by making an ingestion service opt in, and it bit.

Proven live, by the holdout scenarios against a running app:

- Attaching a 0-byte file in the composer shows "This file is empty and cannot be sent" in the same container as the size warning, 52 ms after the change, visible for 2.5 s. Nothing reaches the network: no POST to the messages endpoint, no attachment chip, Send stays disabled, and the database is byte-identical to the baseline afterwards.
- A 1-byte file attaches normally, so the floor is zero bytes and not something larger.
- The size-limit control still fires on a 50 MB PDF through the same path.

Not proven here:

- A fifth entry point, pasting a file, drops empty files silently and deliberately upstream. Left alone and filed as #525, because warning there risks a spurious alert on every macOS Numbers paste. The internal chat composer filters the same way and is noted on the same issue; its server path builds attachments outside this builder, but no empty file can reach it through the UI.
- An Api inbox pushing `message_type: incoming`. The dev account has no Api inbox and creating one would have left structural residue, so that branch is covered by the builder spec and a model-level probe rather than live.

Rebased onto #523 after it landed, since both touch the messages controller spec. The retry endpoint it changed does not go through this builder, and the property test above is what covers the one place the two could have met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/524)
<!-- Reviewable:end -->
