### PR TITLE
fix(whatsapp): escrever uma linha por pessoa no roster do grupo

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -186,10 +186,7 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
   # members in its copy of the group.
   def add_group_members(phone_numbers)
     inbox = group_contact_inbox&.inbox
-    Array(phone_numbers).each do |phone|
-      normalized = normalize_phone(phone)
-      next if normalized.blank?
-
+    one_per_person(phone_numbers).each do |normalized|
       contact_inbox = ::ContactInboxWithContactBuilder.new(
         source_id: normalized.delete('+'),
         inbox: inbox,
@@ -199,6 +196,24 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
 
       member = GroupMember.find_or_initialize_by(group_contact: @contact, contact: contact_inbox.contact)
       member.update!(role: :member, is_active: true) unless member.persisted? && member.is_active?
+    end
+  end
+
+  # A roster is about people, and a Brazilian or Argentinian number has two spellings of the
+  # same person: with the ninth digit and without it. Submitting both wrote two contacts and
+  # two rows, and the operator saw the group with one member more than it has. Promoting or
+  # removing one of those rows did nothing to the other.
+  #
+  # The first spelling submitted wins, because nothing here knows which one the person's
+  # own device uses and the scheduled participant sync rewrites the roster from what
+  # WhatsApp answers anyway.
+  #
+  # This is the cheap layer of the two the issue names. The correct one is making contact
+  # resolution by phone reach both spellings, which lives in `ContactInboxWithContactBuilder`
+  # and is shared with every channel, so it wants its own change and its own tests.
+  def one_per_person(phone_numbers)
+    Array(phone_numbers).filter_map { |phone| normalize_phone(phone) }.each_with_object([]) do |number, kept|
+      kept << number unless kept.any? { |seen| Whatsapp::Session::PhoneMatch.same_number?(seen, number) }
     end
   end
 

--- a/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
@@ -275,6 +275,33 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
           .to include('+5511999990002')
       end
 
+      # Which is what this is. A Brazilian or Argentinian line has two spellings and one
+      # owner, so WhatsApp accepting both does not make them two members: read literally
+      # they resolved to two contacts and two rows, and the operator saw the group with one
+      # member more than it has, where promoting or removing one row left the other
+      # standing.
+      it 'writes one row when a line is submitted under both of its spellings' do
+        allow(baileys_service).to receive(:validate_provider_config?).and_return(true)
+        allow(baileys_service).to receive(:update_group_participants).and_return(
+          [{ 'address' => { 'kind' => 'phone', 'id' => '5511999990002' }, 'status' => 'success', 'code' => nil },
+           { 'address' => { 'kind' => 'phone', 'id' => '551199990002' }, 'status' => 'success', 'code' => nil }]
+        )
+
+        post "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+             params: { participants: ['+5511999990002', '+551199990002'] },
+             headers: admin.create_new_auth_token
+
+        expect(response).to have_http_status(:ok)
+        # The first spelling submitted, because nothing here knows which one the person's
+        # own device answers under.
+        expect(GroupMember.active.where(group_contact: group_contact).joins(:contact).pluck(:phone_number))
+          .to contain_exactly('+5511999990002')
+        # And the provider is still asked about both, which is the whole reason submitting
+        # both spellings is worth doing: whichever one WhatsApp knows is the one that lands.
+        expect(baileys_service).to have_received(:update_group_participants)
+          .with('group@g.us', ['5511999990002@s.whatsapp.net', '551199990002@s.whatsapp.net'], 'add')
+      end
+
       # A row is only readable where it names an address the way the contract does. A
       # provider that writes the participant as a bare JID has not been refused any less,
       # but it has not said whom in a shape this can act on either, and answering the


### PR DESCRIPTION
Adicionar a mesma pessoa a um grupo escrevendo o número das duas formas (com e sem o nono dígito) colocava duas linhas no roster, e o painel mostrava o grupo com um membro a mais do que ele tem. Promover ou remover uma dessas linhas não mexia na outra. Agora as duas grafias entram como um membro só.

## Closes

- Closes #498

## How to reproduce

1. Num grupo de WhatsApp com o canal nativo ou uazapi, abrir a lista de membros e adicionar participantes.
2. Submeter o mesmo celular brasileiro duas vezes, uma com o nono dígito (`+5511999990002`) e outra sem (`+551199990002`).
3. Antes: a lista passa a mostrar dois membros para a mesma pessoa. Agora: um só, na grafia que foi digitada primeiro.

## What changed

`add_group_members` deduplica as entradas equivalentes com `Whatsapp::Session::PhoneMatch.same_number?` antes de persistir, ficando com a primeira grafia submetida (nada aqui sabe qual delas o aparelho da pessoa usa, e o sync agendado de participantes reescreve o roster a partir do que a WhatsApp responde de qualquer jeito).

O provedor continua sendo perguntado sobre as duas grafias, e isso está pinado por spec: é justamente o que faz submeter as duas valer a pena, porque a que a WhatsApp conhece é a que entra.

Esta é a camada barata das duas que a issue nomeia. A correta é fazer a busca de contato por telefone alcançar as duas grafias, que vive em `ContactInboxWithContactBuilder` e é caminho compartilhado com todos os canais, então quer mudança e testes próprios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/549)
<!-- Reviewable:end -->
