### PR TITLE
feat(whatsapp): medir o anexo antes de enviar, para a bolha nascer do tamanho certo

### DIFF
--- a/.github/workflows/run_foss_spec.yml
+++ b/.github/workflows/run_foss_spec.yml
@@ -250,6 +250,16 @@ jobs:
           rm -rf enterprise
           rm -rf spec/enterprise
 
+      # The deploy image installs ffmpeg (docker/Dockerfile), and the runner image does not.
+      # Without it here the specs that decode audio are filtered out rather than failed, so
+      # a broken invocation ships green: that is how `out.present?` over raw PCM, which
+      # raises on the first byte that is not valid UTF-8, passed every example that handed
+      # samples in directly.
+      - name: Install the media tools the deploy image carries
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends ffmpeg
+
       - name: Create database
         run: bundle exec rake db:create
 

--- a/app/services/whatsapp/session/outbound/attachment_adapter.rb
+++ b/app/services/whatsapp/session/outbound/attachment_adapter.rb
@@ -53,12 +53,65 @@ class Whatsapp::Session::Outbound::AttachmentAdapter
     file = attachment.file
     content::Media.new(
       kind: kind, mime: file.content_type, filename: file.filename.to_s, caption: caption.presence,
-      voice_note: voice_note?, size: file.byte_size,
-      ref: media_ref.url(url, mime: file.content_type, size: file.byte_size)
+      voice_note: voice_note?, size: file.byte_size, ref: media_ref.url(url, mime: file.content_type,
+                                                                             size: file.byte_size),
+      **measurements
     )
   end
 
   private
+
+  # What the recipient's client lays the bubble out from before a byte of the file has
+  # arrived. Without them the conversation jumps when the media lands, and the note that
+  # every other bubble draws bars for arrives with a flat one.
+  #
+  # All of it read from what ActiveStorage already analysed, except the waveform, which no
+  # analyser produces. Absent stays absent: a deployment without ffprobe has no dimensions
+  # to give, and a zero on the wire is a measurement of nothing while an absent field is
+  # what every client already handles.
+  def analysis
+    @analysis ||= (attachment.file.blob.metadata || {}).with_indifferent_access
+  end
+
+  # Seconds, which is what the contract types. A recording of less than half a second is
+  # the one case rounding sends to zero, and zero is a duration the bubble would draw as
+  # an empty track, so it keeps the shortest value it can mean.
+  # Gathered in one place so `perform` stays a description of the frame rather than of how
+  # each field is found, and so an absent measurement drops out of the payload instead of
+  # travelling as a null.
+  def measurements
+    { duration: duration, waveform: waveform }.compact.merge(picture_size)
+  end
+
+  def duration
+    return unless %w[audio video].include?(kind)
+
+    seconds = analysis[:duration]
+    return if seconds.blank?
+
+    [seconds.to_f.round, 1].max
+  end
+
+  # Both sides or neither, which is what the connector refuses on: half a size lays out
+  # nothing, and the two only ever come from the same analysis anyway. Never on audio or a
+  # document, which have no picture to size.
+  def picture_size
+    return {} unless %w[image video sticker].include?(kind)
+
+    sides = [analysis[:width], analysis[:height]].map { |side| side.presence.to_i }
+    return {} unless sides.all?(&:positive?)
+
+    { width: sides.first, height: sides.last }
+  end
+
+  # Only for a note somebody recorded. A music file sent as an attachment is played from a
+  # track, not from a row of bars, so measuring it would cost the decode and change nothing
+  # on screen.
+  def waveform
+    return unless kind == 'audio' && voice_note?
+
+    Whatsapp::Session::Outbound::Waveform.for(attachment)
+  end
 
   # Compared against the same default url options `download_url` builds app-hosted URLs
   # from (it seeds ActiveStorage::Current.url_options with them), so the two can never

