### PR TITLE
fix(groups): recusar apagar a descrição de um grupo em vez de relatar um save que não houve

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/group_metadata_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_metadata_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::Accounts::Contacts::GroupMetadataController < Api::V1::Accounts::
 
   def update
     authorize @contact, :update?
+    refuse_description_removal!
     update_subject if metadata_params[:subject].present?
     update_description if metadata_params[:description].present?
     update_picture if metadata_params[:avatar].present?
@@ -15,6 +16,27 @@ class Api::V1::Accounts::Contacts::GroupMetadataController < Api::V1::Accounts::
 
   def metadata_params
     params.permit(:subject, :description, :avatar)
+  end
+
+  # An emptied description is the one field where "absent" and "cleared" are different
+  # requests, and until now they were the same silence: `present?` skipped the update, the
+  # response came back 200 with the old text still in it, and the operator was told the
+  # save worked.
+  #
+  # Saying no is the honest answer rather than a limitation of this controller. Measured on
+  # 10/09/2026 against both providers: uazapi refuses it at its own API
+  # (`400 Description cannot be empty`), and the native connector sends a stanza WhatsApp
+  # never answers, which costs 75 seconds of the session's executor with every other
+  # command for that account queued behind it. WhatsApp's own protocol has a separate shape
+  # for a removal that neither path produces, which is fazer-ai/chatwoot#546.
+  #
+  # Only when the key was sent: a request that never mentions the description is not asking
+  # for anything.
+  def refuse_description_removal!
+    return unless metadata_params.key?(:description)
+    return if metadata_params[:description].present?
+
+    raise Whatsapp::Session::Errors::NotSupported, I18n.t('errors.whatsapp.group_description_cannot_be_removed')
   end
 
   def update_subject

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -34,6 +34,7 @@ en:
       conversation_not_visible: This conversation is not in your list, so it cannot be pinned.
     whatsapp:
       group_announcement_only: Only administrators are allowed to send messages in this group
+      group_description_cannot_be_removed: WhatsApp does not allow a group description to be removed once it is set. Replace the text instead.
     inboxes:
       channel:
         provider_unavailable: This WhatsApp provider is not available on this installation yet.

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -34,6 +34,7 @@ es:
       conversation_not_visible: Esta conversación no está en su lista, así que no se puede fijar.
     whatsapp:
       group_announcement_only: Solo los administradores pueden enviar mensajes en este grupo
+      group_description_cannot_be_removed: WhatsApp no permite eliminar la descripción de un grupo una vez definida. Reemplace el texto en lugar de borrarlo.
     inboxes:
       channel:
         provider_unavailable: Este proveedor de WhatsApp aún no está disponible en esta instalación.

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -34,6 +34,7 @@ pt_BR:
       conversation_not_visible: Esta conversa não está na sua lista, então não pode ser fixada.
     whatsapp:
       group_announcement_only: Somente administradores podem enviar mensagens neste grupo
+      group_description_cannot_be_removed: O WhatsApp não permite remover a descrição de um grupo depois que ela existe. Substitua o texto em vez de apagá-lo.
     inboxes:
       channel:
         provider_unavailable: Este provedor de WhatsApp ainda não está disponível nesta instalação.

--- a/spec/controllers/api/v1/accounts/contacts/group_metadata_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_metadata_controller_spec.rb
@@ -47,6 +47,35 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_metadata', type
         expect(baileys_service).to have_received(:update_group_description).with('group@g.us', 'A new description')
       end
 
+      # An emptied field used to be indistinguishable from an absent one: `present?` skipped
+      # the update, the response came back 200 with the old text intact, and the operator
+      # was told the save worked. Neither provider can remove a description (measured on
+      # 10/09/2026), so the honest answer is to say no rather than to report a success that
+      # did not happen.
+      it 'refuses to clear a description instead of reporting a save that did not happen' do
+        group_contact.update!(additional_attributes: group_contact.additional_attributes.merge('description' => 'antes'))
+
+        patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_metadata",
+              params: { description: '' },
+              headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to match(/description/i)
+        expect(group_contact.reload.additional_attributes['description']).to eq('antes')
+        expect(baileys_service).not_to have_received(:update_group_description)
+      end
+
+      # A request that never mentions the description is not asking for anything, and has
+      # to keep working: the subject panel saves on its own.
+      it 'still updates the subject when the description was not part of the request' do
+        patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_metadata",
+              params: { subject: 'Só o nome' },
+              headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        expect(group_contact.reload.name).to eq('Só o nome')
+      end
+
       it 'updates both subject and description' do
         patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_metadata",
               params: { subject: 'Updated Name', description: 'Updated Desc' },


### PR DESCRIPTION
Fecha #546. O defeito é maior do que aquele corpo descrevia, e apareceu ao ler o controller.

## O que a issue não sabia

`GroupMetadataController#update`:

```ruby
update_description if metadata_params[:description].present?
```

`present?` não distingue **"não mandou o campo"** de **"mandou vazio"**. Então uma descrição apagada nunca chegava a provider nenhum: o controller a descartava em silêncio, respondia `200`, e a descrição antiga continuava lá.

Ou seja, o operador apaga o texto, vê a tela dizer que salvou, recarrega e o texto está de volta. Nada no log, nada na resposta.

## O que os dois providers fazem, medido

Contra uma instância uazapi ao vivo e, do lado nativo, pela fase ao vivo do connector, em 10/09/2026:

| provider | resposta | tempo |
|---|---|---|
| uazapi | `400 {"error":"Description cannot be empty"}` | 0,08s |
| native | `timeout` do comando | 75s |

Setar uma descrição funciona nos dois, no mesmo grupo, segundos antes.

A raiz é do protocolo: o `parseGroupChange` do whatsmeow lê remoção de um filho `<delete/>` do nó `description`, **não** de um `<body>` vazio. A WhatsApp tem uma forma distinta para "apagada" e `SetGroupTopic("")` manda a outra, então ela não responde nada em vez de responder erro. Registrado em fazer-ai/whatsapp-connector#163.

**No nativo o custo não fica contido no comando que falhou:** o IQ segura o executor da sessão pelos 75 segundos, e o executor é um só, então mensagem, recibo e todo o resto daquela conta ficam na fila atrás. Apertar um botão cala a inbox por um minuto e meio.

## A correção

Como nenhum provider consegue, o pedido é recusado na entrada, com frase traduzida em `en`, `pt_BR` e `es`, e renderizado pelo mesmo `rescue` que o resto do endpoint já usa (422 com `{ error: ... }`).

Isso é melhor do que deixar chegar ao provider por duas razões independentes: o operador recebe uma explicação em vez de um erro de provedor, e o caminho nativo não gasta 75 segundos da sessão para chegar à mesma conclusão.

Uma requisição que **não menciona** a descrição continua não pedindo nada, e isso ganhou spec próprio para o painel de nome não quebrar.

## Verificado

- `group_metadata_controller_spec` — 8 exemplos, 2 novos, verdes
- `spec/controllers/api/v1/accounts/contacts/` — 71 exemplos, 0 falhas
- Mutação: tirando a recusa, o exemplo novo cai
- `rubocop` limpo; os três YAML de locale conferidos por parse

## O que fica em aberto

A #546 continua valendo para o conserto de verdade, que é mandar a forma certa do lado do connector. Isto é o que dá para fazer sem esperar por ninguém, e é o que o operador sofre hoje.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/547)
<!-- Reviewable:end -->
