### PR TITLE
feat(whatsapp): oferecer o canal nativo por convite, não por padrão

### DIFF
--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -39,7 +39,8 @@ class AccountDashboard < Administrate::BaseDashboard
     custom_attributes: Field::String,
     hide_agent_unassigned_tab: Field::Boolean,
     hide_agent_all_tab: HideAgentAllTabField,
-    disable_agent_message_deletion: Field::Boolean
+    disable_agent_message_deletion: Field::Boolean,
+    whatsapp_native_enabled: Field::Boolean
   }.merge(enterprise_attribute_types).freeze
 
   # COLLECTION_ATTRIBUTES
@@ -80,6 +81,7 @@ class AccountDashboard < Administrate::BaseDashboard
     hide_agent_unassigned_tab
     hide_agent_all_tab
     disable_agent_message_deletion
+    whatsapp_native_enabled
   ] + enterprise_show_page_attributes).freeze
 
   # FORM_ATTRIBUTES
@@ -101,6 +103,7 @@ class AccountDashboard < Administrate::BaseDashboard
     hide_agent_unassigned_tab
     hide_agent_all_tab
     disable_agent_message_deletion
+    whatsapp_native_enabled
   ] + enterprise_form_attributes).freeze
 
   # COLLECTION_FILTERS

--- a/app/models/concerns/account_settings_schema.rb
+++ b/app/models/concerns/account_settings_schema.rb
@@ -17,7 +17,7 @@ module AccountSettingsSchema
         'hide_agent_unassigned_tab': { 'type': %w[boolean null] },
         'hide_agent_all_tab': { 'type': %w[boolean null] },
         'disable_agent_message_deletion': { 'type': %w[boolean null] },
-        'whatsapp_native_disabled': { 'type': %w[boolean null] },
+        'whatsapp_native_enabled': { 'type': %w[boolean null] },
         'whatsapp_uazapi_disabled': { 'type': %w[boolean null] },
         'captain_auto_resolve_mode': { 'type': %w[string null], 'enum': ['evaluated', 'legacy', 'disabled', nil] },
         'captain_false_promise_harness_enabled': { 'type': %w[boolean null] },

--- a/app/models/concerns/account_whatsapp_providers.rb
+++ b/app/models/concerns/account_whatsapp_providers.rb
@@ -1,10 +1,17 @@
-# Per-account switches for the WhatsApp session providers, and they are named for what
-# they do: a provider this deployment serves is offered to every account, and these take
-# it away from one. Nothing has to be set for a provider to be on offer.
+# Per-account switches for the WhatsApp session providers, and the two are named for
+# what they do, which is not the same thing for both.
 #
-# What decides whether a provider is served at all is its descriptor, not these: `native`
-# needs a connector reachable on this deployment's Redis and answers `available?` on
-# that. These only withdraw something already on offer.
+# `uazapi` is on offer: an account that nobody has touched can create one, and the switch
+# takes it away from one account. `native` is the other way round, and deliberately: it
+# is being rolled out to named accounts rather than announced, so nothing is on offer
+# until somebody says so. A flag whose absence means "yes" cannot do a restricted
+# rollout, because every account created after the switch is flipped joins the rollout
+# without anyone deciding that.
+#
+# What decides whether a provider is served **at all** is still its descriptor, not
+# these: `native` needs a connector reachable on this deployment's Redis and answers
+# `available?` on that. These narrow what the descriptor already allows, in both
+# directions, and neither can offer a provider this deployment does not serve.
 #
 # They live in the `settings` jsonb (see the "Account-level toggles" section in
 # AGENTS.md), keyed by name, so bit positions never drift between CE and Pro.
@@ -15,11 +22,11 @@ module AccountWhatsappProviders
   extend ActiveSupport::Concern
 
   included do
-    store_accessor :settings, :whatsapp_native_disabled, :whatsapp_uazapi_disabled
+    store_accessor :settings, :whatsapp_native_enabled, :whatsapp_uazapi_disabled
   end
 
   # The superadmin form posts "1"/"0" and the settings JSON schema only accepts booleans.
-  def whatsapp_native_disabled=(value)
+  def whatsapp_native_enabled=(value)
     super(ActiveModel::Type::Boolean.new.cast(value))
   end
 
@@ -29,7 +36,7 @@ module AccountWhatsappProviders
 
   def whatsapp_session_provider_enabled?(provider)
     case provider.to_s
-    when 'native' then !whatsapp_native_disabled
+    when 'native' then whatsapp_native_enabled.present?
     when 'uazapi' then !whatsapp_uazapi_disabled
     else false
     end

--- a/spec/controllers/api/v1/accounts/whatsapp/session_providers_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/whatsapp/session_providers_controller_spec.rb
@@ -56,13 +56,33 @@ RSpec.describe 'WhatsApp Session Providers API', type: :request do
         expect(payload.find { |p| p['key'] == 'uazapi' }['creatable']).to be(false)
       end
 
