### PR TITLE
fix(whatsapp): mandar o teardown da sessão nativa pelo stream de controle

### DIFF
--- a/app/services/whatsapp/connector/client.rb
+++ b/app/services/whatsapp/connector/client.rb
@@ -89,8 +89,17 @@ class Whatsapp::Connector::Client
     await(command, timeout)
   end
 
-  # Session-agnostic commands (wake, ping): any live instance answers.
+  # Commands that go to the fleet rather than to one session's owner: a wake, a ping, and
+  # the teardown of a session nobody is running.
+  #
+  # Guarded like `publish` and for the same reason, which used to be covered by accident:
+  # the only caller was `connect`, whose `call` right after raises before anything reads
+  # the wake. A fire-and-forget command written here is the whole of what the caller does,
+  # and a connector that is up and speaks another protocol consumes the frame and drops it
+  # while the caller is told it was queued -- which for a teardown is a device left listed
+  # on somebody's phone with nothing anywhere saying so.
   def control(payload, timeout: RPC_TIMEOUT)
+    ensure_readable!
     rpc = model::Commands.rpc?(payload.class.wire_type)
     command = build(payload, reply_to: rpc, timeout: (timeout - DEADLINE_MARGIN if rpc))
     write(Whatsapp::Connector.key('control'), command)

--- a/app/services/whatsapp/session/backends/connector/backend.rb
+++ b/app/services/whatsapp/session/backends/connector/backend.rb
@@ -106,26 +106,45 @@ class Whatsapp::Session::Backends::Connector::Backend < Whatsapp::Session::Backe
     client.publish(commands::SessionLogout.new)
   end
 
-  # The teardown, published as a pair, and the `logout` is the half that matters most: it
-  # unlinks the device from the customer's phone, which is the part of a pairing that
-  # outlives this inbox. `session.delete` is what clears the session's own rows, and a
-  # connector build without a handler for it answers `unsupported` and undoes nothing -- so
-  # sending `delete` alone leaves a device listed on somebody's phone with nothing in
-  # Chatwoot corresponding to it.
+  # The teardown, and the two halves go by different routes because they cover states the
+  # other cannot reach.
   #
-  # Ordering is what makes the pair safe rather than redundant. Both land on this session's
-  # command stream in the order written, so the `delete` that follows finds nothing linked,
-  # which is a teardown with less to do and not a failure to retry.
+  # `session.delete` goes on the **control stream**, which every connector instance reads.
+  # A connector reads `wa:cmd:<sid>` only for the sessions it is running, so a teardown
+  # written there for an account nobody has adopted is delivered to nobody at all and dies
+  # when the stream is trimmed -- and that is exactly the state a teardown is most often
+  # sent in: an inbox destroyed while its session was down, or destroyed while the
+  # connector fleet was restarting. On the control stream, whoever reads it adopts the
+  # account for the length of the teardown and tears it down without ever connecting.
   #
-  # Published, not called, for two independent reasons. This runs inside the transaction
-  # that destroys the inbox, and an RPC there would hold it open for the round trip. And a
-  # teardown is deliberately left pending, with no reply at all, while the session is
-  # between owners -- being handed over, or waiting on a lease with room to finish -- so a
-  # caller waiting for an answer would time out exactly when the connector is doing the
-  # right thing.
+  # The `session.logout` stays, on the session's own stream, and it is not redundant.
+  # Delivery through the control stream is to *some* instance rather than to the one
+  # running the account: an entry naming a session somebody else owns is left pending and
+  # reclaimed until it reaches that owner, which happens but is not bounded. The logout
+  # rides the owner's own stream, so for a session that is up the device is unlinked at
+  # once, and the delete that follows finds nothing linked, which is a teardown with less
+  # to do rather than a failure. It is also what keeps this working against a connector
+  # build older than fazer-ai/whatsapp-connector#157, whose `session.delete` has no
+  # handler and answers `unsupported`.
+  #
+  # Neither is `call`ed. This runs inside the transaction that destroys the inbox, and an
+  # RPC there would hold it open for the round trip. And a teardown is deliberately left
+  # pending, with no reply at all, while the session is between owners -- being handed
+  # over, or waiting on a lease with room to finish -- so a caller waiting for an answer
+  # would time out exactly when the connector is doing the right thing.
+  #
+  # Logged here, which is the only place it can be. The connector answers a teardown it
+  # could not carry out with `command.failed`, and that event is routed to an inbox by
+  # `session_id`: the inbox this one is about has just been destroyed, so the lookup
+  # misses and the event is dropped as an orphan. What we publish is the last thing about
+  # this session that anybody can see.
+  #
+  # One hash rather than two assignments so the method stays inside this class's line
+  # budget; Ruby evaluates the values in order, so the logout is still written first, and
+  # a spec pins that ordering rather than leaving it to be read out of this comment.
   def delete_session
