### PR TITLE
fix(messages): stop a malformed attachment metadata value from taking the request down

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -158,6 +158,16 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
     values.merge(flags)
   end
 
+  # Anything that is not a hash of its own is ignored rather than coerced. `to_h` answers a
+  # different exception for each shape a caller can leave here -- NoMethodError for a String or
+  # a number, TypeError for a bare array, ArgumentError for an array of short pairs -- and every
+  # one of them took the whole request down. The single shape it does accept is worse than the
+  # crashes: an array of pairs became metadata whose `is_voice_message` was the string "false",
+  # which `cast_metadata_flags` never sees, because it only casts inside a Hash, and which both
+  # providers read as an explicit yes.
+  #
+  # Ignoring keeps the message and the attachment, which is what the caller was asking for, and
+  # leaves the reason in the log rather than in the answer.
   def custom_attachment_metadata(attachment)
     return unless @attachments_metadata.is_a?(Hash)
 
@@ -165,13 +175,27 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
     return unless filename
 
     metadata = @attachments_metadata[filename]
-    metadata.to_h if metadata.present?
+    return if metadata.blank?
+    return metadata.to_h if metadata.is_a?(Hash)
+
+    log_ignored_metadata("for #{filename}", metadata)
   end
 
+  # Answers nil, which is what the caller does with an entry it cannot read.
+  def log_ignored_metadata(where, value)
+    Rails.logger.warn("[MESSAGE BUILDER] ignoring attachments_metadata #{where}: expected a hash, got #{value.class}")
+    nil
+  end
+
+  # The same value can arrive one level up, and there it died even earlier: `attachments_metadata=x`
+  # and `attachments_metadata[]=x` broke on `deep_stringify_keys` before any attachment was looked
+  # at, so a guard on the per-file value alone would have left this one standing.
   def normalize_attachments_metadata(metadata)
     return if metadata.blank?
 
     metadata = metadata.to_unsafe_h if metadata.respond_to?(:to_unsafe_h)
+    return log_ignored_metadata('at the top level', metadata) unless metadata.is_a?(Hash)
+
     metadata.deep_stringify_keys.transform_values { |values| cast_metadata_flags(values) }
   end
 

--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
     trigger_typing_event(CONVERSATION_TYPING_OFF)
   rescue StandardError => e
-    render_could_not_create_error(e.message)
+    render_rescued_error(e)
   end
 
   def update
@@ -48,7 +48,7 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
     ::SendReplyJob.perform_later(message.id)
   rescue StandardError => e
-    render_could_not_create_error(e.message)
+    render_rescued_error(e)
   end
 
   def translate

--- a/app/controllers/concerns/request_exception_handler.rb
+++ b/app/controllers/concerns/request_exception_handler.rb
@@ -15,7 +15,40 @@ module RequestExceptionHandler
                 with: :render_error_response
   end
 
+  # Exceptions whose message describes our own code instead of answering the caller.
+  # `undefined method 'to_h' for an instance of String` tells whoever sent the request nothing
+  # and tells them how the builder is written. They reach HTTP bodies through the blanket
+  # `rescue StandardError` some actions need, which also shadows the handling below.
+  INTERNAL_DIAGNOSIS = [NameError, TypeError, ArgumentError].freeze
+
   private
+
+  # For an action that has to rescue broadly. What the caller can act on keeps its own message,
+  # including the ones the app raises as a plain StandardError, which no rule by class can tell
+  # from a bug. What only describes a bug is logged and answered with a sentence, and a record
+  # that was not found is answered the way this concern already answers it everywhere else,
+  # rather than with the SQL predicate that missed.
+  def render_rescued_error(exception)
+    if exception.is_a?(ActiveRecord::RecordNotFound)
+      log_handled_error(exception)
+      # The status stays what the blanket rescue has been answering for this, rather than the 404
+      # `handle_with_exception` would give it: only the body was the complaint, and a caller that
+      # branches on 422 here would break for a reason that has nothing to do with the leak.
+      return render_could_not_create_error('Resource could not be found')
+    end
+
+    return render_could_not_create_error(exception.message) unless INTERNAL_DIAGNOSIS.any? { |klass| exception.is_a?(klass) }
+
+    log_unexpected_error(exception)
+    render_could_not_create_error(I18n.t('errors.request.unexpected'))
+  end
+
+  # The only record of what actually happened, since the caller no longer carries it.
+  def log_unexpected_error(exception)
+    Rails.logger.error(
+      "Unexpected error: #{exception.class}: #{exception.message}\n#{Array(exception.backtrace).first(5).join("\n")}"
+    )
+  end
 
   def handle_with_exception
     yield

