### PR TITLE
fix(whatsapp): put a ceiling on the connector commands nobody waits for

### DIFF
--- a/app/services/whatsapp/connector/client.rb
+++ b/app/services/whatsapp/connector/client.rb
@@ -69,9 +69,14 @@ class Whatsapp::Connector::Client
 
   # Fire and forget: the command is queued for the session's owner. Failures come back
   # later as a command.failed event.
-  def publish(payload, idempotency_key: nil)
+  #
+  # `timeout` is how long the command may take, counted from now, and it is the only
+  # ceiling it gets: the connector bounds a command's execution by the deadline on its
+  # frame, and nobody here is waiting to give up on this one. Without it the command runs
+  # for as long as it takes, and the session's executor takes one command at a time.
+  def publish(payload, idempotency_key: nil, timeout: nil)
     ensure_readable!
-    command = build(payload, idempotency_key: idempotency_key)
+    command = build(payload, idempotency_key: idempotency_key, timeout: timeout)
     write(command_stream, command)
     command.id
   end
@@ -79,14 +84,15 @@ class Whatsapp::Connector::Client
   # Queues the command and waits for the answer the owner pushes back.
   def call(payload, timeout: RPC_TIMEOUT, idempotency_key: nil)
     ensure_available!
-    command = build(payload, idempotency_key: idempotency_key, reply_to: true, timeout: timeout)
+    command = build(payload, idempotency_key: idempotency_key, reply_to: true, timeout: timeout - DEADLINE_MARGIN)
     write(command_stream, command)
     await(command, timeout)
   end
 
   # Session-agnostic commands (wake, ping): any live instance answers.
   def control(payload, timeout: RPC_TIMEOUT)
-    command = build(payload, reply_to: model::Commands.rpc?(payload.class.wire_type), timeout: timeout)
+    rpc = model::Commands.rpc?(payload.class.wire_type)
+    command = build(payload, reply_to: rpc, timeout: (timeout - DEADLINE_MARGIN if rpc))
     write(Whatsapp::Connector.key('control'), command)
     return command.id unless command.reply_to
 
@@ -147,14 +153,15 @@ class Whatsapp::Connector::Client
     Whatsapp::Connector.key('cmd', session_id)
   end
 
-  def build(payload, idempotency_key: nil, reply_to: false, timeout: RPC_TIMEOUT)
+  # `timeout` is the whole budget the command declares, already net of any margin its
+  # caller wanted: an RPC hands over less than it will wait, a published command hands
+  # over what the command is worth, and either can hand over nothing.
+  def build(payload, idempotency_key: nil, reply_to: false, timeout: nil)
     id = SecureRandom.uuid
     now = (Time.current.to_f * 1000).round
     attributes = { id: id, sid: session_id, ts: now, idempotency_key: idempotency_key }
-    if reply_to
-      attributes[:reply_to] = reply_key(id)
-      attributes[:deadline] = now + ((timeout - DEADLINE_MARGIN) * 1000)
-    end
+    attributes[:reply_to] = reply_key(id) if reply_to
+    attributes[:deadline] = now + (timeout * 1000).round if timeout
     model::Command.build(payload, **attributes)
   end
 

--- a/app/services/whatsapp/session/backends/connector/backend.rb
+++ b/app/services/whatsapp/session/backends/connector/backend.rb
@@ -22,6 +22,34 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
   # holding a worker indefinitely.
   MEDIA_SEND_MAX_TIMEOUT = ENV.fetch('WHATSAPP_MEDIA_SEND_MAX_TIMEOUT', 180).to_i
 