-      # The connector is what serves `native`, so an installation without one must not
-      # offer it however the account is configured.
-      it 'keeps native uncreatable while no connector is deployed' do
-        expect(payload.find { |p| p['key'] == 'native' }).to include('available' => false, 'creatable' => false)
+      # `native` answers to two gates that point the same way and are set by different
+      # people: the deployment has to serve it, and the account has to have been named.
+      describe 'the two gates on native' do
+        let(:native) { payload.find { |p| p['key'] == 'native' } }
 
-        with_modified_env WHATSAPP_CONNECTOR_ENABLED: 'true' do
-          expect(payload.find { |p| p['key'] == 'native' }).to include('available' => true, 'creatable' => true)
+        # The connector is what serves it, so an installation without one must not offer it
+        # however the account is configured.
+        it 'keeps it uncreatable while no connector is deployed, account opted in or not' do
+          account.update!(whatsapp_native_enabled: true)
+
+          expect(native).to include('available' => false, 'creatable' => false)
+        end
+
+        # And the half that makes a restricted first release possible: turning the connector
+        # on for the deployment does not hand the provider to every account on it.
+        it 'keeps it uncreatable for an account nobody named, even with a connector' do
+          with_modified_env WHATSAPP_CONNECTOR_ENABLED: 'true' do
+            expect(native).to include('available' => true, 'creatable' => false)
+          end
+        end
+
+        it 'offers it once both are true' do
+          account.update!(whatsapp_native_enabled: true)
+
+          with_modified_env WHATSAPP_CONNECTOR_ENABLED: 'true' do
+            expect(native).to include('available' => true, 'creatable' => true)
+          end
         end
       end
 

--- a/spec/factories/channel/channel_whatsapp.rb
+++ b/spec/factories/channel/channel_whatsapp.rb
@@ -93,12 +93,22 @@ FactoryBot.define do
       session_provider_enabled { true }
     end
 
-    # The session providers are offered to every account, so a channel on one needs no
-    # setup to be valid. Specs that exercise the gate pass `session_provider_enabled:
-    # false`, which is what turns the provider off for the account.
+    # The two session providers gate opposite ways, so the factory has to say which it is
+    # doing rather than write one key for both. `uazapi` is on offer, so a channel on it
+    # needs no setup to be valid; `native` is opt-in, so the factory opts the account in.
+    #
+    # Opting in here rather than in each spec is deliberate: the gate is what the concern's
+    # and the controller's own examples are about, and a spec exercising the media job or
+    # the echo matcher should not have to know it exists. Both directions still answer to
+    # `session_provider_enabled: false`, which is what those examples pass.
     after(:build) do |channel_whatsapp, options|
-      if !options.session_provider_enabled && channel_whatsapp.provider.in?(Whatsapp::Session::PROVIDERS)
-        channel_whatsapp.account&.update!("whatsapp_#{channel_whatsapp.provider}_disabled" => true)
+      account = channel_whatsapp.account
+      next unless account && channel_whatsapp.provider.in?(Whatsapp::Session::PROVIDERS)
+
+      if channel_whatsapp.provider == 'native'
+        account.update!(whatsapp_native_enabled: options.session_provider_enabled)
+      elsif !options.session_provider_enabled
+        account.update!(whatsapp_uazapi_disabled: true)
       end
     end
 

--- a/spec/models/concerns/account_whatsapp_providers_spec.rb
+++ b/spec/models/concerns/account_whatsapp_providers_spec.rb
@@ -4,29 +4,58 @@ RSpec.describe AccountWhatsappProviders do
   let(:account) { create(:account) }
 
   it 'stores the toggles in settings, keyed by name' do
-    account.update!(whatsapp_native_disabled: true)
+    account.update!(whatsapp_native_enabled: true)
 
-    expect(account.reload.settings['whatsapp_native_disabled']).to be(true)
+    expect(account.reload.settings['whatsapp_native_enabled']).to be(true)
   end
 
   it 'casts the superadmin form values, which arrive as strings' do
     account.update!(whatsapp_uazapi_disabled: '1')
+    account.update!(whatsapp_native_enabled: '1')
 
     expect(account.reload.whatsapp_uazapi_disabled).to be(true)
+    expect(account.whatsapp_native_enabled).to be(true)
   end
 