--- a/app/services/whatsapp/session/outbound/waveform.rb
+++ b/app/services/whatsapp/session/outbound/waveform.rb
@@ -1,0 +1,116 @@
+# The row of bars a voice note's bubble draws: exactly 64 amplitudes, 0 to 100.
+#
+# WhatsApp's own clients draw this from the audio, so a note sent without it arrives with a
+# flat bar where every other note in the conversation has a shape. The connector carries the
+# field and fills nothing in: the caller is the side holding the file.
+#
+# Filling it with a constant was considered and rejected upstream, for the reason that
+# applies here too: a shape that is not the audio is worse than an honest empty bar.
+class Whatsapp::Session::Outbound::Waveform
+  media = Whatsapp::Session::Model::Content::Media
+  SAMPLES = media::WAVEFORM_SAMPLES
+  MAX_AMPLITUDE = media::MAX_AMPLITUDE
+
+  # Mono, 8 kHz, signed 16-bit. The rate is far below anything worth listening to and far
+  # above what 64 buckets can show: a minute of audio still lands ~7500 samples in each
+  # bucket, and the peak of 7500 is the same peak whether they were sampled at 8 kHz or 48.
+  DECODE_RATE = 8_000
+  DECODE_FORMAT = %w[-f s16le -ac 1].freeze
+
+  # Peak per bucket, not RMS. RMS flattens speech into an almost straight line, because a
+  # voice spends most of its time well below its own peaks; the bars a phone draws track
+  # the peaks. The curve then lifts the quiet buckets so the shape reads at a glance
+  # instead of being one tall bar surrounded by stubs.
+  CURVE = 0.7
+
+  # A voice note is a recording somebody made with their thumb on a button, so it is small
+  # by construction. This is not a limit on what can be sent, only on what is measured:
+  # past it the file is something else that happens to be flagged as a voice note, and
+  # reading it into this process to draw 64 bars is not worth what it costs.
+  MAX_MEASURED_BYTES = 10.megabytes
+
+  class << self
+    # The waveform for an attachment, or nil when it cannot be measured. Nil is the honest
+    # answer for every failure here -- no ffmpeg, a file that will not decode, silence that
+    # is not silence -- because the field is optional on the wire and an absent one is what
+    # every client already handles.
+    def for(attachment)
+      return unless measurable?(attachment)
+
+      samples = decode(attachment)
+      return if samples.blank?
+
+      draw(samples)
+    rescue StandardError => e
+      Rails.logger.warn("[WHATSAPP] could not measure the waveform of attachment #{attachment&.id}: #{e.class}: #{e.message}")
+      nil
+    end
+
+    # Amplitudes into the fixed row of bars. Pure, and separated from the decoding on
+    # purpose: this is where the shape is decided, and it is the half that can be measured
+    # without a binary on the machine running the tests.
+    def draw(samples)
+      buckets = bucket(samples)
+      loudest = buckets.max
+      return Array.new(SAMPLES, 0) if loudest.nil? || loudest.zero?
+
+      buckets.map { |peak| (((peak.to_f / loudest)**CURVE) * MAX_AMPLITUDE).round.clamp(0, MAX_AMPLITUDE) }
+    end
+
+    private
+
+    # Every bucket exists even when the audio is shorter than the row is wide, so the
+    # result is always the fixed length the contract types. A bucket no sample fell into is
+    # silence, which is what a recording shorter than 64 frames actually has there.
+    def bucket(samples)
+      return Array.new(SAMPLES, 0) if samples.empty?
+
+      width = samples.length / SAMPLES.to_f
+      Array.new(SAMPLES) do |index|
+        first = (index * width).floor
+        last = [((index + 1) * width).ceil, samples.length].min
+        slice = samples[first...last]
+        slice.blank? ? 0 : slice.max_by(&:abs).abs
+      end
+    end
+
+    def measurable?(attachment)
+      attachment.present? && attachment.file.attached? &&
+        attachment.file.byte_size.to_i.positive? &&
+        attachment.file.byte_size <= MAX_MEASURED_BYTES &&
+        ffmpeg.present?
+    end
+
+    # Read through a tempfile rather than piped in: ffmpeg seeks while it decodes, and a
+    # container whose header sits at the end of the file (which is most of them) does not
+    # decode from a stream it cannot rewind.
+    def decode(attachment)
+      attachment.file.blob.open do |file|
+        # `binmode`, and the length read in bytes rather than through `present?`. What comes
+        # back is raw PCM, and asking a String of arbitrary bytes whether it is blank runs a
+        # whitespace match over it, which raises on the first byte that is not valid UTF-8.
+        out, status = Open3.capture2(ffmpeg, '-v', 'error', '-i', file.path, *DECODE_FORMAT,
+                                     '-ar', DECODE_RATE.to_s, '-', binmode: true)
+        next nil unless status.success? && out.bytesize.positive?
+
+        out.unpack('s<*')
+      end
+    end
+
+    # Absent is "we cannot measure this", never zero. A deployment image carries ffmpeg
+    # (docker/Dockerfile installs it), a developer's machine may not, and a bar of zeros
+    # drawn because a binary was missing is a measurement of nothing presented as one.
+    def ffmpeg
+      return @ffmpeg if defined?(@ffmpeg)
+
+      @ffmpeg = ENV.fetch('FFMPEG_PATH', nil).presence || find_ffmpeg
+    end
+
+    def find_ffmpeg
+      path, status = Open3.capture2('/bin/sh', '-c', 'command -v ffmpeg')
+      status.success? ? path.strip.presence : nil
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/spec/services/whatsapp/session/outbound/attachment_adapter_spec.rb
+++ b/spec/services/whatsapp/session/outbound/attachment_adapter_spec.rb
@@ -28,6 +28,105 @@ RSpec.describe Whatsapp::Session::Outbound::AttachmentAdapter do
     expect(media.voice_note).to be(true)
   end
 