--- a/config/locales/fazer_ai.en.yml
+++ b/config/locales/fazer_ai.en.yml
@@ -12,6 +12,8 @@ en:
     messages:
       deleted: This message was deleted
   errors:
+    request:
+      unexpected: The request could not be completed.
     account:
       brand_name:
         invalid: cannot contain < or >

--- a/config/locales/fazer_ai.es.yml
+++ b/config/locales/fazer_ai.es.yml
@@ -12,6 +12,8 @@ es:
     messages:
       deleted: Este mensaje fue eliminado
   errors:
+    request:
+      unexpected: No se pudo completar la solicitud.
     account:
       brand_name:
         invalid: no puede contener < ni >

--- a/config/locales/fazer_ai.pt_BR.yml
+++ b/config/locales/fazer_ai.pt_BR.yml
@@ -12,6 +12,8 @@ pt_BR:
     messages:
       deleted: Esta mensagem foi excluída
   errors:
+    request:
+      unexpected: Não foi possível completar a requisição.
     account:
       brand_name:
         invalid: não pode conter < ou >

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -257,6 +257,57 @@ describe Messages::MessageBuilder do
         expect(message.attachments.first.meta).to include('description' => 'Profile picture', 'source' => 'upload')
       end
 
+      # `to_h` answers a different exception for each shape a caller can put at a value
+      # position -- NoMethodError for a String or a number, TypeError for a bare array,
+      # ArgumentError for an array of short pairs -- and each of them took the whole request
+      # down and put the Ruby text in the HTTP body. Ignoring the entry keeps the message and
+      # the attachment, which is what the caller was asking for.
+      [['a String', 'lixo'], ['a number', 5], ['a bare array', %w[a b]], ['an array of short pairs', [['a']]]].each do |shape, value|
+        it "ignores metadata sent as #{shape}, and still creates the message and the attachment" do
+          params[:attachments_metadata] = { 'avatar.png' => value }
+
+          message = message_builder
+
+          expect(message.attachments.count).to eq(1)
+          expect(message.attachments.first.meta).to eq({})
+        end
+      end
+
+      # The one shape `to_h` accepts, and the reason ignoring beats coercing: an array of pairs
+      # became metadata whose `is_voice_message` was the string "false", which is `present?` and
+      # reads at both providers as an explicit yes. `cast_metadata_flags` never saw it, because
+      # it only casts inside a Hash.
+      it 'does not turn an array of pairs into metadata with a string boolean' do
+        params[:attachments_metadata] = { 'avatar.png' => [%w[is_voice_message false], %w[description legenda]] }
+
+        message = message_builder
+
+        expect(message.attachments.first.meta['is_voice_message']).not_to eq('false')
+        expect(message.attachments.first.meta).to eq({})
+      end
+
+      it 'says in the log which file had its metadata ignored, and what arrived' do
+        allow(Rails.logger).to receive(:warn)
+        params[:attachments_metadata] = { 'avatar.png' => 'lixo' }
+
+        message_builder
+
+        expect(Rails.logger).to have_received(:warn).with(/avatar\.png.*String/)
+      end
+
+      # The other place the same value can arrive, and it died earlier: `attachments_metadata=lixo`
+      # never reached an attachment at all, it broke on `deep_stringify_keys`.
+      [['a String', 'lixo'], ['an array', %w[a]]].each do |shape, value|
+        it "ignores attachments_metadata sent as #{shape} at the top level" do
+          params[:attachments_metadata] = value
+
+          message = message_builder
+
+          expect(message.attachments.count).to eq(1)
+          expect(message.attachments.first.meta).to eq({})
+        end
+      end
+
       it 'does not apply metadata when filename key does not match' do
         params[:attachments_metadata] = { 'other_file.png' => { description: 'Wrong file' } }
 

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -442,6 +442,84 @@ RSpec.describe 'Conversation Messages API', type: :request do
     end
   end
 
