### PR TITLE
fix(whatsapp): stop an optional Meta call from taking the whole channel down

### DIFF
--- a/app/services/whatsapp/facebook_api_client.rb
+++ b/app/services/whatsapp/facebook_api_client.rb
@@ -73,13 +73,23 @@ class Whatsapp::FacebookApiClient
     data['code_verification_status'] == 'VERIFIED'
   end
 
+  # Two calls, and only the first decides whether anything arrives at all.
+  #
+  # Subscribe app to WABA first — Meta requires it before any callback override (issue #13097).
+  # subscribed_fields (incl. `calls` when voice is enabled) is declared here; the phone-level POST has no such field.
+  #
+  # The phone-level override takes precedence over WABA-level, so numbers on one WABA can route to different URLs.
+  # It is also the half Meta refuses for a whole class of accounts that receive perfectly well without it: a
+  # coexistence number whose WABA sits in the customer's own Business Manager answers `(#200) Permissions error`,
+  # because the integrator's system user cannot manage a WABA in another portfolio. Under one rescue that refusal
+  # reached `Channel::Whatsapp#setup_webhooks` as a setup failure, marked the channel for reauthorization, and
+  # `Webhooks::WhatsappEventsJob` then discarded every inbound webhook for it: a number was dead for hours while
+  # Meta kept delivering, nine webhooks in and no conversations out. So it is best effort here, the same way the
+  # phone registration already is, and refused by the same accounts for the same reason.
   def subscribe_phone_number_webhook(waba_id, phone_number_id, callback_url, verify_token, subscribed_fields: nil)
-    # Subscribe app to WABA first — Meta requires it before any callback override (issue #13097).
-    # subscribed_fields (incl. `calls` when voice is enabled) is declared here; the phone-level POST has no such field.
-    subscribe_app_to_waba(waba_id, subscribed_fields: subscribed_fields || WEBHOOK_DEFAULT_FIELDS)
+    subscription = subscribe_app_to_waba(waba_id, subscribed_fields: subscribed_fields || WEBHOOK_DEFAULT_FIELDS)
 
-    # Phone-level override takes precedence over WABA-level, so numbers on one WABA can route to different URLs.
-    override_phone_number_callback(phone_number_id, callback_url, verify_token)
+    optional_callback_override(phone_number_id, callback_url, verify_token) || subscription
   end
 
   def subscribe_app_to_waba(waba_id, subscribed_fields: WEBHOOK_DEFAULT_FIELDS)
@@ -132,6 +142,21 @@ class Whatsapp::FacebookApiClient
   end
 
   private