+  # What the recipient's client lays the bubble out from before a byte has arrived. All of
+  # it read from what ActiveStorage already analysed, except the waveform, which no analyser
+  # produces.
+  describe 'the measurements the bubble is drawn from' do
+    def analysed(metadata)
+      attachment.file.blob.update!(metadata: attachment.file.blob.metadata.merge(metadata))
+      described_class.new(attachment.reload, channel: channel).perform
+    end
+
+    it 'carries both sides of a picture it has a size for' do
+      media = analysed('width' => 1280, 'height' => 720)
+
+      expect(media.width).to eq(1280)
+      expect(media.height).to eq(720)
+    end
+
+    # The connector refuses one side without the other, and it is right to: half a size
+    # lays out nothing, and the two only ever come from the same analysis anyway.
+    it 'sends neither side when it only has one' do
+      media = analysed('width' => 1280, 'height' => nil)
+
+      expect(media.width).to be_nil
+      expect(media.height).to be_nil
+    end
+
+    # The case this has to get right on a machine with no ffprobe, which is most developer
+    # machines: ActiveStorage stores the analysis with the sizes null. Absent has to stay
+    # absent, because a zero on the wire is a measurement of nothing and the client draws a
+    # bubble from it.
+    it 'sends no size at all when nothing analysed the file' do
+      media = described_class.new(attachment, channel: channel).perform
+
+      expect(media.to_h).not_to have_key(:width)
+      expect(media.to_h).not_to have_key(:height)
+    end
+
+    it 'sends no duration for a picture, which has none' do
+      media = analysed('width' => 1280, 'height' => 720, 'duration' => 12.0)
+
+      expect(media.duration).to be_nil
+    end
+
+    context 'with a video' do
+      before { attachment.update!(file_type: :video) }
+
+      it 'carries the size and the duration, rounded to the seconds the contract types' do
+        media = analysed('width' => 640, 'height' => 360, 'duration' => 8.4)
+
+        expect([media.width, media.height, media.duration]).to eq([640, 360, 8])
+      end
+    end
+
+    context 'with a voice note' do
+      before do
+        attachment.file.blob.update!(content_type: 'audio/ogg', filename: 'gravacao.ogg')
+        attachment.update!(file_type: :audio, meta: { 'is_voice_message' => true })
+      end
+
+      it 'carries the shape of the audio and no picture size' do
+        allow(Whatsapp::Session::Outbound::Waveform).to receive(:for).and_return(Array.new(64, 42))
+
+        media = analysed('duration' => 7.2)
+
+        expect(media.waveform.length).to eq(64)
+        expect(media.duration).to eq(7)
+        expect(media.to_h).not_to have_key(:width)
+      end
+
+      # A note the machine could not measure travels without the field rather than with a
+      # flat row, which is a shape that is not the audio.
+      it 'leaves the field out when the audio could not be measured' do
+        allow(Whatsapp::Session::Outbound::Waveform).to receive(:for).and_return(nil)
+
+        expect(described_class.new(attachment.reload, channel: channel).perform.to_h).not_to have_key(:waveform)
+      end
+    end
+
+    # Played from a track, not from a row of bars, so measuring it would cost the decode
+    # and change nothing on screen.
+    it 'does not measure an audio file nobody recorded as a note' do
+      attachment.file.blob.update!(content_type: 'audio/mpeg', filename: 'musica.mp3')
+      attachment.update!(file_type: :audio, meta: {})
+      allow(Whatsapp::Session::Outbound::Waveform).to receive(:for)
+
+      described_class.new(attachment.reload, channel: channel).perform
+
+      expect(Whatsapp::Session::Outbound::Waveform).not_to have_received(:for)
+    end
+
+    it 'sends nothing measured for a document' do
+      attachment.file.blob.update!(content_type: 'application/pdf', filename: 'contrato.pdf')
+      attachment.update!(file_type: :file)
+
+      media = analysed('width' => 600, 'height' => 800, 'duration' => 3.0)
+
+      expect(media.to_h.keys).not_to include(:width, :height, :duration, :waveform)
+    end
+  end
+
   describe 'the address the provider is told to fetch from' do
     let(:disk_url) { 'http://localhost:3000/rails/active_storage/disk/TOKEN/avatar.png' }
 

