### PR TITLE
fix(whatsapp): say when a number is not routed here, instead of a plain success

### DIFF
--- a/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
+++ b/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
@@ -50,9 +50,12 @@ module Api::V1::Accounts::Concerns::WhatsappHealthManagement
   end
 
   def register_webhook
-    Whatsapp::WebhookSetupService.new(@inbox.channel).register_callback
+    # The per-number override is allowed to be refused without taking the channel down, so
+    # "registered successfully" on its own would be the whole answer for a number Meta refused to
+    # point here. The answer says which half landed.
+    applied = Whatsapp::WebhookSetupService.new(@inbox.channel).register_callback
 
-    render json: { message: 'Webhook registered successfully' }, status: :ok
+    render json: { message: 'Webhook registered successfully', callback_override_applied: applied }, status: :ok
   rescue StandardError => e
     Rails.logger.error "[INBOX WEBHOOK] Webhook registration failed: #{e.message}"
     render json: { error: e.message }, status: :unprocessable_entity

--- a/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
+++ b/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
@@ -72,16 +72,19 @@ module Api::V1::Accounts::Concerns::WhatsappHealthManagement
   private
 
   # Meta answers three levels of webhook routing and delivery follows the most specific one that
-  # exists. This number pointed here, or the WhatsApp Business Account it belongs to, means the
-  # inbox owns its delivery; neither of them means it is riding on the app's own callback, which
-  # belongs to the installation rather than to this inbox and can be pointed elsewhere at any
-  # time. Read on every request rather than stored, so it cannot go stale against Meta, and false
-  # when Meta did not answer the configuration at all, because not knowing is not a warning.
+  # EXISTS, wherever it points. So this asks about existence, not about the URL: an override of
+  # its own, for this number or for the WhatsApp Business Account it belongs to, means the inbox
+  # owns its routing even when that override points somewhere wrong, which is a different problem
+  # and already has its own warning. Only when neither exists does delivery ride on the app's own
+  # callback, which belongs to the installation rather than to this inbox and can be pointed
+  # elsewhere at any time. Read on every request rather than stored, so it cannot go stale against
+  # Meta, and false when Meta answered no configuration at all, because not knowing is not a
+  # warning.
   def routed_by_app_callback_only?(health_data)
     configuration = health_data[:webhook_configuration]
     return false if configuration.blank?
 
-    configuration.values_at('phone_number', 'whatsapp_business_account').exclude?(health_data[:expected_webhook_url])
+    configuration.values_at('phone_number', 'whatsapp_business_account').all?(&:blank?)
   end
 
   def whatsapp_channel

--- a/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
+++ b/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
@@ -32,7 +32,7 @@ module Api::V1::Accounts::Concerns::WhatsappHealthManagement
 
   def health
     health_data = Whatsapp::HealthService.new(@inbox.channel).sync_health_status!
-    render json: health_data
+    render json: health_data.merge(routed_by_app_callback_only: routed_by_app_callback_only?(health_data))
   rescue Whatsapp::HealthService::ApiError => e
     Rails.logger.error "[INBOX HEALTH] Error fetching health data: #{e.message}"
     render json: {
@@ -70,6 +70,19 @@ module Api::V1::Accounts::Concerns::WhatsappHealthManagement
   end
 
   private
+
+  # Meta answers three levels of webhook routing and delivery follows the most specific one that
+  # exists. This number pointed here, or the WhatsApp Business Account it belongs to, means the
+  # inbox owns its delivery; neither of them means it is riding on the app's own callback, which
+  # belongs to the installation rather than to this inbox and can be pointed elsewhere at any
+  # time. Read on every request rather than stored, so it cannot go stale against Meta, and false
+  # when Meta did not answer the configuration at all, because not knowing is not a warning.
+  def routed_by_app_callback_only?(health_data)
+    configuration = health_data[:webhook_configuration]
+    return false if configuration.blank?
+
+    configuration.values_at('phone_number', 'whatsapp_business_account').exclude?(health_data[:expected_webhook_url])
+  end
 
   def whatsapp_channel
     channel = @inbox.channel

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -184,7 +184,7 @@
       "WEBHOOK": {
         "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered. Meta refused to point this number itself here, so delivery depends on the account-level callback shown below.",
         "RIDES_ON_APP_CALLBACK": "Delivery follows the app callback URL: neither this number nor its WhatsApp Business Account is pointed at this installation, so it stops arriving if that URL changes.",
-        "APP_CALLBACK_POINTS_ELSEWHERE": "This number has no routing of its own, so delivery follows the app callback URL shown below, which is not this installation. Registering the webhook points this number here; if Meta refuses that for this account, the app callback is what has to change."
+        "APP_CALLBACK_POINTS_ELSEWHERE": "This number has no routing of its own, so delivery follows the app callback URL shown below, which is not the one expected for this number. Registering the webhook points this number here; if Meta refuses that for this account, the app callback is what has to change."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -182,7 +182,7 @@
     },
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
-        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered. Meta refused to point this number itself here, so delivery depends on the account-level callback shown below.",
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered, but Meta did not accept pointing this number itself here, so this number's own routing was not changed. The card below shows which URL delivery follows.",
         "RIDES_ON_APP_CALLBACK": "Delivery follows the app callback URL: neither this number nor its WhatsApp Business Account is pointed at this installation, so it stops arriving if that URL changes.",
         "APP_CALLBACK_POINTS_ELSEWHERE": "This number has no routing of its own, so delivery follows the app callback URL shown below, which is not the one expected for this number. Registering the webhook points this number here; if Meta refuses that for this account, the app callback is what has to change."
       }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -179,6 +179,12 @@
       "WHATSAPP_ZAPI": "WhatsApp - Z-API",
       "WHATSAPP_NATIVE": "WhatsApp - native",
       "WHATSAPP_UAZAPI": "WhatsApp - Uazapi"
+    },
+    "ACCOUNT_HEALTH": {
+      "WEBHOOK": {
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered. Meta refused to route this number here, so delivery follows the app callback URL shown below.",
+        "NUMBER_NOT_ROUTED": "Delivery follows the app callback URL: this number is not pointed at this installation, so it stops arriving if that URL changes."
+      }
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -182,8 +182,8 @@
     },
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
-        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered. Meta refused to route this number here, so delivery follows the app callback URL shown below.",
-        "NUMBER_NOT_ROUTED": "Delivery follows the app callback URL: this number is not pointed at this installation, so it stops arriving if that URL changes."
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered. Meta refused to point this number itself here, so delivery depends on the account-level callback shown below.",
+        "NUMBER_NOT_ROUTED": "Delivery follows the app callback URL: neither this number nor its WhatsApp Business Account is pointed at this installation, so it stops arriving if that URL changes."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -183,7 +183,8 @@
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
         "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered. Meta refused to point this number itself here, so delivery depends on the account-level callback shown below.",
