### PR TITLE
fix(whatsapp): fazer o sync do contrato nomear o que ele de fato copiou

### DIFF
--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -1,3 +1,4 @@
+require 'open3'
 require 'tmpdir'
 
 # rubocop:disable Metrics/BlockLength
@@ -36,14 +37,14 @@ namespace :whatsapp do
       source = Pathname.new(ENV.fetch('WHATSAPP_CONNECTOR_PATH', Rails.root.join('../../whatsapp-connector').to_s)).expand_path
       raise "no contract at #{source}/contract" unless source.join('contract').directory?
 
-      ref = args[:ref].presence || `git -C #{source} rev-parse HEAD`.strip
+      ref = WhatsappContractSource.commit_for(source, args[:ref])
       target = Whatsapp::SessionContract.root
       FileUtils.rm_rf(target)
       FileUtils.mkdir_p(target)
       FileUtils.cp_r("#{source}/contract/.", target)
       FileUtils.rm_f(target.join('README.md'))
       Whatsapp::SessionContract.write_reference(repo: 'fazer-ai/whatsapp-connector', ref: ref)
-      puts "vendored #{ref[0, 12]} (checksum #{Whatsapp::SessionContract.checksum})"
+      puts "vendored #{ref[0, 12]} (checksum #{Whatsapp::SessionContract.checksum})#{WhatsappContractSource.local_edits(source)}"
     end
   end
 
@@ -302,6 +303,63 @@ module WhatsappProviderConversion
 
       puts "  #{verb}    #{label}#{note ? ": #{note}" : ''}"
       true
+    end
+  end
+end
+
+# Which commit the copy `sync` makes actually comes from.
+#
+# The task used to stamp CONTRACT_REF with the ref it was handed and copy whatever the
+# working tree held, two facts with nothing tying them together: a checkout sitting on a
+# branch from before that ref vendored the old contract under the new ref's name. Nothing
+# caught it, because `verify` with no argument compares the files against the checksum this
+# very task had just written from those same files, so the pair is internally consistent and
+# names a commit it does not correspond to. `verify[<ref>]` would have caught it, and nobody
+# runs it right after a sync that just said it worked.
+module WhatsappContractSource
+  class << self
+    # Refuses rather than checking the ref out: the checkout belongs to whoever is working
+    # in it, and moving somebody else's HEAD to make a copy is not this task's to do. Both
+    # commits go in the message, since "wrong ref" without them is a puzzle.
+    def commit_for(source, ref)
+      head = rev_parse(source, 'HEAD')
+      abort "#{source} is not a git checkout, so there is no commit to name; nothing was vendored" if head.nil?
+      return head if ref.blank?
+
+      asked = rev_parse(source, ref)
+      abort "#{source} does not know #{ref}; fetch it there first, or omit the ref to vendor what is checked out" if asked.nil?
+      return head if asked == head
+
+      abort "#{source} is checked out at #{head[0, 12]}, not #{ref} (#{asked[0, 12]}). " \
+            'Check it out there, or omit the ref to vendor what is checked out.'
+    end
+
+    # Vendoring an uncommitted state is a real thing to want -- a contract change is tried
+    # from both sides before it is a commit -- so this does not refuse. What it must not do
+    # is let the success line claim the copy is that commit, which is the same lie the ref
+    # check above is about, arriving through the working tree instead of through HEAD.
+    def local_edits(source)
+      count = git(source, 'status', '--porcelain', '--', 'contract').to_s.lines.count
+      return '' if count.zero?
+
+      " plus #{count} uncommitted change(s) to contract/"
+    end
+
+    private
+
+    def rev_parse(source, ref)
+      # `^{commit}` so a tag, a branch and a short sha all answer the same thing, and an
+      # existing ref that names something other than a commit answers nothing.
+      git(source, 'rev-parse', '--verify', '--quiet', "#{ref}^{commit}")&.strip.presence
+    end
+
+    # capture2e, so git's own "fatal: not a git repository" does not print past this: a
+    # failure here is answered as nil and spoken for by the abort messages above.
+    def git(source, *)
+      out, status = Open3.capture2e('git', '-C', source.to_s, *)
+      status.success? ? out : nil
+    rescue Errno::ENOENT
+      nil
     end
   end
 end