--- a/spec/services/whatsapp/session/outbound/waveform_spec.rb
+++ b/spec/services/whatsapp/session/outbound/waveform_spec.rb
@@ -105,31 +105,27 @@ RSpec.describe Whatsapp::Session::Outbound::Waveform do
     end
 
     # The only example that runs the decoder, and the only proof that the two halves meet:
-    # everything above hands samples in or stubs the binary away. It is skipped rather than
-    # stubbed where ffmpeg is missing, and says so, because a green suite that quietly never
-    # decoded anything is what would let a broken invocation ship.
+    # everything above hands samples in or stubs the binary away. It reads a file that is
+    # checked in rather than one built here, so what it measures is the decoding and not
+    # whether this machine's ffmpeg can also write the fixture.
+    #
+    # Skipped rather than stubbed where ffmpeg is missing, and it says so: a green suite
+    # that quietly never decoded anything is what let `out.present?` over raw PCM ship,
+    # which raises on the first byte that is not valid UTF-8 and was read as "could not
+    # measure". CI installs ffmpeg for this reason.
     it 'measures a real recording end to end', if: described_class.send(:ffmpeg).present? do
-      audio = Tempfile.new(['nota', '.ogg'])
-      loud = 'sine=frequency=440:duration=1'
-      quiet = 'anullsrc=r=44100:cl=mono:d=1'
-      system('ffmpeg', '-v', 'error', '-y', '-f', 'lavfi', '-i', loud, '-f', 'lavfi', '-i', quiet,
-             '-filter_complex', '[1:a][0:a][1:a][0:a][1:a]concat=n=5:v=0:a=1', '-c:a', 'libopus',
-             audio.path, exception: false)
-      skip 'this build of ffmpeg cannot write opus' unless File.size?(audio.path)
+      attachment.file.attach(io: Rails.root.join('spec/assets/sample.ogg').open, filename: 'nota.ogg',
+                             content_type: 'audio/ogg')
 
-      attachment.file.attach(io: File.open(audio.path), filename: 'nota.ogg', content_type: 'audio/ogg')
       bars = described_class.for(attachment.reload)
 
