### PR TITLE
fix(avatar): stamp the sync markers only when a download was attempted

### DIFF
--- a/app/jobs/avatar/avatar_from_url_job.rb
+++ b/app/jobs/avatar/avatar_from_url_job.rb
@@ -22,16 +22,27 @@ class Avatar::AvatarFromUrlJob < ApplicationJob
     return unless syncable_avatar?(avatarable, avatar_url)
     return if superseded?(avatarable, resolved_at)
 
+    attempt_download(avatarable, avatar_url)
+    update_avatar_sync_attributes(avatarable, avatar_url)
+  end
+
+  private
+
+  # The markers belong to whoever actually tried to download. They used to be stamped from an
+  # `ensure`, which the early returns above run straight through: a job that downloaded nothing
+  # would open a fresh rate-limit window and record a URL it never fetched as already synced, and
+  # the job carrying the new picture was then thrown away as a duplicate.
+  #
+  # A download that was attempted and failed still counts, so a URL that is permanently broken
+  # does not get retried on every event. An error that is not SafeFetch's propagates without
+  # stamping, because the job will be retried and must not find itself already marked.
+  def attempt_download(avatarable, avatar_url)
     fetch_and_attach_avatar(avatarable, avatar_url)
   rescue SafeFetch::HttpError => e
     log_http_error(avatar_url, e)
   rescue SafeFetch::Error => e
     Rails.logger.error "AvatarFromUrlJob error for #{avatar_url}: #{e.class} - #{e.message}"
-  ensure
-    update_avatar_sync_attributes(avatarable, avatar_url)
   end
-
-  private
 
   # A removal recorded after the URL was resolved makes that URL a picture the contact
   # has already taken down. Only Contacts carry the marker, which is where this job

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -128,7 +128,9 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(authenticated_url))
     end
 
-    it 'returns early when rate limited' do
+    # A job that never downloaded must not move the markers. It used to stamp both, which both
+    # extended its own rate-limit window and recorded a URL it had not fetched as synced.
+    it 'returns early when rate limited, leaving the markers where they were' do
       ts = 30.seconds.ago.iso8601
       avatarable.update!(additional_attributes: { 'last_avatar_sync_at' => ts })
 
@@ -142,14 +144,12 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       described_class.perform_now(avatarable, valid_url)
       avatarable.reload
       expect(avatarable.avatar).not_to be_attached
-      expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
-      expect(Time.zone.parse(avatarable.additional_attributes['last_avatar_sync_at']))
-        .to be > Time.zone.parse(ts)
-      expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(valid_url))
+      expect(avatarable.additional_attributes['last_avatar_sync_at']).to eq(ts)
+      expect(avatarable.additional_attributes['avatar_url_hash']).to be_nil
       expect(WebMock).not_to have_requested(:get, valid_url)
     end
 
-    it 'returns early when hash unchanged' do
+    it 'returns early when hash unchanged, without opening a new rate-limit window' do
       avatarable.update!(additional_attributes: { 'avatar_url_hash' => Digest::SHA256.hexdigest(valid_url) })
 
       stub_request(:get, valid_url)
@@ -162,18 +162,20 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       described_class.perform_now(avatarable, valid_url)
       expect(avatarable.avatar).not_to be_attached
       avatarable.reload
-      expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
+      expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_nil
       expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(valid_url))
       expect(WebMock).not_to have_requested(:get, valid_url)
     end
 
-    it 'updates sync attributes even when URL is invalid' do
+    # A URL the job refuses to even parse is not a sync. Stamping it opened a rate-limit window
+    # that a good URL arriving seconds later would then be turned away by.
+    it 'leaves the markers alone when the URL is invalid' do
       invalid_url = 'invalid_url'
       described_class.perform_now(avatarable, invalid_url)
       avatarable.reload
       expect(avatarable.avatar).not_to be_attached
-      expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
-      expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(invalid_url))
+      expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_nil
+      expect(avatarable.additional_attributes['avatar_url_hash']).to be_nil
     end
 
     it 'updates sync attributes when file download is valid but content type is unsupported' do
@@ -203,6 +205,53 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       expect(avatarable.avatar).not_to be_attached
       expect(avatarable.additional_attributes['last_avatar_sync_at']).to be_present
       expect(avatarable.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(blocked_url))
+    end
+  end
+
+  # An infrastructure error is not an answer about the URL. The job will be retried, and a marker
+  # written on the way out would make the retry skip the download it exists to perform.
+  it 'leaves the markers alone when an error other than a fetch error escapes' do
+    contact = create(:contact)
+    allow(SafeFetch).to receive(:fetch).and_raise(ActiveRecord::ConnectionNotEstablished)
+
+    expect { described_class.perform_now(contact, valid_url) }.to raise_error(ActiveRecord::ConnectionNotEstablished)
+
+    contact.reload
+    expect(contact.additional_attributes['last_avatar_sync_at']).to be_nil
+    expect(contact.additional_attributes['avatar_url_hash']).to be_nil
+  end
+
+  # The sequence from #504. Each step looks harmless on its own, and the cost only shows when
+  # they run in order: the new picture never arrives, and nothing retries until the contact
+  # changes their photo again.
+  context 'when a superseded job runs just before the job that carries the new picture' do
+    let(:contact) { create(:contact) }
+    let(:old_url) { 'https://example.com/old-avatar.png' }
+    let(:new_url) { 'https://example.com/new-avatar.png' }
+
+    before do
+      [old_url, new_url].each do |url|
+        stub_request(:get, url).to_return(
+          status: 200,
+          body: File.read(Rails.root.join('spec/assets/avatar.png')),
+          headers: { 'Content-Type' => 'image/png' }
+        )
+      end
+    end
+
+    it 'still attaches the new picture' do
+      resolved_at = 1.minute.ago.iso8601
+      Whatsapp::Session::AvatarSync.remove(contact)
+
+      # The job carrying the URL from before the removal. It must not download, and must not
+      # leave a marker that the next job will be measured against.
+      described_class.perform_now(contact, old_url, resolved_at: resolved_at)
+      described_class.perform_now(contact, new_url, resolved_at: Time.current.iso8601)
+
+      expect(contact.reload.avatar).to be_attached
+      expect(WebMock).to have_requested(:get, new_url)
+      expect(WebMock).not_to have_requested(:get, old_url)
+      expect(contact.additional_attributes['avatar_url_hash']).to eq(Digest::SHA256.hexdigest(new_url))
     end
   end
 

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -149,6 +149,32 @@ RSpec.describe Avatar::AvatarFromUrlJob do
       expect(WebMock).not_to have_requested(:get, valid_url)
     end
 
