### PR TITLE
fix(attachments): say a pasted file was empty when nothing else on the clipboard explains it

### DIFF
--- a/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
+++ b/app/javascript/dashboard/components-next/NewConversation/components/ActionButtons.vue
@@ -3,6 +3,8 @@ import { defineAsyncComponent, ref, computed, watch, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useUISettings } from 'dashboard/composables/useUISettings';
 import { useFileUpload } from 'dashboard/composables/useFileUpload';
+import { useAlert } from 'dashboard/composables';
+import { usableFilesFromTransfer } from 'dashboard/helper/pastedFiles';
 import { vOnClickOutside } from '@vueuse/components';
 import { useEventListener } from '@vueuse/core';
 import { ALLOWED_FILE_TYPES } from 'shared/constants/messages';
@@ -187,14 +189,19 @@ const onPaste = e => {
   const files = e.clipboardData?.files;
   if (!files?.length) return;
 
-  // Filter valid files (non-zero size)
-  Array.from(files)
-    .filter(file => file.size > 0)
-    .forEach(file => {
-      const { name, type, size } = file;
-      // Add unique ID for clipboard-pasted files
-      onFileUpload({ file, name, type, size, id: generateUid() });
-    });
+  // Same rule as the reply composer: empty files are dropped, and the refusal is said out loud
+  // unless the clipboard also carried text, which is the shape of a rich copy bringing an
+  // invalid zero-byte attachment nobody chose.
+  const { files: usable, shouldAlertEmpty } = usableFilesFromTransfer(
+    e.clipboardData
+  );
+  if (shouldAlertEmpty) useAlert(t('CONVERSATION.FILE_IS_EMPTY'));
+
+  usable.forEach(file => {
+    const { name, type, size } = file;
+    // Add unique ID for clipboard-pasted files
+    onFileUpload({ file, name, type, size, id: generateUid() });
+  });
 };
 
 useEventListener(document, 'paste', onPaste);

--- a/app/javascript/dashboard/components-next/NewConversation/components/specs/ActionButtons.spec.js
+++ b/app/javascript/dashboard/components-next/NewConversation/components/specs/ActionButtons.spec.js
@@ -1,0 +1,90 @@
+import { shallowMount } from '@vue/test-utils';
+import ActionButtons from '../ActionButtons.vue';
+
+const mockAlert = vi.fn();
+vi.mock('dashboard/composables', async () => {
+  const actual = await vi.importActual('dashboard/composables');
+  return { ...actual, useAlert: (...args) => mockAlert(...args) };
+});
+
+const mockOnFileUpload = vi.fn();
+vi.mock('dashboard/composables/useFileUpload', () => ({
+  useFileUpload: () => ({
+    onFileUpload: (...args) => mockOnFileUpload(...args),
+  }),
+}));
+
+vi.mock('dashboard/composables/useUISettings', () => ({
+  useUISettings: () => ({
+    uiSettings: {},
+    updateUISettings: vi.fn(),
+    isEditorHotKeyEnabled: () => false,
+  }),
+}));
+
+const file = (name, type, size) =>
+  new File(size ? [new Uint8Array(size)] : [], name, { type });
+
+// The paste listener is bound to `document` and outlives the component in this environment
+// (measured with a bare probe component too, so it is @vueuse plus the test runner rather than
+// anything this component does). Every example still unmounts, and the upload assertions look at
+// the last call rather than the count, so a listener from an earlier example cannot decide the
+// result.
+const mounted = [];
+afterEach(() => {
+  while (mounted.length) mounted.pop().unmount();
+});
+
+const mountButtons = () => {
+  const wrapper = shallowMount(ActionButtons, {
+    props: { isEmailOrWebWidgetInbox: true },
+    global: { mocks: { $t: key => key } },
+  });
+  mounted.push(wrapper);
+  return wrapper;
+};
+
+const paste = clipboardData => {
+  const event = new Event('paste');
+  event.clipboardData = clipboardData;
+  document.dispatchEvent(event);
+};
+
+// The third composer with the same paste handler, and the one nobody would think to check: it
+// only exists inside the new-conversation modal. Without an example here, the empty-file
+// refusal could be removed from it and every other test would stay green.
+describe('ActionButtons paste', () => {
+  it('says the pasted file was empty when the clipboard carried no text', () => {
+    mountButtons();
+
+    paste({ types: ['Files'], files: [file('vazio.txt', 'text/plain', 0)] });
+
+    expect(mockAlert).toHaveBeenCalledWith('CONVERSATION.FILE_IS_EMPTY');
+    expect(mockOnFileUpload).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet for a rich paste that brings an empty attachment along', () => {
+    mountButtons();
+
+    paste({
+      types: ['text/plain', 'text/html', 'text/rtf', 'Files'],
+      files: [file('image.png', 'image/png', 0)],
+    });
+
+    expect(mockAlert).not.toHaveBeenCalled();
+    expect(mockOnFileUpload).not.toHaveBeenCalled();
+  });
+
+  it('still uploads a real pasted file', () => {
+    mountButtons();
+
+    paste({ types: ['Files'], files: [file('valido.txt', 'text/plain', 4)] });
+
+    expect(mockAlert).not.toHaveBeenCalled();
+    expect(mockOnFileUpload).toHaveBeenCalled();
+    expect(mockOnFileUpload.mock.calls.at(-1)[0]).toMatchObject({
+      name: 'valido.txt',
+      size: 4,
+    });
+  });
+});

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -30,6 +30,7 @@ import AudioRecorder from 'dashboard/components/widgets/WootWriter/AudioRecorder
 import { AUDIO_FORMATS } from 'shared/constants/messages';
 import { BUS_EVENTS } from 'shared/constants/busEvents';
 import { CMD_AI_ASSIST } from 'dashboard/helper/commandbar/events';