+      expect(bars).to be_present
       expect(bars.length).to eq(samples)
       expect(bars).to all(be_between(0, ceiling))
-      # Five seconds of silence, tone, silence, tone, silence, so a second is about 12.8
-      # bars. Windows taken inside the second they describe, never across a boundary.
-      average = ->(range) { bars[range].sum / bars[range].length }
-
-      expect(average.call(15..23)).to be > average.call(2..10)
-      expect(average.call(41..49)).to be > average.call(55..62)
-    ensure
-      audio&.close!
+      # Normalized against its own peak, so a recording with sound in it always reaches the
+      # top somewhere. A row that never does is silence, which this file is not.
+      expect(bars.max).to eq(ceiling)
+      expect(bars.count(&:zero?)).to be < samples
     end
   end
 end

--- a/spec/services/whatsapp/session/outbound/waveform_spec.rb
+++ b/spec/services/whatsapp/session/outbound/waveform_spec.rb
@@ -114,22 +114,19 @@ RSpec.describe Whatsapp::Session::Outbound::Waveform do
     # which raises on the first byte that is not valid UTF-8 and was read as "could not
     # measure". CI installs ffmpeg for this reason.
     it 'measures a real recording end to end', if: described_class.send(:ffmpeg).present? do
-      attachment.file.attach(io: Rails.root.join('spec/assets/sample.ogg').open, filename: 'nota.ogg',
-                             content_type: 'audio/ogg')
-      record = attachment.reload
+      # Built as its own row rather than by replacing what the factory attached. `attach` on
+      # a persisted record saves without a bang, so a refused save is silent and the old
+      # blob stays: this example spent a CI round decoding a 27 KB PNG and reporting that
+      # the output had no stream.
+      record = message.attachments.new(account_id: message.account_id, file_type: :audio,
+                                       meta: { 'is_voice_message' => true })
+      record.file.attach(io: Rails.root.join('spec/assets/sample.ogg').open, filename: 'nota.ogg',
+                         content_type: 'audio/ogg')
+      record.save!
 
-      # Reported in the failure message, because a bare nil here is not debuggable on a
-      # machine nobody can open.
-      diagnosis = record.file.blob.open do |file|
-        out, err, status = Open3.capture3(described_class.send(:ffmpeg), '-v', 'error', '-i', file.path,
-                                          '-f', 's16le', '-ac', '1', '-ar', '8000', '-', binmode: true)
-        { bytes: out.bytesize, exit: status.exitstatus, on_disk: File.size(file.path),
-          stderr: err.byteslice(0, 300) }
-      end
+      bars = described_class.for(record.reload)
 
-      bars = described_class.for(record)
-
-      expect(bars).to be_present, "waveform nil; ffmpeg=#{described_class.send(:ffmpeg)} #{diagnosis}"
+      expect(bars).to be_present, "waveform nil para um blob de #{record.file.byte_size} bytes"
       expect(bars.length).to eq(samples)
       expect(bars).to all(be_between(0, ceiling))
       # Normalized against its own peak, so a recording with sound in it always reaches the

