### PR TITLE
fix(whatsapp): resolver o chat do histórico pelas duas metades do par telefone/LID

### DIFF
--- a/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
+++ b/app/services/whatsapp/baileys_handlers/messaging_history_set.rb
@@ -103,18 +103,38 @@ module Whatsapp::BaileysHandlers::MessagingHistorySet
     end
   end
 
-  # Matched on the id alone, without the domain: the answer is addressed the way WhatsApp
-  # holds the chat, which is not always the way the request was addressed -- a request sent
-  # to a LID comes back answered as `<phone>@s.whatsapp.net`. The id either side of that
-  # swap is the one the contact inbox was keyed by.
+  # The answer is addressed the way WhatsApp holds the chat, which is not always the way the
+  # request was addressed: a request sent to a LID comes back answered as
+  # `<phone>@s.whatsapp.net`. Matching the id by equality only lands when the row happens to
+  # have been keyed by the same half of the pair the answer used, and a row on a Baileys
+  # inbox can legitimately be keyed by either.
+  #
+  # `ContactLookup` is where that question already has one answer, covering the three keys
+  # that can hold the same person: the id as given, the other ninth-digit spelling of the
+  # number, and the phone on the contact itself, which is all that survives once
+  # consolidation re-keys the row to a LID. Asking it here rather than writing a fourth
+  # version is the point -- the miss was never in the logic, it was in there being several.
   def conversations_for_chat(jid)
-    source_id = jid.to_s.split('@').first
-    return Conversation.none if source_id.blank?
-
-    contact_inbox = inbox.contact_inboxes.find_by(source_id: source_id)
+    party = party_for(jid)
+    contact_inbox = Whatsapp::Session::Inbound::ContactLookup.find(inbox: inbox, party: party)
     return Conversation.none if contact_inbox.blank?
 
     inbox.conversations.where(contact_id: contact_inbox.contact_id)
+  end
+
+  # Resolved per call rather than aliased to a constant: a constant pointing at another
+  # file's class keeps the pre-reload object, and in development that object is the one
+  # Zeitwerk already discarded.
+  def model = Whatsapp::Session::Model
+
+  # One jid names one half of the pair and never says what the other is, so which half it
+  # is has to come from the domain: `@lid` is the LID namespace and everything else is the
+  # phone one.
+  def party_for(jid)
+    id, domain = jid.to_s.split('@')
+    return if id.blank?
+
+    domain == 'lid' ? model::Party.new(lid: id) : model::Party.new(phone: id)
   end
 
   def flag_exhausted(conversation)

--- a/spec/services/whatsapp/baileys_handlers/messaging_history_set_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messaging_history_set_spec.rb
@@ -200,6 +200,32 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
       expect(conversation.reload.additional_attributes['history_exhausted']).to be(true)
     end
 
+    # The case the equality match could not reach, and the one that actually happens: a row
+    # keyed by the LID, answered by the phone. Consolidation re-keys a contact inbox to its
+    # LID and the phone survives only on the contact, so the two ids are different strings
+    # and stripping the domain does not bring them together.
+    context 'when the row is keyed by the LID and the answer comes addressed by the phone' do
+      let!(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '199887766554433') }
+
+      it 'still records the answer on the thread' do
+        perform({ syncType: 6, messages: [], exhausted: ['5511912345678@s.whatsapp.net'] })
+
+        expect(conversation.reload.additional_attributes['history_exhausted']).to be(true)
+      end
+    end
+
+    # Brazilian and Argentinian numbers have two spellings, and which one a row carries
+    # depends on who wrote it first.
+    context 'when the row carries the other ninth-digit spelling' do
+      let!(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '551112345678') }
+
+      it 'still records the answer on the thread' do
+        perform({ syncType: 6, messages: [], exhausted: ['5511912345678@s.whatsapp.net'] })
+
+        expect(conversation.reload.additional_attributes['history_exhausted']).to be(true)
+      end
+    end
+
     it 'leaves the thread alone when no chat was flagged' do
       perform({ syncType: 6, messages: [raw_message('A', '5511912345678@s.whatsapp.net')] })
 

