### PR TITLE
docs(deploy): registrar o modelo de application do Coolify

### DIFF
--- a/docker/README-coolify-deploy.md
+++ b/docker/README-coolify-deploy.md
@@ -1,0 +1,75 @@
+# Implantar no Coolify como applications
+
+Medido em 10/09/2026, no dia em que `chat.fazer.ai` migrou de um service do Coolify para applications.
+
+O `docker-compose.coolify.yaml` descreve a instalação como um **service** do Coolify, ou seja, um compose que o painel gerencia. Este documento descreve a outra forma, em que cada processo é uma **application** e cada banco é um **database**, todos na mesma rede Docker. As duas funcionam; a segunda evita as armadilhas listadas no fim.
+
+## A forma
+
+Cada recurso é declarado sozinho, com alias fixo, na rede do destino (`coolify`, por padrão). Não há compose, não há `depends_on`, e nada depende de nome curto interno de stack.
+
+| papel | tipo de recurso | alias sugerido |
+| --- | --- | --- |
+| web | application (dockerimage) | `chatwoot` |
+| worker | application (dockerimage) | `chatwoot-sidekiq` |
+| banco | database postgresql | o uuid do recurso |
+| fila | database redis | o uuid do recurso |
+| conector WhatsApp (opcional) | application (dockerimage) | `whatsapp-connector` |
+
+**Alias de application se declara em `custom_network_aliases`.** Não em `custom_docker_run_options: --network-alias`, que não tem efeito. Sem alias, o container de uma application se chama `<uuid>-<timestamp>`, e esse nome muda a cada deploy: qualquer coisa que aponte para ele quebra no deploy seguinte.
+
+Database não precisa de alias: o container tem o nome do uuid e ele é estável entre deploys. É por isso que `POSTGRES_HOST` e `REDIS_URL` costumam carregar uuid em vez de nome amigável.
+
+## O papel de cada container vem do entrypoint, não de `command`
+
+Uma application de `dockerimage` **não recebe `command`** no compose que o Coolify gera, e esta imagem não declara `CMD`. Web e worker saem da mesma imagem por `--entrypoint` dentro de `custom_docker_run_options`:
+
+```
+web     --entrypoint "docker/entrypoints/rails.sh bundle exec rails s -p 3000 -b 0.0.0.0"
+worker  --entrypoint "docker/entrypoints/sidekiq.sh bundle exec sidekiq -C config/sidekiq.yml"
+```
+
+O que o `post_start` do compose fazia depois do boot vira `post_deployment_command` na application (por exemplo `bundle exec rails branding:update`).
+
+## A ordem entre web e worker não existe, e é por isso que o portão importa
+
+Entre duas applications não há `depends_on`. As duas sobem ao mesmo tempo, e o `rails.sh` é quem roda `db:chatwoot_prepare`.
+
+O que impede o worker de subir contra um schema velho é o portão em `docker/entrypoints/sidekiq.sh`, que segura até `db:abort_if_pending_migrations` passar. Desde a #573 ele também viaja no `ENTRYPOINT` da imagem, decidindo por argv, então vale mesmo se alguém esquecer o `--entrypoint`.
+
+Neste modelo o portão deixou de ser cinto e virou pré-requisito. Sem ele, todo deploy que traga migração perde em silêncio o que chegar na janela: o ActiveRecord lê as colunas de um modelo uma vez por processo, e só quebra quem **cria** registro, então containers ficam saudáveis, filas ficam vazias, e mensagem some.
+
+## Volume compartilhado entre web e worker
+
+Os dois precisam do mesmo `/app/storage`, onde o Active Storage local guarda os anexos. O Coolify nomeia volume por recurso (`<uuid>-<nome>`), então **dois applications não compartilham volume nomeado**. A saída é `host_path`, que faz bind do mesmo diretório do host nos dois:
+
+```
+/data/<instalacao>/storage -> /app/storage   (nos dois recursos)
+```
+
+Instalações que usam S3 ou GCS não precisam disso.
+
+## Envs
+
+Web e worker carregam o mesmo conjunto, com `SIDEKIQ_CONCURRENCY` só no worker. Dois merecem atenção porque erram em silêncio:
+
+**`INTERNAL_HOST_URL`** é o endereço pelo qual um provedor **busca** o arquivo de um anexo. Texto e reação viajam inteiros no comando; anexo não, porque isso colocaria um vídeo de 60 MB dentro do processo Rails e dentro do frame do comando. O `AttachmentAdapter` troca o host do `download_url` por este valor. Se ele não resolver do lado de quem busca, **só o envio de anexo quebra**, com `could not fetch the file to send`, e todo o resto segue funcionando. Em application, o valor é o alias: `http://chatwoot:3000`.
+
+**`WHATSAPP_CONNECTOR_EVENT_SHARDS`** não é opcional quando `WHATSAPP_CONNECTOR_ENABLED=true`: o `config/database.yml` **soma** esse número ao pool de todo processo. O valor tem que bater com o `WAC_EVENT_SHARDS` do conector, senão o consumo abre mais threads do que o pool comporta.
+
+## O conector WhatsApp
+
+Roda como application separada, com imagem e trem de release próprios, porque o whatsmeow muda a cada duas semanas e um hotfix de protocolo não pode esperar um trem de release do Rails.
+
+- **`REDIS_URL` e `REDIS_PASSWORD` são sem prefixo `WAC_`, de propósito:** os dois lados leem a mesma variável, então não dá para apontá-los para servidores diferentes. Redis separado produziria silêncio, não erro.
+- **`WAC_ADVERTISE_URL` fica vazia.** O conector deriva o valor do próprio hostname, o que acompanha o container a cada deploy; um valor fixo apontaria para um container que deixou de existir.
+- **Banco próprio**, onde ficam as credenciais de pareamento. É por isso que reiniciar o conector não desfaz o pareamento.
+- **Healthcheck do Coolify desligado:** a imagem é distroless e não tem `/bin/sh`, então o healthcheck do painel falha mesmo com o serviço de pé. A imagem carrega o próprio `HEALTHCHECK`.
+
+## Armadilhas medidas
+
+**Service do Coolify perde a rede `coolify` no deploy pela API.** A flag `connect_to_docker_network` está certa, mas quem executa o `docker network connect` é o `StartService`, e o deploy pela API não chama. O sintoma é um recurso vizinho deixar de resolver o nome da stack, sem erro no painel. Applications não têm esse problema: elas entram na rede do destino por construção.
+
+**Redis do Coolify sobe com `appendonly yes`.** Copiar um `dump.rdb` para dentro não restaura nada, porque ele carrega do AOF. Para migrar dados entre duas instâncias, use `MIGRATE` chave a chave.
+
+**Application de `dockerimage` sem `command` e sem `CMD` na imagem não sobe.** É o `--entrypoint` que resolve.