-  it 'offers the session providers to an account nobody has touched' do
-    expect(account.settings).not_to have_key('whatsapp_native_disabled')
+  # The two switches point opposite ways, and this is the example that says so. `uazapi`
+  # is on offer and the switch withdraws it; `native` is being rolled out to named
+  # accounts, so an account nobody has named cannot create one.
+  it 'offers uazapi to an account nobody has touched, and not native' do
+    expect(account.settings).not_to have_key('whatsapp_native_enabled')
+
+    expect(account.whatsapp_session_provider_enabled?('uazapi')).to be(true)
+    expect(account.whatsapp_session_provider_enabled?('native')).to be(false)
+  end
+
+  # The half that makes it a rollout rather than a wall: an account created after the
+  # provider was turned on for somebody else does not join by existing.
+  it 'does not offer native to an account created later' do
+    account.update!(whatsapp_native_enabled: true)
+
+    expect(create(:account).whatsapp_session_provider_enabled?('native')).to be(false)
+  end
+
+  it 'offers native to the account it was turned on for, and only that one' do
+    account.update!(whatsapp_native_enabled: true)
 
     expect(account.whatsapp_session_provider_enabled?('native')).to be(true)
-    expect(account.whatsapp_session_provider_enabled?('uazapi')).to be(true)
+    expect(create(:account).whatsapp_session_provider_enabled?('native')).to be(false)
   end
 
-  it 'takes a provider away from the account it was turned off for, and only that one' do
-    account.update!(whatsapp_native_disabled: true)
+  it 'takes uazapi away from the account it was turned off for, and leaves native alone' do
+    account.update!(whatsapp_uazapi_disabled: true, whatsapp_native_enabled: true)
 
-    expect(account.whatsapp_session_provider_enabled?('native')).to be(false)
-    expect(account.whatsapp_session_provider_enabled?('uazapi')).to be(true)
+    expect(account.whatsapp_session_provider_enabled?('uazapi')).to be(false)
+    expect(account.whatsapp_session_provider_enabled?('native')).to be(true)
+  end
+
+  # Turning it off again is what makes it reversible without a console: `false` reads the
+  # same way an absent key does.
+  it 'withdraws native again when the switch is turned back off' do
+    account.update!(whatsapp_native_enabled: true)
+    account.update!(whatsapp_native_enabled: false)
+
+    expect(account.reload.whatsapp_session_provider_enabled?('native')).to be(false)
   end
 
   it 'never enables a provider this layer does not serve' do


### PR DESCRIPTION
O canal nativo passa a ser liberado conta a conta, pelo painel do superadmin, em vez de aparecer para todo mundo assim que a instalação liga o conector. É o que uma primeira versão restrita precisa.

## Closes

Nada. É o portão que a primeira versão do canal nativo pediu.

## O problema

O portão por conta existia, mas apontava para o lado errado: `whatsapp_native_disabled` é opt-out, então ligar `WHATSAPP_CONNECTOR_ENABLED` oferecia o `native` a **todas** as contas da instalação. Restringir seria marcar todas as outras uma a uma, e uma conta criada depois nasceria habilitada sem ninguém decidir isso. Portão cuja ausência significa "sim" não faz lançamento restrito.

## O que mudou

- `whatsapp_native_enabled` (opt-in) substitui `whatsapp_native_disabled`. O `uazapi` continua em `whatsapp_uazapi_disabled` (opt-out), que é a polaridade certa para ele: está em oferta, e o switch tira de uma conta.
- A assimetria está explicada no comentário do concern, porque ela não se adivinha lendo os dois nomes lado a lado.
- O switch entra no painel do superadmin (`ATTRIBUTE_TYPES`, `SHOW_PAGE_ATTRIBUTES`, `FORM_ATTRIBUTES`), que é a parte que faz dele operável. Sem isso, cada liberação seria um console no servidor de produção.

As duas portas continuam existindo e apontam para o mesmo lado: a instalação tem que servir o provider (`WHATSAPP_CONNECTOR_ENABLED`, que o descritor lê) **e** a conta tem que ter sido nomeada. Nenhuma das duas sozinha oferece o canal.

## How to test

1. Sem conector: `native` aparece na lista com `available: false, creatable: false`, com a conta habilitada ou não.
2. Com `WHATSAPP_CONNECTOR_ENABLED=true` e a conta intocada: `available: true, creatable: false`. É o caso novo.
3. Marcando **WhatsApp native enabled** na conta no super admin: `available: true, creatable: true`, e só naquela conta.
4. Desmarcando: volta a `creatable: false`, sem console.

## Sobre o nome antigo

`whatsapp_native_disabled` sai. Ele nunca gateou nada, porque `native` nunca esteve disponível em instalação nenhuma (`WHATSAPP_CONNECTOR_ENABLED` tem default `false`), então não há estado gravado para migrar. **A suposição é essa**, e se alguma instalação já tiver ligado o conector, a chave antiga vira ruído inofensivo no `settings` e a conta precisa ser habilitada pela nova.

## Um detalhe da factory

`spec/factories/channel/channel_whatsapp.rb` passa a opt-in a conta quando o canal é `native`. O portão é assunto dos exemplos que falam dele (o do concern e o do controller, ambos reescritos aqui), e não das trinta e cinco suítes que só precisam de um canal de pé. Ambas as direções continuam respondendo a `session_provider_enabled: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/562)
<!-- Reviewable:end -->