+
+  # Any failure at all, and deliberately not a status or a message: the same refusal arrives as a
+  # 403 carrying Meta's code 200, as a plain 500, and as a connection that closes with nothing to
+  # read. A guard that recognizes one shape leaves the other two killing the channel.
+  #
+  # It is the only record that the routing was not applied, so it names the call and the number:
+  # on an installation whose app-level callback points elsewhere, this line is the difference
+  # between a quiet inbox and a diagnosis.
+  def optional_callback_override(phone_number_id, callback_url, verify_token)
+    override_phone_number_callback(phone_number_id, callback_url, verify_token)
+  rescue StandardError => e
+    Rails.logger.warn('[WHATSAPP] Phone number webhook callback override failed but continuing ' \
+                      "(phone_number_id #{phone_number_id}, #{callback_url}): #{e.message}")
+    nil
+  end
 
   def request_headers
     {

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -63,6 +63,82 @@ RSpec.describe Channel::Whatsapp do
     end
   end
 
+  # The incident behind these: a coexistence number whose WABA sits in the customer's own
+  # Business Manager answers the phone-level override with `(#200) Permissions error`, because
+  # the integrator's system user cannot manage a WABA in another portfolio. Under a shared
+  # rescue that refusal marked the channel for reauthorization, and `Webhooks::WhatsappEventsJob`
+  # then discarded every inbound webhook for it: the number was dead for hours while Meta kept
+  # delivering, nine webhooks in and no conversations out.
+  describe '#setup_webhooks' do
+    let(:waba_id) { 'waba_568' }
+    let(:phone_number_id) { 'phone_568' }
+    # Written after create, not through the factory: its `whatsapp_cloud` branch merges its own
+    # ids over whatever the caller passed, so a phone number id given here would be silently
+    # replaced by the WABA's and the two calls would be indistinguishable in the stubs.
+    let(:channel) do
+      create(:channel_whatsapp, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false).tap do |created|
+        created.provider_config = { 'api_key' => 'test_key', 'phone_number_id' => phone_number_id,
+                                    'business_account_id' => waba_id, 'source' => 'embedded_signup',
+                                    'webhook_verify_token' => 'verify_token' }
+        created.save!(validate: false)
+      end
+    end
+
+    before do
+      stub_request(:get, %r{graph\.facebook\.com/.*/#{phone_number_id}})
+        .to_return(status: 200, body: { code_verification_status: 'VERIFIED', platform_type: 'CLOUD_API' }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+      stub_request(:post, %r{graph\.facebook\.com/.*/#{waba_id}/subscribed_apps})
+        .to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
+      # Read while the reauthorization notice is built, so only the failing branch reaches it.
+      stub_request(:get, %r{graph\.facebook\.com/.*/#{waba_id}\?})
+        .to_return(status: 200, body: { id: waba_id, name: 'WABA' }.to_json, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    context 'when only the phone-level callback override fails' do
+      before do
+        stub_request(:post, %r{graph\.facebook\.com/.*/#{phone_number_id}\z})
+          .to_return(status: 403, body: { error: { message: '(#200) Permissions error', code: 200 } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'keeps the channel authorized, because the WABA subscription is what makes Meta deliver' do
+        channel.setup_webhooks
+
+        expect(channel.reauthorization_required?).to be(false)
+      end
+    end
+
+    # The same refusal reaches this code as a 403 carrying Meta's code 200, as a plain 500, and
+    # as a connection that closes with nothing to read. A fix that keys on the status or on the
+    # message covers the first and leaves the other two marking the channel.
+    context 'when the override fails with no response at all' do
+      before do
+        stub_request(:post, %r{graph\.facebook\.com/.*/#{phone_number_id}\z}).to_raise(Errno::ECONNRESET)
+      end
+
+      it 'keeps the channel authorized' do
+        channel.setup_webhooks
+
+        expect(channel.reauthorization_required?).to be(false)
+      end
+    end
+
+    context 'when the WABA subscription itself fails' do
+      before do
+        stub_request(:post, %r{graph\.facebook\.com/.*/#{waba_id}/subscribed_apps})
+          .to_return(status: 400, body: { error: { message: 'App subscription to WABA failed' } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'marks the channel for reauthorization' do
+        channel.setup_webhooks
+
+        expect(channel.reauthorization_required?).to be(true)
+      end
+    end
+  end
+
   describe 'concerns' do
     let(:channel) { create(:channel_whatsapp) }
 

--- a/spec/services/whatsapp/facebook_api_client_spec.rb
+++ b/spec/services/whatsapp/facebook_api_client_spec.rb
@@ -238,32 +238,60 @@ describe Whatsapp::FacebookApiClient do
       end
     end
 
+    # The override is the half a channel can live without: the WABA subscription is what makes
+    # Meta deliver at all, and the override only re-routes one number of a shared WABA. Meta
+    # refuses it for a whole class of accounts that receive perfectly well without it, and under
+    # a shared rescue that refusal marked the channel for reauthorization and cost it every
+    # inbound webhook.
     context 'when phone number callback override fails' do
       before do
-        # Step 1 succeeds
         stub_request(:post, "https://graph.facebook.com/#{api_version}/#{waba_id}/subscribed_apps")
-          .with(
-            headers: { 'Authorization' => "Bearer #{access_token}", 'Content-Type' => 'application/json' }
-          )
-          .to_return(
-            status: 200,
-            body: { success: true }.to_json,
-            headers: { 'Content-Type' => 'application/json' }
-          )
-
-        # Step 2 fails
-        stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")
-          .with(
-            headers: { 'Authorization' => "Bearer #{access_token}", 'Content-Type' => 'application/json' },
-            body: { webhook_configuration: { override_callback_uri: callback_url, verify_token: verify_token } }.to_json
-          )
-          .to_return(status: 400, body: { error: 'Phone number webhook callback override failed' }.to_json)
+          .with(headers: { 'Authorization' => "Bearer #{access_token}", 'Content-Type' => 'application/json' })
+          .to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
+        allow(Rails.logger).to receive(:warn)
       end
 
-      it 'raises an error' do
-        expect do
-          api_client.subscribe_phone_number_webhook(waba_id, phone_number_id, callback_url, verify_token)
-        end.to raise_error(/Phone number webhook callback override failed/)
+      # Three shapes of the same refusal, because a fix that reads the status or the message
+      # covers one of them and leaves the other two killing the channel.
+      [
+        ['a permissions error',
+         ->(stub) { stub.to_return(status: 403, body: { error: { message: '(#200) Permissions error', code: 200 } }.to_json) }],
+        ['a plain server error',
+         ->(stub) { stub.to_return(status: 500, body: { error: { message: 'Internal server error' } }.to_json) }],
+        ['a connection that answers nothing', ->(stub) { stub.to_raise(Errno::ECONNRESET) }]
+      ].each do |shape, refuse|
+        context "when Meta answers with #{shape}" do
+          before { refuse.call(stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")) }
+
+          it 'does not raise, and answers with the subscription that did land' do
+            result = api_client.subscribe_phone_number_webhook(waba_id, phone_number_id, callback_url, verify_token)
+
+            expect(result['success']).to be(true)
+          end
+
+          it 'says in the log which call was refused and for which number' do
+            api_client.subscribe_phone_number_webhook(waba_id, phone_number_id, callback_url, verify_token)
+
+            expect(Rails.logger).to have_received(:warn).with(/override failed but continuing.*#{phone_number_id}/)
+          end
+        end
+      end
+    end
+
+    # Still attempted whenever it can work: dropping the call altogether would take the routing
+    # away from every installation that shares a WABA between numbers.
+    context 'when both calls succeed' do
+      it 'sends the override with the callback url and the verify token' do
+        subscription = stub_request(:post, "https://graph.facebook.com/#{api_version}/#{waba_id}/subscribed_apps")
+                       .to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
+        override = stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")
+                   .with(body: { webhook_configuration: { override_callback_uri: callback_url, verify_token: verify_token } }.to_json)
+                   .to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+        api_client.subscribe_phone_number_webhook(waba_id, phone_number_id, callback_url, verify_token)
+
+        expect(subscription).to have_been_requested
+        expect(override).to have_been_requested
       end
     end
   end


### PR DESCRIPTION
A WhatsApp Cloud inbox could go completely deaf right after being connected: messages kept arriving at Meta's side, the webhooks kept being delivered, and nothing appeared in Chatwoot. The number that reported this was unusable for hours, with nine webhooks delivered and no conversation, message or contact created. It happened whenever Meta refused one optional call during setup, which it does for a whole class of accounts that work perfectly well without it. That call is now allowed to fail without taking the inbox with it.

## Closes

- Fixes #568

## How to reproduce

Connect a **coexistence** number (`is_on_biz_app: true`) through embedded signup, where the WABA belongs to the customer's own Business Manager rather than the integrator's.

Setup makes two calls. `POST /{waba_id}/subscribed_apps` is what makes Meta deliver webhooks to this app at all, and it succeeds. `POST /{phone_number_id}` with `webhook_configuration.override_callback_uri` only re-routes one number of a shared WABA to this installation's URL, and it answers `(#200) Permissions error` (HTTP 403), because the integrator's system user cannot manage a WABA in another portfolio.

Both were inside one `rescue StandardError` in `Channel::Whatsapp#setup_webhooks`, so the refusal of the optional one marked the channel with `prompt_reauthorization!`. From then on `Webhooks::WhatsappEventsJob#channel_is_inactive?` returned true for every inbound webhook of that channel, and the job returned before doing anything. The delivery was never the problem: it was working the whole time.

The same account class already refuses the phone registration in the same setup, and that one has been handled as best effort since long before this (`[WHATSAPP] Phone registration failed but continuing`). The override was the one that still killed the channel.

## What changed

`FacebookApiClient#subscribe_phone_number_webhook` keeps making both calls, in the same order and with the same bodies. The WABA subscription still raises on failure. The phone-level override is now best effort: it is attempted whenever it can work, and its refusal is logged with the call and the number instead of propagating.

Any failure is tolerated, deliberately not a status or a message. The same refusal reaches this code in three shapes — a 403 carrying Meta's code 200, a plain 500, and a connection that closes with nothing to read — and a guard that recognizes one of them would leave the other two killing the channel. All three are pinned.

What does not change, and is pinned by tests that were already green before this and stay green:

- a failure of the WABA subscription still marks the channel for reauthorization;
- it still reaches the operator who pressed "register webhook" as a 422 naming it;
- it still stops `enable_voice_calling!` from persisting `calling_enabled`, since `calls` is a field of that subscription and not of the override;
- a manual (non embedded signup) channel still receives webhooks even when marked, and an embedded-signup channel that is genuinely marked still has its webhooks discarded.

One premise of the issue no longer held and was not acted on: the discard is not silent any more. `Webhooks::WhatsappEventsJob` already logs `Inactive WhatsApp channel: <phone>` before returning, so suggestion 2 of the report is already in the tree.

## Validation scope

Proven by test: the three refusal shapes each leave the channel authorized and leave a warning naming the override and the phone number id; both calls are still made when both can succeed; the WABA failure still marks the channel. Red before the change: 8 examples failing at `c57f5611e9`. Ten mutations of the change were run; nine failed a spec, including narrowing the rescue to the raise from `handle_response`, keying the tolerance on the error message, dropping the optional call instead of tolerating it, tolerating the WABA failure too, and removing or downgrading the log line. The tenth survivor is the method's return value on the tolerated path, which no caller reads; pinning it would only mirror the implementation.

Proven against the running app, both halves on the same harness (Puma, a real Sidekiq, Meta's Graph pointed at a local fake that logs every request, inbound webhooks posted over HTTP and signed with `X-Hub-Signature-256`). With the client file at `c57f5611e9` and only the override refused, the channel came out of setup marked for reauthorization, the next signed webhook was accepted with HTTP 200 and produced no conversation, no message and no contact, and the log carried `Inactive WhatsApp channel`. With the same refusal at this commit, the channel stays authorized and the same webhook produces one conversation and one message. The other side was measured in the same run and is unchanged: a failing `subscribed_apps` still marks the channel, still discards the next webhook, still answers `register_webhook` with 422, and still stops `enable_voice_calling!` from persisting `calling_enabled`.

One caveat found while measuring, worth knowing for whoever touches these logs later: the word "override" in the log line discriminates nothing, because the fatal message before this change already contained it. What separates the two is the severity, the identifier, and saying that it continued — `WARN ... but continuing (phone_number_id ..., <url>)` against `ERROR [WHATSAPP] Webhook setup failed: ...` with no channel or number in it.

Not proven here: the behaviour against Meta itself. The three shapes are reproduced from the refusal quoted in the report rather than from a live call to a coexistence number in a customer's Business Manager, which is not something this repository can arrange.

Not covered, and worth naming: on an installation whose app-level callback URL points somewhere other than this one, the override is not a nicety — it is the only thing routing that number here, and tolerating its failure means the inbox is quiet rather than marked. That trade is deliberate (the marker was misleading, said "reauthorization required" when the credentials were fine, and cost every inbound webhook), and the warning line is what a diagnosis starts from. A signal for the operator that is not "reauthorization required" is #575.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/576)
<!-- Reviewable:end -->