### PR DESCRIPTION
## Por que aqui e não no Pro

Escrevi isto primeiro no repositório do Pro, e estava errado. Medindo, **todo mecanismo que o documento explica mora no CE**:

| o que o documento explica | onde mora |
| --- | --- |
| portão de schema do worker | `docker/entrypoints/sidekiq.sh` |
| `WHATSAPP_CONNECTOR_EVENT_SHARDS` somado ao pool | `config/database.yml` |
| `INTERNAL_HOST_URL` e a busca do anexo | `app/services/whatsapp/session/outbound/attachment_adapter.rb` |
| envs do conector | `app/services/whatsapp/connector.rb` |

Do Pro só seriam os **nomes**: a imagem do harbor, os nomes dos recursos e o `FAZER_AI_HUB_URL`. Deixar no Pro custava duas coisas: o self-hosted do CE, que é a população maior e a que mais sofre com fricção de instalação, não receberia nada; e o documento passaria a divergir do código que descreve. Aqui ele desce por merge para o Pro sozinho.

## O que entra

`docker/README-coolify-deploy.md`, escrito a partir da configuração **medida** de uma instalação real, não de lembrança. O repositório já descreve a instalação como service (`docker-compose.coolify.yaml`); isto descreve a outra forma, com cada processo como application e cada banco como database na mesma rede.

Registra o que só se descobre errando:

- **Application de `dockerimage` não recebe `command`**, e esta imagem não declara `CMD`. Web e worker saem da mesma imagem por `--entrypoint` dentro de `custom_docker_run_options`.
- **Alias fixo é `custom_network_aliases`**, não `custom_docker_run_options: --network-alias`, que não tem efeito. Sem alias, o container se chama `<uuid>-<timestamp>` e o nome muda a cada deploy.
- **Dois applications não compartilham volume nomeado** (o Coolify nomeia por recurso), então o `/app/storage` comum entre web e worker é `host_path`.
- **Entre applications não existe `depends_on`**, e é por isso que o portão de schema da #573 deixou de ser cinto e virou pré-requisito deste modelo.
- **`INTERNAL_HOST_URL` erra em silêncio parcial:** se não resolver do lado de quem busca o arquivo, só o envio de anexo quebra, e todo o resto segue funcionando.

Mais três armadilhas medidas no mesmo dia: service do Coolify perde a rede `coolify` no deploy pela API (o `docker network connect` só sai do `StartService`), Redis do Coolify sobe com `appendonly yes` e ignora um `dump.rdb` copiado para dentro, e application sem `command` nem `CMD` não sobe.

## Verificação

Não há código, então o que dá para verificar é fidelidade: cada valor foi lido da API do Coolify de uma instalação rodando neste modelo no momento de escrever, incluindo imagem, alias, entrypoint, storage e envs de cada recurso. O portão de schema descrito na seção da ordem foi observado ao vivo segurando o worker enquanto o web migrava.

O lado Pro (os nomes específicos, e o que fazer com o compose herdado) fica em fazer-ai/chatwoot-pro#84, que passa a referenciar este arquivo em vez de repetir o conteúdo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/580)
<!-- Reviewable:end -->