-    client.publish(commands::SessionLogout.new)
-    client.publish(commands::SessionDelete.new)
+    asked = { logout: client.publish(commands::SessionLogout.new), delete: client.control(commands::SessionDelete.new) }
+    Rails.logger.info("[WHATSAPP] tearing session #{session_id} down for inbox #{channel.inbox&.id}: #{asked.to_json}")
   end
 
   def fetch_connection_state

--- a/spec/services/whatsapp/connector/client_spec.rb
+++ b/spec/services/whatsapp/connector/client_spec.rb
@@ -134,6 +134,28 @@ RSpec.describe Whatsapp::Connector::Client, :redis_streams do
       expect(frame).not_to have_key('deadline')
     end
 
+    # The wake used to be the only caller here, and what refused a connector speaking
+    # another protocol was the `call` that `connect` makes right after it. A teardown has
+    # no call behind it: written to a connector that reads the frame and drops it, the
+    # caller is told it was queued, and the device stays listed on the customer's phone
+    # with the inbox already destroyed.
+    it 'refuses to queue for a connector that speaks another protocol' do
+      redis.hset("#{prefix}instance:one", 'protocol_min', '2', 'protocol_max', '3')
+      redis.sadd("#{prefix}instances", 'one')
+
+      expect { client.control(model::Commands::SessionDelete.new) }
+        .to raise_error(Whatsapp::Session::Errors::ProviderUnavailable, /speaks protocol 1/)
+      expect(redis.exists?("#{prefix}control")).to be(false)
+    end
+
+    # An empty registry is a different thing, and it is fine for the same reason it is on
+    # publish: the stream holds the frame until a connector comes up and reads it, which
+    # is what a teardown nobody waits on is for.
+    it 'queues a control command with nobody listening yet' do
+      expect { client.control(model::Commands::SessionDelete.new) }.not_to raise_error
+      expect(redis.xrange("#{prefix}control").size).to eq(1)
+    end
+
     it 'bounds a control command that answers the way it bounds an RPC' do
       allow(SecureRandom).to receive(:uuid).and_return('cmd-0003')
       redis.lpush("#{prefix}reply:cmd-0003", { 'v' => 1, 'id' => 'cmd-0003', 'ok' => true, 'result' => {} }.to_json)

--- a/spec/services/whatsapp/session/backends/connector/backend_publish_ceiling_spec.rb
+++ b/spec/services/whatsapp/session/backends/connector/backend_publish_ceiling_spec.rb
@@ -18,21 +18,38 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
     let(:unbounded_on_purpose) { %w[disconnect logout delete_session] }
 
     # [method name, source line] for every `client.publish` call in the backend.
-    let(:publish_sites) do
+    let(:publish_sites) { sites_calling('client.publish(') }
+
+    # The same question, asked of the other fire-and-forget door. A command written to the
+    # control stream has no caller waiting on it either, so nothing else bounds it, and
+    # moving a command from one door to the other must not take it out of the sweep.
+    let(:control_sites) { sites_calling('client.control(') }
+
+    def sites_calling(call)
       method = nil
       source.readlines.each_with_object([]) do |line, sites|
         method = Regexp.last_match(1) if line =~ /^\s*def ([a-z_0-9?!]+)/
