### PR TITLE
fix(groups): refuse a group action with no inbox instead of answering 500

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     @page = [(params[:page] || 1).to_i, 1].max
     @per_page = (params[:per_page] || DEFAULT_PER_PAGE).to_i.clamp(1, 100)
     @inbox_phone_number = inbox_phone_number
-    @own_member = Whatsapp::Session::Owner.group_member(channel, @contact)
+    @own_member = Whatsapp::Session::Owner.group_member(channel_if_any, @contact)
     @is_inbox_admin = @own_member&.role == 'admin'
 
     paginated = base_query.order(role: :desc, id: :asc)
@@ -88,7 +88,7 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
   end
 
   def inbox_phone_number
-    channel&.phone_number
+    channel_if_any&.phone_number
   end
 
   def pin_own_member_on_first_page(paginated)

--- a/app/controllers/concerns/group_channel_resolver.rb
+++ b/app/controllers/concerns/group_channel_resolver.rb
@@ -12,8 +12,18 @@ module GroupChannelResolver
 
   private
 
+  # The channel a group action runs as. Every action that actually talks to WhatsApp needs a real
+  # one, so this refuses rather than handing back nil for the provider call to raise on: an agent
+  # with no claim to any of this group's inboxes was answered 500 for a request that is simply not
+  # theirs. Use `channel_if_any` in the few reads that are meant to work without one.
   def channel
-    @channel ||= group_contact_inbox&.inbox&.channel
+    channel_if_any || raise(ActiveRecord::RecordNotFound)
+  end
+
+  def channel_if_any
+    return @channel_if_any if defined?(@channel_if_any)
+
+    @channel_if_any = group_contact_inbox&.inbox&.channel
   end
 
   def group_contact_inbox
@@ -38,6 +48,9 @@ module GroupChannelResolver
   def resolve_group_contact_inbox
     candidates = @contact.contact_inboxes.includes(:inbox).where(inbox: Current.user.assigned_inboxes)
     return candidates.find_by!(inbox_id: params[:inbox_id]) if params[:inbox_id].present?
+
+    # None and one both answer nil here, and that is the honest answer: whether nil is fatal is
+    # the caller's question, not this one's. `channel` refuses on it, `channel_if_any` does not.
     return candidates.first if candidates.size <= 1
 
     raise ActionController::BadRequest, I18n.t('contacts.group.inbox_id_required')

--- a/app/controllers/concerns/group_channel_resolver.rb
+++ b/app/controllers/concerns/group_channel_resolver.rb
@@ -20,6 +20,11 @@ module GroupChannelResolver
     channel_if_any || raise(ActiveRecord::RecordNotFound)
   end
 
+  # Returns nil rather than refusing, which is the very shape the bug above had, so reach for it
+  # only where nil is a real answer. Today that is `GroupMembersController#index`, which is a read
+  # governed by `ContactPolicy` rather than by inbox membership and shows the roster without the
+  # "am I an admin here" flag. Anything that acts on the group needs `channel` and must not borrow
+  # this because it happens to be nearby.
   def channel_if_any
     return @channel_if_any if defined?(@channel_if_any)
 

--- a/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
@@ -71,6 +71,75 @@ RSpec.describe 'group actions and the inbox they run as', type: :request do
     expect(response).to have_http_status(:not_found)
   end
 
+  # An agent on none of the group's inboxes has no candidate at all, and `size <= 1` read
+  # that as "exactly one", handing a nil channel to the action. The first dereference
+  # raised, so a request that is simply not this agent's answered 500.
+  #
+  # The answer has to be the one an inbox the group is not in already gets. Answering
+  # differently would tell an agent whether that number is in the group, which is the
+  # disclosure the named-inbox path is careful to avoid.
+  context 'when the agent is on none of the inboxes this group is in' do
+    let(:outsider) do
+      agent = create(:user, account: account, role: :agent)
+      create(:inbox_member, user: agent,
+                            inbox: create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false,
+                                                             sync_templates: false, account: account).inbox)
+      agent
+    end
+
+    it 'refuses instead of failing, when the caller names no inbox' do
+      post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_admin/leave",
+           headers: outsider.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    # The same request the previous example makes, from an agent who is on one of them.
+    # Both are refused, and the refusals are indistinguishable.
+    it 'answers exactly as it does for an inbox the group is not in' do
+      stranger = create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,
+                                           account: account)
+      insider = create(:user, account: account, role: :agent)
+      create(:inbox_member, user: insider, inbox: looking_at.inbox)
+
+      post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_admin/leave",
+           headers: outsider.create_new_auth_token, as: :json
+      absent_inbox = [response.status, response.parsed_body]
+
+      post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_admin/leave",
+           params: { inbox_id: stranger.inbox.id }, headers: insider.create_new_auth_token, as: :json
+
+      expect(absent_inbox).to eq([response.status, response.parsed_body])
+    end
+  end
+
+  # The read that tolerates a missing channel must still refuse an inbox that was named and
+  # is wrong. Without the bang it would answer 200 with the list and no admin flag, turning a
+  # wrong request into a slightly wrong answer.
+  it 'refuses a named inbox the group is not in even on the tolerant read' do
+    stranger = create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false,
+                                         account: account)
+
+    get "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+        params: { inbox_id: stranger.inbox.id }, headers: admin.create_new_auth_token, as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  # A fence, not a checklist. `channel` refusing is what keeps a new group endpoint from
+  # answering 500 the way this one did, and the tolerant reader exists for the two reads
+  # that are meant to degrade. Adding a third without meaning to is the way back in.
+  it 'is read tolerantly in exactly the two places that mean to' do
+    roots = %w[app enterprise lib].select { |dir| Rails.root.join(dir).directory? }
+    readers = Dir.glob(Rails.root.join("{#{roots.join(',')}}/**/*.rb")).select do |path|
+      File.read(path).include?('channel_if_any')
+    end
+
+    expect(readers.map { |path| Pathname.new(path).relative_path_from(Rails.root).to_s })
+      .to contain_exactly('app/controllers/concerns/group_channel_resolver.rb',
+                          'app/controllers/api/v1/accounts/contacts/group_members_controller.rb')
+  end
+
   # The endpoints predate the parameter and are documented without it, so a group that is
   # in one inbox still answers on its own.
   it 'needs no inbox when the group is in only one' do