--- a/spec/services/whatsapp/session/outbound/waveform_spec.rb
+++ b/spec/services/whatsapp/session/outbound/waveform_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.describe Whatsapp::Session::Outbound::Waveform do
+  let(:samples) { described_class::SAMPLES }
+  let(:ceiling) { described_class::MAX_AMPLITUDE }
+
+  # The decoding needs a binary on the machine and the shape does not, so the shape is
+  # tested on samples handed straight in. This is where the answer is actually decided:
+  # everything below is about what 64 bars say about the audio.
+  describe '.draw' do
+    it 'always answers the fixed row of bars the contract types' do
+      bars = described_class.draw(Array.new(1_000) { rand(-32_768..32_767) })
+
+      expect(bars.length).to eq(samples)
+      expect(bars).to all(be_between(0, ceiling))
+    end
+
+    # Not merely "quiet": a recording with no sound in it must not be drawn as though the
+    # loudest thing in it were loud. Normalizing against its own peak would turn dithering
+    # noise into a full row of bars.
+    it 'draws silence as silence' do
+      expect(described_class.draw(Array.new(1_000, 0))).to eq(Array.new(samples, 0))
+    end
+
+    # The acceptance shape, in the same form the issue described: tone, silence, tone. What
+    # matters is that a reader can see three separate things, which is the whole reason the
+    # field exists.
+    it 'separates loud passages from the quiet ones between them' do
+      block = ->(amplitude, count) { Array.new(count) { |i| i.even? ? amplitude : -amplitude } }
+      audio = block.call(30_000, 1_000) + block.call(0, 1_000) + block.call(30_000, 1_000) +
+              block.call(0, 1_000) + block.call(30_000, 1_000)
+
+      bars = described_class.draw(audio)
+      # Windows taken inside each block rather than by slicing the row into five: a bucket
+      # spans about 78 samples, so the ones straddling a boundary carry both sides and say
+      # nothing about either.
+      average = ->(range) { bars[range].sum / bars[range].length }
+
+      expect(average.call(2..10)).to be > 80
+      expect(average.call(15..23)).to be < 20
+      expect(average.call(28..36)).to be > 80
+      expect(average.call(41..49)).to be < 20
+      expect(average.call(55..62)).to be > 80
+    end
+
+    # The quiet half of a recording is what a curve is for. Peak alone leaves a voice as one
+    # tall bar surrounded by stubs, because speech spends most of its time well under its
+    # own peaks, so a passage at a tenth of the loudest has to read as more than a tenth of
+    # the height.
+    it 'lifts a quiet passage above its share of the peak' do
+      loud = Array.new(1_000) { |i| i.even? ? 30_000 : -30_000 }
+      quiet = Array.new(1_000) { |i| i.even? ? 3_000 : -3_000 }
+
+      bars = described_class.draw(loud + quiet)
+      tail = bars.last(samples / 4)
+
+      expect(tail.sum / tail.length).to be > (ceiling / 10)
+    end
+
+    # A note shorter than the row is wide still has to fill it, because the length is what
+    # the reader on the other side is typed against.
+    it 'fills the row for a recording shorter than it is wide' do
+      bars = described_class.draw([10_000, -10_000, 5_000])
+
+      expect(bars.length).to eq(samples)
+      expect(bars.max).to eq(ceiling)
+    end
+
+    it 'answers a row of silence for no audio at all' do
+      expect(described_class.draw([])).to eq(Array.new(samples, 0))
+    end
+  end
+
+  describe '.for' do
+    let(:channel) { create(:channel_whatsapp, provider: 'native', validate_provider_config: false, sync_templates: false) }
+    let(:message) { create(:message, :with_attachment, account: channel.account, inbox: channel.inbox) }
+    let(:attachment) { message.attachments.first }
+
+    # Absent is "we could not measure this", and it has to stay absent. A row of zeros
+    # written because a binary was missing is a measurement of nothing presented as one, and
+    # the recipient's client draws it as a note with no sound in it.
+    it 'answers nothing when the machine has no ffmpeg' do
+      allow(described_class).to receive(:ffmpeg).and_return(nil)
+
+      expect(described_class.for(attachment)).to be_nil
+    end
+
+    it 'answers nothing rather than raising when the file will not decode' do
+      allow(described_class).to receive(:ffmpeg).and_return('/bin/false')
+
+      expect(described_class.for(attachment)).to be_nil
+    end
+
+    # A recording somebody made with their thumb on a button is small. Past the cap the file
+    # is something else carrying the voice-note flag, and reading it into this process to
+    # draw 64 bars is not worth what it costs.
+    it 'does not measure a file too large to be a voice note' do
+      allow(attachment.file).to receive(:byte_size).and_return(described_class::MAX_MEASURED_BYTES + 1)
+
+      expect(described_class.for(attachment)).to be_nil
+    end
+
+    it 'answers nothing for an attachment with no file' do
+      expect(described_class.for(Attachment.new)).to be_nil
+    end
+
+    # The only example that runs the decoder, and the only proof that the two halves meet:
+    # everything above hands samples in or stubs the binary away. It is skipped rather than
+    # stubbed where ffmpeg is missing, and says so, because a green suite that quietly never
+    # decoded anything is what would let a broken invocation ship.
+    it 'measures a real recording end to end', if: described_class.send(:ffmpeg).present? do
+      audio = Tempfile.new(['nota', '.ogg'])
+      loud = 'sine=frequency=440:duration=1'
+      quiet = 'anullsrc=r=44100:cl=mono:d=1'
+      system('ffmpeg', '-v', 'error', '-y', '-f', 'lavfi', '-i', loud, '-f', 'lavfi', '-i', quiet,
+             '-filter_complex', '[1:a][0:a][1:a][0:a][1:a]concat=n=5:v=0:a=1', '-c:a', 'libopus',
+             audio.path, exception: false)
+      skip 'this build of ffmpeg cannot write opus' unless File.size?(audio.path)
+
+      attachment.file.attach(io: File.open(audio.path), filename: 'nota.ogg', content_type: 'audio/ogg')
+      bars = described_class.for(attachment.reload)
+
+      expect(bars.length).to eq(samples)
+      expect(bars).to all(be_between(0, ceiling))
+      # Five seconds of silence, tone, silence, tone, silence, so a second is about 12.8
+      # bars. Windows taken inside the second they describe, never across a boundary.
+      average = ->(range) { bars[range].sum / bars[range].length }
+
+      expect(average.call(15..23)).to be > average.call(2..10)
+      expect(average.call(41..49)).to be > average.call(55..62)
+    ensure
+      audio&.close!
+    end
+  end
+end

