### PR TITLE
fix(whatsapp): citar o motivo que o uazapi manda em `error`, não só o de `message`

### DIFF
--- a/app/services/whatsapp/session/backends/uazapi/client.rb
+++ b/app/services/whatsapp/session/backends/uazapi/client.rb
@@ -159,11 +159,20 @@ class Whatsapp::Session::Backends::Uazapi::Client
     STATUS_CODES[status] || (status >= 500 ? 'wa_error' : 'invalid_payload')
   end
 
-  # The provider's own message, when it sends one, and only that field. The rest of an
-  # error body is echoed request data, and on `/send/*` that includes the file we just
-  # uploaded.
+  # The provider's own words, when it sends any, and only that field. The rest of an error
+  # body is echoed request data, and on `/send/*` that includes the file we just uploaded.
+  #
+  # Two keys, because this provider uses two and the one it uses for failures was the one
+  # not being read: `error` carries the refusal ("the number ... is not on WhatsApp",
+  # "Description cannot be empty"), and `message` carries prose that is usually a report
+  # rather than a complaint. Reading only `message` left the operator with the bare status
+  # and no reason, on exactly the answers that had one.
+  ERROR_KEYS = %w[error message].freeze
+
   def detail(body)
-    message = body.is_a?(Hash) ? body['message'] : nil
-    ": #{message}" if message.present?
+    return unless body.is_a?(Hash)
+
+    said = ERROR_KEYS.filter_map { |key| body[key] }.find { |value| value.is_a?(String) && value.present? }
+    ": #{said}" if said
   end
 end

--- a/spec/services/whatsapp/session/backends/uazapi/client_spec.rb
+++ b/spec/services/whatsapp/session/backends/uazapi/client_spec.rb
@@ -111,6 +111,29 @@ RSpec.describe Whatsapp::Session::Backends::Uazapi::Client do
       end
     end
 
+    # Measured against the live instance on 10/09/2026: a refused group description answers
+    # `{"error":"Description cannot be empty"}`. This provider puts refusals under `error`
+    # and reports under `message`, and reading only `message` left the operator with a bare
+    # status on exactly the answers that carried a reason.
+    it 'quotes the reason when the provider files it under error' do
+      stub_request(:post, 'https://uazapi.test/group/updateDescription')
+        .to_return(status: 400, body: { error: 'Description cannot be empty' }.to_json)
+
+      expect { client.post('/group/updateDescription') }
+        .to raise_error(errors::InvalidPayload, /Description cannot be empty/)
+    end
+
+    # Nothing to say is still nothing to say: a body with neither key must not turn into a
+    # trailing colon with a blank after it.
+    it 'says only what happened when the body carries no words' do
+      stub_request(:get, 'https://uazapi.test/instance/status')
+        .to_return(status: 400, body: { data: { token: 'instance-token' } }.to_json)
+
+      expect { client.get('/instance/status') }.to raise_error(errors::InvalidPayload) do |raised|
+        expect(raised.message).to end_with('answered 400')
+      end
+    end
+
     it 'reports a provider that does not answer as one to ask again later' do
       stub_request(:get, 'https://uazapi.test/instance/status').to_timeout
 


### PR DESCRIPTION
Achado medindo o espelho da fazer-ai/whatsapp-connector#163 contra uma instância uazapi ao vivo.

## A medição

Tentando apagar a descrição de um grupo, pelo mesmo endpoint que `Backend#update_group_description` chama:

| descrição enviada | resposta | tempo |
|---|---|---|
| `"medicao da issue 163"` | `200` | 1,32s |
| `""` | `400 {"error":"Description cannot be empty"}` | 0,08s |
| `null` | `400 {"error":"Description cannot be empty"}` | 0,09s |

## O defeito

`Client#detail` lia só `body['message']`:

```ruby
def detail(body)
  message = body.is_a?(Hash) ? body['message'] : nil
  ": #{message}" if message.present?
end
```

O uazapi usa **as duas chaves**, e elas não são sinônimos. Nos próprios fixtures capturados deste repositório:

- `"error": "the number 5500010000000@s.whatsapp.net is not on WhatsApp"` — uma recusa
- `"message": "No WhatsApp restriction for starting new conversations was detected..."` — um relatório

Ou seja, `error` é onde as recusas moram, e era a chave que não estava sendo lida. O operador recebia `uazapi /group/updateDescription answered 400` sem nenhuma pista, quando o provedor tinha dito exatamente o que estava errado.

## A correção

Lê as duas, `error` primeiro. Continua citando só esse campo e nada mais do corpo, pela razão que já estava escrita ali: o resto é eco da requisição, e em `/send/*` isso inclui o arquivo recém-enviado. Um corpo sem nenhuma das duas continua produzindo a frase sem dois-pontos pendurado, o que ganhou spec próprio.

## Verificado

- `client_spec` — 20 exemplos, 2 novos, verdes
- `spec/services/whatsapp/session/backends/uazapi/` — 120 exemplos, 0 falhas, 1 pending pré-existente
- Mutação: voltando a ler só `message`, o exemplo novo do `error` cai
- `rubocop` nos dois arquivos, sem ofensa

## O que a mesma medição respondeu sobre a #163

Fica registrado aqui porque é a outra metade do que essa sessão mediu: **o uazapi não tem o travamento do connector.** Ele recusa na fronteira da API em 80ms, com 400. O connector, no mesmo caso, estoura 75 segundos de IQ e segura o executor da sessão com toda a fila daquela conta atrás.

A lacuna de capacidade é compartilhada (nenhum dos dois apaga descrição de grupo), o modo de falha não é. Comentado em detalhe na issue do connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/545)
<!-- Reviewable:end -->
