### PR TITLE
fix(whatsapp): não afirmar para que lado a aprovação de entrada de um grupo foi movida

### DIFF
--- a/app/services/whatsapp/session/backends/uazapi/group_change_mapper.rb
+++ b/app/services/whatsapp/session/backends/uazapi/group_change_mapper.rb
@@ -20,18 +20,36 @@ class Whatsapp::Session::Backends::Uazapi::GroupChangeMapper
     changes if changes.any?
   end
 
+  # Whether the event named a change this contract has no truthful way to carry, which is
+  # not the same as naming no change at all. The caller answers it with a `group.activity`,
+  # so the group is read from a snapshot instead of from an assertion.
+  def uncarried?
+    event[:MembershipApprovalMode].present?
+  end
+
   private
 
   def model = Whatsapp::Session::Model
   def events = Whatsapp::Session::Model::Events
 
+  # No `join_approval`, and its absence is the correction. Measured against real accounts on
+  # 10/09/2026: turning approval on and turning it off both arrive as
+  # `MembershipApprovalMode: {IsJoinApprovalRequired: true}`. WhatsApp sends the same tag in
+  # both directions with the state in a child element, and whatsmeow -- which this provider
+  # wraps, and whose `GroupChange` it forwards -- reads the tag's presence and never the
+  # child, so the library has no way to say "off".
+  #
+  # Reading it anyway is worse than not reading it, because the two halves of the damage are
+  # not alike. The stored value heals: the next `group.info` reads approval from a snapshot,
+  # where presence of the element is the whole signal and is right in both directions. The
+  # activity written into the group's thread does not heal, and an operator is left reading
+  # "join approval enabled" at the moment somebody disabled it, with nothing to contradict it.
   def settings
     {
       subject: nested(event[:Name], 'Name'),
       description: nested(event[:Topic], 'Topic'),
       announce: nested(event[:Announce], 'IsAnnounce'),
-      locked: nested(event[:Locked], 'IsLocked'),
-      join_approval: nested(event[:MembershipApprovalMode], 'IsJoinApprovalRequired')
+      locked: nested(event[:Locked], 'IsLocked')
     }
   end
 

--- a/app/services/whatsapp/session/backends/uazapi/webhook_translator.rb
+++ b/app/services/whatsapp/session/backends/uazapi/webhook_translator.rb
@@ -237,7 +237,17 @@ class Whatsapp::Session::Backends::Uazapi::WebhookTranslator
   # A membership change carries no `Type` at all: which of the arrays is populated is what
   # says what happened.
   def updated(payload)
-    changes = uazapi::GroupChangeMapper.new(payload).perform
+    mapper = uazapi::GroupChangeMapper.new(payload)
+    changes = mapper.perform
+    # Something changed and the contract has no truthful field for it, so the group is
+    # pinged instead of described: this side reads it back from a snapshot, which is the
+    # only source that knows which way an approval setting was moved.
+    #
+    # Only when nothing else came with it, because one webhook produces one event here. A
+    # notification carrying both a carriable change and this one describes what it can, and
+    # the setting waits for the next scheduled sync. WhatsApp was measured sending one
+    # change per notification, so that is a residue rather than the common case.
+    return event(events::GroupActivity.new(groups: [model::Address.parse(payload[:JID])])) if changes.nil? && mapper.uncarried?
     return if changes.nil?
 
     timestamp = timestamp_ms(payload[:Timestamp])

--- a/spec/services/whatsapp/session/backends/uazapi/webhook_translator_spec.rb
+++ b/spec/services/whatsapp/session/backends/uazapi/webhook_translator_spec.rb
@@ -319,6 +319,48 @@ RSpec.describe Whatsapp::Session::Backends::Uazapi::WebhookTranslator do
       end
     end
 