+  # --- the ceiling on a published command ------------------------------------------
+  #
+  # A published command carries no `reply_to`, so nobody here is waiting to give up on it,
+  # and the `deadline` on its frame is the only limit the connector has for it: it refuses
+  # a command whose deadline passed before it was reached, and it bounds the execution of
+  # one it does run. The session's executor takes one command at a time, so a published
+  # command with no ceiling, parked on a socket write, is every send behind it parked too.
+  #
+  # How much budget differs by what a late execution would mean, because the one field
+  # says "do not start after this" and "do not run longer than this" at the same time.
+
+  # A momentary state that lands late is not late, it is wrong: an `available` applied
+  # after the agent went offline flips the account back, and a `composing` applied minutes
+  # later is a typing bubble for something nobody is typing.
+  MOMENTARY_TIMEOUT = 30
+
+  # These are still right whenever they land, so the only reason to bound them is the
+  # executor, and the ceiling has to clear the longest command that can legitimately be
+  # ahead of them on the same queue: a send carrying a file. A queue holding several of
+  # those back to back can still expire one, and what that costs is a receipt the
+  # customer's phone never shows, repaired the next time the same chat is read.
+  DEFERRABLE_TIMEOUT = MEDIA_SEND_MAX_TIMEOUT + Whatsapp::Connector::Client::RPC_TIMEOUT
+
+  # A pairing code is worth as long as the attempt that asked for it, which is the ceiling
+  # the pairing screen already runs on: past it, the screen the operator would type the
+  # code into is gone.
+  PAIRING_TIMEOUT = Whatsapp::Session::PairingPollJob::DEADLINES.fetch('code').to_i
+
   class << self
     def provider_key
       'native'
@@ -65,6 +93,11 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
     model::ConnectionState.from_h(client.call(command))
   end
 
+  # The teardown carries no ceiling, and that is the one place where the two readings of
+  # `deadline` pull against each other hard enough to matter: a command dropped for
+  # arriving late is a device left listed on the customer's phone, while the executor a
+  # stuck teardown holds belongs to the session that is going away rather than to an
+  # account still in use.
   def disconnect
     client.publish(commands::SessionDisconnect.new)
   end
@@ -102,7 +135,7 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
   # The code itself arrives as a pairing.code event: WhatsApp takes its time issuing it,
   # and the inbox screen is already listening for connection updates.
   def request_pairing_code(command)
-    client.publish(command)
+    client.publish(command, timeout: PAIRING_TIMEOUT)
     nil
   end
 
@@ -147,11 +180,11 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
   end
 
   def mark_read(command)
-    client.publish(command)
+    client.publish(command, timeout: DEFERRABLE_TIMEOUT)
   end
 
   def mark_unread(command)
-    client.publish(command)
+    client.publish(command, timeout: DEFERRABLE_TIMEOUT)
   end
 
   # The connector keeps the bytes on its own disk and serves them over its internal HTTP
@@ -177,15 +210,15 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
   # --- presence and contacts -----------------------------------------------------
 
   def send_chat_presence(command)
-    client.publish(command)
+    client.publish(command, timeout: MOMENTARY_TIMEOUT)
   end
 
   def update_presence(command)
-    client.publish(command)
+    client.publish(command, timeout: MOMENTARY_TIMEOUT)
   end
 
   def subscribe_presence(command)
-    client.publish(command)
+    client.publish(command, timeout: DEFERRABLE_TIMEOUT)
   end
 
   def check_numbers(command)

--- a/spec/services/whatsapp/connector/client_spec.rb
+++ b/spec/services/whatsapp/connector/client_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe Whatsapp::Connector::Client, :redis_streams do
     # the frame and drops it, while the caller is told the command was queued. A logout
     # or a delete discarded that way leaves the session paired, and the conversion or the
     # destruction that asked for it reports success.
