### PR TITLE
fix(attachments): resolve the file name for every shape an attachment arrives in

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -75,11 +75,38 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
   end
 
   def attachment_file_type(uploaded_attachment)
-    if uploaded_attachment.is_a?(String)
-      file_type_by_signed_id(uploaded_attachment)
-    else
-      file_type(uploaded_attachment&.content_type)
-    end
+    return file_type(uploaded_attachment&.content_type) unless uploaded_attachment.is_a?(String)
+
+    file_type(blob_for(uploaded_attachment)&.content_type)
+  end
+
+  # A direct upload sends an ActiveStorage signed ID, which is a String, so everything that used
+  # to ask the uploaded file about itself has to ask the blob instead. Memoised because the file
+  # type asks first and the metadata asks second, and resolving the same signed ID twice per
+  # attachment is a query nobody needs.
+  def blob_for(signed_id)
+    @blobs_by_signed_id ||= {}
+    return @blobs_by_signed_id[signed_id] if @blobs_by_signed_id.key?(signed_id)
+
+    @blobs_by_signed_id[signed_id] = ActiveStorage::Blob.find_signed(signed_id)
+  end
+
+  # The name the caller used when they picked the file, whichever of the three shapes they sent.
+  # An upload answers `original_filename`, a signed ID has to be resolved, and a blob, which is
+  # what a macro and an automation rule pass, answers `filename`. Nil when there is no name to be
+  # had, which is what both readers below already treat as "no metadata for this one" rather than
+  # as an error.
+  #
+  # No caller sends a blob together with per-attachment metadata today, so that branch is
+  # consistency rather than a fix. What it does remove is a latent raise: `recorded_audio_metadata`
+  # asked a blob for `original_filename` too, and would have died the same way it died on a
+  # signed ID the day someone passed both.
+  def uploaded_filename(uploaded_attachment)
+    return uploaded_attachment.original_filename if uploaded_attachment.respond_to?(:original_filename)
+    return uploaded_attachment.filename.to_s if uploaded_attachment.respond_to?(:filename)
+    return unless uploaded_attachment.is_a?(String)
+
+    blob_for(uploaded_attachment)&.filename&.to_s
   end
 
   def tag_voice_message(attachment)
@@ -100,12 +127,13 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
     return unless @is_recorded_audio
     return { is_recorded_audio: true } if @is_recorded_audio == true || @is_recorded_audio == 'true'
 
-    return { is_recorded_audio: true } if @is_recorded_audio.is_a?(Array) && attachment.original_filename.in?(@is_recorded_audio)
+    filename = uploaded_filename(attachment)
+    return { is_recorded_audio: true } if @is_recorded_audio.is_a?(Array) && filename.in?(@is_recorded_audio)
 
     # FIXME: Remove backwards compatibility with old format.
     if @is_recorded_audio.is_a?(String)
       parsed = JSON.parse(@is_recorded_audio)
-      { is_recorded_audio: true } if parsed.is_a?(Array) && attachment.original_filename.in?(parsed)
+      { is_recorded_audio: true } if parsed.is_a?(Array) && filename.in?(parsed)
     end
   rescue JSON::ParserError
     nil
@@ -129,7 +157,7 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
   def custom_attachment_metadata(attachment)
     return unless @attachments_metadata.is_a?(Hash)
 
-    filename = attachment.respond_to?(:original_filename) ? attachment.original_filename : nil
+    filename = uploaded_filename(attachment)
     return unless filename
 
     metadata = @attachments_metadata[filename]

--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -106,6 +106,10 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
     return uploaded_attachment.filename.to_s if uploaded_attachment.respond_to?(:filename)
     return unless uploaded_attachment.is_a?(String)
 
