### PR TITLE
fix(attachments): cast the boolean attachment metadata flags

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -111,6 +111,21 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
     nil
   end
 
+  # A multipart request carries every value as a string, so `is_voice_message=false` arrives as
+  # the string "false", which is `present?` and reads at both providers as an explicit yes. The
+  # sibling top-level parameter is cast in the constructor; these were not, and the wrong value
+  # was reaching the database rather than being misread on the way out. Only these two keys are
+  # touched: everything else a caller puts in the metadata is theirs to shape.
+  BOOLEAN_ATTACHMENT_METADATA_KEYS = %w[is_voice_message is_recorded_audio].freeze
+
+  def cast_metadata_flags(values)
+    return values unless values.is_a?(Hash)
+
+    flags = values.slice(*BOOLEAN_ATTACHMENT_METADATA_KEYS)
+                  .transform_values { |value| ActiveModel::Type::Boolean.new.cast(value) }
+    values.merge(flags)
+  end
+
   def custom_attachment_metadata(attachment)
     return unless @attachments_metadata.is_a?(Hash)
 
@@ -125,7 +140,7 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
     return if metadata.blank?
 
     metadata = metadata.to_unsafe_h if metadata.respond_to?(:to_unsafe_h)
-    metadata.deep_stringify_keys
+    metadata.deep_stringify_keys.transform_values { |values| cast_metadata_flags(values) }
   end
 
   def should_transcode?(attachment)

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -351,6 +351,26 @@ describe Messages::MessageBuilder do
       end
     end
 