+    # The connector reads `deadline` whether or not a reply was asked for: it refuses a
+    # command whose deadline passed before it was reached, and it bounds the execution of
+    # one it does run. A published command has no caller waiting on it to give up, so the
+    # ceiling the frame declares is the only one it gets.
+    it 'bounds a published command by the ceiling its caller declared' do
+      client.publish(model::Commands::ChatPresence.new(chat: model::Address.phone('5541999990000'), state: 'composing'),
+                     timeout: 30)
+
+      frame = frame_of(redis.xrange("#{prefix}cmd:#{session_id}").first)
+      expect(frame['deadline'].to_i - frame['ts'].to_i).to eq(30_000)
+      # Still fire and forget: the ceiling is for the connector, not for a caller waiting.
+      expect(frame).not_to have_key('reply_to')
+    end
+
+    # The teardown is published exactly so it can sit pending while the session is between
+    # owners, and `deadline` means "do not start after this" as much as it means "do not
+    # run longer than this": a ceiling here would discard the logout that unlinks the
+    # device from the customer's phone.
+    it 'leaves a published command unbounded when its caller declared no ceiling' do
+      client.publish(model::Commands::SessionLogout.new)
+
+      expect(frame_of(redis.xrange("#{prefix}cmd:#{session_id}").first)).not_to have_key('deadline')
+    end
+
     it 'refuses to queue for a connector that speaks another protocol' do
       redis.hset("#{prefix}instance:one", 'protocol_min', '2', 'protocol_max', '3')
       redis.sadd("#{prefix}instances", 'one')
@@ -64,7 +88,10 @@ RSpec.describe Whatsapp::Connector::Client, :redis_streams do
 
       frame = frame_of(redis.xrange("#{prefix}cmd:#{session_id}").first)
       expect(frame['reply_to']).to eq("#{prefix}reply:cmd-0001")
-      expect(frame['deadline'].to_i).to be > frame['ts'].to_i
+      # Shorter than the caller's own wait by the margin, so the connector stops working
+      # on the command before the caller stops caring about the answer.
+      expect(frame['deadline'].to_i - frame['ts'].to_i)
+        .to eq((described_class::RPC_TIMEOUT - described_class::DEADLINE_MARGIN) * 1000)
     end
 
     it 'raises the error the connector reported, mapped to its class' do
@@ -91,6 +118,32 @@ RSpec.describe Whatsapp::Connector::Client, :redis_streams do
 
       expect { client.call(command) }.to raise_error(Whatsapp::Session::Errors::ProviderUnavailable, /speaks protocol 1/)
       expect(redis.exists?("#{prefix}cmd:#{session_id}")).to be(false)
+    end
+  end
+
+  # The control stream carries both kinds: a `session.wake` any instance may take and
+  # nobody waits on, and an `admin.ping` that answers. The margin belongs to the one that
+  # answers, and a wake that carried a deadline could be dropped for arriving late at the
+  # very moment there is no owner to take the session -- which is when it is sent.
+  describe '#control' do
+    it 'leaves a control command that answers nothing unbounded' do
+      client.control(model::Commands::SessionWake.new(desired: 'connected'))
+
+      frame = frame_of(redis.xrange("#{prefix}control").first)
+      expect(frame).not_to have_key('reply_to')
+      expect(frame).not_to have_key('deadline')
+    end
+
+    it 'bounds a control command that answers the way it bounds an RPC' do
+      allow(SecureRandom).to receive(:uuid).and_return('cmd-0003')
+      redis.lpush("#{prefix}reply:cmd-0003", { 'v' => 1, 'id' => 'cmd-0003', 'ok' => true, 'result' => {} }.to_json)
+
+      client.control(model::Commands::AdminPing.new)
+
+      frame = frame_of(redis.xrange("#{prefix}control").first)
+      expect(frame['reply_to']).to eq("#{prefix}reply:cmd-0003")
+      expect(frame['deadline'].to_i - frame['ts'].to_i)
+        .to eq((described_class::RPC_TIMEOUT - described_class::DEADLINE_MARGIN) * 1000)
     end
   end
 

