### PR TITLE
fix(docker): fazer o portão de schema viajar na imagem, não no compose

### DIFF
--- a/.github/workflows/run_foss_spec.yml
+++ b/.github/workflows/run_foss_spec.yml
@@ -107,6 +107,13 @@ jobs:
                 spec/enterprise/*|enterprise/*) continue ;;   # stripped before the suite runs
                 spec/*_spec.rb) [ -f "$f" ] && specs+="$f"$'\n' ;;
                 app/javascript/*) continue ;;
+                docker/entrypoints/*|docker/Dockerfile)
+                  # A shell script has no `_spec.rb` twin, so the filename map below cannot
+                  # reach spec/docker and the entrypoint's own guard would change with
+                  # nothing running against it.
+                  found=$(find spec/docker -name '*_spec.rb' 2>/dev/null || true)
+                  [ -n "$found" ] && specs+="$found"$'\n'
+                  ;;
                 app/*.rb|lib/*.rb)
                   # Every spec named after the file, wherever it sits (spec/models, spec/requests...).
                   base=$(basename "$f" .rb)

--- a/docker-compose.coolify.yaml
+++ b/docker-compose.coolify.yaml
@@ -88,6 +88,10 @@ services:
       - BAILEYS_PROVIDER_USE_INTERNAL_HOST_URL=true
       - MAILER_SENDER_EMAIL=${MAILER_SENDER_EMAIL}
       - RESEND_API_KEY=${RESEND_API_KEY}
+    # The image's own ENTRYPOINT already routes a sidekiq command through this same
+    # script, so this line is redundant on a current image and kept for the one case it
+    # still covers: a new compose rolled out against an older image that predates the
+    # ENTRYPOINT. The gate lives in the image; this is the belt.
     entrypoint: docker/entrypoints/sidekiq.sh
     command:
       - bundle

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -154,3 +154,9 @@ COPY --from=pre-builder /app/.git_sha /app/.git_sha
 WORKDIR /app
 
 EXPOSE 3000
+
+# The worker's schema gate rides in the image instead of in a compose, because a gate that
+# has to be remembered in every deployment's compose is one that goes missing. It dispatches
+# by argv: a sidekiq command waits for the schema, everything else execs straight through.
+# A compose that sets its own `entrypoint:` still replaces this.
+ENTRYPOINT ["docker/entrypoints/docker-entrypoint.sh"]

--- a/docker/entrypoints/docker-entrypoint.sh
+++ b/docker/entrypoints/docker-entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# The image's own entrypoint, so the schema gate cannot be left out of a deployment.
+#
+# The gate itself lives in sidekiq.sh, and until now it was wired from exactly one file:
+# docker-compose.coolify.yaml. Every other compose in this repository starts the worker
+# with a bare `command:`, and so does every compose an operator writes by hand or a panel
+# generates, which means the protection was present precisely where somebody had
+# remembered it. It went missing twice, and both times the loss was silent: ActiveRecord
+# reads a model's columns once per process, a worker that boots one migration behind keeps
+# that schema until it is restarted, and only the paths that CREATE a record raise.
+# Containers stay healthy, queues stay empty, and messages disappear.
+#
+# Deciding here, by argv, instead of in a compose, is what makes the gate travel with the
+# image. A compose is still free to set its own `entrypoint:` and replace this, which is
+# what docker-compose.coolify.yaml does for the web container: that one has to RUN the
+# migrations rather than wait for them.
+#
+# Everything that is not a worker execs straight through. `rails console`, `rake`, a
+# shell and the web server must not wait on migrations: the web container is usually the
+# one running them, and a console that blocks is a console nobody can use to fix the thing
+# that is blocking it.
+
+set -e
+
+if [ "$#" -eq 0 ]; then
+  echo "docker-entrypoint: no command given" >&2
+  exit 1
+fi
+
+# Two arms because the worker arrives in two shapes. `bundle exec sidekiq -C ...` carries
+# `sidekiq` as its own argument, so a standalone word match finds it and a quoted
+# `rails runner 'Sidekiq::Queue.new.size'` -- one argument, contents invisible to a word
+# match -- correctly does not count as a worker. The substring arm covers
+# `sh -c 'bundle exec sidekiq ...'`, where the whole command is a single argument.
+for arg in "$@"; do
+  case "$arg" in
+    sidekiq | *'exec sidekiq'*)
+      exec docker/entrypoints/sidekiq.sh "$@"
+      ;;
+  esac
+done
+
+exec "$@"

--- a/docker/entrypoints/sidekiq.sh
+++ b/docker/entrypoints/sidekiq.sh
@@ -18,10 +18,16 @@ set -x
 # the ordering when a single container is restarted later. The gate has to live somewhere
 # it cannot be dropped, which is here.
 #
-# Wired into docker-compose.coolify.yaml and nowhere else. docker-compose.production.yaml
-# is upstream's file and names upstream's image, which has no such script: pointing its
-# worker here would break every deployment that runs it as checked in, to install a gate
-# for a container that is not this fork's.
+# Reached from the image's ENTRYPOINT (docker/entrypoints/docker-entrypoint.sh), which
+# dispatches by argv, so every deployment of this image gets the gate whether or not its
+# compose knows this file exists. That indirection is the point: while this was wired from
+# docker-compose.coolify.yaml and nowhere else, the protection was present exactly where
+# somebody had remembered it, and it went missing twice.
+#
+# docker-compose.production.yaml stays untouched on purpose. It is upstream's file and
+# names upstream's image, which has no such script; pointing its worker here by name would
+# break every deployment that runs it as checked in. Running that same file against this
+# fork's image does get the gate, because the gate travels in the image.
 #
 # The Rails container owns the migrations; this one only waits for them. A worker that
 # comes up alone against a database nobody is migrating waits forever, on purpose: the

--- a/spec/docker/docker_entrypoint_spec.rb
+++ b/spec/docker/docker_entrypoint_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
+
+# The entrypoint decides, from argv alone, whether a container is a worker that has to wait
+# for the schema. Getting that wrong in either direction is expensive and silent: a worker
+# that is not recognised boots against a stale schema and drops records, and a console or a
+# web server that IS recognised blocks on migrations that the web container is the one
+# supposed to run.
+#
+# Run against a stub gate rather than the real one, in a temporary directory shaped like the
+# app: the real sidekiq.sh waits on postgres, and what is under test here is the dispatch,
+# not the wait.
+# rubocop:disable RSpec/DescribeClass -- the subject is a shell script, not a constant
+RSpec.describe 'docker/entrypoints/docker-entrypoint.sh', type: :script do
+  let(:app_dir) { Dir.mktmpdir }
+
+  before do
+    FileUtils.mkdir_p(File.join(app_dir, 'docker/entrypoints'))
+
+    entrypoint = File.join(app_dir, 'docker/entrypoints/docker-entrypoint.sh')
+    FileUtils.cp(File.expand_path('../../docker/entrypoints/docker-entrypoint.sh', __dir__), entrypoint)
+    FileUtils.chmod(0o755, entrypoint)
+
+    gate = File.join(app_dir, 'docker/entrypoints/sidekiq.sh')
+    File.write(gate, %(#!/bin/sh\necho "GATED: $*"\n))
+    FileUtils.chmod(0o755, gate)
+  end
+
+  after { FileUtils.remove_entry(app_dir) }
+
+  def run(*argv)
+    Open3.capture3('docker/entrypoints/docker-entrypoint.sh', *argv, chdir: app_dir)
+  end
+
+  describe 'a worker' do
+    it 'sends the ordinary sidekiq command through the gate' do
+      out, _err, status = run('bundle', 'exec', 'sidekiq', '-C', 'config/sidekiq.yml')
+
+      expect(status).to be_success
+      expect(out).to eq("GATED: bundle exec sidekiq -C config/sidekiq.yml\n")
+    end
+
+    it 'sends a sidekiq command wrapped in sh -c through the gate' do
+      out, _err, status = run('sh', '-c', 'bundle exec sidekiq -C config/sidekiq.yml')
+
+      expect(status).to be_success
+      expect(out).to eq("GATED: sh -c bundle exec sidekiq -C config/sidekiq.yml\n")
+    end
+
+    it 'passes the command on unchanged, so the gate can exec what was asked for' do
+      out, _err, _status = run('bundle', 'exec', 'sidekiq')
+
+      expect(out).to eq("GATED: bundle exec sidekiq\n")
+    end
+  end
+
+  describe 'everything else' do
+    it 'execs the web server without waiting' do
+      out, _err, status = run('echo', 'rails', 's')
+
+      expect(status).to be_success
+      expect(out).to eq("rails s\n")
+    end
+
+    it 'does not mistake a runner script that merely mentions Sidekiq for a worker' do
+      out, _err, status = run('echo', 'rails', 'runner', 'Sidekiq::Queue.new.size')
+
+      expect(status).to be_success
+      expect(out).to eq("rails runner Sidekiq::Queue.new.size\n")
+    end
+
+    # The discriminating case for how narrow the match has to be: a broad `*sidekiq*` glob
+    # would gate this, and gating a one-shot command that is not a worker hangs it against a
+    # database nobody is migrating.
+    it 'does not mistake a path that merely contains sidekiq for a worker' do
+      out, _err, status = run('echo', 'bundle', 'exec', 'rails', 'runner', 'config/initializers/sidekiq.rb')
+
+      expect(status).to be_success
+      expect(out).to eq("bundle exec rails runner config/initializers/sidekiq.rb\n")
+    end
+
+    it 'does not gate a non-worker command wrapped in sh -c' do
+      out, _err, status = run('sh', '-c', 'echo rails s')
+
+      expect(status).to be_success
+      expect(out).to eq("rails s\n")
+    end
+
+    it 'refuses an empty command instead of exiting quietly as a container that did nothing' do
+      _out, err, status = run
+
+      expect(status).not_to be_success
+      expect(err).to include('no command given')
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
Fecha #573.

## O problema

O portão que segura o worker até o schema estar corrente (`docker/entrypoints/sidekiq.sh`) existia, mas estava ligado a partir de **um arquivo só**, o `docker-compose.coolify.yaml`. Os outros três composes deste repositório sobem o worker com `command:` pelado, e todo compose escrito à mão ou gerado por painel também. A proteção existia exatamente onde alguém tinha lembrado dela.

Sumiu duas vezes. A segunda foi em 10/09/2026, num deploy do Pro:

```
sidekiq iniciou                                    21:11:25Z
migração AddStatusChangedAtToConversations rodou   21:13:56Z
NoMethodError: undefined method 'status_changed_at=' for an instance of Conversation
shard 4 dropped 1789075798015-0
shard 4 dropped 1789075798367-0
```

O ActiveRecord lê as colunas uma vez por processo. Só quebra quem **cria** registro, então a perda é silenciosa: containers saudáveis, filas vazias, mensagem sumindo.

## O que muda

O `ENTRYPOINT` da imagem passa a decidir pelo argv. Comando de sidekiq vai pelo portão; qualquer outro executa direto, porque `rails console`, `rake` e o servidor web não podem esperar por migração (o container web costuma ser quem a roda, e um console que trava é um console que ninguém usa para destravar o que travou).

O casamento é por palavra isolada, com um braço a mais para a forma `sh -c '...'` onde o comando inteiro é um argumento só. Essa estreiteza é o ponto: um glob largo tipo `*sidekiq*` prenderia `rails runner config/initializers/sidekiq.rb` contra um banco que ninguém está migrando.

A linha do `docker-compose.coolify.yaml` fica, comentada como cinto para compose novo contra imagem antiga.

## Verificação

**Numa imagem de verdade**, não só no spec, porque o risco real era o `ENTRYPOINT` em forma exec com caminho relativo:

```
worker                          -> GATED: bundle exec sidekiq -C config/sidekiq.yml
worker via sh -c                -> GATED: sh -c bundle exec sidekiq -C config/sidekiq.yml
nao worker                      -> rails s
caminho com sidekiq no nome     -> bundle exec rails runner config/initializers/sidekiq.rb
sem comando                     -> "no command given", exit 1
```

**Mutação**, para provar que os 8 exemplos prendem o comportamento e não a implementação:

| mutação | falhas |
| --- | --- |
| tira o braço exato de `sidekiq` | 2 |
| tira o braço do `sh -c` | 1 |
| alarga para `*sidekiq*` | 1 |
| remove a guarda de argv vazio | 1 |
| baseline | 0 |

## Um buraco que esta mudança cairia dentro

O mapa de specs afetados da CI é por nome de arquivo: um `.sh` não tem gêmeo `_spec.rb`, então mudar o entrypoint rodaria **zero** specs. Adicionei o braço que mapeia `docker/entrypoints/*` e `docker/Dockerfile` para `spec/docker/`, simulado contra o `case` real do workflow.

Esta PR mexe no `run_foss_spec.yml`, que está na lista de arquivos compartilhados, então a CI dela roda a suíte inteira de qualquer forma.

## O que não está aqui

O lado Pro (o `docker-compose.coolify.yaml` do repositório do Pro descreve o CE, e a topologia de rede do conector) está em fazer-ai/chatwoot-pro#83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/574)
<!-- Reviewable:end -->