+    # The constructor casts this sibling parameter and always did, but nothing measured it, so
+    # the guard that keeps a multipart `is_voice_message=false` from going out as a voice note
+    # was free to disappear unnoticed. Same string, same request, one line away from the flags
+    # this change casts.
+    context 'when is_voice_message arrives as the string false' do
+      let(:params) do
+        ActionController::Parameters.new({
+                                           content: 'test',
+                                           attachments: [Rack::Test::UploadedFile.new('spec/assets/sample.ogg', 'audio/ogg')],
+                                           is_voice_message: 'false'
+                                         })
+      end
+
+      it 'leaves the voice flag off' do
+        message = message_builder
+
+        expect(message.attachments.first.meta).not_to include('is_voice_message')
+      end
+    end
+
     context 'when the voice message is a private note' do
       let(:params) do
         ActionController::Parameters.new({

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -185,6 +185,35 @@ describe Messages::MessageBuilder do
         expect(message.attachments.first.meta).to eq({ 'is_recorded_audio' => true })
       end
 
+      # A multipart request carries every value as a string, so `is_voice_message=false` arrives as
+      # the string "false", which is `present?` and reads as an explicit yes at both providers.
+      # The sibling top-level parameter is already cast one line away; this one was not.
+      it 'casts a boolean metadata flag sent as a string' do
+        params[:attachments_metadata] = { 'avatar.png' => { is_voice_message: 'false', is_recorded_audio: 'false' } }
+
+        message = message_builder
+
+        expect(message.attachments.first.meta)
+          .to include('is_voice_message' => false, 'is_recorded_audio' => false)
+      end
+
+      it 'casts a boolean metadata flag sent as the string true' do
+        params[:attachments_metadata] = { 'avatar.png' => { is_voice_message: 'true' } }
+
+        message = message_builder
+
+        expect(message.attachments.first.meta).to include('is_voice_message' => true)
+      end
+
+      # Only the flags that are booleans. Everything else a caller sends is theirs.
+      it 'leaves other metadata values exactly as they were sent' do
+        params[:attachments_metadata] = { 'avatar.png' => { description: 'false', source: '0' } }
+
+        message = message_builder
+
+        expect(message.attachments.first.meta).to include('description' => 'false', 'source' => '0')
+      end
+
       it 'creates attachment with custom metadata from attachments_metadata param' do
         params[:attachments_metadata] = { 'avatar.png' => { description: 'Profile picture', source: 'upload' } }
 

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -205,6 +205,41 @@ describe Messages::MessageBuilder do
         expect(message.attachments.first.meta).to include('is_voice_message' => true)
       end
 
+      # The case that separates casting the value from dropping the key, and the only one that
+      # does. The per-attachment metadata merges over the top-level flag, so a cast `false` wins
+      # and the note goes out silent. Dropping the key instead would leave the top-level `true`
+      # standing alone and send it as a voice note, which is the opposite of what was asked.
+      it 'lets a per-attachment refusal beat the top-level flag' do
+        params[:is_recorded_audio] = true
+        params[:attachments_metadata] = { 'avatar.png' => { is_recorded_audio: 'false' } }
+
+        message = message_builder
+
+        expect(message.attachments.first.meta).to include('is_recorded_audio' => false)
+      end
+
+      # What the cast covers is `ActiveModel::Type::Boolean`'s own list, and no more. Widening it
+      # would be inventing a second truth table one line from the sibling parameter that uses the
+      # standard one, which is the inconsistency this exists to remove.
+      it 'turns the flag off for every value Rails treats as false' do
+        %w[false FALSE 0 off f].each do |falsey|
+          params[:attachments_metadata] = { 'avatar.png' => { is_voice_message: falsey } }
+
+          expect(described_class.new(user, conversation, params).perform.attachments.first.meta)
+            .to include('is_voice_message' => false), "expected #{falsey.inspect} to turn the flag off"
+        end
+      end
+
+      # Measured, not aspired to: `no` is not on that list, so it still reads as a yes. Anyone who
+      # wants it to stop has to change the truth table, not this cast.
+      it 'still reads a value Rails does not know as a yes' do
+        params[:attachments_metadata] = { 'avatar.png' => { is_voice_message: 'no' } }
+
+        message = message_builder
+
+        expect(message.attachments.first.meta).to include('is_voice_message' => true)
+      end
+
       # Only the flags that are booleans. Everything else a caller sends is theirs.
       it 'leaves other metadata values exactly as they were sent' do
         params[:attachments_metadata] = { 'avatar.png' => { description: 'false', source: '0' } }

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -224,6 +224,25 @@ describe Whatsapp::Providers::WhatsappCloudService do
         end
       end
 
+      # The end of the path the cast in `Messages::MessageBuilder` protects: a caller that writes
+      # `is_voice_message=false` through `attachments_metadata` over multipart sends the string,
+      # and before the cast it arrived here as an explicit yes.
+      it 'leaves the voice flag off for a flag the caller sent as the string false' do
+        message = create(:message, message_type: :outgoing, content: nil, conversation: conversation)
+        Messages::MessageBuilder.new(
+          nil, message.conversation,
+          ActionController::Parameters.new(
+            content: nil,
+            attachments: [Rack::Test::UploadedFile.new('spec/assets/sample.mp3', 'audio/mpeg')],
+            attachments_metadata: { 'sample.mp3' => { is_voice_message: 'false' } }
+          )
+        ).perform
+
+        built = message.conversation.messages.last
+        expect(built.attachments.first.meta).to include('is_voice_message' => false)
+        expect(service.send(:voice_message?, 'audio', built.attachments.first)).to be(false)
+      end
+
       # A caller that says "this is not a voice message" is not the same as one that says nothing,
       # and both have to come out the same way: no flag. Both keys are set, because `false || nil`
       # is `nil` and would let a presence check and a nil check agree by accident. The API lets a


### PR DESCRIPTION
Fixes #532

## What was broken

A multipart request carries every value as a string. So a caller sending `attachments_metadata[file][is_voice_message]=false` does not send the boolean `false`, they send `"false"`, and `"false".present?` is `true`.

Three readers decide with `present?`, one more than the issue named: the WhatsApp Cloud provider, the baileys provider, and `Whatsapp::Session::Outbound::AttachmentAdapter` for the native and uazapi channels.

```ruby
(attachment.meta&.dig('is_voice_message') || attachment.meta&.dig('is_recorded_audio')).present?
```

So an explicit refusal was read as an explicit yes, and the audio went out as a voice note against the caller's own instruction.

The inconsistency that gives it away: the sibling top-level parameter is cast in the constructor, one line from where the per-attachment metadata is normalised without casting.

```ruby
@is_voice_message = ActiveModel::Type::Boolean.new.cast(params[:is_voice_message])
```

## What changed

`normalize_attachments_metadata` now casts the two keys that are booleans. Everything else a caller puts in the metadata passes through untouched, because it is theirs to shape: a `description` of `"false"` is a description, not a flag.

**What the cast covers, exactly.** `ActiveModel::Type::Boolean`'s own list and no more, so `"false"`, `"FALSE"`, `"0"`, `"off"` and `"f"` turn the flag off, while `"no"` and `"nao"` still read as a yes. Widening that would mean inventing a second truth table one line from the sibling parameter that uses the standard one, which is the inconsistency this removes. There is a test that measures `"no"` still reading as true, so the limit is written down rather than discovered later.

The cast is at the builder rather than at the readers, deliberately. Casting at the readers would leave the wrong value in the database and would put the same question in two provider services that have no reason to know it exists. Every other writer of these keys, the transcode pipeline, the media fetch job and the inbound webhook, already writes a literal `true`, so this is the only path that could carry a string.

## Validation scope

Proven by test:

- A flag sent as `"false"` and one sent as `"true"` are both stored as booleans.
- Other metadata values are stored exactly as sent, including a `description` of `"false"` and a `source` of `"0"`.
- End to end at the provider: a message built through `Messages::MessageBuilder` with `is_voice_message: 'false'` comes out with the flag off, which is the path where the defect was visible.

- The one case that separates casting the value from dropping the key: a top-level `is_recorded_audio` of `true` with a per-attachment `"false"`. The per-attachment metadata merges last, so the cast `false` wins and the note goes out silent. Dropping the key instead would leave the top-level `true` standing alone and send it as a voice note, which is the opposite of what the caller asked. That case was found by the holdout scenarios, not by me.

**What the holdout scenarios measured, and the one thing they changed my mind about.** 21 scenarios, 18 pass, 0 fail, 0 blocked, run in a tree with the fix and in a tree without it: 22 examples 0 failures with, 22 examples 7 failures without, and the seven are the central ones. The premise was proven with a real multipart body read off the `start_processing.action_controller` payload rather than a hand-typed hash, so the string is the request's doing and not the test's. All three readers turned together from the one change at the builder.

The scenarios also found a shape I had not considered: `attachments_metadata[file][is_voice_message][]=false` arrives as `["false"]`, and `ActiveModel::Type::Boolean` casts an array to `true`. So the flag stays on, exactly as before this change, and what changes is only the stored value, from `["false"]` to `true`. Left alone on purpose. `true` is the honest record of what the system will do with that input, where `["false"]` was a value that read as a yes while looking like a no. The argument for the caller who meant it as a refusal belongs upstream of the cast, in #553, where the per-attachment path is the subject.

9 mutations, all killed, control clean at 102 examples. They include dropping the cast, casting every value instead of the two flags, dropping each key from the list, casting to `present?` instead of a boolean, flipping the merge so the raw value wins, and dropping the key on a false instead of casting it.

One of them survived at first, and it is worth naming because it was not in the diff. Removing the cast from the sibling top-level parameter, the very line this change points at as the precedent, left every example green. Measured against the base as well: it survived there too, on the specs as they stood before this branch. So it was never a guard this change unpinned, it was a guard nothing had ever measured, and a multipart `is_voice_message=false` could have gone back to reading as a yes without a single test objecting. The last commit adds the example that pins it.

Not proven here:

- Rows already written with the string. This stops new ones; it does not rewrite what is stored. Fixing those would be a data migration against production data, which is a separate decision and not one to smuggle into a cast.
- A boolean sent as a real boolean per attachment, because there is no transport that reaches this code with one. `custom_attachment_metadata` returns early unless the attachment responds to `original_filename`, which only an `UploadedFile` does, so a JSON request with a direct-upload signed id has its `attachments_metadata` ignored entirely. Multipart is not merely the transport that spoils the value; it is the only one that arrives.
- Anything against a live send. The provider example asserts the payload decision rather than the delivered message, which is what the existing suite for that service does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/543)
<!-- Reviewable:end -->