+    # The shortest path to the same loss, and it needs no removal at all: a contact who changes
+    # their photo twice inside one window. The first job fetches, the second is turned away by the
+    # window, and while it stamped on the way out the second URL was recorded as synced without a
+    # byte having been read. Found by a parallel session working the same issue.
+    it 'still fetches the second picture when two arrive inside one window' do
+      second_url = 'https://example.com/avatar-2.png'
+      [valid_url, second_url].each do |url|
+        stub_request(:get, url).to_return(
+          status: 200,
+          body: File.read(Rails.root.join('spec/assets/avatar.png')),
+          headers: { 'Content-Type' => 'image/png' }
+        )
+      end
+
+      described_class.perform_now(avatarable, valid_url)
+      described_class.perform_now(avatarable, second_url)
+
+      travel_to((described_class::RATE_LIMIT_WINDOW + 1.second).from_now) do
+        described_class.perform_now(avatarable, second_url)
+      end
+
+      expect(WebMock).to have_requested(:get, second_url)
+      expect(avatarable.reload.additional_attributes['avatar_url_hash'])
+        .to eq(Digest::SHA256.hexdigest(second_url))
+    end
+
     it 'returns early when hash unchanged, without opening a new rate-limit window' do
       avatarable.update!(additional_attributes: { 'avatar_url_hash' => Digest::SHA256.hexdigest(valid_url) })
 


### PR DESCRIPTION
Fixes #504

## What was broken

`Avatar::AvatarFromUrlJob` wrote its two sync markers from an `ensure`, and `ensure` runs on the way out of an early `return` as well. So a job that downloaded nothing still stamped `last_avatar_sync_at` with the current time and `avatar_url_hash` with the URL it had just declined to fetch.

Both markers are gates. `last_avatar_sync_at` is a one minute rate limit, and `avatar_url_hash` means "this URL is already synced". Writing them without having downloaded turns the job into something that blocks the next job instead of doing its own work.

The sequence in the issue, confirmed on `main`:

1. Job A is enqueued with the old URL.
2. The photo is removed.
3. A new photo appears and job B is enqueued with the new URL.
4. Job A runs, is correctly identified as superseded, downloads nothing, and stamps the markers.
5. Job B runs inside the minute, hits the rate limit, exits without downloading, and its own `ensure` records the hash of the new URL.
6. Every later attempt for that URL is discarded as already synced.

The new picture never arrives, and nothing retries until the contact changes their photo again.

## What changed

The stamping moved out of `ensure` and onto the path that actually reached the download. The two guards at the top now return without touching anything.

Two decisions inside that, both deliberate:

- **A download that was attempted and failed still stamps.** A 404, an unsupported content type or an SSRF refusal are answers about the URL, and re-fetching them on every avatar event would be a retry storm. The existing examples for those paths are unchanged.
- **An error that is not `SafeFetch`'s now propagates without stamping.** A database or storage failure is not an answer about the URL; the job will be retried, and a marker written on the way out would make the retry skip the download it exists to perform.

## What the issue understated

The issue frames the defect around the superseded job. The same `ensure` also runs for the rate-limited job, the duplicate-URL job and an unparseable URL, and two of those were asserted as correct by existing examples:

- `returns early when rate limited` asserted that the timestamp advanced and the new URL's hash was written. That is step 5 of the sequence above, written down as an expectation.
- `updates sync attributes even when URL is invalid` asserted a hash for a URL the job refuses to parse. Stamping there opens a rate-limit window that a good URL arriving seconds later is then turned away by.

Both are rewritten rather than deleted quietly, since they were the encoded form of the behaviour this PR reverses.

## Validation scope

Proven by test, 18 examples:

- The full six-step sequence from the issue: the superseded job runs first, and the new picture still attaches, with the old URL never fetched.
- Rate-limited, duplicate-hash and invalid-URL jobs leave the markers exactly as they found them.
- A failed download still stamps, across the three failure paths that already had coverage.
- An escaping non-fetch error leaves the markers untouched.

8 mutations, all killed, control clean. They include putting the `ensure` back, dropping the stamping entirely, moving it ahead of the download, and flipping each of the two time comparisons.

Not proven here: nothing was exercised against a live WhatsApp avatar event. The job is driven by `Whatsapp::Session::AvatarSync`, and this PR does not change who calls it or with what.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/529)
<!-- Reviewable:end -->