+    # The safe navigation cannot fire today and is kept on purpose: a signed ID that does not
+    # resolve already raises one line earlier, at `attachments.build`, so nothing unresolvable
+    # reaches this method. Dropping it would make that ordering load-bearing, and the failure it
+    # would produce is a `NoMethodError` on nil in place of a legible 422.
     blob_for(uploaded_attachment)&.filename&.to_s
   end
 

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -333,6 +333,102 @@ describe Messages::MessageBuilder do
           message = message_builder
           expect(message.attachments.first.file_type).to eq 'image'
         end
+
+        # A direct upload sends an ActiveStorage signed ID, which is a String, and a String has no
+        # `original_filename`. The per-attachment metadata is keyed off that name, so the whole of
+        # `attachments_metadata` was dropped on this path, silently, with a 200 and a stored message.
+        it 'applies the per-attachment metadata, which is keyed off a name a signed ID also has' do
+          params[:attachments_metadata] = { 'avatar.png' => { description: 'legenda' } }
+
+          message = message_builder
+
+          expect(message.attachments.first.meta).to include('description' => 'legenda')
+        end
+
+        # Worse than losing metadata: losing a refusal. The top-level `is_recorded_audio` is merged
+        # first and the per-attachment entry merges over it, so a caller saying "not this one" was
+        # honoured on multipart and ignored here, where the entry never arrived.
+        it 'lets a per-attachment refusal beat the top-level flag, as multipart does' do
+          params[:attachments] = [get_blob_for('spec/assets/sample.ogg', 'audio/ogg').signed_id]
+          params[:is_recorded_audio] = true
+          params[:attachments_metadata] = { 'sample.ogg' => { is_recorded_audio: 'false' } }
+
+          message = message_builder
+
+          expect(message.attachments.first.meta).to include('is_recorded_audio' => false)
+        end
+
+        # The sibling reader in the same `process_metadata` has no `respond_to?` guard at all, so
+        # this raised `NoMethodError` for a String and the request answered 422 with nothing stored.
+        it 'reads the recorded-audio file list instead of raising on a signed ID' do
+          params[:attachments] = [get_blob_for('spec/assets/sample.ogg', 'audio/ogg').signed_id]
+          params[:is_recorded_audio] = ['sample.ogg']
+
+          message = message_builder
+
+          expect(message.attachments.first.meta).to include('is_recorded_audio' => true)
+        end
+
+        it 'reads the recorded-audio list sent as a JSON string too' do
+          params[:attachments] = [get_blob_for('spec/assets/sample.ogg', 'audio/ogg').signed_id]
+          params[:is_recorded_audio] = '["sample.ogg"]'
+
+          message = message_builder
+
+          expect(message.attachments.first.meta).to include('is_recorded_audio' => true)
+        end
+
+        # Parity, not a new decision: the multipart path already applies one entry to every
+        # attachment of the same name, with no error and no warning. Inventing a tie-break on one
+        # side only is what would be wrong.
+        it 'applies one entry to every attachment of that name, exactly as multipart does' do
+          params[:attachments] = [
+            get_blob_for('spec/assets/avatar.png', 'image/png').signed_id,
+            get_blob_for('spec/assets/avatar.png', 'image/png').signed_id
+          ]
+          params[:attachments_metadata] = { 'avatar.png' => { description: 'legenda' } }
+
+          message = message_builder
+
+          expect(message.attachments.map(&:meta)).to all(include('description' => 'legenda'))
+        end
+
+        # A signed ID that does not resolve already fails at the attach, before any of this runs,
+        # and it has to keep failing exactly there. Resolving a name must not add a second way to
+        # raise, and must not swallow the first one either.
+        it 'keeps failing at the attach for a signed ID that does not resolve' do
+          params[:attachments] = ['not-a-signed-id']
+          params[:attachments_metadata] = { 'avatar.png' => { description: 'legenda' } }
+
+          expect { message_builder }.to raise_error(ActiveSupport::MessageVerifier::InvalidSignature)
+        end
+
+        # The third shape: a macro and an automation rule pass blobs, which answer `filename` and
+        # not `original_filename`. No caller sends one together with per-attachment metadata today,
+        # so this is consistency, and what it removes is a raise that was waiting for the first one
+        # that did.
+        it 'reads the name of a blob attachment too' do
+          blob = get_blob_for('spec/assets/sample.ogg', 'audio/ogg')
+          params[:attachments] = ActiveStorage::Blob.where(id: blob.id)
+          params[:is_recorded_audio] = ['sample.ogg']
+          params[:attachments_metadata] = { 'sample.ogg' => { description: 'legenda' } }
+
+          message = message_builder
+
+          expect(message.attachments.first.meta)
+            .to include('description' => 'legenda', 'is_recorded_audio' => true)
+        end
+
+        # Resolving the name must not pay for a second lookup: the file type already resolves the
+        # same signed ID once per attachment.
+        it 'resolves each signed ID once, not twice' do
+          allow(ActiveStorage::Blob).to receive(:find_signed).and_call_original
+          params[:attachments_metadata] = { 'avatar.png' => { description: 'legenda' } }
+
+          message_builder
+
+          expect(ActiveStorage::Blob).to have_received(:find_signed).once
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #553

