### PR TITLE
fix(api): answer a missing record with 404 on the two actions that rescue broadly

### DIFF
--- a/app/controllers/concerns/request_exception_handler.rb
+++ b/app/controllers/concerns/request_exception_handler.rb
@@ -31,10 +31,11 @@ module RequestExceptionHandler
   def render_rescued_error(exception)
     if exception.is_a?(ActiveRecord::RecordNotFound)
       log_handled_error(exception)
-      # The status stays what the blanket rescue has been answering for this, rather than the 404
-      # `handle_with_exception` would give it: only the body was the complaint, and a caller that
-      # branches on 422 here would break for a reason that has nothing to do with the leak.
-      return render_could_not_create_error('Resource could not be found')
+      # The same answer `handle_with_exception` gives for it everywhere else, status included. A
+      # record that is not there is not a refused write, and while the two paths said different
+      # sentences the status was at least redundant; with one sentence it was all that separated
+      # them, and it separated by who caught the exception rather than by what happened.
+      return render_not_found_error('Resource could not be found')
     end
 
     return render_could_not_create_error(exception.message) unless INTERNAL_DIAGNOSIS.any? { |klass| exception.is_a?(klass) }

--- a/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/conversations/messages_controller_spec.rb
@@ -668,11 +668,16 @@ RSpec.describe 'Conversation Messages API', type: :request do
       end
 
       it 'returns not found error' do
+        allow(Rails.logger).to receive(:info)
+
         post "/api/v1/accounts/#{account.id}/conversations/#{message.conversation.display_id}/messages/99999/retry",
              headers: agent.create_new_auth_token,
              as: :json
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body['error']).to eq('Resource could not be found')
+        # the body no longer names the record, so the log is the only place left that does
+        expect(Rails.logger).to have_received(:info).with(/Handled error.*RecordNotFound/)
       end
     end
   end


### PR DESCRIPTION
Asking the API to retry a message that no longer exists now answers `404 Not Found`, the same status every other endpoint gives for a record that is not there. Until now those two actions answered `422 Unprocessable Entity` with the identical sentence, so the status said who caught the exception rather than what happened.

## Closes

- Fixes #579

## How to reproduce

`POST /api/v1/accounts/:id/conversations/:cid/messages/999999/retry` for a message id that does not exist. Before this: `422 {"error":"Resource could not be found"}`. Every other action answering the same exception through `handle_with_exception`: `404 {"error":"Resource could not be found"}`.

The 422 is older than the sentence. `create` and `retry` carry a blanket `rescue StandardError` that shadows the concern's own `rescue_from`, and it has always answered 422. That was invisible while the two paths said different things: the blanket one leaked `Couldn't find Message with 'id'=... [WHERE ...]`, which is the leak #563 closed. With one sentence on both, the status became the only thing separating them, and it separates by the wrong thing.

## What changed

One line in `RequestExceptionHandler#render_rescued_error`: a rescued `ActiveRecord::RecordNotFound` is rendered with `render_not_found_error` instead of `render_could_not_create_error`. The body, the log line and every other class handled there are untouched.

This is a status change on two endpoints, so it is a contract change. What was measured before taking it:

- the dashboard does not branch on it. `sendMessageWithData` (`store/modules/conversations/actions.js`), the only caller of both `MessageApi.create` and `MessageApi.retry`, reads `error.response.data.error` and stores it on the failed message; no status is inspected on that path, and a search for `422` across `app/javascript` finds no branch belonging to messages;
- `retry` is not in `swagger/`, so no published contract promises a status for it;
- the spec that asserted 422 was already named `returns not found error`, which is the inconsistency written down in the repository a year before the issue.

Not measured: the mobile app, which lives in another repository. A client that branched on 422 for a message id that does not exist would already be inconsistent with the rest of this API, and the body it reads does not change.

## Validation scope

Proven by test: the retry of a missing message answers 404 with the same sentence, and the handled-error log still names the class, which is the only place left that names the record now that the body does not. Red before the change: 1 failing at `45c675f4`. Eight mutations were run and seven failed a spec, including answering 422 again, changing the sentence, dropping the log line, making `handle_with_exception` answer 422, removing the branch, answering 410, and rendering the exception's own message. The survivor adds `RecordNotFound` to `INTERNAL_DIAGNOSIS`, which cannot change this path because the branch returns before that list is consulted.

Not covered here: any client outside this repository, as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/582)
<!-- Reviewable:end -->