--- a/spec/services/whatsapp/session/backends/connector/backend_publish_ceiling_spec.rb
+++ b/spec/services/whatsapp/session/backends/connector/backend_publish_ceiling_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+# The same question at every `client.publish` site, asked of the source rather than of a
+# checklist: how long may this command hold the session?
+#
+# A published command has no caller waiting on it, so the `deadline` on its frame is the
+# only ceiling the connector has for it, and the session's executor runs one command at a
+# time -- one parked on a socket write is every send behind it parked too. A tenth publish
+# site added without a ceiling would reintroduce that with nothing failing.
+#
+# The teardown is the deliberate exception, and it is named here rather than inferred:
+# `deadline` means "do not start after this" as much as "do not run longer than this", and
+# a `session.logout` dropped for arriving late leaves a device listed on the customer's
+# phone. It is published precisely so it can sit pending between owners.
+RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
+  describe 'the ceiling on every published command' do
+    let(:source) { Rails.root.join('app/services/whatsapp/session/backends/connector/backend.rb') }
+    let(:unbounded_on_purpose) { %w[disconnect logout delete_session] }
+
+    # [method name, source line] for every `client.publish` call in the backend.
+    let(:publish_sites) do
+      method = nil
+      source.readlines.each_with_object([]) do |line, sites|
+        method = Regexp.last_match(1) if line =~ /^\s*def ([a-z_0-9?!]+)/
+        sites << [method, line] if line.include?('client.publish(')
+      end
+    end
+
+    it 'finds every publish site the backend has' do
+      # Vacuity guard: a rename or a refactor that hides the calls would leave the sweep
+      # passing over nothing at all.
+      expect(publish_sites.size).to eq(10)
+      expect(publish_sites.map(&:first).uniq)
+        .to contain_exactly('disconnect', 'logout', 'delete_session', 'request_pairing_code', 'mark_read',
+                            'mark_unread', 'send_chat_presence', 'update_presence', 'subscribe_presence')
+    end
+
+    it 'declares a ceiling at every publish site that is not the teardown' do
+      missing = publish_sites.reject { |method, line| unbounded_on_purpose.include?(method) || line.include?('timeout:') }
+
+      expect(missing.map(&:first)).to be_empty,
+                                      "these publish a command with no ceiling: #{missing.map(&:first).uniq.join(', ')}. " \
+                                      'Nobody waits on a published command, so the deadline on the frame is the only ' \
+                                      'limit the connector has for it.'
+    end
+
+    it 'covers both sides of the exception' do
+      # The fence proves nothing if every site is on the exception list, and nothing if none
+      # is: it has to be reached by both kinds.
+      bounded, unbounded = publish_sites.partition { |_, line| line.include?('timeout:') }
+
+      expect(bounded.map(&:first).uniq).to contain_exactly('request_pairing_code', 'mark_read', 'mark_unread',
+                                                           'send_chat_presence', 'update_presence', 'subscribe_presence')
+      expect(unbounded.map(&:first).uniq).to match_array(unbounded_on_purpose)
+    end
+
+    it 'names methods that exist' do
+      expect(described_class.instance_methods(false).map(&:to_s)).to include(*unbounded_on_purpose)
+    end
+  end
+end

--- a/spec/services/whatsapp/session/backends/connector/backend_spec.rb
+++ b/spec/services/whatsapp/session/backends/connector/backend_spec.rb
@@ -287,4 +287,68 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
     backend.mark_read(model::Commands::MessageMarkRead.new(chat: model::Address.phone('5541999990000'), message_ids: ['3EB0AAAA']))
     backend.disconnect
   end
