### PR TITLE
feat(folders): let the folder list be sorted, instead of always newest-first

### DIFF
--- a/app/javascript/dashboard/api/inbox/conversation.js
+++ b/app/javascript/dashboard/api/inbox/conversation.js
@@ -41,6 +41,10 @@ class ConversationApi extends ApiClient {
     return axios.post(`${this.url}/filter`, payload.queryData, {
       params: {
         page: payload.page,
+        // Sent as a query param, not in the body: the body is the filter payload the
+        // server validates attribute by attribute, and an extra key there is rejected
+        // rather than ignored. Omitted when absent so the server keeps its own default.
+        ...(payload.sortBy ? { sort_by: payload.sortBy } : {}),
       },
     });
   }

--- a/app/javascript/dashboard/api/specs/inbox/conversation.spec.js
+++ b/app/javascript/dashboard/api/specs/inbox/conversation.spec.js
@@ -249,6 +249,31 @@ describe('#ConversationAPI', () => {
       );
     });
 
+    it('#filter forwards the sort order when one is given', () => {
+      const payload = {
+        page: 2,
+        sortBy: 'last_activity_at_asc',
+        queryData: { payload: [] },
+      };
+      conversationAPI.filter(payload);
+      expect(axiosMock.post).toHaveBeenCalledWith(
+        '/api/v1/conversations/filter',
+        payload.queryData,
+        { params: { page: 2, sort_by: 'last_activity_at_asc' } }
+      );
+    });
+
+    // Absent rather than null: the server picks its own default when the key is missing,
+    // and sending an empty one would have to be handled as a special case there.
+    it('#filter omits sort_by when no order is given', () => {
+      conversationAPI.filter({ page: 1, queryData: { payload: [] } });
+      expect(axiosMock.post).toHaveBeenCalledWith(
+        '/api/v1/conversations/filter',
+        { payload: [] },
+        { params: { page: 1 } }
+      );
+    });
+
     it('#getAllAttachments', () => {
       conversationAPI.getAllAttachments(1);
       expect(axiosMock.get).toHaveBeenCalledWith(

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -397,10 +397,11 @@ const conversationList = computed(() => {
     });
   }
 
-  if (
-    !hasAppliedFiltersOrActiveFolders.value &&
-    activeSortBy.value === wootConstants.SORT_BY_TYPE.UNREAD
-  ) {
+  // Filtered lists included. `unread` is the one option with no entry in the store's
+  // SORT_OPTIONS, so `getFilteredConversations` re-sorts by last activity and silently
+  // undoes what the server returned; this pass is what puts the order back. Skipping it
+  // for folders was harmless only while the sort control was hidden there.
+  if (activeSortBy.value === wootConstants.SORT_BY_TYPE.UNREAD) {
     localConversationList = sortByUnreadStatus(localConversationList);
   }
 

--- a/app/javascript/dashboard/components/ChatList.vue
+++ b/app/javascript/dashboard/components/ChatList.vue
@@ -452,6 +452,7 @@ function fetchFilteredConversations(payload) {
     .dispatch('fetchFilteredConversations', {
       queryData: filterQueryGenerator(payload),
       page,
+      sortBy: activeSortBy.value,
     })
     .catch(() => useAlert(t('CHAT_LIST.FETCH_ERROR')))
     // emit even on failure so a deep-linked conversation still loads via
@@ -468,6 +469,7 @@ function fetchSavedFilteredConversations(payload) {
     .dispatch('fetchFilteredConversations', {
       queryData: payload,
       page,
+      sortBy: activeSortBy.value,
     })
     .catch(() => useAlert(t('CHAT_LIST.FETCH_ERROR')))
     .finally(emitConversationLoaded);
@@ -690,6 +692,20 @@ function onBasicFilterChange(value, type) {
   } else {
     activeSortBy.value = value;
   }
+
+  // An ad-hoc filter cannot go through resetAndFetchData: that path calls
+  // `clearConversationFilters` and falls back to the unfiltered list, so re-sorting would
+  // silently throw the agent's filter away. It never showed before because this control
+  // was hidden whenever a filter was applied. Folders are safe there (resetAndFetchData
+  // refetches the saved query), so only this branch is special-cased.
+  if (hasAppliedFilters.value && !hasActiveFolders.value) {
+    resetBulkActions();
+    store.dispatch('conversationPage/reset');
+    store.dispatch('emptyAllConversations');
+    fetchFilteredConversations(appliedFilters.value);
+    return;
+  }
+
   resetAndFetchData();
 }
 

--- a/app/javascript/dashboard/components/ChatListHeader.vue
+++ b/app/javascript/dashboard/components/ChatListHeader.vue
@@ -166,9 +166,15 @@ const toggleConversationLayout = () => {
           :class="{ 'ltr:right-0 rtl:left-0': isOnExpandedLayout }"
         />
       </div>
+      <!--
+        Shown in folders too, where it used to be hidden entirely. The list there was
+        always newest-first and nothing on screen said so, which is the worst version of
+        the problem: a team that works oldest-first had no control and no explanation.
+        `sort-only` because the folder's own query already decides status and group type.
+      -->
       <ConversationBasicFilter
-        v-if="!hasAppliedFiltersOrActiveFolders"
         :is-on-expanded-layout="isOnExpandedLayout"
+        :sort-only="hasAppliedFiltersOrActiveFolders"
         @change-filter="onBasicFilterChange"
       />
       <SwitchLayout

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
@@ -9,10 +9,17 @@ import wootConstants from 'dashboard/constants/globals';
 import SelectMenu from 'dashboard/components-next/selectmenu/SelectMenu.vue';
 import NextButton from 'dashboard/components-next/button/Button.vue';
 
-defineProps({
+const props = defineProps({
   isOnExpandedLayout: {
     type: Boolean,
     required: true,
+  },
+  // Inside a folder or an applied filter, status and group type are already decided by
+  // the query itself, so offering them here would let the agent contradict the folder
+  // they are standing in. Order is the one choice that stays theirs.
+  sortOnly: {
+    type: Boolean,
+    default: false,
   },
 });
 
@@ -28,6 +35,9 @@ const chatSortFilter = useMapGetter('getChatSortFilter');
 const chatGroupTypeFilter = useMapGetter('getChatGroupTypeFilter');
 
 const [showActionsDropdown, toggleDropdown] = useToggle();
+
+// One row instead of three does not need the full width of the panel.
+const dropdownWidth = computed(() => (props.sortOnly ? 'w-64' : 'w-72'));
 
 const currentStatusFilter = computed(() => {
   return chatStatusFilter.value || wootConstants.STATUS_TYPE.OPEN;
@@ -173,13 +183,14 @@ const handleGroupTypeChange = value => {
     <div
       v-if="showActionsDropdown"
       v-on-click-outside="() => toggleDropdown()"
-      class="mt-1 bg-n-alpha-3 backdrop-blur-[100px] border border-n-weak w-72 rounded-xl p-4 absolute z-40 top-full flex flex-col gap-4"
+      class="mt-1 bg-n-alpha-3 backdrop-blur-[100px] border border-n-weak rounded-xl p-4 absolute z-40 top-full flex flex-col gap-4"
       :class="{
+        [dropdownWidth]: true,
         'ltr:left-0 rtl:right-0': !isOnExpandedLayout,
         'ltr:right-0 rtl:left-0': isOnExpandedLayout,
       }"
     >
-      <div class="flex items-center justify-between gap-2">
+      <div v-if="!sortOnly" class="flex items-center justify-between gap-2">
         <span class="text-sm truncate text-n-slate-12">
           {{ $t('CHAT_LIST.CHAT_SORT.STATUS') }}
         </span>
@@ -203,7 +214,7 @@ const handleGroupTypeChange = value => {
           @update:model-value="handleSortChange"
         />
       </div>
-      <div class="flex items-center justify-between gap-2">
+      <div v-if="!sortOnly" class="flex items-center justify-between gap-2">
         <span class="text-sm truncate text-n-slate-12">
           {{ $t('GROUP.FILTER.TYPE_LABEL') }}
         </span>

--- a/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ConversationBasicFilter.vue
@@ -36,8 +36,10 @@ const chatGroupTypeFilter = useMapGetter('getChatGroupTypeFilter');
 
 const [showActionsDropdown, toggleDropdown] = useToggle();
 
-// One row instead of three does not need the full width of the panel.
-const dropdownWidth = computed(() => (props.sortOnly ? 'w-64' : 'w-72'));
+// Wider, not narrower. Narrowing it for the single-row case was the wrong instinct: with
+// only the sort row left, the label sits next to the longest value in the whole menu
+// ("Atividade mais recente primeiro"), and at w-72 the label truncated to "Orden...".
+const dropdownWidth = computed(() => (props.sortOnly ? 'w-[22rem]' : 'w-72'));
 
 const currentStatusFilter = computed(() => {
   return chatStatusFilter.value || wootConstants.STATUS_TYPE.OPEN;
@@ -203,7 +205,10 @@ const handleGroupTypeChange = value => {
         />
       </div>
       <div class="flex items-center justify-between gap-2">
-        <span class="text-sm truncate text-n-slate-12">
+        <span
+          class="text-sm truncate text-n-slate-12"
+          :class="{ 'shrink-0': sortOnly }"
+        >
           {{ $t('CHAT_LIST.CHAT_SORT.ORDER_BY') }}
         </span>
         <SelectMenu

--- a/app/javascript/dashboard/helper/ReconnectService.js
+++ b/app/javascript/dashboard/helper/ReconnectService.js
@@ -77,11 +77,16 @@ class ReconnectService {
     );
   };
 
+  // The sort travels with the refetch, and it has to: page 1 of oldest-first and page 1 of
+  // newest-first are different conversations entirely, so refetching without it merges a
+  // page the agent is not looking at and leaves the visible ones stale -- the exact staleness
+  // this reconnect exists to clear.
   fetchFilteredOrSavedConversations = async queryData => {
     try {
       await this.store.dispatch('fetchFilteredConversations', {
         queryData,
         page: 1,
+        sortBy: this.store.getters.getChatSortFilter,
       });
     } catch (error) {
       // Ignore error, reconnect flow should continue

--- a/app/javascript/dashboard/helper/specs/ReconnectService.spec.js
+++ b/app/javascript/dashboard/helper/specs/ReconnectService.spec.js
@@ -176,7 +176,20 @@ describe('ReconnectService', () => {
       await reconnectService.fetchFilteredOrSavedConversations(payload);
       expect(storeMock.dispatch).toHaveBeenCalledWith(
         'fetchFilteredConversations',
-        { queryData: payload, page: 1 }
+        { queryData: payload, page: 1, sortBy: undefined }
+      );
+    });
+
+    // Page 1 of oldest-first and page 1 of newest-first are different conversations, so a
+    // refetch without the sort merges a page the agent is not looking at and leaves the
+    // visible ones stale, which is what the reconnect exists to prevent.
+    it('should carry the selected sort order', async () => {
+      storeMock.getters.getChatSortFilter = 'last_activity_at_asc';
+      const payload = { test: 'data' };
+      await reconnectService.fetchFilteredOrSavedConversations(payload);
+      expect(storeMock.dispatch).toHaveBeenCalledWith(
+        'fetchFilteredConversations',
+        { queryData: payload, page: 1, sortBy: 'last_activity_at_asc' }
       );
     });
   });

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -88,6 +88,9 @@ const actions = {
   fetchFilteredConversations: async ({ commit, dispatch }, params) => {
     commit(types.SET_LIST_LOADING_STATUS);
     try {
+      // `params` carries `sortBy` straight through to the API. Folders used to come back
+      // newest-first regardless of what the agent picked, because the filter endpoint
+      // ignored the order entirely.
       const { data } = await ConversationApi.filter(params);
       buildConversationList(
         { commit, dispatch },

--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -49,8 +49,23 @@ class Conversations::FilterService < FilterService
     }
   end
 
+  # Folders and ad-hoc filters go through here, and until now they ignored `sort_by`
+  # entirely: the list came back newest-first no matter what the agent picked, while the
+  # ordinary conversation list (ConversationFinder) honoured ten different orders. The
+  # sort control is hidden in that view, so the disagreement was invisible rather than
+  # broken-looking, and a team working a folder oldest-first had no way to ask for it.
+  #
+  # SORT_OPTIONS is reused rather than redefined so the two paths cannot drift: one
+  # allowlist, one set of names, and an unknown value falls back to the previous default
+  # instead of reaching `send` (the params here are `permit!`ed straight from the request).
   def conversations
-    @conversations.pinned_first_for(@user).sort_on_last_activity_at.page(current_page).per(per_page)
+    sort_by, sort_direction = ConversationFinder::SORT_OPTIONS[@params[:sort_by]] ||
+                              ConversationFinder::SORT_OPTIONS['last_activity_at_desc']
+
+    # `pinned_first_for` orders too, and every sort_on_* uses `order` rather than
+    # `reorder`, so pinned conversations keep leading the list in every order. That is the
+    # existing behaviour of the ordinary list and it stays true here.
+    @conversations.pinned_first_for(@user).send(sort_by, sort_direction).page(current_page).per(per_page)
   end
 
   def per_page

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -437,6 +437,60 @@ describe Conversations::FilterService do
     end
   end
 
+  describe '#perform with sort_by' do
+    let!(:params) { { payload: [], page: 1 } }
+
+    before do
+      # Activity ascending with creation, so newest-created is also newest-active. Both
+      # orders are then unambiguous and each one is the exact reverse of the other.
+      account.conversations.order(:created_at).each_with_index do |conversation, index|
+        conversation.update_columns(last_activity_at: (100 - index).minutes.ago) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+
+    it 'defaults to newest activity first, as before' do
+      result = filter_service.new(params, user_1, account).perform
+
+      expect(result[:conversations].pluck(:id)).to eq(
+        account.conversations.order(last_activity_at: :desc).pluck(:id)
+      )
+    end
+
+    it 'honours last_activity_at_asc, which the folder view could not ask for' do
+      result = filter_service.new(params.merge(sort_by: 'last_activity_at_asc'), user_1, account).perform
+
+      expect(result[:conversations].pluck(:id)).to eq(
+        account.conversations.order(last_activity_at: :asc).pluck(:id)
+      )
+    end
+
+    it 'honours created_at_asc' do
+      result = filter_service.new(params.merge(sort_by: 'created_at_asc'), user_1, account).perform
+
+      expect(result[:conversations].pluck(:id)).to eq(account.conversations.order(created_at: :asc).pluck(:id))
+    end
+
+    # The params reaching this service are `permit!`ed straight off the request, so an
+    # unknown value must not become a method name.
+    it 'falls back to the default instead of calling an arbitrary method' do
+      result = filter_service.new(params.merge(sort_by: 'destroy_all'), user_1, account).perform
+
+      expect(result[:conversations].pluck(:id)).to eq(
+        account.conversations.order(last_activity_at: :desc).pluck(:id)
+      )
+      expect(account.conversations.count).to be_positive
+    end
+
+    it 'keeps a pinned conversation first in every order' do
+      pinned = account.conversations.order(:last_activity_at).first
+      create(:conversation_pin, conversation: pinned, user: user_1, account: account)
+
+      result = filter_service.new(params.merge(sort_by: 'last_activity_at_desc'), user_1, account).perform
+
+      expect(result[:conversations].first.id).to eq(pinned.id)
+    end
+  end
+
   describe '#perform with pinned conversations' do
     let!(:params) { { payload: [], page: 1 } }
     let(:pinned_conversation) { user_2_assigned_conversation }


### PR DESCRIPTION
## O problema

`Conversations::FilterService#conversations` chamava `sort_on_last_activity_at` sem argumento e ignorava `sort_by` por completo. Pasta e filtro aplicado voltavam sempre com a conversa mais recente no topo, enquanto a lista comum honra dez ordenações diferentes pelo `ConversationFinder`.

O controle de ordenação está escondido nessa tela (`v-if="!hasAppliedFiltersOrActiveFolders"`), então a discordância nunca pareceu quebrada: um time que trabalha da mais antiga para a mais nova simplesmente não tinha como pedir isso, e nada na tela explicava o motivo.

Achado num cliente com 2.400 conversas abertas numa caixa de e-mail, onde as atendentes precisam começar pelas mais antigas e a pasta entregava exatamente o contrário.

## O que muda

**Backend.** O serviço lê `sort_by` da mesma tabela `SORT_OPTIONS` que o finder usa. Uma allowlist só, para os dois caminhos não divergirem, e valor desconhecido cai no default anterior em vez de chegar no `send` com um nome que veio de um request `permit!`ado.

**Front.** `ConversationBasicFilter` ganha a prop `sort-only` e passa a ser renderizado dentro de pastas. Status e tipo de grupo continuam escondidos ali porque a query da própria pasta já os define, e oferecê-los deixaria a atendente contradizer a pasta em que está.

**Um bug que veio junto de tornar o controle alcançável.** Reordenar com filtro ad-hoc aplicado passava pelo `resetAndFetchData`, que chama `clearConversationFilters` e cai na lista sem filtro: o filtro da atendente sumiria. Esse caminho agora refaz a mesma busca. Pasta já era segura ali.

## O que foi conferido e ficou de fora

**Segmentos de contato não têm o problema.** O `contacts_controller` roda `filtrate` no `filter` igual ao `index`, e o front já manda `sort` no `ContactAPI.filter`. Eles honram a ordenação hoje, então não entram nesta PR.

**Conversa fixada continua em primeiro em qualquer ordem.** Todo `sort_on_*` usa `order` e não `reorder`, então o `pinned_first_for` que vem antes segue valendo. Tem exemplo cobrindo isso.

**`Conversations::UnreadCounts::FilterQueryCounter`** herda do serviço mas sobrescreve `perform` e nunca chama `conversations`, então não é afetado.

## Testes

```
bundle exec rspec spec/services/conversations/filter_service_spec.rb \
  spec/services/conversations/filter_service_frontend_alignment_spec.rb \
  spec/services/conversations/unread_counts
184 examples, 0 failures

vitest run app/javascript/dashboard/api/specs/inbox/conversation.spec.js \
  app/javascript/dashboard/store/modules/specs/conversations/actions.spec.js \
  app/javascript/dashboard/helper/specs/ReconnectService.spec.js
110 tests, 0 failures

rubocop: 2 files, no offenses
eslint: 0 errors
```

Cinco exemplos novos no backend cobrem o default preservado, `last_activity_at_asc`, `created_at_asc`, o fallback de valor inválido (com `destroy_all` como entrada, para provar que não vira chamada de método) e a fixada em primeiro. Dois no front cobrem o `sort_by` indo como query param e a ausência dele quando nenhuma ordem é escolhida.

## Teste manual pendente

Ainda não subi o app para percorrer a tela. Falta conferir no browser: o botão aparecendo dentro de uma pasta com só a linha de ordenação, a ordem mudando de fato ao escolher, e reordenar com filtro ad-hoc aplicado sem perder o filtro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/554)
<!-- Reviewable:end -->
