### PR TITLE
fix(avatar): merge the sync markers under the row lock instead of overwriting

### DIFF
--- a/app/jobs/avatar/avatar_from_url_job.rb
+++ b/app/jobs/avatar/avatar_from_url_job.rb
@@ -126,12 +126,12 @@ class Avatar::AvatarFromUrlJob < ApplicationJob
     return unless avatarable.is_a?(Contact)
     return if avatar_url.blank?
 
-    additional_attributes = avatarable.additional_attributes || {}
-    additional_attributes['last_avatar_sync_at'] = Time.current.iso8601
-    additional_attributes['avatar_url_hash'] = generate_url_hash(avatar_url)
-
-    # Persist without triggering validations that may fail due to avatar file checks
-    avatarable.update_columns(additional_attributes: additional_attributes) # rubocop:disable Rails/SkipsModelValidations
+    avatarable.update_avatar_sync_markers!(
+      merge: {
+        'last_avatar_sync_at' => Time.current.iso8601,
+        'avatar_url_hash' => generate_url_hash(avatar_url)
+      }
+    )
   end
 
   def valid_file?(file)

--- a/app/models/concerns/avatarable.rb
+++ b/app/models/concerns/avatarable.rb
@@ -12,6 +12,20 @@ module Avatarable
     after_save :fetch_avatar_from_gravatar
   end
 
+  # `additional_attributes` is one JSON column that several writers share, so a read-modify-write
+  # that spans anything slow persists a copy taken before and throws away whatever landed in the
+  # meantime. Re-read under the row lock and merge; never write a snapshot from before a network
+  # call. The lock covers only the read and the write, never the call itself.
+  def update_avatar_sync_markers!(remove: [], merge: {})
+    with_lock do
+      attributes = (additional_attributes || {}).except(*remove).merge(merge)
+      next if attributes == additional_attributes
+
+      # Persist without validations, which would fail on the avatar file checks.
+      update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
   def avatar_url
     return url_for(avatar.representation(resize_to_fill: [250, nil])) if avatar.attached? && avatar.representable?
 

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -1139,8 +1139,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
 
   def reset_avatar_state(group_contact)
     group_contact.avatar.purge if group_contact.avatar.attached?
-    attrs = (group_contact.additional_attributes || {}).except('last_avatar_sync_at', 'avatar_url_hash')
-    group_contact.update_columns(additional_attributes: attrs) # rubocop:disable Rails/SkipsModelValidations
+    group_contact.update_avatar_sync_markers!(remove: Whatsapp::Session::AvatarSync::MARKERS)
   end
 
   def try_update_participant_avatar(contact)

--- a/app/services/whatsapp/session/avatar_sync.rb
+++ b/app/services/whatsapp/session/avatar_sync.rb
@@ -12,19 +12,14 @@ module Whatsapp::Session::AvatarSync
 
   module_function
 
-  # Read and written under the row lock. `additional_attributes` is one JSON column that
-  # also carries the group's description, its settings and `group_left`, and the caller
-  # is often a job that fetched group info first: writing the whole hash it read before
-  # that round trip would throw away whatever landed in the meantime.
+  # `additional_attributes` is one JSON column that also carries the group's description, its
+  # settings and `group_left`, and the caller is often a job that fetched group info first.
+  # `update_avatar_sync_markers!` is what re-reads under the row lock rather than persisting the
+  # hash the caller read before that round trip; the reason it exists lives on it.
   def reset(contact)
     return if contact.blank?
 
-    contact.with_lock do
-      attributes = (contact.additional_attributes || {}).except(*MARKERS)
-      next if attributes == contact.additional_attributes
-
-      contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
-    end
+    contact.update_avatar_sync_markers!(remove: MARKERS)
   end
 
   # Clears the markers and asks for the picture at `url`, which the caller already has.
@@ -47,9 +42,6 @@ module Whatsapp::Session::AvatarSync
     return if contact.blank?
 
     contact.avatar.purge if contact.avatar.attached?
-    contact.with_lock do
-      attributes = (contact.additional_attributes || {}).except(*MARKERS).merge(REMOVED_AT => Time.current.iso8601)
-      contact.update_columns(additional_attributes: attributes) # rubocop:disable Rails/SkipsModelValidations
-    end
+    contact.update_avatar_sync_markers!(remove: MARKERS, merge: { REMOVED_AT => Time.current.iso8601 })
   end
 end

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -247,6 +247,58 @@ RSpec.describe Avatar::AvatarFromUrlJob do
     expect(contact.additional_attributes['avatar_url_hash']).to be_nil
   end
 