--- a/spec/services/whatsapp/session/outbound/waveform_spec.rb
+++ b/spec/services/whatsapp/session/outbound/waveform_spec.rb
@@ -116,10 +116,20 @@ RSpec.describe Whatsapp::Session::Outbound::Waveform do
     it 'measures a real recording end to end', if: described_class.send(:ffmpeg).present? do
       attachment.file.attach(io: Rails.root.join('spec/assets/sample.ogg').open, filename: 'nota.ogg',
                              content_type: 'audio/ogg')
+      record = attachment.reload
 
-      bars = described_class.for(attachment.reload)
+      # Reported in the failure message, because a bare nil here is not debuggable on a
+      # machine nobody can open.
+      diagnosis = record.file.blob.open do |file|
+        out, err, status = Open3.capture3(described_class.send(:ffmpeg), '-v', 'error', '-i', file.path,
+                                          '-f', 's16le', '-ac', '1', '-ar', '8000', '-', binmode: true)
+        { bytes: out.bytesize, exit: status.exitstatus, on_disk: File.size(file.path),
+          stderr: err.byteslice(0, 300) }
+      end
 
-      expect(bars).to be_present
+      bars = described_class.for(record)
+
+      expect(bars).to be_present, "waveform nil; ffmpeg=#{described_class.send(:ffmpeg)} #{diagnosis}"
       expect(bars.length).to eq(samples)
       expect(bars).to all(be_between(0, ceiling))
       # Normalized against its own peak, so a recording with sound in it always reaches the


### PR DESCRIPTION
Fecha #511. Base é a branch de integração, não a `main`: os campos `width`, `height` e `waveform` do `Content::Media` só existem lá, vindos da #518.

## O que faltava