+import { usableFilesFromTransfer } from 'dashboard/helper/pastedFiles';
 import {
   getMessageVariables,
   getUndefinedVariablesInMessage,
@@ -995,9 +996,16 @@ export default {
       // NOTE: Don't handle paste if scheduled message modal is open
       if (this.showScheduledMessageModal) return;
 
-      // Filter valid files (non-zero size)
-      Array.from(e.clipboardData.files)
-        .filter(file => file.size > 0)
+      // An empty file is refused at every other entry point, so it is refused here too. The
+      // helper decides whether to say it out loud: a rich copy (a spreadsheet cell) brings an
+      // invalid zero-byte attachment along with its text, and warning about that one would fire
+      // on an ordinary paste, about a file nobody chose.
+      const { files, shouldAlertEmpty } = usableFilesFromTransfer(
+        e.clipboardData
+      );
+      if (shouldAlertEmpty) useAlert(this.$t('CONVERSATION.FILE_IS_EMPTY'));
+
+      files
         .filter(file => {
           const isAllowed = isFileTypeAllowedForChannel(file, {
             channelType: this.channelType || this.inbox?.channel_type,

--- a/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
+++ b/app/javascript/dashboard/components/widgets/conversation/specs/ReplyBox.spec.js
@@ -997,4 +997,111 @@ describe('ReplyBox', () => {
       }
     );
   });
+
+  // A paste is the fifth way a file reaches the composer, and the only one that used to drop a
+  // zero-byte file without a word. The filter is deliberate and comes from upstream: the macOS
+  // Numbers app puts an invalid zero-byte attachment on the clipboard next to the copied text,
+  // so warning on every dropped file would fire on every spreadsheet paste.
+  //
+  // The shapes below were measured (macOS, Chromium 153) rather than guessed, and they are what
+  // separates the two cases: a Numbers copy carries text/plain, text/html and text/rtf beside
+  // its zero-byte `image.png`; a file copied in Finder arrives as `Files` alone, with the file
+  // name that the pasteboard does carry as text dropped by the browser.
+  describe('pasting a file', () => {
+    const file = (name, type, size) =>
+      new File(size ? [new Uint8Array(size)] : [], name, { type });
+
+    const clipboard = (types, files) => ({
+      clipboardData: {
+        types,
+        files: files.map(([name, type, size]) => file(name, type, size)),
+      },
+    });
+
+    const NUMBERS = clipboard(
+      ['text/plain', 'text/html', 'text/rtf', 'Files'],
+      [['image.png', 'image/png', 0]]
+    );
+    const EMPTY_FILE = clipboard(['Files'], [['vazio.txt', 'text/plain', 0]]);
+
+    it('says the file was empty instead of dropping it in silence', () => {
+      const { wrapper } = mountWith({
+        inbox: { channel_type: 'Channel::Api' },
+      });
+
+      wrapper.vm.onPaste(EMPTY_FILE);
+
+      expect(mockAlert).toHaveBeenCalledWith('CONVERSATION.FILE_IS_EMPTY');
+      expect(wrapper.vm.attachedFiles).toHaveLength(0);
+    });
+
+    it('stays quiet for a spreadsheet paste, which is why the filter exists', () => {
+      const { wrapper } = mountWith({
+        inbox: { channel_type: 'Channel::Api' },
+      });
+
+      wrapper.vm.onPaste(NUMBERS);
+
+      expect(mockAlert).not.toHaveBeenCalled();
+      expect(wrapper.vm.attachedFiles).toHaveLength(0);
+    });
+
+    it('attaches a real file without saying anything', async () => {
+      const { wrapper } = mountWith({
+        inbox: { channel_type: 'Channel::Api' },
+      });
+
+      wrapper.vm.onPaste(
+        clipboard(['Files'], [['valido.txt', 'text/plain', 4]])
+      );
+      // stageFile finishes through a FileReader, so the attachment lands a tick later.
+      await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+      expect(mockAlert).not.toHaveBeenCalled();
+      expect(wrapper.vm.attachedFiles).toHaveLength(1);
+    });
+
+    it('keeps the valid file of a mixed paste and still explains the empty one', async () => {
+      const { wrapper } = mountWith({
+        inbox: { channel_type: 'Channel::Api' },
+      });
+
+      wrapper.vm.onPaste(
+        clipboard(
+          ['Files'],
+          [
+            ['vazio.txt', 'text/plain', 0],
+            ['valido.txt', 'text/plain', 4],
+          ]
+        )
+      );
+
+      await vi.waitUntil(() => wrapper.vm.attachedFiles.length > 0);
+
+      expect(mockAlert).toHaveBeenCalledWith('CONVERSATION.FILE_IS_EMPTY');
+      expect(wrapper.vm.attachedFiles).toHaveLength(1);
+      expect(wrapper.vm.attachedFiles[0].resource.name).toBe('valido.txt');
+    });
+
+    // The refusal is one alert, not one per dropped file: two empty files pasted together are
+    // one thing that happened to the person pasting.
+    it('explains once, however many empty files came in the same paste', () => {
+      const { wrapper } = mountWith({
+        inbox: { channel_type: 'Channel::Api' },
+      });
+
+      wrapper.vm.onPaste(
+        clipboard(
+          ['Files'],
+          [
+            ['um.txt', 'text/plain', 0],
+            ['dois.txt', 'text/plain', 0],
+          ]
+        )
+      );
+
+      expect(mockAlert).toHaveBeenCalledTimes(1);
+      expect(wrapper.vm.attachedFiles).toHaveLength(0);
+    });
+  });
 });

--- a/app/javascript/dashboard/helper/pastedFiles.js
+++ b/app/javascript/dashboard/helper/pastedFiles.js
@@ -9,7 +9,11 @@
  * Chromium 153):
  *
  *   - a Numbers copy, one cell or a range, reports `text/plain`, `text/html`, `text/rtf` and
- *     `Files`, the file being `image.png` of `image/png` at 0 bytes;
+ *     `Files`, the file being `image.png` of `image/png`. Its size is a race, not a state: the
+ *     pasteboard promises the image and macOS fills it in afterwards, so a paste in the first
+ *     seconds reads 0 bytes and the same clipboard read tens of seconds later gives a real
+ *     image (0 then, 10594 bytes at 45 s, measured on the same copy). The empty case is
+ *     therefore the window right after Cmd+C, which is also when a person pastes;
  *   - a file copied in Finder reports `Files` alone. The macOS pasteboard does carry the file
  *     name as text, and the browser suppresses every text flavour once a file URL is present,
  *     so the paste event sees no text at all.

--- a/app/javascript/dashboard/helper/pastedFiles.js
+++ b/app/javascript/dashboard/helper/pastedFiles.js
@@ -9,11 +9,12 @@
  * Chromium 153):
  *
  *   - a Numbers copy, one cell or a range, reports `text/plain`, `text/html`, `text/rtf` and