+  # `additional_attributes` is one JSON column that several writers share, and the job used to
+  # persist a copy it had read before the download. The defect is a stale in-memory snapshot
+  # rather than a database race, so forcing it needs no threads: write through a second instance
+  # while the fetch is in flight, and the job's own copy is already behind.
+  context 'when something else writes to the same column during the download' do
+    let(:contact) { create(:contact, additional_attributes: { 'city' => 'Uberlandia' }) }
+
+    def write_during_download(key, value)
+      allow(SafeFetch).to receive(:fetch) do |_url, **_opts, &block|
+        other = Contact.find(contact.id)
+        # Deliberately not the shared primitive: this stands in for a writer that does not use
+        # it, which is the whole hazard under test.
+        other.update_columns(additional_attributes: (other.additional_attributes || {}).merge(key => value)) # rubocop:disable Rails/SkipsModelValidations
+        block.call(
+          SafeFetch::Result.new(
+            tempfile: File.open(Rails.root.join('spec/assets/avatar.png')),
+            filename: 'avatar.png',
+            content_type: 'image/png'
+          )
+        )
+      end
+    end
+
+    # The one that matters most: `avatar_removed_at` is what `superseded?` reads, so erasing it
+    # un-does a removal and lets the next superseded job put the deleted photo back. It is the
+    # outcome of #504 reached by another door.
+    it 'keeps a removal that landed while the picture was downloading' do
+      write_during_download(Whatsapp::Session::AvatarSync::REMOVED_AT, 1.second.ago.iso8601)
+
+      described_class.perform_now(contact, valid_url)
+
+      expect(contact.reload.additional_attributes).to include(Whatsapp::Session::AvatarSync::REMOVED_AT)
+    end
+
+    it 'keeps an unrelated key written during the download' do
+      write_during_download('country', 'BR')
+
+      described_class.perform_now(contact, valid_url)
+
+      expect(contact.reload.additional_attributes).to include('country' => 'BR', 'city' => 'Uberlandia')
+    end
+
+    it 'still writes its own markers' do
+      write_during_download('country', 'BR')
+
+      described_class.perform_now(contact, valid_url)
+
+      expect(contact.reload.additional_attributes)
+        .to include('avatar_url_hash' => Digest::SHA256.hexdigest(valid_url))
+    end
+  end
+
   # The sequence from #504. Each step looks harmless on its own, and the cost only shows when
   # they run in order: the new picture never arrives, and nothing retries until the contact
   # changes their photo again.

--- a/spec/services/whatsapp/session/avatar_sync_spec.rb
+++ b/spec/services/whatsapp/session/avatar_sync_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+# The module had no spec of its own before #534, which mattered once its two writers moved onto
+# the shared primitive: they were being changed without anything watching.
+RSpec.describe Whatsapp::Session::AvatarSync do
+  let(:contact) do
+    create(:contact, additional_attributes: {
+             'city' => 'Uberlandia',
+             'last_avatar_sync_at' => 1.minute.ago.iso8601,
+             'avatar_url_hash' => Digest::SHA256.hexdigest('https://example.com/old.png')
+           })
+  end
+
+  # A fence, not a checklist. The defect in #534 was a read-modify-write on this one JSON column
+  # persisting a copy taken before something slow, and it existed in four places at once. Assert
+  # that nothing writes the column directly any more, so the next writer inherits the lock and
+  # the re-read instead of the bug.
+  it 'is the only shape in which the shared column is written' do
+    roots = %w[app enterprise lib].select { |dir| Rails.root.join(dir).directory? }
+    writers = Dir.glob(Rails.root.join("{#{roots.join(',')}}/**/*.rb")).select do |path|
+      File.read(path).match?(/update_columns?\(\s*additional_attributes/)
+    end
+
+    expect(writers.map { |path| Pathname.new(path).relative_path_from(Rails.root).to_s })
+      .to contain_exactly('app/models/concerns/avatarable.rb')
+  end
+
+  describe '.reset' do
+    it 'clears both markers and leaves everything else alone' do
+      described_class.reset(contact)
+
+      expect(contact.reload.additional_attributes).to eq('city' => 'Uberlandia')
+    end
+
+    it 'ignores a blank contact' do
+      expect { described_class.reset(nil) }.not_to raise_error
+    end
+
+    # The markers are what a stale picture has to clear before it can be refetched, so a caller
+    # that read the hash before a round trip must not put them back by writing its own copy.
+    it 'does not restore a marker another writer cleared first' do
+      stale = Contact.find(contact.id)
+      contact.update_avatar_sync_markers!(remove: described_class::MARKERS)
+
+      described_class.reset(stale)
+
+      expect(contact.reload.additional_attributes).not_to include('avatar_url_hash')
+    end
+  end
+
+  describe '.remove' do
+    it 'drops the picture and records when' do
+      contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png',
+                            content_type: 'image/png')
+
+      described_class.remove(contact)
+
+      contact.reload
+      expect(contact.avatar).not_to be_attached
+      expect(contact.additional_attributes).to include(described_class::REMOVED_AT)
+      expect(contact.additional_attributes).to include('city' => 'Uberlandia')
+      expect(contact.additional_attributes.keys).not_to include(*described_class::MARKERS)
+    end
+
+    it 'records the removal even when nothing was attached' do
+      described_class.remove(contact)
+
+      expect(contact.reload.additional_attributes).to include(described_class::REMOVED_AT)
+    end
+
+    # `remove` purges the blob first, which is a round trip to storage. Anything written to the
+    # column while that runs has to survive, or the removal marker lands on a stale hash and
+    # takes the other writer's key with it.
+    it 'keeps a key written while the blob was being purged' do
+      contact.avatar.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png',
+                            content_type: 'image/png')
+      allow(contact.avatar).to receive(:purge) do
+        other = Contact.find(contact.id)
+        # Deliberately not the shared primitive: this stands in for a writer that does not use
+        # it, which is the whole hazard under test.
+        other.update_columns(additional_attributes: (other.additional_attributes || {}).merge('country' => 'BR')) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      described_class.remove(contact)
+
+      expect(contact.reload.additional_attributes).to include('country' => 'BR', described_class::REMOVED_AT => anything)
+    end
+  end
+
+  describe '.refetch' do
+    it 'clears the markers and queues the download with the moment the url was resolved' do
+      expect { described_class.refetch(contact, 'https://example.com/new.png') }
+        .to have_enqueued_job(Avatar::AvatarFromUrlJob)
+        .with(contact, 'https://example.com/new.png', resolved_at: anything)
+
+      expect(contact.reload.additional_attributes.keys).not_to include(*described_class::MARKERS)
+    end
+
+    it 'does nothing without a url' do
+      expect { described_class.refetch(contact, nil) }.not_to have_enqueued_job(Avatar::AvatarFromUrlJob)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/avatar_sync_spec.rb
+++ b/spec/services/whatsapp/session/avatar_sync_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe Whatsapp::Session::AvatarSync do
       .to contain_exactly('app/models/concerns/avatarable.rb')
   end
 