-        "NUMBER_NOT_ROUTED": "Delivery follows the app callback URL: neither this number nor its WhatsApp Business Account is pointed at this installation, so it stops arriving if that URL changes."
+        "RIDES_ON_APP_CALLBACK": "Delivery follows the app callback URL: neither this number nor its WhatsApp Business Account is pointed at this installation, so it stops arriving if that URL changes.",
+        "APP_CALLBACK_POINTS_ELSEWHERE": "This number has no routing of its own, so delivery follows the app callback URL shown below, which is not this installation. Registering the webhook here cannot change that: the app callback has to be repointed in the Meta app settings."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -184,7 +184,7 @@
       "WEBHOOK": {
         "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered. Meta refused to point this number itself here, so delivery depends on the account-level callback shown below.",
         "RIDES_ON_APP_CALLBACK": "Delivery follows the app callback URL: neither this number nor its WhatsApp Business Account is pointed at this installation, so it stops arriving if that URL changes.",
-        "APP_CALLBACK_POINTS_ELSEWHERE": "This number has no routing of its own, so delivery follows the app callback URL shown below, which is not this installation. Registering the webhook here cannot change that: the app callback has to be repointed in the Meta app settings."
+        "APP_CALLBACK_POINTS_ELSEWHERE": "This number has no routing of its own, so delivery follows the app callback URL shown below, which is not this installation. Registering the webhook points this number here; if Meta refuses that for this account, the app callback is what has to change."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -184,7 +184,7 @@
       "WEBHOOK": {
         "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. Meta rechazó apuntar este número en sí aquí, así que la entrega depende del callback a nivel de cuenta, que se muestra abajo.",
         "RIDES_ON_APP_CALLBACK": "La entrega sigue la URL de callback de la aplicación: ni este número ni su cuenta de WhatsApp Business apuntan a esta instalación, así que deja de llegar si esa URL cambia.",
-        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número no tiene enrutamiento propio, así que la entrega sigue la URL de callback de la aplicación, mostrada abajo, que no es esta instalación. Registrar el webhook aquí no cambia eso: hay que reapuntar el callback de la aplicación en la configuración de la app en Meta."
+        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número no tiene enrutamiento propio, así que la entrega sigue la URL de callback de la aplicación, mostrada abajo, que no es esta instalación. Registrar el webhook apunta este número aquí; si Meta lo rechaza en esta cuenta, lo que hay que cambiar es el callback de la aplicación."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -184,7 +184,7 @@
       "WEBHOOK": {
         "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. Meta rechazó apuntar este número en sí aquí, así que la entrega depende del callback a nivel de cuenta, que se muestra abajo.",
         "RIDES_ON_APP_CALLBACK": "La entrega sigue la URL de callback de la aplicación: ni este número ni su cuenta de WhatsApp Business apuntan a esta instalación, así que deja de llegar si esa URL cambia.",
-        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número no tiene enrutamiento propio, así que la entrega sigue la URL de callback de la aplicación, mostrada abajo, que no es esta instalación. Registrar el webhook apunta este número aquí; si Meta lo rechaza en esta cuenta, lo que hay que cambiar es el callback de la aplicación."
+        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número no tiene enrutamiento propio, así que la entrega sigue la URL de callback de la aplicación, mostrada abajo, que no es la esperada para este número. Registrar el webhook apunta este número aquí; si Meta lo rechaza en esta cuenta, lo que hay que cambiar es el callback de la aplicación."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -183,7 +183,8 @@
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
         "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. Meta rechazó apuntar este número en sí aquí, así que la entrega depende del callback a nivel de cuenta, que se muestra abajo.",
-        "NUMBER_NOT_ROUTED": "La entrega sigue la URL de callback de la aplicación: ni este número ni su cuenta de WhatsApp Business apuntan a esta instalación, así que deja de llegar si esa URL cambia."
+        "RIDES_ON_APP_CALLBACK": "La entrega sigue la URL de callback de la aplicación: ni este número ni su cuenta de WhatsApp Business apuntan a esta instalación, así que deja de llegar si esa URL cambia.",
+        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número no tiene enrutamiento propio, así que la entrega sigue la URL de callback de la aplicación, mostrada abajo, que no es esta instalación. Registrar el webhook aquí no cambia eso: hay que reapuntar el callback de la aplicación en la configuración de la app en Meta."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -179,6 +179,12 @@
       "WHATSAPP_ZAPI": "WhatsApp - Z-API",
       "WHATSAPP_NATIVE": "WhatsApp - nativo",
       "WHATSAPP_UAZAPI": "WhatsApp - Uazapi"
+    },
+    "ACCOUNT_HEALTH": {
+      "WEBHOOK": {
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. Meta rechazó apuntar este número aquí, así que la entrega sigue la URL de callback de la aplicación, que se muestra abajo.",
+        "NUMBER_NOT_ROUTED": "La entrega sigue la URL de callback de la aplicación: este número no está apuntado a esta instalación, así que deja de llegar si esa URL cambia."
+      }
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -182,8 +182,8 @@
     },
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
-        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. Meta rechazó apuntar este número aquí, así que la entrega sigue la URL de callback de la aplicación, que se muestra abajo.",
-        "NUMBER_NOT_ROUTED": "La entrega sigue la URL de callback de la aplicación: este número no está apuntado a esta instalación, así que deja de llegar si esa URL cambia."
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. Meta rechazó apuntar este número en sí aquí, así que la entrega depende del callback a nivel de cuenta, que se muestra abajo.",
+        "NUMBER_NOT_ROUTED": "La entrega sigue la URL de callback de la aplicación: ni este número ni su cuenta de WhatsApp Business apuntan a esta instalación, así que deja de llegar si esa URL cambia."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -182,7 +182,7 @@
     },
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
-        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. Meta rechazó apuntar este número en sí aquí, así que la entrega depende del callback a nivel de cuenta, que se muestra abajo.",
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado, pero Meta no aceptó apuntar este número en sí aquí, así que su enrutamiento propio no cambió. La tarjeta de abajo muestra qué URL sigue la entrega.",
         "RIDES_ON_APP_CALLBACK": "La entrega sigue la URL de callback de la aplicación: ni este número ni su cuenta de WhatsApp Business apuntan a esta instalación, así que deja de llegar si esa URL cambia.",
         "APP_CALLBACK_POINTS_ELSEWHERE": "Este número no tiene enrutamiento propio, así que la entrega sigue la URL de callback de la aplicación, mostrada abajo, que no es la esperada para este número. Registrar el webhook apunta este número aquí; si Meta lo rechaza en esta cuenta, lo que hay que cambiar es el callback de la aplicación."
       }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -184,7 +184,7 @@
       "WEBHOOK": {
         "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. A Meta recusou apontar este número em si para cá, então a entrega depende do callback de nível de conta, mostrado abaixo.",
         "RIDES_ON_APP_CALLBACK": "A entrega segue a URL de callback do aplicativo: nem este número nem a conta do WhatsApp Business dele estão apontados para esta instalação, então ela para se aquela URL mudar.",
-        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número não tem roteamento próprio, então a entrega segue a URL de callback do aplicativo, mostrada abaixo, que não é esta instalação. Registrar o webhook aponta este número para cá; se a Meta recusar isso nesta conta, o que precisa mudar é o callback do aplicativo."
+        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número não tem roteamento próprio, então a entrega segue a URL de callback do aplicativo, mostrada abaixo, que não é a esperada para este número. Registrar o webhook aponta este número para cá; se a Meta recusar isso nesta conta, o que precisa mudar é o callback do aplicativo."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -183,7 +183,8 @@
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
         "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. A Meta recusou apontar este número em si para cá, então a entrega depende do callback de nível de conta, mostrado abaixo.",
-        "NUMBER_NOT_ROUTED": "A entrega segue a URL de callback do aplicativo: nem este número nem a conta do WhatsApp Business dele estão apontados para esta instalação, então ela para se aquela URL mudar."
+        "RIDES_ON_APP_CALLBACK": "A entrega segue a URL de callback do aplicativo: nem este número nem a conta do WhatsApp Business dele estão apontados para esta instalação, então ela para se aquela URL mudar.",
+        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número não tem roteamento próprio, então a entrega segue a URL de callback do aplicativo, mostrada abaixo, que não é esta instalação. Registrar o webhook aqui não muda isso: o callback do aplicativo precisa ser reapontado nas configurações do app na Meta."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -182,7 +182,7 @@
     },
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
-        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. A Meta recusou apontar este número em si para cá, então a entrega depende do callback de nível de conta, mostrado abaixo.",
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado, mas a Meta não aceitou apontar este número em si para cá, então o roteamento próprio dele não mudou. O cartão abaixo mostra qual URL a entrega segue.",
         "RIDES_ON_APP_CALLBACK": "A entrega segue a URL de callback do aplicativo: nem este número nem a conta do WhatsApp Business dele estão apontados para esta instalação, então ela para se aquela URL mudar.",
         "APP_CALLBACK_POINTS_ELSEWHERE": "Este número não tem roteamento próprio, então a entrega segue a URL de callback do aplicativo, mostrada abaixo, que não é a esperada para este número. Registrar o webhook aponta este número para cá; se a Meta recusar isso nesta conta, o que precisa mudar é o callback do aplicativo."
       }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -184,7 +184,7 @@
       "WEBHOOK": {
         "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. A Meta recusou apontar este número em si para cá, então a entrega depende do callback de nível de conta, mostrado abaixo.",
         "RIDES_ON_APP_CALLBACK": "A entrega segue a URL de callback do aplicativo: nem este número nem a conta do WhatsApp Business dele estão apontados para esta instalação, então ela para se aquela URL mudar.",
-        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número não tem roteamento próprio, então a entrega segue a URL de callback do aplicativo, mostrada abaixo, que não é esta instalação. Registrar o webhook aqui não muda isso: o callback do aplicativo precisa ser reapontado nas configurações do app na Meta."
+        "APP_CALLBACK_POINTS_ELSEWHERE": "Este número não tem roteamento próprio, então a entrega segue a URL de callback do aplicativo, mostrada abaixo, que não é esta instalação. Registrar o webhook aponta este número para cá; se a Meta recusar isso nesta conta, o que precisa mudar é o callback do aplicativo."
       }
     }
   }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -179,6 +179,12 @@
       "WHATSAPP_ZAPI": "WhatsApp - Z-API",
       "WHATSAPP_NATIVE": "WhatsApp - nativo",
       "WHATSAPP_UAZAPI": "WhatsApp - Uazapi"