--- a/spec/services/whatsapp/baileys_handlers/messaging_history_set_spec.rb
+++ b/spec/services/whatsapp/baileys_handlers/messaging_history_set_spec.rb
@@ -205,7 +205,7 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
     # LID and the phone survives only on the contact, so the two ids are different strings
     # and stripping the domain does not bring them together.
     context 'when the row is keyed by the LID and the answer comes addressed by the phone' do
-      let!(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '199887766554433') }
+      let(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '199887766554433') }
 
       it 'still records the answer on the thread' do
         perform({ syncType: 6, messages: [], exhausted: ['5511912345678@s.whatsapp.net'] })
@@ -217,7 +217,7 @@ describe Whatsapp::BaileysHandlers::MessagingHistorySet do
     # Brazilian and Argentinian numbers have two spellings, and which one a row carries
     # depends on who wrote it first.
     context 'when the row carries the other ninth-digit spelling' do
-      let!(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '551112345678') }
+      let(:contact_inbox) { create(:contact_inbox, inbox: inbox, contact: contact, source_id: '551112345678') }
 
       it 'still records the answer on the thread' do
         perform({ syncType: 6, messages: [], exhausted: ['5511912345678@s.whatsapp.net'] })


### PR DESCRIPTION
Fecha #503.

## O defeito

`Whatsapp::BaileysHandlers::MessagingHistorySet#conversations_for_chat` procurava a contact inbox por igualdade exata:

```ruby
contact_inbox = inbox.contact_inboxes.find_by(source_id: source_id)
```

O comentário acima dela reconhecia o problema e assumia que não mordia: *"o id de qualquer lado dessa troca é aquele por que a contact inbox foi chaveada"*.

A premissa não se sustenta. Consolidação re-chaveia a contact inbox para o LID e o telefone sobrevive só no contato, então as duas metades do par são **strings diferentes** e tirar o domínio não as aproxima. O mesmo vale para as duas grafias do nono dígito.

Quando erra, `flag_exhausted` não roda: a conversa nunca recebe `history_exhausted`, e o dashboard continua oferecendo "buscar mensagens mais antigas" depois de a WhatsApp já ter dito que não há mais nada. O agente pede de novo, o pedido vai, e a resposta vazia não muda nada.

## A correção

Não é uma quarta versão da mesma busca. `Whatsapp::Session::Inbound::ContactLookup` já é o lugar onde essa pergunta tem uma resposta só, e o cabeçalho dele já descreve exatamente este caso:

> Three keys can hold the same person and only one of them may exist: the source_id the event names, the other ninth-digit form of that number, and the phone stored on the contact itself, which is all that is left to match on once consolidation re-keyed the row to a LID.

Este handler passa a perguntar lá. O `jid` vira um `Party` com a metade que ele nomeia (`@lid` é a namespace de LID, o resto é a de telefone), e o resto é problema resolvido.

Era a terceira resposta diferente para a mesma pergunta no repositório (esta, o `presence_update`, e o próprio `ContactLookup`). O defeito não estava na lógica de nenhuma delas, estava em haver várias.

## Verificado

- `messaging_history_set_spec` — 20 exemplos, 2 novos, verdes
- `spec/services/whatsapp/baileys_handlers/` — 108 exemplos, 0 falhas
- Mutação: voltando à igualdade exata, os 2 exemplos novos caem, e os antigos continuam passando (eles só variavam o domínio, que a versão antiga já cobria)
- `rubocop` limpo

Os dois exemplos novos são os casos que a igualdade não alcançava: linha chaveada pelo LID com resposta endereçada pelo telefone, e linha com a outra grafia do nono dígito.

## Nota de acoplamento

Um handler Baileys passa a depender de um módulo da camada de sessão. É uma função pura sem estado, e a alternativa era manter três respostas divergentes para uma pergunta só, que é o que a issue pedia para acabar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/548)
<!-- Reviewable:end -->