+
+  # --- the ceiling on a published command ------------------------------------------
+  #
+  # Nobody is waiting on a published command, so the deadline the frame carries is the
+  # only limit the connector has for it, and the session's executor is serial: one parked
+  # on a socket write is every send behind it parked too.
+
+  # A momentary state that lands late is not late, it is wrong: an `available` applied
+  # after the agent went offline flips the account back, and a `composing` applied minutes
+  # later is a typing bubble for something nobody is typing.
+  it 'bounds the momentary states by how long they are still true' do
+    backend.send_chat_presence(model::Commands::ChatPresence.new(chat: model::Address.phone('5541999990000'), state: 'composing'))
+    backend.update_presence(model::Commands::PresenceSet.new(state: 'available'))
+
+    expect(client).to have_received(:publish)
+      .with(an_instance_of(model::Commands::ChatPresence), timeout: described_class::MOMENTARY_TIMEOUT)
+    expect(client).to have_received(:publish)
+      .with(an_instance_of(model::Commands::PresenceSet), timeout: described_class::MOMENTARY_TIMEOUT)
+  end
+
+  # These three are still right whenever they land, so the only reason to bound them is
+  # the executor, and the ceiling has to clear the longest command that can legitimately
+  # be ahead of them on the same queue, which is a send carrying a file.
+  it 'bounds the deferrable commands by what clears a send carrying a file' do
+    backend.mark_read(model::Commands::MessageMarkRead.new(chat: model::Address.phone('5541999990000'), message_ids: ['3EB0AAAA']))
+    backend.mark_unread(model::Commands::MessageMarkUnread.new(chat: model::Address.phone('5541999990000'),
+                                                               last_message_id: '3EB0AAAA', from_me: false))
+    backend.subscribe_presence(model::Commands::PresenceSubscribe.new(party: model::Address.phone('5541999990000')))
+
+    expect(client).to have_received(:publish)
+      .with(an_instance_of(model::Commands::MessageMarkRead), timeout: described_class::DEFERRABLE_TIMEOUT)
+    expect(client).to have_received(:publish)
+      .with(an_instance_of(model::Commands::MessageMarkUnread), timeout: described_class::DEFERRABLE_TIMEOUT)
+    expect(client).to have_received(:publish)
+      .with(an_instance_of(model::Commands::PresenceSubscribe), timeout: described_class::DEFERRABLE_TIMEOUT)
+    expect(described_class::DEFERRABLE_TIMEOUT).to be > described_class::MEDIA_SEND_MAX_TIMEOUT
+    # And the two budgets have to stay on the right sides of each other: the whole point of
+    # splitting them is that a momentary state expires while a deferrable one is still
+    # waiting its turn behind a send.
+    expect(described_class::MOMENTARY_TIMEOUT).to be < described_class::DEFERRABLE_TIMEOUT
+  end
+
+  # The pairing screen runs on a ceiling of its own, and a code produced after it is a code
+  # for a screen the operator is no longer looking at.
+  it 'bounds the pairing code request by the attempt that asked for it' do
+    backend.request_pairing_code(model::Commands::PairingRequestCode.new(phone: '5541999990000'))
+
+    expect(client).to have_received(:publish)
+      .with(an_instance_of(model::Commands::PairingRequestCode), timeout: described_class::PAIRING_TIMEOUT)
+  end
+
+  # `deadline` says "do not start after this" as much as it says "do not run longer than
+  # this", and for the teardown the first costs more than the second buys: a `session.logout`
+  # dropped for arriving late leaves a device listed on the customer's phone forever. It is
+  # published precisely so it can sit pending while the session is between owners.
+  it 'leaves the teardown unbounded' do
+    backend.disconnect
+    backend.logout
+    backend.delete_session
+
+    expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionDisconnect))
+    expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionLogout)).twice
+    expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionDelete))
+  end
 end


### PR DESCRIPTION
A WhatsApp inbox on the native provider could stop sending, with nothing in the dashboard saying why. A typing indicator, a read receipt or a presence subscription is dispatched without waiting for an answer, and until now those left this app carrying no time limit at all. The connector runs one command at a time per account, so any one of them stuck on a dead socket held every message queued behind it, for as long as the session lived. Now each of those commands declares how long it is worth, and one that overruns is dropped instead of holding the account.

## Closes

- Fixes #569

## How to reproduce

`Whatsapp::Connector::Client#build` wrote `deadline` only inside the `if reply_to` branch, so the field existed on `client.call` (RPC) and never on `client.publish`. That is ten command sites in `Backends::Connector::Backend`: `session.disconnect`, `session.logout` (twice), `session.delete`, `pairing.request_code`, `message.mark_read`, `message.mark_unread`, `chat.presence`, `presence.set`, `presence.subscribe`.