+    },
+    "ACCOUNT_HEALTH": {
+      "WEBHOOK": {
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. A Meta recusou apontar este número para cá, então a entrega segue a URL de callback do aplicativo, mostrada abaixo.",
+        "NUMBER_NOT_ROUTED": "A entrega segue a URL de callback do aplicativo: este número não está apontado para esta instalação, então ela para se aquela URL mudar."
+      }
     }
   }
 }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -182,8 +182,8 @@
     },
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
-        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. A Meta recusou apontar este número para cá, então a entrega segue a URL de callback do aplicativo, mostrada abaixo.",
-        "NUMBER_NOT_ROUTED": "A entrega segue a URL de callback do aplicativo: este número não está apontado para esta instalação, então ela para se aquela URL mudar."
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado. A Meta recusou apontar este número em si para cá, então a entrega depende do callback de nível de conta, mostrado abaixo.",
+        "NUMBER_NOT_ROUTED": "A entrega segue a URL de callback do aplicativo: nem este número nem a conta do WhatsApp Business dele estão apontados para esta instalação, então ela para se aquela URL mudar."
       }
     }
   }

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -639,8 +639,17 @@ export default {
 
       try {
         this.isRegisteringWebhook = true;
-        await InboxHealthAPI.registerWebhook(this.inbox.id);
-        useAlert(this.$t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_SUCCESS'));
+        const { data } = await InboxHealthAPI.registerWebhook(this.inbox.id);
+        // Meta refuses the per-number override for a whole class of accounts, and that refusal no
+        // longer takes the channel down, so a plain success here would be the only thing the
+        // operator sees about a number that is not being routed to this installation.
+        useAlert(
+          data?.callback_override_applied === false
+            ? this.$t(
+                'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_SUCCESS_WITHOUT_ROUTING'
+              )
+            : this.$t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_SUCCESS')
+        );
         await this.fetchHealthData();
       } catch (error) {
         useAlert(

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -642,7 +642,11 @@ export default {
         const { data } = await InboxHealthAPI.registerWebhook(this.inbox.id);
         // Meta refuses the per-number override for a whole class of accounts, and that refusal no
         // longer takes the channel down, so a plain success here would be the only thing the
-        // operator sees about a number that is not being routed to this installation.
+        // operator sees about a write that did not land. The answer is about the write and says
+        // nothing about where delivery goes now: a number that already had an override keeps it,
+        // and the rescue behind this flag swallows a transient 500 the same as a refusal. The card
+        // is refreshed on the next line and reads the routing from Meta, so it is what the
+        // sentence points at.
         useAlert(
           data?.callback_override_applied === false
             ? this.$t(

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
@@ -373,18 +373,22 @@ const webhookUrlMismatch = computed(
     webhookUrl.value !== props.healthData?.expected_webhook_url
 );
 
-// The card is green whenever the effective URL is ours, and it is ours in two different
-// situations: this number is pointed here, or the app's own callback happens to be here and this
-// number rides on it. Meta refuses to point a number here for a whole class of accounts, and that
-// refusal no longer takes the channel down, so nothing distinguished the two: delivery works
-// until the app-level URL changes, and then this inbox goes quiet with a green card.
-const numberNotRoutedHere = computed(
-  () =>
+// Meta answers three levels of routing, and `webhookUrl` prefers them in that order: this number,
+// the WhatsApp Business Account it belongs to, and the app's own callback. The card is green
+// whenever the effective one is ours, which hides a real difference: routed by the first two, this
+// inbox owns its delivery; routed by the third, it is riding on a URL that belongs to the app and
+// can be pointed elsewhere at any time, and then this inbox goes quiet with a green card.
+const routedByAppCallbackOnly = computed(() => {
+  const configuration = props.healthData?.webhook_configuration;
+  const expected = props.healthData?.expected_webhook_url;
+
+  return (
     webhookConfigured.value &&
     !webhookUrlMismatch.value &&
-    props.healthData?.webhook_configuration?.phone_number !==
-      props.healthData?.expected_webhook_url
-);
+    configuration?.phone_number !== expected &&
+    configuration?.whatsapp_business_account !== expected
+  );
+});
 
 const handleRegisterWebhook = () => {
   emit('registerWebhook');
@@ -532,7 +536,7 @@ const handleCopyWebhookUrl = async url => {
             </ButtonV4>
           </div>
           <div
-            v-if="numberNotRoutedHere"
+            v-if="routedByAppCallbackOnly"
             class="flex gap-1.5 items-start text-label-small text-n-amber-11"
           >
             <Icon

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
@@ -385,10 +385,11 @@ const appCallbackRoutingMessage = computed(() => {
   if (!webhookConfigured.value) return null;
 
   // Mismatch splits into two repairs that the one chip cannot tell apart. With an override of its
-  // own, the button above rewrites it. With none, the URL on the card IS the app callback, and
-  // the button writes the per-number override that Meta refuses for exactly the accounts that end
-  // up here: pressing it changes nothing and the card comes back identical. The repair is at the
-  // app's callback, outside this screen, and the sentence is the only place that says so.
+  // own, the button above rewrites it and nothing else needs saying. With none, the URL on the
+  // card IS the app callback, so the button is writing a per-number override that does not exist
+  // yet: it repairs this whenever Meta allows it, and Meta refuses it for a whole class of
+  // accounts. Which of the two is only known at the press, and the toast reports it; the sentence
+  // is for before that, and it names the app callback as the fallback rather than as the repair.
   return webhookUrlMismatch.value
     ? 'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.APP_CALLBACK_POINTS_ELSEWHERE'
     : 'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.RIDES_ON_APP_CALLBACK';

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
@@ -373,22 +373,18 @@ const webhookUrlMismatch = computed(
     webhookUrl.value !== props.healthData?.expected_webhook_url
 );
 
-// Meta answers three levels of routing, and `webhookUrl` prefers them in that order: this number,
-// the WhatsApp Business Account it belongs to, and the app's own callback. The card is green
-// whenever the effective one is ours, which hides a real difference: routed by the first two, this
-// inbox owns its delivery; routed by the third, it is riding on a URL that belongs to the app and
-// can be pointed elsewhere at any time, and then this inbox goes quiet with a green card.
-const routedByAppCallbackOnly = computed(() => {
-  const configuration = props.healthData?.webhook_configuration;
-  const expected = props.healthData?.expected_webhook_url;
-
-  return (
+// The card is green whenever the effective URL is ours, which hides a real difference: routed by
+// this number or by its WhatsApp Business Account, the inbox owns its delivery; routed by the
+// app's own callback, it is riding on a URL that belongs to the installation and can be pointed
+// elsewhere at any time, and then this inbox goes quiet with a green card. The reading of Meta's
+// three levels is the endpoint's (`routed_by_app_callback_only`), so an API consumer sees the
+// same thing the screen does; what is decided here is only whether to say it a second time.
+const routedByAppCallbackOnly = computed(
+  () =>
+    props.healthData?.routed_by_app_callback_only === true &&
     webhookConfigured.value &&
-    !webhookUrlMismatch.value &&
-    configuration?.phone_number !== expected &&
-    configuration?.whatsapp_business_account !== expected
-  );
-});
+    !webhookUrlMismatch.value
+);
 
 const handleRegisterWebhook = () => {
   emit('registerWebhook');

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
@@ -373,18 +373,26 @@ const webhookUrlMismatch = computed(
     webhookUrl.value !== props.healthData?.expected_webhook_url
 );
 
-// The card is green whenever the effective URL is ours, which hides a real difference: routed by
-// this number or by its WhatsApp Business Account, the inbox owns its delivery; routed by the
-// app's own callback, it is riding on a URL that belongs to the installation and can be pointed
-// elsewhere at any time, and then this inbox goes quiet with a green card. The reading of Meta's
-// three levels is the endpoint's (`routed_by_app_callback_only`), so an API consumer sees the
-// same thing the screen does; what is decided here is only whether to say it a second time.
-const routedByAppCallbackOnly = computed(
-  () =>
-    props.healthData?.routed_by_app_callback_only === true &&
-    webhookConfigured.value &&
-    !webhookUrlMismatch.value
-);
+// A number with no override of its own rides on the app's own callback, which belongs to the
+// installation and can be pointed elsewhere at any time. The chip above cannot say that: green
+// whenever the effective URL is ours, amber "mismatch" whenever it is not, and both readings are
+// the same for a number that owns its routing and one that does not. The reading of Meta's three
+// levels is the endpoint's (`routed_by_app_callback_only`), so an API consumer sees what the
+// screen sees; what is decided here is which sentence that answer deserves.
+const appCallbackRoutingMessage = computed(() => {
+  if (props.healthData?.routed_by_app_callback_only !== true) return null;
+  // Nothing is configured at all: the chip already says so, and its button is the repair.
+  if (!webhookConfigured.value) return null;
+
+  // Mismatch splits into two repairs that the one chip cannot tell apart. With an override of its
+  // own, the button above rewrites it. With none, the URL on the card IS the app callback, and
+  // the button writes the per-number override that Meta refuses for exactly the accounts that end
+  // up here: pressing it changes nothing and the card comes back identical. The repair is at the
+  // app's callback, outside this screen, and the sentence is the only place that says so.
+  return webhookUrlMismatch.value
+    ? 'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.APP_CALLBACK_POINTS_ELSEWHERE'
+    : 'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.RIDES_ON_APP_CALLBACK';
+});
 
 const handleRegisterWebhook = () => {
   emit('registerWebhook');
@@ -532,7 +540,7 @@ const handleCopyWebhookUrl = async url => {
             </ButtonV4>
           </div>
           <div
-            v-if="routedByAppCallbackOnly"
+            v-if="appCallbackRoutingMessage"
             class="flex gap-1.5 items-start text-label-small text-n-amber-11"
           >
             <Icon
@@ -540,7 +548,7 @@ const handleCopyWebhookUrl = async url => {
               class="flex-shrink-0 mt-0.5 w-3.5 h-3.5"
             />
             <span>
-              {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED') }}
+              {{ t(appCallbackRoutingMessage) }}
             </span>
           </div>
           <div v-if="webhookConfigured" class="pt-1 space-y-2">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
@@ -373,6 +373,19 @@ const webhookUrlMismatch = computed(
     webhookUrl.value !== props.healthData?.expected_webhook_url
 );
 
+// The card is green whenever the effective URL is ours, and it is ours in two different
+// situations: this number is pointed here, or the app's own callback happens to be here and this
+// number rides on it. Meta refuses to point a number here for a whole class of accounts, and that
+// refusal no longer takes the channel down, so nothing distinguished the two: delivery works
+// until the app-level URL changes, and then this inbox goes quiet with a green card.
+const numberNotRoutedHere = computed(
+  () =>
+    webhookConfigured.value &&
+    !webhookUrlMismatch.value &&
+    props.healthData?.webhook_configuration?.phone_number !==
+      props.healthData?.expected_webhook_url
+);
+
 const handleRegisterWebhook = () => {
   emit('registerWebhook');
 };
@@ -517,6 +530,18 @@ const handleCopyWebhookUrl = async url => {
             >
               {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_BUTTON') }}
             </ButtonV4>
+          </div>
+          <div
+            v-if="numberNotRoutedHere"
+            class="flex gap-1.5 items-start text-label-small text-n-amber-11"
+          >
+            <Icon
+              icon="i-lucide-alert-triangle"
+              class="flex-shrink-0 mt-0.5 w-3.5 h-3.5"
+            />
+            <span>
+              {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED') }}
+            </span>
           </div>
           <div v-if="webhookConfigured" class="pt-1 space-y-2">
             <div class="flex items-center gap-3 min-w-0">

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -97,6 +97,23 @@ describe('AccountHealth', () => {
       );
     });
 
+    // Meta routes at three levels, and only the third one belongs to the app. A WABA-level
+    // override pointing here is this account's own routing: changing the app callback does not
+    // touch it.
+    it('stays quiet when the business account is the one pointed here', () => {
+      const wrapper = mountComponent({
+        webhook_configuration: {
+          whatsapp_business_account: expectedUrl,
+          application: 'https://elsewhere.example.com/webhooks/whatsapp/+123',
+        },
+        expected_webhook_url: expectedUrl,
+      });
+
+      expect(wrapper.text()).not.toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED'
+      );
+    });
+
     it('stays quiet when the override is in place for this number', () => {
       const wrapper = mountComponent({
         webhook_configuration: {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -80,11 +80,12 @@ describe('AccountHealth', () => {
     expect(wrapper.text()).toContain('2026');
   });
 
-  // Meta answers with the effective webhook configuration, and the card is green whenever the
-  // effective URL is ours. It is ours in two different situations, and only one of them means
-  // this number is pointed here.
+  // Meta answers with the effective webhook configuration, and the chip above reads it as two
+  // states: ours, or not ours. Both readings cover a number that owns its routing and a number
+  // that owns none, which are different problems with different repairs.
   describe('when the number itself is not pointed at this installation', () => {
     const expectedUrl = 'https://chat.example.com/webhooks/whatsapp/+123';
+    const elsewhereUrl = 'https://elsewhere.example.com/webhooks/whatsapp/+123';
 
     it('says so even though the card is green, because delivery rides on the app URL', () => {
       const wrapper = mountComponent({
@@ -94,7 +95,7 @@ describe('AccountHealth', () => {
       });
 
       expect(wrapper.text()).toContain(
-        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED'
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.RIDES_ON_APP_CALLBACK'
       );
     });
 
@@ -105,39 +106,54 @@ describe('AccountHealth', () => {
       const wrapper = mountComponent({
         webhook_configuration: {
           whatsapp_business_account: expectedUrl,
-          application: 'https://elsewhere.example.com/webhooks/whatsapp/+123',
+          application: elsewhereUrl,
         },
         expected_webhook_url: expectedUrl,
         routed_by_app_callback_only: false,
       });
 
-      expect(wrapper.text()).not.toContain(
-        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED'
-      );
+      expect(wrapper.text()).not.toContain('APP_CALLBACK');
     });
 
     it('stays quiet when the override is in place for this number', () => {
       const wrapper = mountComponent({
         webhook_configuration: {
           phone_number: expectedUrl,
-          application: 'https://elsewhere.example.com/webhooks/whatsapp/+123',
+          application: elsewhereUrl,
         },
         expected_webhook_url: expectedUrl,
         routed_by_app_callback_only: false,
       });
 
-      expect(wrapper.text()).not.toContain(
-        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED'
-      );
+      expect(wrapper.text()).not.toContain('APP_CALLBACK');
     });
 
-    // A mismatch already has its own chip and its own button, and two warnings about one problem
-    // is how the second one stops being read.
-    it('does not repeat itself when the URL already mismatches', () => {
+    // An override of its own pointing at the wrong place is a mismatch the button above repairs:
+    // registering rewrites that override. Saying anything about the app callback here would be
+    // false, since the app callback is not what delivery follows.
+    it('leaves the mismatch chip alone when the number has an override of its own', () => {
       const wrapper = mountComponent({
         webhook_configuration: {
-          application: 'https://elsewhere.example.com/webhooks/whatsapp/+123',
+          phone_number: elsewhereUrl,
+          application: expectedUrl,
         },
+        expected_webhook_url: expectedUrl,
+        routed_by_app_callback_only: false,
+      });
+
+      expect(wrapper.text()).toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.URL_MISMATCH'
+      );
+      expect(wrapper.text()).not.toContain('APP_CALLBACK');
+    });
+
+    // The same chip, the other repair. With no override of its own, the URL on the card IS the
+    // app callback, and the button writes the per-number override that Meta refuses for exactly
+    // these accounts: it comes back identical and the operator presses again. The sentence is the
+    // only thing on the screen that sends them to the app's own callback.
+    it('says the button cannot repoint it when the app callback is what points elsewhere', () => {
+      const wrapper = mountComponent({
+        webhook_configuration: { application: elsewhereUrl },
         expected_webhook_url: expectedUrl,
         routed_by_app_callback_only: true,
       });
@@ -145,9 +161,27 @@ describe('AccountHealth', () => {
       expect(wrapper.text()).toContain(
         'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.URL_MISMATCH'
       );
-      expect(wrapper.text()).not.toContain(
-        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED'
+      expect(wrapper.text()).toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.APP_CALLBACK_POINTS_ELSEWHERE'
       );
+      // The sentence for a URL that still points here would be a lie about one that does not.
+      expect(wrapper.text()).not.toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.RIDES_ON_APP_CALLBACK'
+      );
+    });
+
+    // Nothing configured at all is the chip's own case, and its button is the repair.
+    it('stays quiet when there is no webhook configuration to ride on', () => {
+      const wrapper = mountComponent({
+        webhook_configuration: {},
+        expected_webhook_url: expectedUrl,
+        routed_by_app_callback_only: true,
+      });
+
+      expect(wrapper.text()).toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.ACTION_REQUIRED'
+      );
+      expect(wrapper.text()).not.toContain('APP_CALLBACK');
     });
   });
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -148,10 +148,11 @@ describe('AccountHealth', () => {
     });
 
     // The same chip, the other repair. With no override of its own, the URL on the card IS the
-    // app callback, and the button writes the per-number override that Meta refuses for exactly
-    // these accounts: it comes back identical and the operator presses again. The sentence is the
-    // only thing on the screen that sends them to the app's own callback.
-    it('says the button cannot repoint it when the app callback is what points elsewhere', () => {
+    // app callback: the button is writing an override that does not exist yet, which lands unless
+    // Meta refuses it for this account, and only the press tells which. The sentence names the
+    // app callback as the fallback, so the operator is not sent to a shared URL for a number the
+    // button would have fixed.
+    it('names the app callback as the fallback when it is what points elsewhere', () => {
       const wrapper = mountComponent({
         webhook_configuration: { application: elsewhereUrl },
         expected_webhook_url: expectedUrl,

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -90,6 +90,7 @@ describe('AccountHealth', () => {
       const wrapper = mountComponent({
         webhook_configuration: { application: expectedUrl },
         expected_webhook_url: expectedUrl,
+        routed_by_app_callback_only: true,
       });
 
       expect(wrapper.text()).toContain(
@@ -107,6 +108,7 @@ describe('AccountHealth', () => {
           application: 'https://elsewhere.example.com/webhooks/whatsapp/+123',
         },
         expected_webhook_url: expectedUrl,
+        routed_by_app_callback_only: false,
       });
 
       expect(wrapper.text()).not.toContain(
@@ -121,6 +123,7 @@ describe('AccountHealth', () => {
           application: 'https://elsewhere.example.com/webhooks/whatsapp/+123',
         },
         expected_webhook_url: expectedUrl,
+        routed_by_app_callback_only: false,
       });
 
       expect(wrapper.text()).not.toContain(
@@ -136,6 +139,7 @@ describe('AccountHealth', () => {
           application: 'https://elsewhere.example.com/webhooks/whatsapp/+123',
         },
         expected_webhook_url: expectedUrl,
+        routed_by_app_callback_only: true,
       });
 
       expect(wrapper.text()).toContain(

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -80,6 +80,56 @@ describe('AccountHealth', () => {
     expect(wrapper.text()).toContain('2026');
   });
 
+  // Meta answers with the effective webhook configuration, and the card is green whenever the
+  // effective URL is ours. It is ours in two different situations, and only one of them means
+  // this number is pointed here.
+  describe('when the number itself is not pointed at this installation', () => {
+    const expectedUrl = 'https://chat.example.com/webhooks/whatsapp/+123';
+
+    it('says so even though the card is green, because delivery rides on the app URL', () => {
+      const wrapper = mountComponent({
+        webhook_configuration: { application: expectedUrl },
+        expected_webhook_url: expectedUrl,
+      });
+
+      expect(wrapper.text()).toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED'
+      );
+    });
+
+    it('stays quiet when the override is in place for this number', () => {
+      const wrapper = mountComponent({
+        webhook_configuration: {
+          phone_number: expectedUrl,
+          application: 'https://elsewhere.example.com/webhooks/whatsapp/+123',
+        },
+        expected_webhook_url: expectedUrl,
+      });
+
+      expect(wrapper.text()).not.toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED'
+      );
+    });
+
+    // A mismatch already has its own chip and its own button, and two warnings about one problem
+    // is how the second one stops being read.
+    it('does not repeat itself when the URL already mismatches', () => {
+      const wrapper = mountComponent({
+        webhook_configuration: {
+          application: 'https://elsewhere.example.com/webhooks/whatsapp/+123',
+        },
+        expected_webhook_url: expectedUrl,
+      });
+
+      expect(wrapper.text()).toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.URL_MISMATCH'
+      );
+      expect(wrapper.text()).not.toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.NUMBER_NOT_ROUTED'
+      );
+    });
+  });
+
   it('shows the current error instead of stale health data', () => {
     const wrapper = mountComponent(
       { verified_name: 'Stale Business Name' },

--- a/app/services/whatsapp/facebook_api_client.rb
+++ b/app/services/whatsapp/facebook_api_client.rb
@@ -86,10 +86,16 @@ class Whatsapp::FacebookApiClient
   # `Webhooks::WhatsappEventsJob` then discarded every inbound webhook for it: a number was dead for hours while
   # Meta kept delivering, nine webhooks in and no conversations out. So it is best effort here, the same way the
   # phone registration already is, and refused by the same accounts for the same reason.
+  #
+  # Answers whether that optional half landed. The required one raises when it fails, so reaching
+  # the answer at all means Meta is delivering; `false` means it is delivering to whatever the
+  # app's own callback says, which on an installation that points elsewhere is the difference
+  # between a working inbox and a quiet one. The caller is what turns that answer into something
+  # the operator can see.
   def subscribe_phone_number_webhook(waba_id, phone_number_id, callback_url, verify_token, subscribed_fields: nil)
-    subscription = subscribe_app_to_waba(waba_id, subscribed_fields: subscribed_fields || WEBHOOK_DEFAULT_FIELDS)
+    subscribe_app_to_waba(waba_id, subscribed_fields: subscribed_fields || WEBHOOK_DEFAULT_FIELDS)
 
-    optional_callback_override(phone_number_id, callback_url, verify_token) || subscription
+    callback_override_applied?(phone_number_id, callback_url, verify_token)
   end
 
   def subscribe_app_to_waba(waba_id, subscribed_fields: WEBHOOK_DEFAULT_FIELDS)
@@ -147,15 +153,19 @@ class Whatsapp::FacebookApiClient
   # 403 carrying Meta's code 200, as a plain 500, and as a connection that closes with nothing to
   # read. A guard that recognizes one shape leaves the other two killing the channel.
   #
-  # It is the only record that the routing was not applied, so it names the call and the number:
-  # on an installation whose app-level callback points elsewhere, this line is the difference
-  # between a quiet inbox and a diagnosis.
-  def optional_callback_override(phone_number_id, callback_url, verify_token)
+  # The line names the call and the number because it is what a diagnosis starts from: the answer
+  # below reaches the operator as a sentence, and the log is where you find which number and which
+  # URL were refused.
+  #
+  # The rescue is the whole definition of "not applied": a refusal is the only way this call does
+  # not land, and reading the body for a shape would put the three of them back in play.
+  def callback_override_applied?(phone_number_id, callback_url, verify_token)
     override_phone_number_callback(phone_number_id, callback_url, verify_token)
+    true
   rescue StandardError => e
     Rails.logger.warn('[WHATSAPP] Phone number webhook callback override failed but continuing ' \
                       "(phone_number_id #{phone_number_id}, #{callback_url}): #{e.message}")
-    nil
+    false
   end
 
   def request_headers

--- a/config/initializers/zz_fake_graph.rb
+++ b/config/initializers/zz_fake_graph.rb
@@ -1,0 +1,9 @@
+# Não versionado: redireciona a Graph da Meta para o servidor falso da rodada.
+if ENV['FAKE_GRAPH_BASE_URI'].present?
+  Rails.application.config.to_prepare do
+    [Whatsapp::FacebookApiClient, Whatsapp::HealthService].each do |klass|
+      klass.send(:remove_const, :BASE_URI) if klass.const_defined?(:BASE_URI, false)
+      klass.const_set(:BASE_URI, ENV.fetch('FAKE_GRAPH_BASE_URI'))
+    end
+  end
+end

--- a/config/initializers/zz_fake_graph.rb
+++ b/config/initializers/zz_fake_graph.rb
@@ -1,9 +1,0 @@
-# Não versionado: redireciona a Graph da Meta para o servidor falso da rodada.
-if ENV['FAKE_GRAPH_BASE_URI'].present?
-  Rails.application.config.to_prepare do
-    [Whatsapp::FacebookApiClient, Whatsapp::HealthService].each do |klass|
-      klass.send(:remove_const, :BASE_URI) if klass.const_defined?(:BASE_URI, false)
-      klass.const_set(:BASE_URI, ENV.fetch('FAKE_GRAPH_BASE_URI'))
-    end
-  end
-end

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1621,6 +1621,58 @@ RSpec.describe 'Inboxes API', type: :request do
   # of accounts, and since that refusal stopped taking the channel down (#568) the answer here was
   # "registered successfully" either way, which is the only thing the operator sees at the moment
   # they press it.
+  # Meta answers three levels of webhook routing and delivery follows the most specific one that
+  # exists, so the same green "configured" URL means two different things: the inbox owns its
+  # routing, or it is riding on the app's own callback and stops the day that URL changes.
+  describe 'GET /api/v1/accounts/{account.id}/inboxes/{inbox.id}/health routing level' do
+    let(:whatsapp_channel) do
+      create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false)
+    end
+    let(:whatsapp_inbox) { create(:inbox, account: account, channel: whatsapp_channel) }
+    let(:expected_url) { 'https://chat.example.com/webhooks/whatsapp/+123' }
+    let(:health_service) { instance_double(Whatsapp::HealthService) }
+
+    # The outer keys are the service's own symbols; the ones inside come from Meta's JSON.
+    def stub_health(configuration)
+      allow(Whatsapp::HealthService).to receive(:new).and_return(health_service)
+      allow(health_service).to receive(:sync_health_status!).and_return(
+        { id: 'phone123', webhook_configuration: configuration, expected_webhook_url: expected_url }
+      )
+    end
+
+    def routing_answer
+      get "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/health",
+          headers: admin.create_new_auth_token, as: :json
+      response.parsed_body['routed_by_app_callback_only']
+    end
+
+    it 'is false when this number is the one pointed here' do
+      stub_health({ 'phone_number' => expected_url, 'application' => 'https://elsewhere.example.com/hook' })
+
+      expect(routing_answer).to be(false)
+    end
+
+    it 'is false when the business account is the one pointed here' do
+      stub_health({ 'whatsapp_business_account' => expected_url, 'application' => 'https://elsewhere.example.com/hook' })
+
+      expect(routing_answer).to be(false)
+    end
+
+    it 'is true when only the app callback is pointed here' do
+      stub_health({ 'application' => expected_url })
+
+      expect(routing_answer).to be(true)
+    end
+
+    # Not knowing is not a warning: Meta answering nothing about the configuration says nothing
+    # about where this number is routed.
+    it 'is false when Meta did not answer the configuration' do
+      stub_health(nil)
+
+      expect(routing_answer).to be(false)
+    end
+  end
+
   describe 'POST /api/v1/accounts/{account.id}/inboxes/{inbox.id}/register_webhook' do
     let(:whatsapp_channel) do
       create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false)

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1617,6 +1617,95 @@ RSpec.describe 'Inboxes API', type: :request do
     end
   end
 
+  # The button on the inbox health screen. Meta refuses the per-number override for a whole class
+  # of accounts, and since that refusal stopped taking the channel down (#568) the answer here was
+  # "registered successfully" either way, which is the only thing the operator sees at the moment
+  # they press it.
+  describe 'POST /api/v1/accounts/{account.id}/inboxes/{inbox.id}/register_webhook' do
+    let(:whatsapp_channel) do
+      create(:channel_whatsapp, account: account, provider: 'whatsapp_cloud', sync_templates: false, validate_provider_config: false)
+    end
+    let(:whatsapp_inbox) { create(:inbox, account: account, channel: whatsapp_channel) }
+    let(:phone_number_id) { whatsapp_channel.provider_config['phone_number_id'] }
+    let(:waba_id) { whatsapp_channel.provider_config['business_account_id'] }
+    let(:api_version) { 'v22.0' }
+    let(:subscription) do
+      stub_request(:post, "https://graph.facebook.com/#{api_version}/#{waba_id}/subscribed_apps")
+        .to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    before do
+      allow(GlobalConfigService).to receive(:load).and_call_original
+      allow(GlobalConfigService).to receive(:load).with('WHATSAPP_API_VERSION', 'v22.0').and_return(api_version)
+      subscription
+    end
+
+    context 'when Meta accepts both calls' do
+      before do
+        stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")
+          .to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'says the routing was applied' do
+        post "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/register_webhook",
+             headers: admin.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body).to eq('message' => 'Webhook registered successfully', 'callback_override_applied' => true)
+      end
+    end
+
+    # The refusal this endpoint has to describe: the WABA subscription lands, so Meta delivers,
+    # and the number is not pointed at this installation.
+    context 'when Meta refuses the per-number override' do
+      before do
+        stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")
+          .to_return(status: 403, body: { error: { message: '(#200) Permissions error', code: 200 } }.to_json)
+      end
+
+      it 'still succeeds, and says the routing was not applied' do
+        post "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/register_webhook",
+             headers: admin.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body).to eq('message' => 'Webhook registered successfully', 'callback_override_applied' => false)
+        expect(subscription).to have_been_requested
+      end
+
+      it 'leaves the channel authorized, which is what #568 fixed' do
+        post "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/register_webhook",
+             headers: admin.create_new_auth_token, as: :json
+
+        expect(whatsapp_channel.reload.reauthorization_required?).to be(false)
+      end
+    end
+
+    context 'when the subscription Meta needs fails' do
+      before do
+        stub_request(:post, "https://graph.facebook.com/#{api_version}/#{waba_id}/subscribed_apps")
+          .to_return(status: 400, body: { error: { message: 'App subscription to WABA failed' } }.to_json)
+      end
+
+      it 'answers the failure instead of a partial success' do
+        post "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/register_webhook",
+             headers: admin.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to include('Webhook setup failed')
+        expect(response.parsed_body).not_to have_key('callback_override_applied')
+      end
+    end
+
+    context 'when the user is not an administrator' do
+      it 'refuses' do
+        post "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/register_webhook",
+             headers: agent.create_new_auth_token, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   describe 'POST /api/v1/accounts/:account_id/inboxes/:id/setup_channel_provider' do
     let(:channel) { create(:channel_whatsapp, account: account, provider: 'baileys', validate_provider_config: false) }
     let(:inbox) { channel.inbox }

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1646,14 +1646,23 @@ RSpec.describe 'Inboxes API', type: :request do
       response.parsed_body['routed_by_app_callback_only']
     end
 
-    it 'is false when this number is the one pointed here' do
+    it 'is false when this number has an override of its own' do
       stub_health({ 'phone_number' => expected_url, 'application' => 'https://elsewhere.example.com/hook' })
 
       expect(routing_answer).to be(false)
     end
 
-    it 'is false when the business account is the one pointed here' do
+    it 'is false when the business account has one' do
       stub_health({ 'whatsapp_business_account' => expected_url, 'application' => 'https://elsewhere.example.com/hook' })
+
+      expect(routing_answer).to be(false)
+    end
+
+    # Delivery follows the most specific override that exists, wherever it points: a number sent
+    # to the wrong place is misrouted, not riding on the app callback, and the card already says
+    # so with its own URL mismatch warning.
+    it 'is false when the override exists but points somewhere else' do
+      stub_health({ 'phone_number' => 'https://elsewhere.example.com/hook', 'application' => expected_url })
 
       expect(routing_answer).to be(false)
     end

--- a/spec/services/whatsapp/facebook_api_client_spec.rb
+++ b/spec/services/whatsapp/facebook_api_client_spec.rb
@@ -216,9 +216,9 @@ describe Whatsapp::FacebookApiClient do
           )
       end
 
-      it 'returns success response' do
+      it 'answers that the per-number routing landed' do
         result = api_client.subscribe_phone_number_webhook(waba_id, phone_number_id, callback_url, verify_token)
-        expect(result['success']).to be(true)
+        expect(result).to be(true)
       end
     end
 
@@ -263,10 +263,10 @@ describe Whatsapp::FacebookApiClient do
         context "when Meta answers with #{shape}" do
           before { refuse.call(stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")) }
 
-          it 'does not raise, and answers with the subscription that did land' do
+          it 'does not raise, and answers that the routing was not applied' do
             result = api_client.subscribe_phone_number_webhook(waba_id, phone_number_id, callback_url, verify_token)
 
-            expect(result['success']).to be(true)
+            expect(result).to be(false)
           end
 
           it 'says in the log which call was refused and for which number' do


### PR DESCRIPTION
An inbox whose number Meta refused to point at this installation now says so, in the two places the operator is looking: the answer to the "register webhook" button, and the webhook card on the inbox health tab. Until now both said everything was fine, because delivery does work, right up until the app-level callback URL changes and the inbox goes quiet with a green card.

## Closes

- Fixes #575

## How to reproduce

Connect a **coexistence** number whose WABA sits in the customer's own Business Manager. Setup makes two calls: `POST /{waba_id}/subscribed_apps`, which is what makes Meta deliver at all, and `POST /{phone_number_id}` with `webhook_configuration.override_callback_uri`, which points that one number at this installation. Meta answers `(#200) Permissions error` to the second one for that whole class of accounts.

Since #568 that refusal is tolerated instead of marking the channel for reauthorization, which was the right call and is not changed here. What it left behind is the absence this fixes: press "register webhook" and the answer is `200 {"message":"Webhook registered successfully"}`, and the health card shows the green "configured" chip, because the effective webhook URL it reads from Meta falls back to the app-level one, which on an installation whose app callback already points here is the same URL.

## What changed

The refusal now has an answer and a state, and neither one claims the authorization is broken.

- `FacebookApiClient#subscribe_phone_number_webhook` answers whether the optional half landed (the required half still raises), and `register_webhook` returns it as `callback_override_applied`. The button's toast says "registered, and this number is not pointed here" when it is false.
- `GET .../health` gains `routed_by_app_callback_only`. Meta answers three levels of routing and delivery follows the most specific one that **exists**, wherever it points, so the question is existence and not the URL: an override of this number's own, or of the WhatsApp Business Account it belongs to, means the inbox owns its routing even when that override points somewhere wrong, which is a different problem with its own warning. Only when neither exists does delivery ride on the app's own callback. It is read on every request and deliberately **not** persisted: Meta's answer is the current truth, a stored flag would go stale the moment someone fixes the routing outside a setup run, and it is `false` when Meta answered no configuration at all, because not knowing is not a warning.
- The health card turns that field into one of two lines, so the screen and an API consumer read the same thing. "Webhook URL mismatch" is one chip for two different repairs, and which one it is depends on the same question: with an override of its own pointing at the wrong place, the button above rewrites it and the card says nothing more; with no override at all, the URL on the card **is** the app's callback, and the line names what the button does and what to change if Meta refuses it. An override that does not exist is not an override that Meta refused, and only the press tells which, so the line describes the state and the toast reports the refusal.

One premise of the issue did not survive the reading and was not acted on: the report says a refusal leaves no signal at all, and for the dangerous case it already left one. When the app-level callback points somewhere else, the URL the health card reads back from Meta is that other URL, so it already showed "URL mismatch" in amber with a register button. What had no signal was the case where the app URL happens to be ours: everything works, nothing says the number itself is unpinned, and a change to that URL takes the inbox down silently.

Also not acted on, and named in the issue: how many installations point their app callback elsewhere. That is a question about each installation's Meta app configuration and nothing in this repository can answer it.

## Validation scope

Proven by test, backend: the two calls are made in the same order, a refused override answers `callback_override_applied: false` with HTTP 200 and leaves the channel authorized, an accepted one answers `true`, a failure of the required subscription still answers 422 with no partial success, and an agent still cannot press the button. The health endpoint answers the routing level for each of the five shapes: an override of this number, one of its business account, an override pointing somewhere else, only the app callback, and no configuration at all. Frontend: the line appears when the endpoint says app-only, stays quiet for an override of this number or of its business account, stays quiet when nothing is configured at all, keeps out of the way of a mismatch the button repairs, and switches to its own wording when the mismatched URL is the app callback itself.

Red before the change: 13 failing at `6c29700d` (11 backend, 2 frontend). Twenty-nine mutations were run across two batteries and twenty-eight failed a spec, including counting a refusal as applied, returning the subscription instead of the answer, dropping the log line, dropping either field from a response, answering `true` always, tolerating the required subscription too, reading the app URL instead of the number's, reading where an override points instead of whether it exists, letting one of the two levels decide alone, collapsing the two lines into either one alone, swapping them, dropping the guard for nothing-configured, and ignoring or inverting the endpoint's answer. The whole battery was re-run at this head rather than extended, because the frontend guard changed shape. The survivor is the toast in `Settings.vue`, which no spec harness covers; it is covered by the screenshots instead.

Three of those came out of review rather than out of me: the first pass ignored the WABA-level override entirely, the second asked where an override pointed instead of whether it existed, and the third claimed the register button could not repair a number with no override of its own, which sent the operator to a callback URL shared with every other number on the installation when the button would have fixed it.

Proven against the running app, both halves on the same harness (Puma in the worktree, Meta's Graph pointed at a local fake that logs every request, the inbox health tab driven in a real browser). With the client at `6c29700d` and the override refused with `(#200) Permissions error`, pressing "Register Webhook" answered the toast "Webhook registered successfully" and the green card said nothing about the routing. With the same refusal at this commit, the same click answers "Webhook registered. Meta refused to point this number itself here, so delivery depends on the account-level callback shown below.", and the card carries the new line. The fake's request log shows both calls on each run: `POST /{waba}/subscribed_apps` answering 200 and `POST /{phone_number_id}` answering 403.

The second case was exercised on the same harness at this head: with the fake answering an app callback of `https://other-install.example.com/...` and no override, the card showed only the mismatch chip and its button before the change, and the chip plus the new line after it.

Not proven here: the behaviour against Meta itself. The refusal is reproduced from the shape quoted in the report and in #568, not from a live coexistence number in a customer's Business Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/583)
<!-- Reviewable:end -->