+  # Both actions rescue StandardError and hand the exception's own message to the caller, so a
+  # bug in the builder answered with a Ruby diagnostic and a missing record answered with the
+  # SQL predicate that missed. What the caller can act on has to survive; what only describes
+  # our own code must not be echoed.
+  describe 'what an error answers to the caller' do
+    let!(:inbox) { create(:inbox, account: account) }
+    let!(:conversation) { create(:conversation, inbox: inbox, account: account) }
+    let(:agent) { create(:user, account: account, role: :agent) }
+
+    before do
+      create(:inbox_member, inbox: conversation.inbox, user: agent)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    def create_message
+      post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+           params: { content: 'test-message' }, headers: agent.create_new_auth_token, as: :json
+    end
+
+    context 'when the failure is a bug in our own code' do
+      before do
+        allow(Messages::MessageBuilder).to receive(:new)
+          .and_raise(NoMethodError, "undefined method 'to_h' for an instance of String")
+      end
+
+      it 'does not put the Ruby diagnostic in the body' do
+        create_message
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).not_to include('undefined method')
+        expect(response.body).not_to include('an instance of')
+      end
+
+      it 'records the real error for whoever has to debug it' do
+        create_message
+
+        expect(Rails.logger).to have_received(:error).with(/NoMethodError/)
+      end
+    end
+
+    # Raised by the builder itself as a plain StandardError, which is indistinguishable from a
+    # bug by class alone. The caller can act on it, so it has to keep arriving.
+    context 'when the failure is something the caller can act on' do
+      before do
+        allow(Messages::MessageBuilder).to receive(:new)
+          .and_raise(StandardError, 'Incoming messages are only allowed in Api inboxes')
+      end
+
+      it 'keeps the message the app chose to raise' do
+        create_message
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to include('Incoming messages are only allowed in Api inboxes')
+      end
+    end
+
+    context 'when a validation refuses the message' do
+      it 'keeps the validation text, which names what to fix' do
+        post api_v1_account_conversation_messages_url(account_id: account.id, conversation_id: conversation.display_id),
+             params: { content: 'x' * 150_001 }, headers: agent.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include('too long')
+      end
+    end
+
+    context 'when the message asked for does not exist' do
+      it 'answers without the SQL predicate that missed' do
+        post "/api/v1/accounts/#{account.id}/conversations/#{conversation.display_id}/messages/999999/retry",
+             headers: agent.create_new_auth_token, as: :json
+
+        expect(response.code.to_i).to be_between(400, 499)
+        expect(response.body).not_to include("Couldn't find Message")
+        expect(response.body).not_to include('[WHERE')
+      end
+    end
+  end
+
   describe 'POST /api/v1/accounts/{account.id}/conversations/:conversation_id/messages/:id/retry' do
     let(:message) { create(:message, account: account, message_type: :outgoing, status: :failed, content_attributes: { external_error: 'error' }) }
 


### PR DESCRIPTION
Sending a message with attachment metadata could fail the whole request, and the error the caller got back was a line of Ruby. Worse, one malformed shape did not fail at all: it turned into metadata that marked an audio file as a voice note when the caller had asked for the opposite. Both are fixed, and the API stops answering with internal diagnostics.

## Closes

- Fixes #563

## How to reproduce

