### PR TITLE
fix(conversations): fazer o catch-up ordenar, cortar e avançar pelo mesmo id

### DIFF
--- a/app/finders/message_finder.rb
+++ b/app/finders/message_finder.rb
@@ -43,12 +43,21 @@ class MessageFinder
     end
   end
 
+  CATCH_UP_LIMIT = 100
+
   # Deliberately still by id, unlike `before_cursor`. This one answers "what has been
   # written since I last looked", which is a question about the sequence and not about
   # time: a client catching up has to be told about a backdated message imported a moment
   # ago, and comparing timestamps is exactly what would hide it.
+  #
+  # Which is also why the order is by id and not by time. The filter, the order and the
+  # limit have to agree, or the limit cuts a different set than the filter chose: ordering
+  # by `created_at` handed back the hundred oldest by time, which for a thread carrying
+  # backdated rows is not the hundred lowest ids, and the ones it left out sat above the
+  # cursor the client then moved past. The client sorts by time before rendering either
+  # way, so the order here is the cursor's, not the reader's.
   def messages_after(after_id)
-    messages.reorder('created_at asc').where('id > ?', after_id).limit(100)
+    messages.reorder('id asc').where('id > ?', after_id).limit(CATCH_UP_LIMIT)
   end
 
   def messages_before(before_id)

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -9,6 +9,7 @@ import { emitter } from 'shared/helpers/mitt';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import {
   buildConversationList,
+  highestMessageId,
   isOnMentionsView,
   isOnParticipatingView,
   isOnUnattendedView,
@@ -56,6 +57,13 @@ const UNRECONCILABLE_VIEWS = [
 const tabsBeingReconciled = new Set();
 
 // actions
+// Mirrors `MessageFinder::CATCH_UP_LIMIT`: the number of rows one `after` call answers, and
+// therefore what tells a full window apart from the last one. The page cap is a stop, not a
+// budget -- 2000 rows is far past any real reconnect, and a server that kept answering full
+// windows would otherwise loop here for ever.
+const CATCH_UP_PAGE_SIZE = 100;
+const MAX_CATCH_UP_PAGES = 20;
+
 const actions = {
   getConversation: async ({ commit }, conversationId) => {
     try {
@@ -233,20 +241,35 @@ const actions = {
     { conversationId }
   ) => {
     const { allConversations, syncConversationsMessages } = state;
-    const lastMessageId = syncConversationsMessages[conversationId];
     const selectedChat = allConversations.find(
       conversation => conversation.id === conversationId
     );
     if (!selectedChat) return;
     try {
       const { messages } = selectedChat;
-      // Fetch all the messages after the last message id
-      const {
-        data: { meta, payload },
-      } = await MessageApi.getPreviousMessages({
-        conversationId,
-        after: lastMessageId,
-      });
+      // The server answers a bounded window per call, so an agent who was away long enough
+      // to miss more than one of them used to be handed the first window and told the
+      // catch-up was over: the cursor was cleared and nothing fetched the rest until the
+      // conversation was opened again. Walk the windows instead, each one starting above
+      // the highest id the last one carried.
+      let cursor = syncConversationsMessages[conversationId];
+      let meta;
+      let payload = [];
+      for (let page = 0; page < MAX_CATCH_UP_PAGES; page += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        const { data } = await MessageApi.getPreviousMessages({
+          conversationId,
+          after: cursor,
+        });
+        meta = data.meta;
+        payload = payload.concat(data.payload);
+        // A short window is the last one. A full window that carried nothing above the
+        // cursor would repeat itself for ever, so it ends the walk too.
+        const next = highestMessageId(data.payload);
+        if (data.payload.length < CATCH_UP_PAGE_SIZE || !(next > cursor)) break;
+
+        cursor = next;
+      }
       commit(`conversationMetadata/${types.SET_CONVERSATION_METADATA}`, {
         id: conversationId,
         data: meta,
@@ -284,11 +307,16 @@ const actions = {
     );
     if (!selectedChat) return;
     const { messages } = selectedChat;
-    const lastMessage = messages.last();
-    if (!lastMessage) return;
+    // The highest id, not the last one in the list: the list is sorted by time, and the
+    // catch-up asks for what was written after this id. A backdated row -- a history import
+    // stamps `created_at` from when the message was sent and takes its id from the INSERT --
+    // sits late in the sequence and early in the list, so taking the newest by time set the
+    // cursor above rows the client never received, and nothing asked for them again.
+    const cursor = highestMessageId(messages);
+    if (cursor === undefined) return;
     commit(types.SET_LAST_MESSAGE_ID_IN_SYNC_CONVERSATION, {
       conversationId,
-      messageId: lastMessage.id,
+      messageId: cursor,
     });
   },
 

--- a/app/javascript/dashboard/store/modules/conversations/helpers/actionHelpers.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers/actionHelpers.js
@@ -68,3 +68,14 @@ export const buildConversationList = (
     markEndReached: !conversationList.length,
   });
 };
+
+// The cursor the catch-up asks from, which is the highest id the client holds and not the
+// last row of a list sorted by time. A message still on its way out carries a uuid instead
+// of a server id, and "everything written after this uuid" is not a question the server can
+// answer, so those are skipped rather than allowed to become the cursor.
+export const highestMessageId = messages =>
+  (messages || []).reduce((highest, { id } = {}) => {
+    if (!Number.isFinite(id)) return highest;
+
+    return highest === undefined || id > highest ? id : highest;
+  }, undefined);

--- a/app/javascript/dashboard/store/modules/conversations/helpers/specs/actionHelpers.spec.js
+++ b/app/javascript/dashboard/store/modules/conversations/helpers/specs/actionHelpers.spec.js
@@ -1,4 +1,5 @@
 import {
+  highestMessageId,
   isOnMentionsView,
   isOnFoldersView,
   isOnParticipatingView,
@@ -42,5 +43,37 @@ describe('#isOnParticipatingView', () => {
     expect(
       isOnParticipatingView({ route: { name: 'conversation_messages' } })
     ).toBe(false);
+  });
+});
+
+describe('#highestMessageId', () => {
+  it('answers nothing for a thread with no message', () => {
+    expect(highestMessageId([])).toBeUndefined();
+    expect(highestMessageId(undefined)).toBeUndefined();
+  });
+
+  // The list is sorted by time and the catch-up asks by id. An imported message is stamped
+  // with when it was sent and takes its id from the INSERT, so it sits early in the list and
+  // late in the sequence: taking the last one set the cursor above rows the client never
+  // received, and nothing asked for them again.
+  it('takes the highest id, not the newest by time', () => {
+    const messages = [
+      { id: 90, created_at: 1000 },
+      { id: 91, created_at: 2000 },
+      { id: 42, created_at: 3000 },
+    ];
+
+    expect(highestMessageId(messages)).toBe(91);
+  });
+
+  // A message still on its way out carries a uuid, and "everything after this uuid" is not
+  // a question the server can answer.
+  it('ignores a message that has no server id yet', () => {
+    const messages = [
+      { id: 7, created_at: 1000 },
+      { id: 'c2a0f0e2-0b1f-4a1e-9f0e-0b1f4a1e9f0e', created_at: 2000 },
+    ];
+
+    expect(highestMessageId(messages)).toBe(7);
   });
 });

--- a/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js
@@ -1012,6 +1012,89 @@ describe('#addMentions', () => {
     ]);
   });
 
+  // The server answers a bounded window per call. An agent away long enough to miss more
+  // than one of them was handed the first window and told the catch-up was over: the cursor
+  // was cleared and nothing fetched the rest until the conversation was opened again.
+  it('#syncActiveConversationMessages walks past a full window', async () => {
+    const firstWindow = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 2,
+      content: `page one ${index}`,
+    }));
+    axios.get
+      .mockResolvedValueOnce({ data: { payload: firstWindow, meta: {} } })
+      .mockResolvedValueOnce({
+        data: { payload: [{ id: 500, content: 'page two' }], meta: {} },
+      });
+
+    await actions.syncActiveConversationMessages(
+      {
+        commit,
+        dispatch,
+        state: {
+          allConversations: [{ id: 1, messages: [], inbox_id: 1 }],
+          syncConversationsMessages: { 1: 1 },
+        },
+      },
+      { conversationId: 1 }
+    );
+
+    expect(axios.get.mock.calls.length).toBe(2);
+    // The second call starts above the highest id the first window carried, not above the
+    // cursor it was given.
+    expect(axios.get.mock.calls[1][1]).toEqual({ params: { after: 101 } });
+    const written = commit.mock.calls.find(
+      ([name]) => name === 'SET_MISSING_MESSAGES'
+    );
+    expect(written[1].data.map(message => message.id)).toContain(500);
+  });
+
+  // A full window that carries nothing above the cursor would be asked for again for ever.
+  it('#syncActiveConversationMessages stops on a window that does not advance', async () => {
+    const stuck = Array.from({ length: 100 }, () => ({
+      id: 1,
+      content: 'same',
+    }));
+    axios.get.mockResolvedValue({ data: { payload: stuck, meta: {} } });
+
+    await actions.syncActiveConversationMessages(
+      {
+        commit,
+        dispatch,
+        state: {
+          allConversations: [{ id: 1, messages: [], inbox_id: 1 }],
+          syncConversationsMessages: { 1: 1 },
+        },
+      },
+      { conversationId: 1 }
+    );
+
+    expect(axios.get.mock.calls.length).toBe(1);
+  });
+
+  // The cursor is the highest id the client holds, not the last row of a list sorted by
+  // time: an imported message is stamped with when it was sent and takes its id from the
+  // INSERT, so taking the newest by time set the cursor above rows never received.
+  it('#setConversationLastMessageId takes the highest id, not the newest', async () => {
+    await actions.setConversationLastMessageId(
+      {
+        commit,
+        state: {
+          allConversations: [
+            { id: 1, messages: [{ id: 90 }, { id: 91 }, { id: 42 }] },
+          ],
+        },
+      },
+      { conversationId: 1 }
+    );
+
+    expect(commit.mock.calls).toEqual([
+      [
+        'SET_LAST_MESSAGE_ID_FOR_SYNC_CONVERSATION',
+        { conversationId: 1, messageId: 91 },
+      ],
+    ]);
+  });
+
   describe('#fetchAllAttachments', () => {
     it('fetches all attachments', async () => {
       axios.get.mockResolvedValue({

--- a/spec/finders/message_finder_spec.rb
+++ b/spec/finders/message_finder_spec.rb
@@ -70,6 +70,27 @@ describe MessageFinder do
       end
     end
 
+    # A history import stamps `created_at` from when the message was sent and takes its id
+    # from the INSERT, so for a thread carrying imported rows the two orders disagree.
+    # Ordering the catch-up by time cut a different set than the id filter chose, and the
+    # client moved its cursor past the rows that answer left out.
+    context 'when a backdated row was written after the ones already on screen' do
+      let!(:cursor) { conversation.messages.maximum(:id) }
+      let!(:live) { create(:message, account: account, inbox: inbox, conversation: conversation, created_at: 1.minute.ago) }
+      let!(:imported) { create(:message, account: account, inbox: inbox, conversation: conversation, created_at: 2.days.ago) }
+      let(:params) { { after: cursor } }
+
+      it 'answers in id order, which is the order the cursor advances in' do
+        expect(message_finder.perform.map(&:id)).to eq([live.id, imported.id])
+      end
+
+      it 'cuts the window by id, so what it leaves out is what the next call asks for' do
+        stub_const("#{described_class}::CATCH_UP_LIMIT", 1)
+
+        expect(message_finder.perform.map(&:id)).to eq([live.id])
+      end
+    end
+
     context 'with an after attribute above the message id range' do
       let(:params) { { after: 881_965_304_328 } }
 


### PR DESCRIPTION
Quando o dashboard volta a ficar online, ele pede ao servidor o que foi escrito desde a última mensagem que tinha. Numa conversa com histórico importado, parte do que chegou nesse intervalo não vinha, e o agente ficava vendo a thread sem uma mensagem que já existe até reabrir a conversa.

## Closes

- Closes #531

## How to reproduce

Precisa de linha retrodatada na thread (import de histórico grava `created_at` do horário de envio e id da sequência do INSERT, então as duas ordens divergem) ou de mais de 100 mensagens acumuladas offline.

1. Deixar o dashboard offline com a conversa aberta.
2. Fazer chegar, nesse intervalo, uma mensagem retrodatada e uma mensagem nova.
3. Voltar a ficar online. Antes: a retrodatada não aparece até a conversa ser reaberta. Agora: aparece no catch-up.

## What changed

As três peças da consulta não concordavam entre si: `MessageFinder#messages_after` filtrava por id e ordenava por tempo, e o cursor que o cliente mandava (`setConversationLastMessageId`) era o id da mensagem mais nova **no tempo**, porque a lista no store é ordenada por `created_at`. Duas consequências: linha com id abaixo do cursor nunca era buscada, e com mais de 100 pendentes o `limit` devolvia as 100 mais antigas por tempo, que não são as 100 de menor id.

- O finder ordena por id, que é a ordem em que o cursor anda. O cliente sorteia por `created_at` antes de renderizar de qualquer jeito, então a ordem daqui é a do cursor, não a do leitor.
- O cursor passa a ser o maior id que o cliente tem. Uma mensagem ainda a caminho carrega uuid no lugar de id de servidor, e "tudo depois deste uuid" não é pergunta que o servidor responda, então essas deixam de poder virar cursor.
- O catch-up caminha pelas janelas em vez de pegar a primeira e zerar o cursor. Para na janela curta, na que não avança (uma janela cheia que não trouxe nada acima do cursor se repetiria para sempre) e num teto de páginas.

A `messages_after` é caminho compartilhado com todos os canais, não só WhatsApp, e a prova reflete isso: os specs do finder rodam sobre uma inbox de web widget (é o que o factory `:inbox` constrói), e os do frontend são de store, sem canal nenhum. Nenhuma das duas metades depende de WhatsApp para ficar vermelha quando a correção é revertida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/552)
<!-- Reviewable:end -->