The connector reads that field whether or not a reply was asked for. In `internal/session/session.go` it refuses a command whose deadline passed before it was reached (`expired`, line 1008) and it builds the execution context with `context.WithDeadline` when the frame carries one (line 778); only `stillHeard` (`internal/session/manager.go:923`), which decides whether a refusal would reach anybody, looks at `reply_to`. Without a deadline the execution context is the session's own, so the command runs until it finishes or the session dies.

That this is the expected failure is written in the connector's own test, `TestAPresenceCommandDoesNotWaitPastItsDeadlineOnAWriteThatIsStuck`: *"`presence.set` runs on the session's executor, one command at a time, so a command parked on the presence write is every command behind it parked too. It has its own deadline and has to keep it."* The deadline it describes is the one this client never sent.

The RPC path is bounded from the other end: the caller gives up at `RPC_TIMEOUT` and the frame's deadline is two seconds shorter, so the connector stops first. On the published path nobody gives up, which makes the account going quiet both the most expensive symptom and the least diagnosable.

## What changed

`Client#publish` takes a `timeout:` and `build` writes a deadline whenever one is given, independently of `reply_to`. `call` and `control` now hand `build` a budget already net of `DEADLINE_MARGIN`, so the margin lives with the caller that waits rather than inside the frame builder; the frames those two write are byte-identical to before.

Six sites declare a budget, and they split because the one `deadline` field says *do not start after this* and *do not run longer than this* at the same time:

| budget | commands | why |
| --- | --- | --- |
| `MOMENTARY_TIMEOUT` (30s) | `chat.presence`, `presence.set` | a state that lands late is wrong, not late: an `available` applied after the agent went offline flips the account back |
| `DEFERRABLE_TIMEOUT` (`MEDIA_SEND_MAX_TIMEOUT + RPC_TIMEOUT`, 200s by default) | `message.mark_read`, `message.mark_unread`, `presence.subscribe` | still right whenever they land, so only the executor needs protecting, and the ceiling has to clear the longest command that can legitimately be ahead of them: a send carrying a file |
| `PAIRING_TIMEOUT` (`PairingPollJob::DEADLINES['code']`, 5min) | `pairing.request_code` | a code produced after the pairing attempt ended is a code for a screen the operator has left |

The four teardown sites keep no ceiling on purpose, and what that leaves uncovered is #570. There the expiry reading costs more than the execution reading buys: `delete_session` publishes rather than calls precisely so the pair can sit pending while the session is between owners, and a `session.logout` dropped for arriving late leaves a device listed on the customer's phone with nothing in Chatwoot corresponding to it. The executor a stuck teardown holds belongs to the session that is going away, not to an account still in use.

A source sweep (`backend_publish_ceiling_spec.rb`) asks the same question of every `client.publish` in the backend and names the teardown as the explicit exception. It is what found the tenth site: the hand count in the issue said nine and missed `request_pairing_code`.

## Validation scope

Proven by test: the frame that reaches Redis carries the deadline the caller declared and none when it declared none, for both the session stream and the control stream; each of the six sites passes its own budget; the teardown passes none; the RPC margin is unchanged. Ten mutations of the change were run and all ten failed a spec, including moving a budget between two sites, collapsing the two budgets into one, and adding an eleventh publish site with no ceiling.

Not proven here: that a connector under a dead socket actually gives up at the deadline on a published command. That measurement needs a connector instance and a paired session, and the one running on this machine belongs to another workstream; the connector side of the same question is being measured in fazer-ai/whatsapp-connector#168, whose two existing measurements (22.95s and 50.33s) were taken with a hand-built frame that carried no deadline, which this PR is the reason for.

Also not covered: the teardown's own execution ceiling, which needs the contract to separate *do not start after this* from *do not run longer than this* (#570).

`session.wake`, the one non-RPC command on the control stream, is deliberately left without a ceiling and needs none. The connector hands it to a goroutine of its own rather than running it on the stream reader, and the adoption behind it is bounded by the connector's own `AdoptTimeout` (5s, `internal/session/manager.go:195`), so its work is bounded by construction rather than by the frame. The asymmetry is the design: the manager gives each piece of work its own ceiling, the session executor does not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/571)
<!-- Reviewable:end -->
