### PR TITLE
test(attachments): pin the clipboard shape whose announced text is empty

### DIFF
--- a/app/javascript/dashboard/helper/specs/pastedFiles.spec.js
+++ b/app/javascript/dashboard/helper/specs/pastedFiles.spec.js
@@ -21,14 +21,19 @@ import {
 //
 // That asymmetry is the whole discriminator: warn when every pasted file is empty and nothing
 // on the clipboard is text, stay quiet otherwise.
-const transfer = (types, files) => ({
+// A real DataTransfer answers for every type it announces, so the fixture answers too: whether
+// the announced text has anything in it is the other candidate discriminator, and a fixture that
+// cannot be asked would let it pass untested.
+const transfer = (types, files, data = {}) => ({
   types,
   files: files.map(([name, type, size]) => ({ name, type, size })),
+  getData: type => data[type] ?? '',
 });
 
 const NUMBERS_SINGLE_CELL = transfer(
   ['text/plain', 'text/html', 'text/rtf', 'Files'],
-  [['image.png', 'image/png', 0]]
+  [['image.png', 'image/png', 0]],
+  { 'text/plain': 'planilha 2' }
 );
 const NUMBERS_RANGE = NUMBERS_SINGLE_CELL;
 // The other shape the same gesture has produced, twice and not on demand: a real PNG.
@@ -45,7 +50,24 @@ const FINDER_VALID_FILE = transfer(
   [['valido.txt', 'text/plain', 4]]
 );
 const SCREENSHOT = transfer(['Files'], [['image.png', 'image/png', 40656]]);
-const PLAIN_TEXT = transfer(['text/plain'], []);
+// Copying an EMPTY cell in Numbers, measured on 10/09/2026 in the same probe as the shapes
+// above, in Chromium 153.0.8010.12 and in WebKit 605.1.15 (Version/26.6 Safari): the text flavour
+// is announced with nothing in it, beside the same artifact nobody chose. Four of five copies of
+// an empty cell came out as `text/plain` of zero characters next to `Files`, and a pasteboard
+// carrying an empty text flavour beside a zero-byte PNG reaches both engines exactly like this.
+//
+// This is the shape #567 proposed to treat as "no text", by reading the content instead of
+// trusting the announced type. The measurement says the opposite: when the clipboard carries a
+// file the person actually picked (`public.file-url`), NEITHER engine announces any text flavour
+// at all, empty or filled, in one pasteboard item or in two. So a genuine empty file never
+// arrives with text beside it, deciding on the content recovers no warning that is being missed,
+// and it would turn this paste, an ordinary spreadsheet paste, into a false alarm about a file
+// nobody chose. That is why the rule reads the announced type and not the content.
+const NUMBERS_EMPTY_CELL = transfer(
+  ['text/plain', 'Files'],
+  [['image.png', 'image/png', 0]]
+);
+const PLAIN_TEXT = transfer(['text/plain'], [], { 'text/plain': 'texto' });
 
 describe('pastedFiles', () => {
   describe('clipboardCarriesText', () => {
@@ -67,11 +89,18 @@ describe('pastedFiles', () => {
       type => {
         expect(
           clipboardCarriesText(
-            transfer([type, 'Files'], [['image.png', 'image/png', 0]])
+            transfer([type, 'Files'], [['image.png', 'image/png', 0]], {
+              [type]: 'planilha 2',
+            })
           )
         ).toBe(true);
       }
     );
+
+    it('counts an announced text flavour with nothing in it, the empty spreadsheet cell', () => {
+      expect(clipboardCarriesText(NUMBERS_EMPTY_CELL)).toBe(true);
+      expect(NUMBERS_EMPTY_CELL.getData('text/plain')).toBe('');
+    });
 
     it('survives a transfer with no types at all', () => {
       expect(clipboardCarriesText(undefined)).toBe(false);
@@ -114,6 +143,13 @@ describe('pastedFiles', () => {
       expect(usableFilesFromTransfer(NUMBERS_RANGE).shouldAlertEmpty).toBe(
         false
       );
+    });
+
+    it('stays quiet for an empty spreadsheet cell, whose text is announced empty', () => {
+      expect(usableFilesFromTransfer(NUMBERS_EMPTY_CELL)).toEqual({
+        files: [],
+        shouldAlertEmpty: false,
+      });
     });
 
     it('explains the refusal for a genuine empty file', () => {


### PR DESCRIPTION
An empty file is refused at every entry point, and a paste says so out loud unless the clipboard also carried text, which is the shape of a rich copy bringing an artifact nobody chose. #567 proposed to stop trusting the announced type and read its content instead. The clipboard was measured in both engines, and the measurement says the opposite: that change recovers no warning and turns an ordinary spreadsheet paste into a false alarm. Nothing changes for anyone using the product here; what this adds is the pin that keeps the change from coming back through a reading of the issue.

## Closes

- Fixes #567

## What was measured

macOS 25.5 (arm64), 10/09/2026. Chromium 153.0.8010.12 (Chrome for Testing, a real paste driven over CDP with `Input.dispatchKeyEvent` and `commands: ["paste"]`) and WebKit 605.1.15 (`Version/26.6 Safari`, playwright-core 1.63, visible window). The pasteboard was written flavour by flavour with `NSPasteboard` through JXA, and for the Numbers samples by the application itself. The probe page reads `types`, `getData(type).length` and `files` inside the event.

| clipboard | Chromium `types` | WebKit `types` | `files` |
| --- | --- | --- | --- |
| empty `public.utf8-plain-text` + `public.file-url` of a 0 byte file | `["Files"]` | `["Files"]` | the 0 byte file |
| `public.utf8-plain-text` with content + the same file url | `["Files"]` | `["Files"]` | the 0 byte file |
| the same two, as two separate pasteboard items | `["Files"]` | not run | the 0 byte file |
| empty `public.html`, or empty `public.rtf`, + the file url | `["Files"]` | not run | the 0 byte file |
| empty `public.utf8-plain-text`, no file at all | `["text/plain"]`, 0 characters | not run | none |
| empty `public.utf8-plain-text` + `public.png` of 0 bytes | `["text/plain","Files"]`, 0 characters | `["Files","text/plain"]`, 0 characters | image.png, 0 bytes |
| Numbers, a copy of an **empty** cell | `["text/plain","Files"]`, 0 characters | not run | image.png, 70 bytes |
| a drop of real files | `["Files"]` | not run | 0 bytes and 8 bytes |

Two invariants come out of it:

1. When the clipboard carries a file the person actually picked (`public.file-url`), **neither engine announces any text flavour at all**: empty or filled, in one pasteboard item or in two. The case the warning exists for therefore never arrives with text beside it, and reading the content recovers no warning that is being missed.
2. Text announced beside `Files` only happens when the file is synthesized from an image flavour (`public.png` arrives as `image.png`), which is the spreadsheet artifact. And an empty text in that shape has an ordinary producer: copying an empty cell in Numbers, measured, four samples out of five, `text/plain` of zero characters beside `Files`.

So the proposed change has no case where it recovers a warning and one where it invents one: a spreadsheet paste of an empty cell whose artifact comes through at 0 bytes would say "This file is empty and cannot be sent" about a file nobody chose, which is the false alarm #525 asked to measure and #566 avoided.

## What changed

The spec only. The fixtures now answer `getData` the way a real `DataTransfer` does, because whether the announced text has anything in it is the other candidate discriminator, and a fixture that cannot be asked leaves it untested. Two cases pin the measured shape: an announced text flavour with nothing in it still counts as text, and that paste stays quiet.

## Validation scope

Proven by test: 15 examples green at this commit. The pin's discriminating power was measured rather than asserted: with the implementation proposed in #567 applied verbatim to `clipboardCarriesText`, the two new cases fail and nothing else does. The three per flavour cases were given the content their names describe first, so they keep testing what they say instead of failing for the new reason.

Not measured, and named in the issue: Firefox, Windows and Linux, since no such browser is on the machine that measured; a promised file (`com.apple.pasteboard.promised-file-url`), which is what an attachment dragged out of Mail is; and a real Finder drag into the internal chat editor, the one `drop` caller of this helper. What was measured for drop is a drag built by the browser (`Input.dispatchDragEvent` carrying `files`), which announced `Files` alone; a real Finder drag fills the drag pasteboard through the OS and could carry `text/plain` with the file path, which would be a different question from this one and would need a real mouse gesture on a machine nobody else is using.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/581)
<!-- Reviewable:end -->
