### PR TITLE
fix(whatsapp): tirar da tela o switch do canal nativo, que é de console

### DIFF
--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -39,8 +39,7 @@ class AccountDashboard < Administrate::BaseDashboard
     custom_attributes: Field::String,
     hide_agent_unassigned_tab: Field::Boolean,
     hide_agent_all_tab: HideAgentAllTabField,
-    disable_agent_message_deletion: Field::Boolean,
-    whatsapp_native_enabled: Field::Boolean
+    disable_agent_message_deletion: Field::Boolean
   }.merge(enterprise_attribute_types).freeze
 
   # COLLECTION_ATTRIBUTES
@@ -81,7 +80,6 @@ class AccountDashboard < Administrate::BaseDashboard
     hide_agent_unassigned_tab
     hide_agent_all_tab
     disable_agent_message_deletion
-    whatsapp_native_enabled
   ] + enterprise_show_page_attributes).freeze
 
   # FORM_ATTRIBUTES
@@ -103,7 +101,6 @@ class AccountDashboard < Administrate::BaseDashboard
     hide_agent_unassigned_tab
     hide_agent_all_tab
     disable_agent_message_deletion
-    whatsapp_native_enabled
   ] + enterprise_form_attributes).freeze
 
   # COLLECTION_FILTERS

--- a/app/models/concerns/account_whatsapp_providers.rb
+++ b/app/models/concerns/account_whatsapp_providers.rb
@@ -25,7 +25,12 @@ module AccountWhatsappProviders
     store_accessor :settings, :whatsapp_native_enabled, :whatsapp_uazapi_disabled
   end
 
-  # The superadmin form posts "1"/"0" and the settings JSON schema only accepts booleans.
+  # Deliberately not on the super admin form, either of them: these are console switches by
+  # decision, so that offering the native channel to an account is a step somebody takes on
+  # purpose rather than a checkbox next to the ordinary account settings.
+  #
+  # The cast stays because the value can still arrive as a string, from the settings API or
+  # from a console line that types "1", and the settings JSON schema only accepts booleans.
   def whatsapp_native_enabled=(value)
     super(ActiveModel::Type::Boolean.new.cast(value))
   end


### PR DESCRIPTION
O switch que oferece o canal WhatsApp nativo a uma conta sai do painel do superadmin. Ele continua existindo e continua funcionando; o que muda é que só se mexe nele por console ou pela API de settings.

## Closes

- Closes #564 (que pedia o contrário, e foi respondida por decisão)

## Por quê

O switch tinha entrado na tela junto da #562, por um argumento meu: sem tela, cada liberação de conta vira console no servidor de produção. A decisão do produto é a outra, e é deliberada: oferecer o canal nativo a uma conta deve ser passo que alguém dá de propósito, não caixa de seleção ao lado das opções comuns da conta.

O trade-off fica registrado no lugar certo, que é o comentário do concern, para ninguém "consertar" isso depois achando que foi esquecimento.

## O que muda

Saem as três entradas de `whatsapp_native_enabled` do `AccountDashboard` (`ATTRIBUTE_TYPES`, `SHOW_PAGE_ATTRIBUTES`, `FORM_ATTRIBUTES`).

Ficam o `store_accessor`, o cast do writer e a chave no `SETTINGS_PARAMS_SCHEMA`, porque o valor continua chegando pela API de settings e por linha de console, e nos dois casos pode vir como string.

O `whatsapp_uazapi_disabled` nunca teve tela e continua sem, agora pelo mesmo motivo declarado em vez de por omissão.

## How to test

1. No super admin, abrir uma conta: não há mais campo de WhatsApp native.
2. `Account.find(<id>).update!(whatsapp_native_enabled: true)` num console continua habilitando, e `false` continua desabilitando.
3. Com o conector ligado, a conta habilitada por console vê `native` como `creatable: true` no catálogo de providers; uma conta não habilitada, não.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/565)
<!-- Reviewable:end -->