-        sites << [method, line] if line.include?('client.publish(')
+        sites << [method, line] if line.include?(call)
       end
     end
 
     it 'finds every publish site the backend has' do
       # Vacuity guard: a rename or a refactor that hides the calls would leave the sweep
       # passing over nothing at all.
-      expect(publish_sites.size).to eq(10)
+      expect(publish_sites.size).to eq(9)
       expect(publish_sites.map(&:first).uniq)
         .to contain_exactly('disconnect', 'logout', 'delete_session', 'request_pairing_code', 'mark_read',
                             'mark_unread', 'send_chat_presence', 'update_presence', 'subscribe_presence')
+    end
+
+    # Both are unbounded on purpose, and for one reason: each starts something for a
+    # session that may not be running, where "do not start after this" is the reading of
+    # `deadline` that costs more than the other buys. A wake dropped for arriving late is
+    # a session nobody starts; a teardown dropped for arriving late is a device left
+    # listed on the customer's phone.
+    it 'finds every control site, and each is a command that must not be dropped for being late' do
+      expect(control_sites.map(&:first)).to contain_exactly('connect', 'delete_session')
+      expect(control_sites.select { |_, line| line.include?('timeout:') }).to be_empty
     end
 
     it 'declares a ceiling at every publish site that is not the teardown' do

--- a/spec/services/whatsapp/session/backends/connector/backend_spec.rb
+++ b/spec/services/whatsapp/session/backends/connector/backend_spec.rb
@@ -125,15 +125,40 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
     expect(client).to have_received(:call).ordered
   end
 
+  # A connector reads a session's own command stream only while it is running that
+  # session, so a teardown written there for an account nobody has adopted reaches no
+  # connector at all and dies when the stream is trimmed -- which is the state an inbox is
+  # most often destroyed in. The control stream is read by every instance.
+  it 'asks for the session to be deleted on the control stream, where an account nobody runs is still reachable' do
+    backend.delete_session
+
+    expect(client).to have_received(:control).with(an_instance_of(model::Commands::SessionDelete))
+    expect(client).not_to have_received(:publish).with(an_instance_of(model::Commands::SessionDelete))
+  end
+
   # The pairing is what outlives the inbox: a device stays listed on the customer's phone
-  # with nothing in Chatwoot corresponding to it. `session.delete` is the command that
-  # clears the session's own rows, and a connector build with no handler for it answers
-  # `unsupported` and undoes nothing, so the unlink cannot be left to it alone.
-  it 'unlinks the device before it asks for the session to be deleted' do
+  # with nothing in Chatwoot corresponding to it. Delivery through the control stream is
+  # to some instance rather than to the one running the account, so for a session that is
+  # up the unlink rides the owner's own stream and happens at once.
+  it 'unlinks the device on the session stream before it asks for the session to be deleted' do
     backend.delete_session
 
     expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionLogout)).ordered
-    expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionDelete)).ordered
+    expect(client).to have_received(:control).with(an_instance_of(model::Commands::SessionDelete)).ordered
+  end
+
+  # The connector answers a teardown it could not carry out with `command.failed`, and
+  # that event is routed to an inbox by `session_id`: this inbox is being destroyed, so
+  # the lookup misses and the event is dropped as an orphan. What is written here is the
+  # last thing about the session anybody can see.
+  it 'writes down what it asked for, because the failure has nowhere to be reported' do
+    allow(Rails.logger).to receive(:info)
+
+    backend.delete_session
+
+    # The command ids too: they are what ties this line to the connector's own log, which
+    # is the only other place a teardown that failed leaves a trace.
+    expect(Rails.logger).to have_received(:info).with(/tearing session #{session_id} down.*cmd-0001.*cmd-0002/)
   end
 
   # Not `call`. This runs inside the transaction that destroys the inbox, and the connector
@@ -349,6 +374,6 @@ RSpec.describe Whatsapp::Session::Backends::Connector::Backend do
 
     expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionDisconnect))
     expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionLogout)).twice
-    expect(client).to have_received(:publish).with(an_instance_of(model::Commands::SessionDelete))
+    expect(client).to have_received(:control).with(an_instance_of(model::Commands::SessionDelete))
   end
 end