+    # Measured against real accounts on 10/09/2026: turning approval on and turning it off
+    # both arrive as `MembershipApprovalMode: {IsJoinApprovalRequired: true}`, because
+    # WhatsApp sends the same tag in both directions with the state in a child element and
+    # whatsmeow reads only the tag. So the value is a coin flip, and describing it would put
+    # "join approval enabled" in the thread at the moment somebody disabled it.
+    context 'when the approval setting was moved' do
+      let(:body) do
+        fixture('group_participant_left').tap do |raw|
+          raw['event'].merge!('Leave' => nil, 'LeaveLid' => nil,
+                              'MembershipApprovalMode' => { 'IsJoinApprovalRequired' => true })
+        end
+      end
+
+      it 'pings the group instead of asserting which way it went' do
+        expect(events.first.type).to eq('group.activity')
+        expect(events.first.payload.groups.first.id).to be_present
+      end
+
+      it 'describes nothing about the setting itself' do
+        expect(events.map(&:type)).not_to include('group.updated')
+      end
+    end
+
+    # A change the contract can carry is still described, and the setting simply does not
+    # appear: the handler reads an absent field as "not reported", which is true.
+    context 'when the approval setting moved alongside something describable' do
+      let(:body) do
+        fixture('group_participant_left').tap do |raw|
+          raw['event'].merge!('Leave' => nil, 'LeaveLid' => nil, 'Name' => { 'Name' => 'novo nome' },
+                              'MembershipApprovalMode' => { 'IsJoinApprovalRequired' => true })
+        end
+      end
+
+      it 'describes what it can and stays quiet about the rest' do
+        changes = events.first.payload.changes
+
+        expect(events.first.type).to eq('group.updated')
+        expect(changes.subject).to eq('novo nome')
+        expect(changes.to_h).not_to have_key(:join_approval)
+      end
+    end
+
     context 'when nothing actually changed' do
       let(:body) do
         fixture('group_participant_left').tap { |raw| raw['event'].merge!('Leave' => nil, 'LeaveLid' => nil) }


### PR DESCRIPTION
Fecha #538. O que estava marcado como inferido naquele corpo agora está medido.

## A medição

Fase ao vivo do connector, 10/09/2026, duas contas reais, duas ações consecutivas no mesmo grupo:

```
group.settings.set join_approval=true   -> {"approval":{"IsJoinApprovalRequired":true}, "unknown":0}
group.settings.set join_approval=false  -> {"approval":{"IsJoinApprovalRequired":true}, "unknown":0}
```

**O desligamento chega como `true`.** A WhatsApp manda a tag `membership_approval_mode` nos dois sentidos com o estado num filho, exatamente como o `SetGroupJoinApprovalMode` do whatsmeow a escreve, e o `parseGroupChange` da mesma biblioteca lê a presença da tag e nunca o filho. Não há `not_membership_approval_mode`, como há `not_announcement` e `unlocked`.

`unknown: 0` mata de passagem o reparo que eu tinha proposto primeiro: isso não cai em `UnknownChanges`, então nada acordaria um sync por aquele caminho.

O uazapi embrulha o whatsmeow e repassa a struct (`GroupChangeMapper` diz isso no próprio cabeçalho: *"whatsmeow's `GroupChange` with every field the event did not touch left null"*), então o valor que chegava aqui era cara ou coroa. **Em produção, hoje.**

## Por que não ler é melhor que ler e corrigir depois

As duas metades do dano não se parecem:

| | se cura? |
|---|---|
| valor guardado em `join_approval_mode` | **sim**, o próximo `group.info` lê do snapshot, onde a presença do elemento é o sinal inteiro e está certa nos dois sentidos |
| atividade escrita na thread do grupo | **não**. Fica lá, e nada depois a contradiz |

O operador lê "aprovação de entrada ativada" no instante em que alguém a desativou. Estado converge, linha do tempo diverge, e só um dos dois tem conserto.

## A correção

O `GroupChangeMapper` deixa de mapear o campo. Quando ele é a única coisa que o evento reportou, o tradutor publica **`group.activity`** em vez de `group.updated`: o handler daqui responde com `SyncGroupJob(soft: true)`, que lê o grupo por snapshot e já vem limitado a um sync por 15 minutos.

Quando vem acompanhado de algo descritível (uma renomeação, por exemplo), o `group.updated` é publicado com o que dá para descrever e o campo simplesmente não aparece, o que o `apply_settings` lê como "não reportado" — que é verdade.

Espelha a decisão que o connector tomou em fazer-ai/whatsapp-connector#162, pelo mesmo motivo. Os dois providers ficam com o mesmo comportamento em vez de divergirem, que é o que a #481 existe para evitar.

## O resíduo, nomeado

Um webhook produz um evento aqui (`perform` devolve `[single_event].compact`), então no caso combinado a mudança de aprovação não acorda um sync imediato: espera o agendado. A WhatsApp foi medida hoje mandando **uma mudança por notificação**, então isso é resíduo e não o caso comum. Reestruturar o tradutor para múltiplos eventos por webhook é cirurgia maior do que a correção pede.

## Verificado

- `webhook_translator_spec` — 37 exemplos, verdes, 3 novos
- `spec/services/whatsapp/session/` inteiro — 582 exemplos, 0 falhas, 1 pending pré-existente
- Mutação: devolvendo `join_approval` ao mapper, os 2 exemplos do caso isolado caem
- `rubocop` nos 15 arquivos, sem ofensa

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/544)
<!-- Reviewable:end -->