## What was broken

Per-attachment metadata is keyed off the uploaded file's name, and the builder read that name with `original_filename`. A direct upload does not send a file: it sends an ActiveStorage signed ID, which is a `String`, and a `String` has no `original_filename`.

Measured on the same logical body, both paths:

| path | status | stored meta |
| --- | --- | --- |
| multipart | 200 | `{"description"=>"legenda","is_voice_message"=>true}` |
| direct upload | 200 | `{}` |

Nothing is said to the caller. The parameter is accepted and ignored.

**The sibling reader in the same `process_metadata` is worse.** `recorded_audio_metadata` reaches for `attachment.original_filename` with no `respond_to?` guard at all when `is_recorded_audio` is a list of names, so the same request answers **422 with `undefined method 'original_filename' for an instance of String` in the body and nothing stored**. Same root, two faces: one drops in silence, the other kills the message and leaks the exception text as an API error.

That second half is not in the issue. It is in this PR because it is the same line of code read twice, and one fix closes both: splitting them would mean shipping a change that leaves a crash standing one method away.

## What changed

`uploaded_filename` answers for the three shapes that actually reach this builder:

- an upload, which answers `original_filename`;
- a signed ID, resolved through the blob;
- a blob, which a macro and an automation rule pass and which answers `filename`.

The blob is memoised. The file type resolves the same signed ID one line earlier through `file_type_by_signed_id`, so resolving it again for the name would have doubled the lookups: three attachments would go from three to six.

**The blob branch is consistency, not a fix.** No caller sends a blob together with per-attachment metadata today. What it removes is a raise that was waiting for the first one that did, because `recorded_audio_metadata` asked a blob for `original_filename` too.

## What the holdout scenarios measured, including one thing that changed my mind

**Duplicate names are already decided, and the decision is "apply to all".** Two files named `avatar.png` and one entry keyed `avatar.png`: on multipart, both attachments get that metadata, 200, no warning. So keying by name on the direct upload path inherits an existing tie-break rather than inventing one. What would be wrong is a quiet tie-break on one side only, and there is an example pinning that both paths behave the same way.

**An unresolvable signed ID already fails before any of this runs.** `attachments.build(file: ...)` raises at the attach, ahead of `process_metadata`: garbage gives `mismatched digest`, an expired one gives `expired`, a deleted blob gives `RecordNotFound`, all 422 with nothing stored. The real risk of resolving a name here is the opposite of raising: taking the `nil` that `find_signed` returns and calling `.filename` on it, turning a legible 422 into a `NoMethodError`. There is an example pinning that the attach keeps failing where it always failed.