`POST` a message with an attachment and `attachments_metadata: { 'avatar.png' => 'lixo' }`, on either upload path (multipart or a signed ID). Measured on this branch's base, six shapes break in three different exception classes:

| value at the key | before |
| --- | --- |
| `String`, `Integer`, `Float`, `true` | `NoMethodError: undefined method 'to_h' for an instance of String` |
| `["a","b"]` | `TypeError: wrong element type String at 0` |
| `[["a"]]` | `ArgumentError: wrong array length at 0` |
| `[["is_voice_message","false"], ...]` | **200, and wrong**: `meta.is_voice_message` persisted as the string `"false"` |
| `false`, `null`, `""`, `[]`, `{}` | 200, nothing read (they are `blank?`) |

The 422 body carried the exception text verbatim, because both `create` and `retry` rescue `StandardError` and pass `e.message` to the renderer.

`attachments_metadata` malformed at the top level (`attachments_metadata=lixo`) died one step earlier, on `deep_stringify_keys`, with the same leak. The issue did not name that one; a fix on the per-file value alone would have left it standing.

## What changed

**The builder ignores what it cannot read.** A value that is not a Hash is skipped, the message and the attachment are still created, and the reason goes to the log naming the file and the class that arrived. Same guard one level up, for the whole parameter.

Ignoring rather than coercing is the point of the array case: `to_h` accepts an array of pairs, so it never showed up as an error, and the string `"false"` it produced is `present?` and reads at both providers as an explicit yes. That is the same defect #532 and #561 closed from the other side.

**The answer stops carrying diagnostics.** What the app raises on purpose keeps its own message, including the ones raised as a plain `StandardError` (`Incoming messages are only allowed in Api inboxes`), which no rule by class can tell from a bug. A Ruby-level error (`NameError`, `TypeError`, `ArgumentError`) and `ActiveRecord::RecordNotFound`, whose message carries the SQL predicate that missed, are logged with class and backtrace and answered with a sentence.

Status codes are unchanged, deliberately: only the body was the complaint, and `retry` answering 422 for a missing message is what callers have been getting. A 404 would be more correct and is a contract change for someone else to decide.

## Validation scope

Proven by test, both halves: the four crashing shapes now create the message and the attachment with empty metadata; the array of pairs never persists a string boolean; legitimate metadata is untouched, including the `is_voice_message` and `is_recorded_audio` casts and the per-attachment refusal beating the top-level flag; the ignored entry is named in the log; the expected error bodies (`file is empty`, `too long`, `Incoming messages are only allowed in Api inboxes`) all survive; a Ruby diagnostic never reaches the body and is logged instead; the retry of a missing message no longer answers with the SQL predicate.

Red before the change: 11 examples failing at `eec5bf5e9f`. Ten mutations of the change were run and all ten failed a spec, including guarding with `rescue NoMethodError` (which leaves the TypeError and ArgumentError shapes crashing), coercing arrays instead of ignoring them, dropping either guard, and both directions of the error rule (everything generic, nothing generic).

The rule generalizes by class list, not by a notion of "unexpected", and that is deliberate: `NameError`, `TypeError` and `ArgumentError` are the classes this defect produced, plus `RecordNotFound` for its SQL predicate. An unexpected exception of any other class still delivers its own message to the caller — `ActiveSupport::MessageVerifier::InvalidSignature` on a bad signed ID still answers `mismatched digest`, as it did before. Widening it to every unexpected class would have swallowed messages that are useful today, including the ones the app raises as a plain `StandardError`.

One consequence worth naming, and now #579: `RecordNotFound` produces the same sentence with two different statuses depending on which handler caught it — 404 through `handle_with_exception`, 422 in these two actions. Before this change the two texts differed, so the paths were distinguishable; now only the status separates them.

Not covered: whether any caller in the wild sends an array of pairs deliberately. It could not have been working for them — the flag it produced was a string that read as the opposite of what it said — but they will now get empty metadata plus a log line instead of a wrong flag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/578)
<!-- Reviewable:end -->

