### PR TITLE
fix(whatsapp): desligar o aparelho antes de pedir para apagar a sessão

### DIFF
--- a/app/services/whatsapp/session/backends/connector/backend.rb
+++ b/app/services/whatsapp/session/backends/connector/backend.rb
@@ -73,7 +73,25 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
     client.publish(commands::SessionLogout.new)
   end
 
+  # The teardown, published as a pair, and the `logout` is the half that matters most: it
+  # unlinks the device from the customer's phone, which is the part of a pairing that
+  # outlives this inbox. `session.delete` is what clears the session's own rows, and a
+  # connector build without a handler for it answers `unsupported` and undoes nothing -- so
+  # sending `delete` alone leaves a device listed on somebody's phone with nothing in
+  # Chatwoot corresponding to it.
+  #
+  # Ordering is what makes the pair safe rather than redundant. Both land on this session's
+  # command stream in the order written, so the `delete` that follows finds nothing linked,
+  # which is a teardown with less to do and not a failure to retry.
+  #
+  # Published, not called, for two independent reasons. This runs inside the transaction
+  # that destroys the inbox, and an RPC there would hold it open for the round trip. And a
+  # teardown is deliberately left pending, with no reply at all, while the session is
+  # between owners -- being handed over, or waiting on a lease with room to finish -- so a
+  # caller waiting for an answer would time out exactly when the connector is doing the
+  # right thing.
   def delete_session
+    client.publish(commands::SessionLogout.new)
     client.publish(commands::SessionDelete.new)
   end
 

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -63,9 +63,18 @@ class Whatsapp::Session::Facade
   # so it is a teardown, not a pause: the Baileys service answers it with
   # `DELETE /connections/<phone>`. Merely disconnecting would leave the pairing and its
   # credentials alive on the provider under a session id Chatwoot no longer has.
+  #
+  # A refusal is said out loud rather than swallowed. What the fallback can do is end the
+  # connection, and a session whose pairing outlived the inbox that owned it is exactly the
+  # kind of thing an installation log has to carry: nothing else in this path leaves any
+  # trace, and the operator sees the inbox disappear and concludes it is over.
   def disconnect_channel_provider
     backend.delete_session
-  rescue Whatsapp::Session::Errors::NotSupported
+  rescue Whatsapp::Session::Errors::NotSupported => e
+    Rails.logger.warn(
+      "[WHATSAPP] #{provider} cannot tear down its session (#{e.message}); disconnecting instead, " \
+      "which leaves the pairing alive on the provider for inbox #{channel.inbox&.id}"
+    )
     backend.disconnect
   end
 

--- a/spec/services/whatsapp/session/backends/connector/backend_spec.rb
+++ b/spec/services/whatsapp/session/backends/connector/backend_spec.rb
@@ -70,6 +70,26 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
     expect(client).to have_received(:call).ordered
   end
 
+  # The pairing is what outlives the inbox: a device stays listed on the customer's phone
+  # with nothing in Chatwoot corresponding to it. `session.delete` is the command that
+  # clears the session's own rows, and a connector build with no handler for it answers
+  # `unsupported` and undoes nothing, so the unlink cannot be left to it alone.
+  it 'unlinks the device before it asks for the session to be deleted' do
+    backend.delete_session
+
+    expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionLogout)).ordered
+    expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionDelete)).ordered
+  end
+
+  # Not `call`. This runs inside the transaction that destroys the inbox, and the connector
+  # deliberately leaves a teardown pending with no reply while the session is between
+  # owners, so there is no answer to wait for.
+  it 'asks for the teardown without waiting for an answer' do
+    backend.delete_session
+
+    expect(client).not_to have_received(:call)
+  end
+
   it 'turns the connect reply into the connection state the inbox stores' do
     state = backend.connect(model::Commands::SessionConnect.new(pairing: 'qr'))
 

--- a/spec/services/whatsapp/session/facade_spec.rb
+++ b/spec/services/whatsapp/session/facade_spec.rb
@@ -424,6 +424,22 @@ RSpec.describe Whatsapp::Session::Facade do
     expect(backend.commands_of('session.delete')).to be_present
   end
 
+  # A backend that cannot tear down its session is not a quiet case. What the fallback can
+  # do is end the connection, which leaves the pairing alive under a session id nothing
+  # points at any more, and this line is the only trace of that anywhere: the operator sees
+  # the inbox disappear and concludes it is over.
+  it 'says so in the log when the provider has no teardown' do
+    allow(backend).to receive(:delete_session).and_raise(
+      Whatsapp::Session::Errors::NotSupported, 'no teardown here'
+    )
+    allow(Rails.logger).to receive(:warn)
+
+    channel.disconnect_channel_provider
+
+    expect(Rails.logger).to have_received(:warn).with(/leaves the pairing alive/)
+    expect(backend.commands_of('session.disconnect')).to be_present
+  end
+
   # Chatwoot availability is online/offline/busy; the contract knows available and
   # unavailable. The Baileys service maps them, and this used to forward them raw.
   it 'maps account availability onto the two states the contract accepts' do


### PR DESCRIPTION
Fecha #507.

## O defeito

`Whatsapp::Session::Facade#disconnect_channel_provider` é o teardown do provedor, chamado quando a inbox é destruída ou convertida. No backend do connector ele vira `client.publish(SessionDelete)`, e duas coisas se somam:

1. `publish` é fire-and-forget, não há reply para ler.
2. O connector não implementa `session.delete` (fazer-ai/whatsapp-connector#151): responde `unsupported` e não faz nada.

O `rescue NotSupported` do facade cobria só a recusa do lado Ruby, um backend sem o método. A que volta pelo fio não passa por ali.

**Resultado:** o aparelho continua listado no celular do cliente sem nada no Chatwoot correspondendo a ele, a sessão segue sendo adotada e publicando eventos para uma inbox que não existe, e não há erro em lugar nenhum.

## A correção: o par, na ordem

O teardown do connector passa a publicar `session.logout` e depois `session.delete`.

O `logout` é a metade que importa mais, porque é a que sobrevive à inbox: desliga o aparelho do celular do cliente, e é servido por **toda** versão do connector, inclusive as que não têm handler para o `delete`. A ordem é o que torna o par seguro em vez de redundante: os dois caem no stream de comandos da sessão na ordem em que foram escritos, então o `delete` encontra nada pareado, que é um teardown com menos a fazer e não uma falha para retentar.

Vale contra o connector de hoje **e** contra o da #151, sem este lado precisar saber qual está do outro.

## Por que continua `publish` e não `call`

A issue propunha mandar por `call` e tratar a resposta. Levantei isso com o peer do connector e a proposta não sobrevive a duas objeções, uma delas verificável aqui:

1. **Isto roda dentro da transação que destrói a inbox.** `before_destroy :disconnect_channel_provider` em `app/models/channel/whatsapp.rb:60`. Um RPC ali manteria a transação aberta pelo round trip inteiro, com `RPC_TIMEOUT = 20`.
2. **O connector deixa o teardown pendente de propósito**, sem resposta nenhuma, em quatro situações: conta rodando em outra instância, adoção que falhou por Redis fora, lease sem folga para cobrir o teardown, e conta sendo devolvida naquele instante. Nesses casos o comando é retentado depois, possivelmente por outra instância. Um `call` estouraria o timeout justamente quando o sistema está fazendo a coisa certa.

**Também verifiquei a alternativa de consumir `command.failed`, e ela não alcança o caminho que importa.** O evento é roteado por `ShardWorker#channel_for`, que procura a inbox pelo `session_id`; numa inbox destruída ela não existe mais, então o evento é descartado com um `warn` que diz "no inbox for session", não "o teardown foi recusado". Serve para o caminho de conversão, onde a inbox sobrevive, e não para o de destroy.

## O log

O `rescue NotSupported` do facade deixa de engolir a recusa. Um provedor sem teardown diz isso no log, com a inbox nomeada, porque essa linha é o único rastro que esse caminho deixa em qualquer lugar.

## Verificado

- `spec/models/channel/whatsapp_spec.rb`, `spec/services/whatsapp/session/` inteiro e `inboxes_controller_spec` — **814 exemplos, 0 falhas**, 1 pending pré-existente
- Mutação, uma metade por vez:
  - tirando o `logout` do par → falha `unlinks the device before it asks for the session to be deleted`
  - tirando o log do facade → falha `says so in the log when the provider has no teardown`
- `rubocop` nos quatro arquivos, sem ofensa

Um exemplo a mais afirma que o teardown **não** usa `call`, para que trocar de volta para RPC seja uma decisão e não um deslize.

## Nota sobre o Uazapi

Ficou de fora de propósito. Lá `logout` já é `disconnect` (o provedor responde 405 em `/instance/logout`, não há unpair) e `delete_session` é `disconnect` mais `withdraw_webhook`. Publicar um `logout` antes seria um POST a mais sem efeito novo. Por isso a mudança vive no backend do connector e não no facade.

## Achado colateral, não corrigido aqui

A `main` ainda lê `WHATSAPP_GROUPS_ENABLED` sem `.presence`, então uma variável declarada vazia é truthy e mata o fallback da era Baileys. O `.presence` existe, mas só na branch de integração (PR #512). O spec `still honours the Baileys-era variable name` passa na CI porque lá a variável é **ausente**, não vazia, ou seja passa pelo motivo errado. Chega na `main` quando a integração mergear; não mexi nele aqui para não criar conflito com aquela branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/536)
<!-- Reviewable:end -->


## Correção de escopo, depois de verificação do lado do connector

O corpo acima diz que o par vale contra o connector de hoje e contra o da #151. Isso é verdade **quando a sessão está de pé na hora do destroy**, e o peer do connector verificou que há um caso em que não é:

`Adopt` tem dois chamadores em produção, e o único gatilho é um `session.wake` chegando. Nada readota na subida da instância, nada readota por timer. Então:

- **sessão de pé:** ela continua adotada, o lease é renovado, ela lê o próprio stream e encontra o par. Funciona.
- **sessão fora do ar:** ninguém a readota, porque o cliente que acabou de destruir a inbox não manda mais nenhum `wake`. O par fica em `wa:cmd:<sid>` sem leitor até o `MAXLEN` cortar.

O segundo é justamente o caso motivador da #151 (inbox destruída enquanto a sessão estava fora, ou durante restart da frota), e nele o aparelho continua pareado no celular do cliente.

**Esta PR continua sendo uma melhoria estrita** e não é regressão: sem ela o `session.delete` sozinho já não era entregue nesse caso, e ainda por cima é respondido `unsupported` no caso em que chega. O que ela não faz é fechar a metade que depende da sessão estar viva.

Registrado na issue #537, com o caminho candidato (mandar um `session.wake` antes do par, que é o mecanismo que o `connect` já usa) e o que falta medir antes de adotá-lo. Fora do escopo aqui porque muda comportamento contra um connector cujo teardown está sendo reprojetado.