### PR DESCRIPTION
Fixes #505

## What was broken

`GroupChannelResolver#resolve_group_contact_inbox` collapsed two different cases:

```ruby
return candidates.first if candidates.size <= 1
```

Exactly one candidate and none at all are not the same answer. With none, `candidates.first` is `nil`, `channel` is `nil`, and the first group action that dereferences it raises `NoMethodError`.

An agent who is on none of the inboxes a group is in, and who omits the optional `inbox_id`, gets a 500. `ContactPolicy` lets every agent of the account read and update a contact, so reaching this needs nothing special. Nothing leaks and nothing is written wrong, but a request that is simply not this agent's is recorded as a server fault.

## Where the fix went, and why not where I first put it

The obvious patch is to raise in the resolver when there is no candidate. I wrote that first and it broke five examples in the members endpoint.

`GroupMembersController#index` is a read that is meant to work without a channel: it passes `channel` to `Whatsapp::Session::Owner.group_member`, and reads `channel&.phone_number` with a safe navigation. It degrades on purpose, showing the member list without the "am I an admin here" flag. Refusing inside the resolver takes that away from every consumer at once.

So the refusal lives on the accessor instead. `channel` raises when there is nothing to run as, which is what every action that actually talks to WhatsApp needs, and `channel_if_any` is what the two tolerant reads use. That also makes refusing the default: a group endpoint added later gets a 404 rather than a 500 without anyone having to remember.

The resolver itself went back to `size <= 1`. Returning nil for both none and one is the honest answer there, since whether nil is fatal belongs to the caller, and the mutation battery showed the version I had written was dead code: `candidates.first` on an empty relation is already nil.

The refusal is `ActiveRecord::RecordNotFound`, the same 404 that naming an inbox the group is not in already produced. That is deliberate and the file's own comments explain why: answering differently would tell an agent whether that number is in the group.

## Validation scope

Proven by test, 69 examples across the contacts controllers:

- An agent on none of the group's inboxes is refused rather than failing, with no `inbox_id`.
- That refusal is compared byte for byte against the refusal for an inbox the group is not in, status and body, so the two stay indistinguishable.
- The tolerant read still refuses a named inbox that is wrong, rather than answering 200 with a partial result.
- A fence: `channel_if_any` appears in exactly two files, so a third tolerant reader cannot appear by accident.
- The five members examples that exercise the degrade-without-a-channel path still pass, which is what caught the first version.

7 mutations, all killed, control clean. Two survived an earlier round and both were informative rather than noise: one showed my resolver change was dead code, the other showed the tolerant read had no coverage for a wrong `inbox_id`.

Proven live, by the holdout scenarios against the running endpoints, 15 of 15:

- The security axis, compared with `eq` rather than by eye: no candidate and no `inbox_id` answers byte for byte like the four other refusals, an inbox the group is not in, an inbox the agent is not on, a group with no contact inbox at all, and a contact that does not exist. All are `{"error":"Resource could not be found"}`.
- A sweep of all 12 routes that use the concern. Eleven now refuse with 404 and the provider double recorded zero calls, so nothing came near acting.
- `sync_group` closed: it answered 202 and enqueued the job with a nil channel, which the service then resolved by picking whichever contact inbox came first. It is now 404 with the queue verified empty.
- The guards did not regress: a single candidate still answers without `inbox_id`, ambiguity still answers 400 carrying `inbox_id_required`, a named `inbox_id` still decides the channel, and the not-a-group guards still run before resolution.

Not proven here: nothing was exercised against a live WhatsApp session. Every example drives the HTTP endpoints with the provider doubled, which is how the existing suite for this concern is written.

## One thing deliberately left alone

`GroupMembersController#index` still answers 200 with the roster for an agent on none of the group's inboxes, while the same route with a wrong `inbox_id` answers 404. That asymmetry is on `main` already and this PR neither creates nor widens it.

It is left because the roster is contact data and `ContactPolicy` already lets any agent of the account read a contact, so who may read it is a visibility question rather than a channel question. Changing it here would be a policy change smuggled in behind a 500 fix. Filed as #535, together with an empty `group_metadata` request that returns 200 for the same reason: the writer only resolves the channel when it has work to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/533)
<!-- Reviewable:end -->