O connector abriu os três campos no contrato (fazer-ai/whatsapp-connector#152, já mergeada e na v0.1.0) e o `AttachmentAdapter` nunca preencheu nenhum, nem o `duration` que já existia antes. O resultado no destinatário:

- nota de voz com a barra lisa em vez das barrinhas
- imagem e vídeo com a bolha num tamanho chutado, que salta quando o arquivo termina de baixar
- vídeo sem duração no canto

## De onde vem cada medida

**Dimensão e duração**: do que o ActiveStorage já analisou. Uma leitura do jsonb do blob, sem custo novo e sem processo novo.

**Waveform**: nenhum analisador produz. Sai de um `Whatsapp::Session::Outbound::Waveform` novo, que decodifica com ffmpeg para PCM mono a 8 kHz e reduz a 64 baldes.

## As escolhas de forma, e por que

**Pico por balde, não RMS.** RMS achata fala numa linha quase reta, porque a voz passa a maior parte do tempo bem abaixo dos próprios picos; as barras que o telefone desenha acompanham os picos.

**Curva de 0.7 sobre o pico normalizado.** Levanta os baldes quietos para a forma ser legível, em vez de uma barra alta cercada de tocos.

Medido contra áudio de padrão conhecido (1s de tom, 1s de silêncio, três vezes), decodificado de verdade:

```
  0   0   0   0   0   0   0   0   0 100  97  97  97  97  97  97
 97  97  97   3   1   0   0   0   0   0   0 100  97  97  97  97
 97  97  97  97  97   5   1   0   0   0   0   0   0 100  98  97
 97  97  97  97  97  97  97   8   2   0   0   0   0   0   0   0
```

Os três tons aparecem separados, que é o critério que a issue nomeou.

**8 kHz mono.** Muito abaixo do que vale ouvir e muito acima do que 64 baldes mostram: um minuto de áudio ainda põe ~7500 amostras em cada balde, e o pico de 7500 é o mesmo pico a 8 kHz ou a 48.

## Ausência continua ausência

O ponto que a issue mandou não errar, e que vale em todo caminho: máquina sem `ffprobe` não tem dimensão para dar, máquina sem `ffmpeg` não tem waveform, arquivo que não decodifica não tem nada. Nenhum desses vira zero. **Zero no fio é uma medida de nada, e campo ausente é o que todo cliente já trata.**

Também: os dois lados de uma imagem viajam juntos ou nenhum viaja, que é o que o `drawable()` do connector recusa; nada de dimensão em áudio ou documento; waveform só em nota de voz, porque um arquivo de música é tocado numa trilha e não numa fileira de barras, então medi-lo custaria a decodificação e não mudaria nada na tela.

## Sem cache, de propósito

A issue propunha guardar em `attachment.meta` para um reenvio não pagar de novo. Medi antes de decidir:

| arquivo | decodificar + desenhar |
|---|---|
| nota de 7s | ~30ms |
| 3,5 minutos (1,5MB) | 336ms |

Guardar isso custaria uma leitura-modificação-escrita no mesmo jsonb que outro código escreve, que é exatamente a corrida documentada na #534, para poupar 30ms num caminho que já faz upload para a WhatsApp. Fica sem cache, com a medição registrada aqui para quem quiser reabrir.

Há um teto de 10MB no que é medido, que não é limite do que pode ser enviado: passando disso o arquivo é outra coisa carregando a marca de nota de voz, e lê-lo para dentro deste processo para desenhar 64 barras não vale o que custa.

## Verificado

- 26 exemplos novos entre `waveform_spec` e `attachment_adapter_spec`
- Suíte em volta: `spec/services/whatsapp/session/` inteiro mais `attachment_spec` — **705 exemplos, 0 falhas**, 1 pending pré-existente
- Mutação: tirando `**measurements` do payload, 3 exemplos caem
- `rubocop` nos 9 arquivos, sem ofensa

**Um bug real que o teste de ponta a ponta pegou.** A decodificação usava `out.present?` sobre a saída do ffmpeg, e `present?` roda uma comparação de espaço em branco sobre a string: em PCM cru isso estoura `ArgumentError: invalid byte sequence in UTF-8`, e o `rescue` transformava em "não consegui medir". Todos os exemplos que entregam amostras direto passavam. Corrigido com `binmode: true` e leitura do tamanho em bytes. É o único exemplo que roda o decodificador de verdade, e é o motivo de ele existir.

Esse exemplo é pulado onde não há ffmpeg, e diz que foi pulado. A imagem de deploy carrega ffmpeg (`docker/Dockerfile:131`); esta máquina tem ffmpeg 6.0 e **não** tem ffprobe, que é justamente o cenário que a issue mandou tratar como "não sei".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/540)
<!-- Reviewable:end -->