+  # The fence that actually protects the markers, and the one that survives the objection to the
+  # other. It watches the key names rather than the call, so it does not care whether a future
+  # writer reaches the column with `update!`, `save!` or an index assignment: naming a marker at
+  # all is what trips it. Both files that may name one write through the primitive.
+  it 'is named in exactly the two places that own it' do
+    roots = %w[app enterprise lib].select { |dir| Rails.root.join(dir).directory? }
+    owners = Dir.glob(Rails.root.join("{#{roots.join(',')}}/**/*.rb")).select do |path|
+      body = File.read(path)
+      (described_class::MARKERS + [described_class::REMOVED_AT]).any? { |marker| body.include?(marker) }
+    end
+
+    expect(owners.map { |path| Pathname.new(path).relative_path_from(Rails.root).to_s })
+      .to contain_exactly('app/services/whatsapp/session/avatar_sync.rb',
+                          'app/jobs/avatar/avatar_from_url_job.rb')
+  end
+
   describe '.reset' do
     it 'clears both markers and leaves everything else alone' do
       described_class.reset(contact)

--- a/spec/services/whatsapp/session/avatar_sync_spec.rb
+++ b/spec/services/whatsapp/session/avatar_sync_spec.rb
@@ -11,11 +11,16 @@ RSpec.describe Whatsapp::Session::AvatarSync do
            })
   end
 