### PR DESCRIPTION
Destruir uma inbox nativa com a sessão fora do ar não desligava nada: o aparelho continuava pareado no telefone do cliente, e não havia log, evento ou recusa em lugar nenhum dizendo isso.

## Closes

Closes #537

## O que acontecia

`delete_session` publicava `session.logout` e `session.delete` em `wa:cmd:<sid>`. Uma instância do connector lê o stream de comando **só das sessões que ela roda** (`sids := c.manager.SIDs()` alimenta o `streamsFor`, e o mesmo escopo vale para os reclaims), então `wa:cmd:<sid>` de uma conta que ninguém adotou não está no read set de instância nenhuma. O par fica no stream sem leitor até o `MAXLEN` cortar.

Não é um caso de borda: é o estado em que a maior parte dos teardowns chega. Inbox destruída com a sessão desconectada, e inbox destruída durante um restart da frota.

## A correção

`session.delete` vai pelo **control**, que toda instância lê. Quem pegar a entrada adota a conta pelo tempo da destruição e a derruba sem nunca conectar. O outro lado disso entrou no connector hoje: fazer-ai/whatsapp-connector#157, no `main` em `03f6774`, que roteia o `session.delete` pelo tipo do comando e não pelo stream em que ele chegou, então as duas rotas funcionam.

## O `session.logout` fica, e a issue dizia que ele sairia

A #537 previa tirá-lo, e mudei de ideia ao medir o que a rota nova garante. Entrega pelo control é para **alguma** instância, não para a que está rodando a conta: uma entrada que nomeia sessão de outro dono é solta por quem a leu e reclamada depois até chegar nele, o que acontece mas não tem prazo. O logout vai pelo stream do próprio dono, então com a sessão de pé o aparelho é desvinculado na hora, e o `delete` que chega depois encontra nada pareado, que é um teardown com menos a fazer e não uma falha (o connector trata esse caso explicitamente, com log de debug).

Cada um cobre o estado que o outro não alcança, e há um terceiro efeito: isto continua funcionando contra um connector anterior à #157, cujo `session.delete` responde `unsupported`. É o que evita uma janela de regressão entre o deploy do Chatwoot e o da imagem nova do connector.

## Duas coisas vêm junto

**`control` passa a chamar `ensure_readable!`.** A proteção existia por acidente: o único chamador era o `connect`, cujo `call` logo em seguida recusa um connector que fala outro protocolo. Um comando fire-and-forget escrito ali é tudo o que o chamador faz, e um connector de outro protocolo consome o frame e descarta enquanto o chamador é informado de que foi enfileirado. Registro vazio continua liberado, como no `publish`: o stream segura o frame até alguém subir.

**O teardown é registrado no log daqui**, com os ids dos dois comandos. É o único lugar onde pode ser: o connector responde um teardown que falhou com `command.failed`, e esse evento é roteado para a inbox por `session_id`. A inbox em questão acabou de ser destruída, então a busca não acha e o evento é descartado com o aviso genérico de órfão.

## Validação

`spec/services/whatsapp/session/`, `spec/services/whatsapp/connector/` e `spec/models/channel/whatsapp_spec.rb`: **877 exemplos, 0 falhas** (1 pending que já era). `rubocop` em `app` e `spec`: 2498 arquivos, 0 offenses.

As três alterações de produção foram revertidas uma a uma e todas morreram:

| o que foi mutado | teste que pegou |
|---|---|
| o `ensure_readable!` do `control` | `#control refuses to queue for a connector that speaks another protocol` |
| o delete voltando para `publish` | `asks for the session to be deleted on the control stream...` |
| o log local removido | `writes down what it asked for, because the failure has nowhere to be reported` |

A varredura do `backend_publish_ceiling_spec` passou a cobrir também os sites de `client.control`, senão mover um comando de uma porta para a outra o tiraria da cerca sem nada falhar.

**Não testei contra um connector rodando.** O caminho é o mesmo que o `session.wake` do `connect` já usa, e o lado do connector tem teste próprio na #157, mas a ponta a ponta com inbox destruída de verdade não foi feita aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/584)
<!-- Reviewable:end -->