- *     `Files`, the file being `image.png` of `image/png`. Its size is a race, not a state: the
- *     pasteboard promises the image and macOS fills it in afterwards, so a paste in the first
- *     seconds reads 0 bytes and the same clipboard read tens of seconds later gives a real
- *     image (0 then, 10594 bytes at 45 s, measured on the same copy). The empty case is
- *     therefore the window right after Cmd+C, which is also when a person pastes;
+ *     `Files`, the file being `image.png` of `image/png`. Its size is almost always 0 and not
+ *     always: reading the pasteboard directly gave 0 bytes on nine reads across three copies,
+ *     and twice the same gesture produced a real PNG (4972 and 10594 bytes) that nobody could
+ *     reproduce on command afterwards. Whatever decides that, this rule does not rest on it:
+ *     the decision is made on the text beside the file, so an empty artifact is dropped in
+ *     silence and a filled one is an ordinary attachment;
  *   - a file copied in Finder reports `Files` alone. The macOS pasteboard does carry the file
  *     name as text, and the browser suppresses every text flavour once a file URL is present,
  *     so the paste event sees no text at all.

--- a/app/javascript/dashboard/helper/pastedFiles.js
+++ b/app/javascript/dashboard/helper/pastedFiles.js
@@ -1,0 +1,49 @@
+/**
+ * A zero-byte file is refused everywhere it can be picked, and until now a paste was the one
+ * entry point that dropped it without a word. The silence is deliberate and comes from upstream
+ * (PR #13135): the macOS Numbers app puts an invalid zero-byte attachment on the clipboard
+ * beside the copied cells, so warning on every dropped file would fire on every spreadsheet
+ * paste, about a file the person never chose.
+ *
+ * What separates the two cases is text, and it was measured rather than assumed (macOS,
+ * Chromium 153):
+ *
+ *   - a Numbers copy, one cell or a range, reports `text/plain`, `text/html`, `text/rtf` and
+ *     `Files`, the file being `image.png` of `image/png` at 0 bytes;
+ *   - a file copied in Finder reports `Files` alone. The macOS pasteboard does carry the file
+ *     name as text, and the browser suppresses every text flavour once a file URL is present,
+ *     so the paste event sees no text at all.
+ *
+ * So the rule is: drop empty files as before, and say so only when the clipboard carried no
+ * text. A rich copy that happens to bring an empty attachment stays as quiet as it is today.
+ */
+import { isFileEmpty } from 'shared/helpers/FileHelper';
+
+const TEXT_TYPES = ['text/plain', 'text/html', 'text/rtf'];
+
+export const clipboardCarriesText = transfer =>
+  Array.from(transfer?.types || []).some(type => TEXT_TYPES.includes(type));
+
+export const splitFilesBySize = files => {
+  const all = Array.from(files || []).filter(Boolean);
+
+  // `isFileEmpty` is the same predicate the four entry points that already explain themselves
+  // use, so a paste cannot drift from them on what counts as empty.
+  return {
+    files: all.filter(file => !isFileEmpty(file)),
+    empty: all.filter(isFileEmpty),
+  };
+};
+
+/**
+ * The files worth attaching, plus whether the caller should explain what it dropped. One alert
+ * per paste, not one per file: two empty files pasted together are one thing that happened.
+ */
+export const usableFilesFromTransfer = transfer => {
+  const { files, empty } = splitFilesBySize(transfer?.files);
+
+  return {
+    files,
+    shouldAlertEmpty: empty.length > 0 && !clipboardCarriesText(transfer),
+  };
+};

--- a/app/javascript/dashboard/helper/specs/pastedFiles.spec.js
+++ b/app/javascript/dashboard/helper/specs/pastedFiles.spec.js
@@ -11,10 +11,11 @@ import {
 //
 //   * a Numbers copy really does carry an invalid attachment, and it is `image.png` of
 //     `image/png`, never a spreadsheet file. It arrives WITH text/plain, text/html and text/rtf,
-//     because the point of copying a cell is to paste its text somewhere. Its 0 bytes are a
-//     race rather than a state: the pasteboard promises the image, so a paste seconds after
-//     Cmd+C reads 0 and the same clipboard 45 s later gives 10594 bytes. Both are covered here:
-//     the empty one must not warn, and the filled one is an ordinary attachment.
+//     because the point of copying a cell is to paste its text somewhere. Its size is almost
+//     always 0: nine direct pasteboard reads across three copies gave 0 bytes, and twice the
+//     same gesture gave a real PNG that nobody could reproduce on command. Both shapes are
+//     covered below, because the decision never looks at the size of that file: the empty one
+//     must not warn, and the filled one is an ordinary attachment.
 //   * a file copied in Finder arrives as `Files` alone. The macOS pasteboard does carry the
 //     file name as text, and the browser drops it, so `types` has no text flavour at all.
 //
@@ -30,7 +31,7 @@ const NUMBERS_SINGLE_CELL = transfer(
   [['image.png', 'image/png', 0]]
 );
 const NUMBERS_RANGE = NUMBERS_SINGLE_CELL;
-// The same copy, pasted once the promised image has been filled in.
+// The other shape the same gesture has produced, twice and not on demand: a real PNG.
 const NUMBERS_SETTLED = transfer(
   ['text/plain', 'text/html', 'text/rtf', 'Files'],
   [['image.png', 'image/png', 10594]]
@@ -122,7 +123,7 @@ describe('pastedFiles', () => {
       });
     });
 