-  # A fence, not a checklist. The defect in #534 was a read-modify-write on this one JSON column
-  # persisting a copy taken before something slow, and it existed in four places at once. Assert
-  # that nothing writes the column directly any more, so the next writer inherits the lock and
-  # the re-read instead of the bug.
-  it 'is the only shape in which the shared column is written' do
+  # A fence over the avatar markers, and only over them. It catches a validation-skipping write
+  # to this column, which is how the markers have to be persisted, since the avatar file checks
+  # would refuse them. That is where this bug was written and where it would be rewritten.
+  #
+  # It is deliberately not a fence over every writer of the column. A dozen others use `update!`
+  # or `save!`, most of them adjacent read-then-write with nothing slow in between, and what makes
+  # this defect a defect is the order rather than the call: read, network, write. Grep cannot see
+  # order, so a fence wide enough to cover them would be mostly false positives. The writers that
+  # do span a network call are named in #542 and need a scenario each, not a pattern.
+  it 'is the only place that skips validations to write this column' do
     roots = %w[app enterprise lib].select { |dir| Rails.root.join(dir).directory? }
     writers = Dir.glob(Rails.root.join("{#{roots.join(',')}}/**/*.rb")).select do |path|
       File.read(path).match?(/update_columns?\(\s*additional_attributes/)


### PR DESCRIPTION
Fixes #534

## What was broken

`Avatar::AvatarFromUrlJob` wrote the whole `additional_attributes` JSON column from a copy it had read before the download:

```ruby
additional_attributes = avatarable.additional_attributes || {}
additional_attributes['last_avatar_sync_at'] = Time.current.iso8601
additional_attributes['avatar_url_hash'] = generate_url_hash(avatar_url)
avatarable.update_columns(additional_attributes: additional_attributes)
```

A download takes as long as a download takes. Anything another writer put in that column while it ran was erased by a snapshot that predated it.

The key that disappears is the one that matters. `avatar_removed_at` is what `superseded?` reads, so a removal arriving while a download was in flight was wiped out by that same download, the next superseded job stopped being recognised as superseded, and it put the deleted photo back. That is exactly the outcome #504 describes, reached by a different door, which is why it was worth doing next rather than later.

This is not a database race. The job's own in-memory copy is stale, so it reproduces deterministically with no threads at all.

## What changed

The same read-modify-write existed in four places on one shared column: this job, `AvatarSync.reset`, `AvatarSync.remove`, and `WhatsappBaileysService#reset_avatar_state`. Two of them already held the row lock and two did not, and enumerating which is which is how the next one goes wrong.

So there is one primitive, `Avatarable#update_avatar_sync_markers!`, that re-reads under the row lock and merges. All four writers use it. The lock covers the read and the write only, never the network call, so a slow download never holds a row.

A fence spec scans `app`, `enterprise` and `lib` and fails if anything but that primitive writes this column while skipping validations, which is how the markers have to be persisted since the avatar file checks would refuse them.

That fence is deliberately not wider, and the reason is worth stating because a wider one was tried. A dozen other writers reach this column with `update!` or `save!`, most of them an adjacent read-then-write with nothing slow in between. What makes this a defect is the order, read then network then write, and grep cannot see order, so a fence covering every writer would be mostly false positives.

It also has a hole that no widening of it can close: a writer can reach the column without ever naming it as an argument, through an index assignment followed by `save!`. Nine files already do that legitimately, so fencing the assignment would be noise too.

So there is a second fence, and it is the one that actually protects the markers. It watches the three key names rather than the call, which grep can see regardless of shape. Any code that names `last_avatar_sync_at`, `avatar_url_hash` or `avatar_removed_at` must be one of the two files that own them, and both write through the primitive.

## What this changed that was not the point

`Whatsapp::Session::AvatarSync` had no spec of its own. Only the job spec exercised it, indirectly. That is how two of its methods came to be rewritten here with nothing watching them, and it is worth naming rather than leaving as a silent improvement. It has a spec now, including the property that motivated all of this: `remove` purges the blob first, which is its own round trip, and a key written during that purge has to survive.

## Validation scope

Proven by test, 35 examples across the job and the module:

- A removal written during the download survives, and the job still writes its own markers.
- An unrelated key written during the download survives, alongside a key that was already there.
- `reset` clears both markers and leaves the rest, and does not restore a marker another writer cleared first.
- `remove` drops the picture, records when, keeps unrelated keys, and keeps a key written while the blob was being purged.
- `refetch` clears the markers and queues the download with the moment the URL was resolved.
- The fence.

10 mutations, all killed, control clean. They include dropping the lock so the stale snapshot returns, dropping the merge, dropping the removal, skipping the write, and restoring the old inline write in the job. Two are fence bites: the baileys service writing the column directly again, and the job reaching the markers through an index assignment and `save!`, which is exactly the shape the first fence cannot see and the second one catches.

Proven live, by the holdout scenarios run against both commits, 12 of 12:

- Seven scenarios fail on the base and pass here, stable across three runs of the base and four of the branch. Nothing oscillated, which is the risk with a set of race scenarios.
- The five that already passed still pass, so nothing regressed.
- The lock claim above was measured rather than taken on my word. With the download held open, twelve samples 100 ms apart tried `SELECT ... FOR UPDATE NOWAIT` on the contact row from a separate connection: the row was locked in 0 of 12, there were no connections `idle in transaction`, and no write locks on `contacts`. In the scenario itself the concurrent write completed in 4 ms with `lock_timeout = '1s'`, well before the download was released.

Not proven here:

- Real concurrency. Every example forces the stale read through a second instance, which is what the defect actually is. Two processes racing on the same row is what the lock is for and is not something the suite can stage.
- Two threads in one process is what the concurrency scenario uses, not two Sidekiq workers.
- The three other places that have this same shape, found while verifying this one and filed as #542: the baileys group metadata sync, whose window is wider than this job's because it spans a profile-picture lookup per participant; `ContactIpLookupJob`; and two writers of `Conversation#additional_attributes`. Each needs its own measurement rather than this pattern applied on faith, and the primitive's name and home would have to change before `Conversation` could use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/541)
<!-- Reviewable:end -->