**One measurement in the holdout report did not survive checking, and correcting it made the finding sharper rather than smaller.** It said a per-attachment `is_voice_message: 'false'` beats the top-level flag on multipart and is swallowed on direct upload. Measured on both paths with the same body: both store `true`, because `tag_voice_message` runs after `process_metadata` and merges `true` in whenever the top-level flag is set. So on **that** key there is no inversion, and this PR does not claim one; what it surfaced instead is a defect of both paths, tracked as #561 and deliberately not fixed here.

The inversion is real on the sibling key, and it was then measured all the way to the provider rather than only in the column:

| path | stored meta | `WhatsappCloudService#voice_message?` |
| --- | --- | --- |
| multipart | `{"is_recorded_audio" => false}` | `false` |
| direct upload | `{"is_recorded_audio" => true}` | `true` |

`is_recorded_audio` has no step after `process_metadata` to overwrite it, so a caller's explicit refusal is honoured on multipart and dropped on direct upload, and the audio goes out as a voice note against what was asked. All three readers OR the two keys together, so the refusal has to survive in the column for any of them to see it. That is the outcome this PR closes.

## This is not gated by `DIRECT_UPLOADS_ENABLED`

The issue framed the reach as "total or nonexistent per instance", because the dashboard branches once on that switch. That is true of the dashboard and false of the builder.

`ScheduledMessages::SendScheduledMessageJob#send_message` builds `params[:attachments] = [scheduled_message.attachment.blob.signed_id]` unconditionally, with no reference to the switch. So the signed ID branch is exercised by every instance that sends a scheduled message with an attachment, including the ones with direct uploads off, which is the default. Campaigns do not pass attachments at all.

## One behaviour change that is not a fix

Resolving the name is what makes the per-attachment entry findable, and it also makes a **malformed** entry findable. `attachments_metadata` is read as a hash of hashes, and a value that is not a hash reaches `metadata.to_h` and raises. Multipart has always crashed on that input; the direct upload path never got far enough to try.

Measured on both paths with `attachments_metadata: { 'avatar.png' => 'lixo' }`:

| path | base `a9c38c40` | here |
| --- | --- | --- |
| multipart | 422, `undefined method 'to_h' for an instance of String`, nothing stored | unchanged |
| direct upload | **200, message stored, metadata dropped** | 422, same error, nothing stored |

So a caller who sends a malformed value through a direct upload today gets a stored message and after this gets a 422. That is parity with multipart, which is what this PR is for, but it is parity on the wrong behaviour: a malformed value should be ignored or refused with a legible error, not crash the builder and hand the caller a Ruby diagnostic. Fixing that means changing multipart too, so it is #563 and not this PR.

## Validation scope

Proven by test:

- 6 examples fail on `a9c38c40` and pass here: per-attachment metadata applied through a signed ID; a per-attachment refusal beating the top-level `is_recorded_audio`; the recorded-audio list read instead of raising, both as an array and as a JSON string; one entry applied to every attachment of that name; and the blob shape.
- Pinned so they cannot regress quietly: an unresolvable signed ID still fails at the attach with the same error, and each signed ID is resolved exactly once.

- 10 mutations, 8 killed. Both survivors are equivalent rather than untested, and both were measured rather than argued: reversing the order of the upload and blob branches changes nothing because neither upload class answers `filename` (`Rack::Test::UploadedFile` and `ActionDispatch::Http::UploadedFile`, both false), and the safe navigation cannot fire because an unresolvable signed ID raises at the attach one line earlier. The second is kept anyway and the code now says why.

  Two of the killed ones are worth naming, because the holdout pass asked for them specifically: `blob.filename` is an `ActiveStorage::Filename`, not a String, and its comparisons are asymmetric (`fn == 'x'` is true while `fn.eql?('x')` and `fn.in?(['x'])` are false, and `hash[fn]` misses where `hash[fn.to_s]` hits). Dropping either `.to_s` fails silently into exactly the defect this PR closes: no metadata, 200, no log. Both are pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/560)
<!-- Reviewable:end -->