-    it('attaches the spreadsheet image once the pasteboard has filled it in', () => {
+    it('attaches the spreadsheet image on the runs where it comes through filled', () => {
       expect(usableFilesFromTransfer(NUMBERS_SETTLED)).toEqual({
         files: [{ name: 'image.png', type: 'image/png', size: 10594 }],
         shouldAlertEmpty: false,

--- a/app/javascript/dashboard/helper/specs/pastedFiles.spec.js
+++ b/app/javascript/dashboard/helper/specs/pastedFiles.spec.js
@@ -9,9 +9,12 @@ import {
 // the round's holdout folder (clipboard-measurements.json). Two of them decide the whole
 // question, and they are the two the issue said had to be measured before shipping:
 //
-//   * a Numbers copy really does carry an invalid zero-byte attachment, and it is `image.png`
-//     of `image/png`, never a spreadsheet file. It arrives WITH text/plain, text/html and
-//     text/rtf, because the point of copying a cell is to paste its text somewhere.
+//   * a Numbers copy really does carry an invalid attachment, and it is `image.png` of
+//     `image/png`, never a spreadsheet file. It arrives WITH text/plain, text/html and text/rtf,
+//     because the point of copying a cell is to paste its text somewhere. Its 0 bytes are a
+//     race rather than a state: the pasteboard promises the image, so a paste seconds after
+//     Cmd+C reads 0 and the same clipboard 45 s later gives 10594 bytes. Both are covered here:
+//     the empty one must not warn, and the filled one is an ordinary attachment.
 //   * a file copied in Finder arrives as `Files` alone. The macOS pasteboard does carry the
 //     file name as text, and the browser drops it, so `types` has no text flavour at all.
 //
@@ -27,6 +30,11 @@ const NUMBERS_SINGLE_CELL = transfer(
   [['image.png', 'image/png', 0]]
 );
 const NUMBERS_RANGE = NUMBERS_SINGLE_CELL;
+// The same copy, pasted once the promised image has been filled in.
+const NUMBERS_SETTLED = transfer(
+  ['text/plain', 'text/html', 'text/rtf', 'Files'],
+  [['image.png', 'image/png', 10594]]
+);
 const FINDER_ZERO_BYTE_FILE = transfer(
   ['Files'],
   [['vazio.txt', 'text/plain', 0]]
@@ -111,6 +119,13 @@ describe('pastedFiles', () => {
       expect(usableFilesFromTransfer(FINDER_ZERO_BYTE_FILE)).toEqual({
         files: [],
         shouldAlertEmpty: true,
+      });
+    });
+
+    it('attaches the spreadsheet image once the pasteboard has filled it in', () => {
+      expect(usableFilesFromTransfer(NUMBERS_SETTLED)).toEqual({
+        files: [{ name: 'image.png', type: 'image/png', size: 10594 }],
+        shouldAlertEmpty: false,
       });
     });
 

--- a/app/javascript/dashboard/helper/specs/pastedFiles.spec.js
+++ b/app/javascript/dashboard/helper/specs/pastedFiles.spec.js
@@ -1,0 +1,141 @@
+import {
+  clipboardCarriesText,
+  splitFilesBySize,
+  usableFilesFromTransfer,
+} from '../pastedFiles';
+
+// The shapes below are not invented: they were measured on 10/09/2026, macOS, Chromium 153,
+// by pasting each source into a probe page and reading `e.clipboardData`. The record lives in
+// the round's holdout folder (clipboard-measurements.json). Two of them decide the whole
+// question, and they are the two the issue said had to be measured before shipping:
+//
+//   * a Numbers copy really does carry an invalid zero-byte attachment, and it is `image.png`
+//     of `image/png`, never a spreadsheet file. It arrives WITH text/plain, text/html and
+//     text/rtf, because the point of copying a cell is to paste its text somewhere.
+//   * a file copied in Finder arrives as `Files` alone. The macOS pasteboard does carry the
+//     file name as text, and the browser drops it, so `types` has no text flavour at all.
+//
+// That asymmetry is the whole discriminator: warn when every pasted file is empty and nothing
+// on the clipboard is text, stay quiet otherwise.
+const transfer = (types, files) => ({
+  types,
+  files: files.map(([name, type, size]) => ({ name, type, size })),
+});
+
+const NUMBERS_SINGLE_CELL = transfer(
+  ['text/plain', 'text/html', 'text/rtf', 'Files'],
+  [['image.png', 'image/png', 0]]
+);
+const NUMBERS_RANGE = NUMBERS_SINGLE_CELL;
+const FINDER_ZERO_BYTE_FILE = transfer(
+  ['Files'],
+  [['vazio.txt', 'text/plain', 0]]
+);
+const FINDER_VALID_FILE = transfer(
+  ['Files'],
+  [['valido.txt', 'text/plain', 4]]
+);
+const SCREENSHOT = transfer(['Files'], [['image.png', 'image/png', 40656]]);
+const PLAIN_TEXT = transfer(['text/plain'], []);
+
+describe('pastedFiles', () => {
+  describe('clipboardCarriesText', () => {
+    it('is true for the shapes a rich copy produces', () => {
+      expect(clipboardCarriesText(NUMBERS_SINGLE_CELL)).toBe(true);
+      expect(clipboardCarriesText(PLAIN_TEXT)).toBe(true);
+    });
+
+    it('is false for a file copy, which the browser reports as Files alone', () => {
+      expect(clipboardCarriesText(FINDER_ZERO_BYTE_FILE)).toBe(false);
+      expect(clipboardCarriesText(SCREENSHOT)).toBe(false);
+    });
+
+    // Each flavour on its own, because a copy does not always bring all three: a web page gives
+    // text/html, a rich text editor gives text/rtf, and treating any one of them as "no text"
+    // would put the spurious alert back for that source alone.
+    it.each(['text/plain', 'text/html', 'text/rtf'])(
+      'counts %s on its own as text',
+      type => {
+        expect(
+          clipboardCarriesText(
+            transfer([type, 'Files'], [['image.png', 'image/png', 0]])
+          )
+        ).toBe(true);
+      }
+    );
+
+    it('survives a transfer with no types at all', () => {
+      expect(clipboardCarriesText(undefined)).toBe(false);
+      expect(clipboardCarriesText({})).toBe(false);
+    });
+  });
+
+  describe('splitFilesBySize', () => {
+    it('keeps the order and drops nothing on the floor', () => {
+      const files = [
+        { name: 'a.png', size: 0 },
+        { name: 'b.png', size: 10 },
+        { name: 'c.png', size: 0 },
+      ];
+
+      expect(splitFilesBySize(files)).toEqual({
+        files: [{ name: 'b.png', size: 10 }],
+        empty: [
+          { name: 'a.png', size: 0 },
+          { name: 'c.png', size: 0 },
+        ],
+      });
+    });
+
+    it('ignores holes rather than crashing on them', () => {
+      expect(splitFilesBySize([null, undefined])).toEqual({
+        files: [],
+        empty: [],
+      });
+      expect(splitFilesBySize(null)).toEqual({ files: [], empty: [] });
+    });
+  });
+
+  describe('usableFilesFromTransfer', () => {
+    it('stays quiet for a Numbers paste, which is why the filter exists', () => {
+      expect(usableFilesFromTransfer(NUMBERS_SINGLE_CELL)).toEqual({
+        files: [],
+        shouldAlertEmpty: false,
+      });
+      expect(usableFilesFromTransfer(NUMBERS_RANGE).shouldAlertEmpty).toBe(
+        false
+      );
+    });
+
+    it('explains the refusal for a genuine empty file', () => {
+      expect(usableFilesFromTransfer(FINDER_ZERO_BYTE_FILE)).toEqual({
+        files: [],
+        shouldAlertEmpty: true,
+      });
+    });
+
+    it('says nothing when there was nothing to drop', () => {
+      expect(usableFilesFromTransfer(FINDER_VALID_FILE)).toEqual({
+        files: [{ name: 'valido.txt', type: 'text/plain', size: 4 }],
+        shouldAlertEmpty: false,
+      });
+      expect(usableFilesFromTransfer(SCREENSHOT).shouldAlertEmpty).toBe(false);
+      expect(usableFilesFromTransfer(PLAIN_TEXT).shouldAlertEmpty).toBe(false);
+    });
+
+    it('keeps the valid file and still explains the empty one beside it', () => {
+      const mixed = transfer(
+        ['Files'],
+        [
+          ['vazio.txt', 'text/plain', 0],
+          ['valido.txt', 'text/plain', 4],
+        ]
+      );
+
+      expect(usableFilesFromTransfer(mixed)).toEqual({
+        files: [{ name: 'valido.txt', type: 'text/plain', size: 4 }],
+        shouldAlertEmpty: true,
+      });
+    });
+  });
+});

--- a/app/javascript/dashboard/helper/specs/pastedFilesFence.spec.js
+++ b/app/javascript/dashboard/helper/specs/pastedFilesFence.spec.js
@@ -1,0 +1,72 @@
+import { readFileSync, readdirSync, statSync } from 'fs';
+import path from 'path';
+
+// The same question was open in three composers at once, and each of them had answered it with
+// its own inline `filter(file => file.size > 0)`. Fixing three call sites without a fence just
+// resets the clock: the fourth composer copies the line from one of the first three, and the
+// silent drop is back with nobody to notice.
+//
+// So the rule is that the size test lives in one place. A new entry point either uses the
+// helper, which decides whether to explain the refusal, or this fails and asks why.
+const ROOT = path.resolve(__dirname, '../../..');
+// `isFileEmpty` in shared/helpers/FileHelper.js is the one predicate, and dashboard/helper/
+// pastedFiles.js is the one place that decides what to do about a file it refuses. Everything
+// else asks them.
+const HELPER = path.join(ROOT, 'shared/helpers/FileHelper.js');
+const EXTENSIONS = ['.js', '.vue'];
+const SKIP_DIRS = new Set(['node_modules', 'specs', 'i18n']);
+
+// `size` is a common enough name that a bare mention would flag unrelated code, so the fence
+// matches the shape that drops files: a size comparison inside a filter or a guard over
+// something named like a file.
+const SIZE_FILTER =
+  /\b(?:file|f|attachment)\s*(?:&&\s*\1\s*)?\.size\s*(?:>|>=|===|!==|==)\s*0/;
+
+const walk = dir =>
+  readdirSync(dir).flatMap(entry => {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      return SKIP_DIRS.has(entry) ? [] : walk(full);
+    }
+    return EXTENSIONS.includes(path.extname(entry)) ? [full] : [];
+  });
+
+describe('the zero-byte test lives in one place', () => {
+  it('has no other file deciding on its own what an empty file means', () => {
+    const offenders = walk(ROOT)
+      .filter(file => file !== HELPER)
+      .filter(file => SIZE_FILTER.test(readFileSync(file, 'utf8')))
+      .map(file => path.relative(ROOT, file));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('still finds the predicate itself, so the fence is not matching nothing', () => {
+    expect(SIZE_FILTER.test(readFileSync(HELPER, 'utf8'))).toBe(true);
+  });
+
+  // Three of the four sites that had the inline filter were `.vue` files, so a sweep that only
+  // reads `.js` would pass while saying nothing about the composers this issue is actually
+  // about. The list is checked rather than the extensions constant: what matters is that the
+  // walk reaches them.
+  it('sweeps the components, not only the plain modules', () => {
+    const swept = walk(ROOT);
+
+    expect(swept.some(file => file.endsWith('.vue'))).toBe(true);
+    expect(swept).toContain(
+      path.join(ROOT, 'dashboard/components/widgets/conversation/ReplyBox.vue')
+    );
+    expect(swept).toContain(
+      path.join(
+        ROOT,
+        'dashboard/routes/dashboard/internalChat/MessageEditor.vue'
+      )
+    );
+    expect(swept).toContain(
+      path.join(
+        ROOT,
+        'dashboard/components-next/NewConversation/components/ActionButtons.vue'
+      )
+    );
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/internalChat/MessageEditor.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/MessageEditor.vue
@@ -3,6 +3,11 @@ import { ref, computed, watch, onBeforeUnmount } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Icon from 'dashboard/components-next/icon/Icon.vue';
 import WootWriter from 'dashboard/components/widgets/WootWriter/Editor.vue';
+import { useAlert } from 'dashboard/composables';
+import {
+  splitFilesBySize,
+  usableFilesFromTransfer,
+} from 'dashboard/helper/pastedFiles';
 
 const props = defineProps({
   disabled: {
@@ -140,7 +145,13 @@ function openFilePicker() {
 }
 
 function handleFileChange(event) {
-  const files = Array.from(event.target.files || []);
+  // A file chosen in the picker was chosen on purpose, so an empty one is always worth a word:
+  // there is no rich-copy artifact to confuse it with, and this was the one path that attached
+  // a zero-byte file and let the send carry it (internal chat builds attachments outside
+  // Messages::MessageBuilder, so nothing refuses it on the server either).
+  const { files, empty } = splitFilesBySize(event.target.files);
+  if (empty.length) useAlert(t('CONVERSATION.FILE_IS_EMPTY'));
+
   attachedFiles.value = [...attachedFiles.value, ...files];
   if (fileInputRef.value) fileInputRef.value.value = '';
 }
@@ -149,8 +160,12 @@ function removeFile(index) {
   attachedFiles.value.splice(index, 1);
 }
 
-function addFiles(fileList) {
-  const files = Array.from(fileList || []).filter(f => f && f.size > 0);
+// Paste and drop share the rule with the conversation composer: empty files are dropped, and
+// the refusal is said out loud only when the transfer carried no text, which is what tells a
+// genuine empty file apart from the invalid zero-byte attachment a rich copy brings along.
+function addFiles(transfer) {
+  const { files, shouldAlertEmpty } = usableFilesFromTransfer(transfer);
+  if (shouldAlertEmpty) useAlert(t('CONVERSATION.FILE_IS_EMPTY'));
   if (!files.length) return;
   attachedFiles.value = [...attachedFiles.value, ...files];
 }
@@ -159,7 +174,7 @@ function handlePaste(event) {
   const files = event.clipboardData?.files;
   if (!files?.length) return;
   event.preventDefault();
-  addFiles(files);
+  addFiles(event.clipboardData);
 }
 
 function hasFileDrag(event) {
@@ -193,7 +208,7 @@ function handleDrop(event) {
   event.preventDefault();
   dragCounter = 0;
   isDragging.value = false;
-  addFiles(event.dataTransfer?.files);
+  addFiles(event.dataTransfer);
 }
 
 function filePreviewUrl(file) {

--- a/app/javascript/dashboard/routes/dashboard/internalChat/MessageEditor.vue
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/MessageEditor.vue
@@ -163,18 +163,25 @@ function removeFile(index) {
 // Paste and drop share the rule with the conversation composer: empty files are dropped, and
 // the refusal is said out loud only when the transfer carried no text, which is what tells a
 // genuine empty file apart from the invalid zero-byte attachment a rich copy brings along.
+// Returns what it took, so a caller can tell "I handled this" from "there was nothing to take".
 function addFiles(transfer) {
   const { files, shouldAlertEmpty } = usableFilesFromTransfer(transfer);
   if (shouldAlertEmpty) useAlert(t('CONVERSATION.FILE_IS_EMPTY'));
-  if (!files.length) return;
+  if (!files.length) return false;
+
   attachedFiles.value = [...attachedFiles.value, ...files];
+  return true;
 }
 
+// The paste is taken over only when something is actually attached. A rich copy carries its
+// zero-byte artifact beside the text the person meant to paste, and cancelling the paste for
+// that artifact attaches nothing in its place. The text still arrives today because the editor's
+// own handler runs before this one, which is ordering rather than a decision made here.
 function handlePaste(event) {
-  const files = event.clipboardData?.files;
-  if (!files?.length) return;
+  if (!event.clipboardData?.files?.length) return;
+  if (!addFiles(event.clipboardData)) return;
+
   event.preventDefault();
-  addFiles(event.clipboardData);
 }
 
 function hasFileDrag(event) {

--- a/app/javascript/dashboard/routes/dashboard/internalChat/specs/MessageEditor.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/specs/MessageEditor.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import MessageEditor from '../MessageEditor.vue';
 
 const mockAlert = vi.fn();
@@ -25,6 +26,16 @@ const mountEditor = () =>
 describe('MessageEditor attachments', () => {
   // The paste and drop listeners sit on the composer's root element.
   const editor = wrapper => wrapper;
+
+  // `trigger` builds its own event object, so a spy passed as an option never becomes the
+  // event's `preventDefault`. Dispatching a real event is the only way to read whether the
+  // handler took the paste over, which is what decides if the editor still gets the text.
+  const dispatchPaste = (wrapper, clipboardData) => {
+    const event = new Event('paste', { bubbles: true, cancelable: true });
+    event.clipboardData = clipboardData;
+    wrapper.element.dispatchEvent(event);
+    return event;
+  };
   const attachmentNames = wrapper =>
     wrapper.findAll('.truncate.text-xs').map(node => node.text());
 
@@ -95,6 +106,38 @@ describe('MessageEditor attachments', () => {
     });
 
     expect(mockAlert).not.toHaveBeenCalled();
+    expect(attachmentNames(wrapper)).toEqual(['valido.txt']);
+  });
+
+  // A rich copy brings its zero-byte artifact along with the text the person actually copied, and
+  // the paste handler used to call preventDefault() the moment it saw any file, cancelling a
+  // paste that then attached nothing. Measured in a browser, the text still lands, because the
+  // editor's own paste handler runs first and inserts it. Nothing is lost today, and that is the
+  // point: the text survives by listener ordering rather than by anything this code decided.
+  it('lets the text of a rich paste through instead of eating it for an empty artifact', async () => {
+    const wrapper = mountEditor();
+
+    const event = dispatchPaste(wrapper, {
+      types: ['text/plain', 'text/html', 'text/rtf', 'Files'],
+      files: [file('image.png', 'image/png', 0)],
+    });
+    await nextTick();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(mockAlert).not.toHaveBeenCalled();
+    expect(attachmentNames(wrapper)).toEqual([]);
+  });
+
+  it('still takes over the paste when there is a real file to attach', async () => {
+    const wrapper = mountEditor();
+
+    const event = dispatchPaste(wrapper, {
+      types: ['Files'],
+      files: [file('valido.txt', 'text/plain', 4)],
+    });
+    await nextTick();
+
+    expect(event.defaultPrevented).toBe(true);
     expect(attachmentNames(wrapper)).toEqual(['valido.txt']);
   });
 

--- a/app/javascript/dashboard/routes/dashboard/internalChat/specs/MessageEditor.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/internalChat/specs/MessageEditor.spec.js
@@ -1,0 +1,113 @@
+import { shallowMount } from '@vue/test-utils';
+import MessageEditor from '../MessageEditor.vue';
+
+const mockAlert = vi.fn();
+vi.mock('dashboard/composables', async () => {
+  const actual = await vi.importActual('dashboard/composables');
+  return { ...actual, useAlert: (...args) => mockAlert(...args) };
+});
+
+const file = (name, type, size) =>
+  new File(size ? [new Uint8Array(size)] : [], name, { type });
+
+const mountEditor = () =>
+  shallowMount(MessageEditor, {
+    global: {
+      mocks: { $t: key => key },
+      stubs: { WootWriter: true, Icon: true },
+    },
+  });
+
+// The internal chat composer answered the empty-file question three different ways at once: the
+// picker attached a zero-byte file and let the send carry it (attachments here are built outside
+// Messages::MessageBuilder, so nothing refuses it on the server either), while paste and drop
+// dropped it without a word. None of the three said anything to the person.
+describe('MessageEditor attachments', () => {
+  // The paste and drop listeners sit on the composer's root element.
+  const editor = wrapper => wrapper;
+  const attachmentNames = wrapper =>
+    wrapper.findAll('.truncate.text-xs').map(node => node.text());
+
+  it('refuses an empty file chosen in the picker instead of attaching it', async () => {
+    const wrapper = mountEditor();
+    const input = wrapper.find('input[type="file"]');
+
+    Object.defineProperty(input.element, 'files', {
+      value: [file('vazio.txt', 'text/plain', 0)],
+      configurable: true,
+    });
+    await input.trigger('change');
+
+    expect(mockAlert).toHaveBeenCalledWith('CONVERSATION.FILE_IS_EMPTY');
+    expect(attachmentNames(wrapper)).toEqual([]);
+  });
+
+  it('keeps attaching a real file chosen in the picker', async () => {
+    const wrapper = mountEditor();
+    const input = wrapper.find('input[type="file"]');
+
+    Object.defineProperty(input.element, 'files', {
+      value: [file('valido.txt', 'text/plain', 4)],
+      configurable: true,
+    });
+    await input.trigger('change');
+
+    expect(mockAlert).not.toHaveBeenCalled();
+    expect(attachmentNames(wrapper)).toEqual(['valido.txt']);
+  });
+
+  it('says the pasted file was empty, since a paste of Files alone carries no text', async () => {
+    const wrapper = mountEditor();
+
+    await editor(wrapper).trigger('paste', {
+      clipboardData: {
+        types: ['Files'],
+        files: [file('vazio.txt', 'text/plain', 0)],
+      },
+    });
+
+    expect(mockAlert).toHaveBeenCalledWith('CONVERSATION.FILE_IS_EMPTY');
+  });
+
+  // Internal chat has no macOS Numbers argument of its own, but it shares the composer's rule so
+  // the two do not drift: a rich copy brings an invalid zero-byte attachment beside its text.
+  it('stays quiet for a rich paste that carries text beside its empty attachment', async () => {
+    const wrapper = mountEditor();
+
+    await editor(wrapper).trigger('paste', {
+      clipboardData: {
+        types: ['text/plain', 'text/html', 'text/rtf', 'Files'],
+        files: [file('image.png', 'image/png', 0)],
+      },
+    });
+
+    expect(mockAlert).not.toHaveBeenCalled();
+  });
+
+  it('still attaches a real pasted file', async () => {
+    const wrapper = mountEditor();
+
+    await editor(wrapper).trigger('paste', {
+      clipboardData: {
+        types: ['Files'],
+        files: [file('valido.txt', 'text/plain', 4)],
+      },
+    });
+
+    expect(mockAlert).not.toHaveBeenCalled();
+    expect(attachmentNames(wrapper)).toEqual(['valido.txt']);
+  });
+
+  it('applies the same rule to a drop', async () => {
+    const wrapper = mountEditor();
+
+    await editor(wrapper).trigger('drop', {
+      dataTransfer: {
+        types: ['Files'],
+        files: [file('vazio.txt', 'text/plain', 0)],
+      },
+    });
+
+    expect(mockAlert).toHaveBeenCalledWith('CONVERSATION.FILE_IS_EMPTY');
+  });
+});


### PR DESCRIPTION
Fixes #525

## What was broken

An empty file is refused wherever it can be named. Four entry points say `This file is empty and cannot be sent`; a paste said nothing at all, in three different composers, and the internal chat picker did something worse than nothing.

| entry point | before |
| --- | --- |
| reply composer, paste | file dropped, no warning |
| new conversation composer, paste | file dropped, no warning |
| internal chat, paste and drop | file dropped, no warning |
| internal chat, file picker | file **attached**, and the send carried it |

The picker is the one that is not merely silent. Internal chat builds its attachments in `InternalChat::MessageCreateService#process_attachments`, outside `Messages::MessageBuilder`, so the server-side refusal that covers conversation messages never runs on that path either.

## Why the silence was there, and why it could not simply be removed

The `filter(file => file.size > 0)` comes from upstream (`53c21e6ad3`, PR #13135) and the reason is written down in `Editor.vue`: the macOS Numbers app puts an invalid zero-byte attachment on the clipboard next to the copied cells, so warning about every dropped file would fire an alert on every spreadsheet paste, about a file nobody chose.

The issue proposed warning only when every pasted file is empty **and** there is no text on the clipboard, and said plainly that this was a guess about clipboard shapes and had to be measured against a real Numbers paste before shipping. It was measured, on macOS with Chromium 153, by pasting each source into a probe page and reading `e.clipboardData`:

| source | `types` | `files` | `text/plain` |
| --- | --- | --- | --- |
| Numbers, one cell | `text/plain, text/html, text/rtf, Files` | `image.png`, **0 bytes**, `image/png` | `"celula unica"` |
| the same Numbers copy, on two runs out of many | same | `image.png`, **4972 / 10594 bytes** | same |
| Numbers, a range | same | same | the cells, tab separated |
| empty file copied in Finder | `Files` | `vazio.txt`, 0 bytes | empty |
| 4-byte file copied in Finder | `Files` | `valido.txt`, 4 bytes | empty |
| screenshot | `Files` | `image.png`, 40656 bytes | empty |
| plain text | `text/plain` | none | the text |

Two things came out of it, and both matter:

1. **The upstream rationale is accurate, and the artifact's size is almost always 0 and not always.** The invalid attachment exists, it is `image.png` of `image/png`, not a spreadsheet file, and it always arrives with text beside it, which makes sense: copying a cell is copying its text. On the size: reading the pasteboard directly, with no browser in between, gave 0 bytes on nine reads across three copies, repeats of the same copy included; twice the same gesture produced a real PNG instead, and neither run could be reproduced on command. Nobody here can say what decides that, and this fix does not rest on it: the decision is made on the text beside the file, never on its size. Both shapes are pinned.
2. **A genuine empty-file paste carries no text at all.** The macOS pasteboard does put the file name on it as `public.utf8-plain-text`, and Chromium suppresses every text flavour once a file URL is present. Measured directly by writing text and HTML onto the pasteboard beside a file URL: the browser still reported `types: ["Files"]` with an empty `text/plain`.

So the discriminator is text, it separates the two cases cleanly, and it is not a guess.

## What changed

`dashboard/helper/pastedFiles.js` holds the rule, and the three paste sites plus the internal chat drop ask it:

- empty files are dropped exactly as before;
- the refusal is said out loud only when the transfer carried no text;
- one alert per paste, not one per file.

The internal chat picker always explains itself, because a file chosen in a picker is deliberate and there is no rich-copy artifact to confuse it with.

The size test itself now goes through `isFileEmpty` in `shared/helpers/FileHelper.js`, the same predicate the four honest entry points use, so a paste cannot drift from them on what counts as empty.

## The fence

The same question was open in three composers at once and each had answered it with its own inline `filter(file => file.size > 0)`. Fixing three call sites without a fence just resets the clock, so `pastedFilesFence.spec.js` sweeps `app/javascript` for a size comparison over anything named like a file, outside the one predicate. It also asserts that the sweep reaches `.vue` files and names the three composers, because three of the four original sites were components and a `.js`-only sweep would have passed while proving nothing.

## What this does not change

- Anything already attached, sent or stored: no path here persisted a zero-byte file except the internal chat picker, and that one now refuses before attaching.
- The four entry points that already explain themselves.
- The server side. `Messages::MessageBuilder` keeps its own refusal; internal chat still has none, which is why the picker's own check matters.


## A second commit, and a premise of it that did not survive measurement

The holdout scenarios flagged that `handlePaste` in the internal chat called `preventDefault()` the moment it saw any file and only filtered zero-byte files out afterwards, and predicted that pasting a spreadsheet cell there would lose the text entirely.

The first half is true and is fixed here: the composer now takes the paste over only when it actually attaches something. The prediction is not. Measured in the browser on the code before that commit, with an empty composer and a real Numbers copy: `defaultPrevented` comes back `true` and **the text still lands**, because the editor's own paste handler runs before this listener and inserts it.

So nothing was being lost, and the change is worth making for a smaller reason than the one that prompted it: the text surviving is a property of listener ordering, not of a decision this code makes. `addFiles` now reports whether it took anything, and the two cases are pinned by reading `event.defaultPrevented` on a real dispatched event.

## Where the evidence comes from, since CI does not cover this

`Frontend Lint & Test` (`frontend-fe.yml`) and `Lint PR` are `disabled_manually` on this repo, so no workflow runs `app/javascript` on a pull request and there was no run to dispatch. The suite was run locally instead, in a worktree, and the numbers above are from there. The Ruby workflow that is active does not touch this change.

The live half was measured in a browser with the real macOS clipboard, not with synthetic events: with the three components reverted to `5171eaab26`, pasting a zero-byte file fires the paste (confirmed by a listener on the page reporting `types: ["Files"]` and a 0-byte `vazio.txt`), shows nothing and attaches nothing; with this branch the same gesture shows the refusal. Pasting two cells copied from Numbers shows no alert and drops the text into the composer.

## A known limitation, registered rather than hidden

`clipboardCarriesText` decides on the presence of the type, not on its content, so a source that announces an **empty** `text/plain` beside a zero-byte file would silence the refusal and put the silence back. None of the six measured shapes does that, on macOS with Chromium; nothing was measured on Safari, Firefox, Windows or Linux. It is #567, with the fix sketched there, and it is out of this PR because the shape of that fix depends on measuring one real case where it happens, which is the same discipline this issue demanded before shipping the guard itself.

## Validation scope

Proven by test:

- 6 examples fail on `5171eaab26` and pass here: the reply composer explaining an empty paste, keeping the valid file of a mixed paste while still explaining, explaining once for two empty files, and the internal chat refusing an empty file in the picker, in a paste and in a drop.
- The Numbers shape is pinned in every one of the three composers: an alert there is a failing test.
- 16 mutations, 16 killed. Inverting the text guard, removing it, hardcoding it off, dropping any one of the three text flavours, inverting the size partition, removing either composer's alert, regressing the internal chat picker, passing a `FileList` where the transfer is expected on paste or on drop, and narrowing the fence to `.js` are all caught.

Measured, not tested: the six clipboard shapes above, on Chromium 153 / macOS. Safari and Firefox were not measured, and the rule degrades safely there: a browser that exposes text alongside a pasted file would warn less, never more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/566)
<!-- Reviewable:end -->