--- a/spec/lib/tasks/whatsapp_contract_source_spec.rb
+++ b/spec/lib/tasks/whatsapp_contract_source_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+# `sync` writes the ref it was handed into CONTRACT_REF and copies the checkout's working
+# tree, and those were unrelated facts. A checkout sitting on a branch from before the ref
+# vendored the old contract under the new ref's name, and nothing said so: `verify` with no
+# argument compares the files against the checksum `sync` had just computed from those same
+# files, so it agreed about a pair that names a commit it does not correspond to.
+RSpec.describe WhatsappContractSource do
+  let(:source) { Pathname.new(Dir.mktmpdir) }
+
+  def git(*arguments)
+    out, status = Open3.capture2e('git', '-C', source.to_s, *arguments)
+    raise "git #{arguments.join(' ')} failed: #{out}" unless status.success?
+
+    out.strip
+  end
+
+  before do
+    git('init', '--quiet', '--initial-branch', 'main')
+    git('config', 'user.email', 'spec@fazer.ai')
+    git('config', 'user.name', 'spec')
+    source.join('contract').mkpath
+    source.join('contract/PROTOCOL_VERSION').write("1\n")
+    git('add', '-A')
+    git('commit', '--quiet', '-m', 'first')
+  end
+
+  after { FileUtils.rm_rf(source) }
+
+  describe '.commit_for' do
+    it 'answers the checked out commit when no ref was named' do
+      expect(described_class.commit_for(source, nil)).to eq(git('rev-parse', 'HEAD'))
+    end
+
+    it 'answers it when the ref names that same commit' do
+      expect(described_class.commit_for(source, git('rev-parse', 'HEAD'))).to eq(git('rev-parse', 'HEAD'))
+    end
+
+    # The whole point: the copy would be the old contract and the stamp would be the new
+    # ref, and every check downstream compares the copy against a checksum taken from it.
+    it 'refuses a ref the checkout is not on, naming both commits' do
+      behind = git('rev-parse', 'HEAD')
+      source.join('contract/PROTOCOL_VERSION').write("2\n")
+      git('commit', '--quiet', '-am', 'second')
+      ahead = git('rev-parse', 'HEAD')
+      git('checkout', '--quiet', behind)
+
+      expect { described_class.commit_for(source, ahead) }
+        .to raise_error(SystemExit).and output(/#{behind[0, 12]}.*#{ahead[0, 12]}/m).to_stderr
+    end
+
+    # A branch or a tag has to resolve the same way a sha does, or naming the ref a release
+    # was cut from would be refused for being spelled differently.
+    it 'accepts a tag that resolves to the checked out commit' do
+      git('tag', 'v1.0.0')
+
+      expect(described_class.commit_for(source, 'v1.0.0')).to eq(git('rev-parse', 'HEAD'))
+    end
+
+    it 'refuses a ref the checkout has never heard of' do
+      expect { described_class.commit_for(source, 'no-such-ref') }
+        .to raise_error(SystemExit).and output(/does not know no-such-ref/).to_stderr
+    end
+
+    it 'refuses a directory that is no checkout at all, rather than stamping an empty ref' do
+      plain = Pathname.new(Dir.mktmpdir)
+
+      expect { described_class.commit_for(plain, nil) }.to raise_error(SystemExit).and output(/not a git checkout/).to_stderr
+    ensure
+      FileUtils.rm_rf(plain)
+    end
+  end
+
+  # Not a refusal: a contract change is tried from both sides before it is a commit. What it
+  # must not do is let the line the task prints claim the copy is that commit.
+  describe '.local_edits' do
+    it 'says nothing about a clean checkout' do
+      expect(described_class.local_edits(source)).to eq('')
+    end
+
+    it 'counts what the working tree carries on top of the commit' do
+      source.join('contract/PROTOCOL_VERSION').write("2\n")
+
+      expect(described_class.local_edits(source)).to eq(' plus 1 uncommitted change(s) to contract/')
+    end
+
+    it 'ignores changes outside the contract directory' do
+      source.join('main.go').write("package main\n")
+
+      expect(described_class.local_edits(source)).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
`rails whatsapp:contract:sync[<ref>]` gravava no `CONTRACT_REF` o ref que recebeu e copiava o que estivesse no working tree do checkout apontado por `WHATSAPP_CONNECTOR_PATH`. Os dois não precisavam ter nada a ver um com o outro: um checkout parado numa branch anterior àquele ref vendorizava o contrato antigo com o nome do novo, e a linha de sucesso dizia que tinha dado certo.

## Closes

- Closes #519

## How to reproduce

1. Deixar o checkout do connector em qualquer commit que não seja o ref que você vai passar.
2. `WHATSAPP_CONNECTOR_PATH=/caminho/do/connector rails "whatsapp:contract:sync[<outro ref>]"`.
3. Antes: `vendored <outro ref> (checksum ...)`, com os arquivos do commit que estava no disco. Agora:

```
/caminho/do/connector is checked out at 2addfd6cbc98, not HEAD~3 (6b291bc9b6ad). Check it out there, or omit the ref to vendor what is checked out.
```

## What changed

A task resolve o ref dentro do checkout (`rev-parse --verify <ref>^{commit}`, então sha, branch e tag respondem igual) e recusa quando ele não é o HEAD, dizendo os dois commits. Não faz `checkout` no lugar de ninguém: o checkout é de quem está trabalhando nele, e mexer no HEAD dos outros para tirar uma cópia não é papel desta task. Quem quer vendorizar um estado local continua omitindo o argumento.

A outra metade da mesma mentira vem pelo working tree, e essa não recusa: experimentar uma mudança de contrato pelos dois lados antes de virar commit é coisa real. O que ela não pode é deixar a linha de sucesso afirmar que a cópia é aquele commit, então a linha passa a dizer quantas mudanças não commitadas vieram junto.

```
vendored 2addfd6cbc98 (checksum 308eea576c1e...) plus 1 uncommitted change(s) to contract/
```

Um diretório que não é checkout nenhum também passa a recusar, em vez de gravar `ref=` vazio, que era o que a leitura crua de `rev-parse HEAD` produzia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/551)
<!-- Reviewable:end -->
