### PR TITLE
test(groups): acertar o contrato do sync_group com a recusa que a #533 trouxe

### DIFF
--- a/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts_controller_spec.rb
@@ -802,13 +802,32 @@ RSpec.describe 'Contacts API', type: :request do
     end
 
     context 'when it is an authenticated user' do
-      it 'enqueues SyncGroupJob and returns accepted' do
+      # The refresh runs through a session, so the inbox it runs as is the agent's own.
+      it 'enqueues SyncGroupJob as the inbox the agent is on and returns accepted' do
+        whatsapp_channel = create(:channel_whatsapp, account: account, validate_provider_config: false, sync_templates: false)
+        create(:contact_inbox, contact: contact, inbox: whatsapp_channel.inbox, source_id: '12345678901234567890')
+        create(:inbox_member, user: agent, inbox: whatsapp_channel.inbox)
+
         post "/api/v1/accounts/#{account.id}/contacts/#{contact.id}/sync_group",
              headers: agent.create_new_auth_token,
              as: :json
 
         expect(response).to have_http_status(:accepted)
-        expect(Contacts::SyncGroupJob).to have_been_enqueued.with(contact, channel: nil)
+        expect(Contacts::SyncGroupJob).to have_been_enqueued.with(contact, channel: whatsapp_channel)
+      end
+
+      # An agent with no claim to any inbox this group is in is refused, the same way the
+      # group endpoints refuse an inbox the group is not in. Before, the job was queued with
+      # no channel and the service picked the group's first contact inbox, so the refresh ran
+      # over a session the caller has no claim to -- and for a group in no inbox at all, over
+      # nothing.
+      it 'refuses a group it can reach no inbox of the agent for' do
+        post "/api/v1/accounts/#{account.id}/contacts/#{contact.id}/sync_group",
+             headers: agent.create_new_auth_token,
+             as: :json
+
+        expect(response).to have_http_status(:not_found)
+        expect(Contacts::SyncGroupJob).not_to have_been_enqueued
       end
 
       # A group contact is account-scoped, so the same WhatsApp group can sit in two


### PR DESCRIPTION
A `main` está vermelha desde `6dd8b3c60d` (#533) em `spec/controllers/api/v1/accounts/contacts_controller_spec.rb:805`. Não é uma regressão de comportamento: a #533 fez toda ação de grupo recusar quando o agente não alcança nenhuma inbox em que o grupo esteja, em vez de passar um canal `nil` adiante e estourar no primeiro deref, e o `sync_group` do controller de contatos usa o mesmo `channel`. O spec dele ainda afirmava o contrato antigo (grupo em inbox nenhuma, job enfileirado com `channel: nil`).

Passou batido na CI da #533 porque o modo afetado mapeia `app/controllers/concerns/group_channel_resolver.rb` para `group_channel_resolver_spec.rb`, e não para o spec do controller de contatos.

## Closes

Nada. Destrava a `main`.

## What changed

Só spec. O exemplo que passava agora roda com uma inbox do próprio agente e afirma o canal que entra no job, em vez de `channel: nil`. Junto vai um exemplo novo para a recusa, que é o que mudou de verdade e não estava pinado neste endpoint: antes o refresh corria por cima da primeira contact inbox do grupo, uma sessão que quem pediu não tem direito de usar, e para um grupo em inbox nenhuma corria por cima de nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/550)
<!-- Reviewable:end -->
