### PR TITLE
fix(whatsapp): answer where delivery goes, not just what the write did

### DIFF
--- a/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
+++ b/app/controllers/api/v1/accounts/concerns/whatsapp_health_management.rb
@@ -52,10 +52,11 @@ module Api::V1::Accounts::Concerns::WhatsappHealthManagement
   def register_webhook
     # The per-number override is allowed to be refused without taking the channel down, so
     # "registered successfully" on its own would be the whole answer for a number Meta refused to
-    # point here. The answer says which half landed.
+    # point here. The answer says which half landed, and then where delivery goes.
     applied = Whatsapp::WebhookSetupService.new(@inbox.channel).register_callback
 
-    render json: { message: 'Webhook registered successfully', callback_override_applied: applied }, status: :ok
+    render json: { message: 'Webhook registered successfully', callback_override_applied: applied }
+      .merge(routing_after_attempt), status: :ok
   rescue StandardError => e
     Rails.logger.error "[INBOX WEBHOOK] Webhook registration failed: #{e.message}"
     render json: { error: e.message }, status: :unprocessable_entity
@@ -70,6 +71,28 @@ module Api::V1::Accounts::Concerns::WhatsappHealthManagement
   end
 
   private
+
+  # `callback_override_applied` answers one write, and it answers `false` for a refusal, for a 500
+  # and for a connection that closed with nothing to read alike: the rescue behind it is that wide
+  # on purpose, because the same refusal arrives in all three shapes (#568). Where delivery goes
+  # after the attempt is a different question, and the only authority on it is Meta. Reading it
+  # back is also what separates the two cases the write cannot: a refusal leaves the routing where
+  # it was, and an error that arrived after Meta stored the override leaves it changed.
+  #
+  # Best effort, and `routing_read_back` is why it is stated rather than implied: the write may
+  # well have landed, so a read that did not come back must not turn a registration into an error,
+  # and must not be answered as a routing nobody read.
+  def routing_after_attempt
+    health_data = Whatsapp::HealthService.new(@inbox.channel).sync_health_status!
+
+    {
+      routing_read_back: true,
+      health: health_data.merge(routed_by_app_callback_only: routed_by_app_callback_only?(health_data))
+    }
+  rescue StandardError => e
+    Rails.logger.warn("[INBOX WEBHOOK] Registered, but reading the routing back failed: #{e.message}")
+    { routing_read_back: false }
+  end
 
   # Meta answers three levels of webhook routing and delivery follows the most specific one that
   # EXISTS, wherever it points. So this asks about existence, not about the URL: an override of

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/en/inboxMgmt.json
@@ -182,7 +182,7 @@
     },
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
-        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered, but Meta did not accept pointing this number itself here, so this number's own routing was not changed. The card below shows which URL delivery follows.",
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registered, but Meta did not confirm pointing this number itself here. Check the card below for where delivery goes now.",
         "RIDES_ON_APP_CALLBACK": "Delivery follows the app callback URL: neither this number nor its WhatsApp Business Account is pointed at this installation, so it stops arriving if that URL changes.",
         "APP_CALLBACK_POINTS_ELSEWHERE": "This number has no routing of its own, so delivery follows the app callback URL shown below, which is not the one expected for this number. Registering the webhook points this number here; if Meta refuses that for this account, the app callback is what has to change."
       }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/es/inboxMgmt.json
@@ -182,7 +182,7 @@
     },
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
-        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado, pero Meta no aceptó apuntar este número en sí aquí, así que su enrutamiento propio no cambió. La tarjeta de abajo muestra qué URL sigue la entrega.",
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado, pero Meta no confirmó apuntar este número en sí aquí. Consulta en la tarjeta de abajo adónde va la entrega ahora.",
         "RIDES_ON_APP_CALLBACK": "La entrega sigue la URL de callback de la aplicación: ni este número ni su cuenta de WhatsApp Business apuntan a esta instalación, así que deja de llegar si esa URL cambia.",
         "APP_CALLBACK_POINTS_ELSEWHERE": "Este número no tiene enrutamiento propio, así que la entrega sigue la URL de callback de la aplicación, mostrada abajo, que no es la esperada para este número. Registrar el webhook apunta este número aquí; si Meta lo rechaza en esta cuenta, lo que hay que cambiar es el callback de la aplicación."
       }

--- a/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/fazer-ai/locale/pt_BR/inboxMgmt.json
@@ -182,7 +182,7 @@
     },
     "ACCOUNT_HEALTH": {
       "WEBHOOK": {
-        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado, mas a Meta não aceitou apontar este número em si para cá, então o roteamento próprio dele não mudou. O cartão abaixo mostra qual URL a entrega segue.",
+        "REGISTER_SUCCESS_WITHOUT_ROUTING": "Webhook registrado, mas a Meta não confirmou o apontamento deste número em si para cá. Veja no cartão abaixo para onde a entrega vai agora.",
         "RIDES_ON_APP_CALLBACK": "A entrega segue a URL de callback do aplicativo: nem este número nem a conta do WhatsApp Business dele estão apontados para esta instalação, então ela para se aquela URL mudar.",
         "APP_CALLBACK_POINTS_ELSEWHERE": "Este número não tem roteamento próprio, então a entrega segue a URL de callback do aplicativo, mostrada abaixo, que não é a esperada para este número. Registrar o webhook aponta este número para cá; se a Meta recusar isso nesta conta, o que precisa mudar é o callback do aplicativo."
       }

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -642,11 +642,9 @@ export default {
         const { data } = await InboxHealthAPI.registerWebhook(this.inbox.id);
         // Meta refuses the per-number override for a whole class of accounts, and that refusal no
         // longer takes the channel down, so a plain success here would be the only thing the
-        // operator sees about a write that did not land. The answer is about the write and says
-        // nothing about where delivery goes now: a number that already had an override keeps it,
-        // and the rescue behind this flag swallows a transient 500 the same as a refusal. The card
-        // is refreshed on the next line and reads the routing from Meta, so it is what the
-        // sentence points at.
+        // operator sees about a write that did not land. The flag is about that write and nothing
+        // else: it reads `false` for a refusal, for a 500 and for a connection that closed, so the
+        // sentence sends the reader to the card instead of claiming where delivery goes.
         useAlert(
           data?.callback_override_applied === false
             ? this.$t(
@@ -654,7 +652,14 @@ export default {
               )
             : this.$t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_SUCCESS')
         );
-        await this.fetchHealthData();
+        // The answer already carries the routing Meta reported after the write, so the card comes
+        // from it instead of a second round trip. When that read did not come back the field says
+        // so, and then the card is fetched rather than left showing what it had before the press.
+        if (data?.routing_read_back) {
+          this.healthData = data.health;
+        } else {
+          await this.fetchHealthData();
+        }
       } catch (error) {
         useAlert(
           error.response?.data?.error ||

--- a/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/inboxes_controller_spec.rb
@@ -1695,10 +1695,28 @@ RSpec.describe 'Inboxes API', type: :request do
         .to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
     end
 
+    # The endpoint reads the routing back after the attempt, so every example here answers that read
+    # too. One stub covers both GETs because the factory gives the phone number and the business
+    # account the same id, and each formatter reads its own keys out of the body.
+    let(:health_api_version) { 'v24.0' }
+    let(:elsewhere_url) { 'https://elsewhere.example.com/webhooks/whatsapp/+123' }
+
+    def stub_health_read(phone_number_override)
+      stub_request(:get, %r{graph\.facebook\.com/#{health_api_version}/#{phone_number_id}})
+        .to_return(status: 200, headers: { 'Content-Type' => 'application/json' }, body: {
+          id: phone_number_id,
+          display_phone_number: '+1 234 567 8911',
+          webhook_configuration: { phone_number: phone_number_override }.compact,
+          name: 'WABA',
+          owner_business_info: { id: 'biz', name: 'Portfolio' }
+        }.to_json)
+    end
+
     before do
       allow(GlobalConfigService).to receive(:load).and_call_original
       allow(GlobalConfigService).to receive(:load).with('WHATSAPP_API_VERSION', 'v22.0').and_return(api_version)
       subscription
+      stub_health_read(elsewhere_url)
     end
 
     context 'when Meta accepts both calls' do
@@ -1712,7 +1730,7 @@ RSpec.describe 'Inboxes API', type: :request do
              headers: admin.create_new_auth_token, as: :json
 
         expect(response).to have_http_status(:success)
-        expect(response.parsed_body).to eq('message' => 'Webhook registered successfully', 'callback_override_applied' => true)
+        expect(response.parsed_body).to include('message' => 'Webhook registered successfully', 'callback_override_applied' => true)
       end
     end
 
@@ -1729,7 +1747,7 @@ RSpec.describe 'Inboxes API', type: :request do
              headers: admin.create_new_auth_token, as: :json
 
         expect(response).to have_http_status(:success)
-        expect(response.parsed_body).to eq('message' => 'Webhook registered successfully', 'callback_override_applied' => false)
+        expect(response.parsed_body).to include('message' => 'Webhook registered successfully', 'callback_override_applied' => false)
         expect(subscription).to have_been_requested
       end
 
@@ -1754,6 +1772,92 @@ RSpec.describe 'Inboxes API', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body['error']).to include('Webhook setup failed')
         expect(response.parsed_body).not_to have_key('callback_override_applied')
+      end
+    end
+
+    # `callback_override_applied` answers one write, and a refusal, a 500 and a connection that
+    # closes with nothing to read all reach it as the same `false`. Where delivery goes afterwards
+    # is a different question, and the only authority on it is Meta, read back after the attempt.
+    context 'when the answer has to say where delivery goes' do
+      let(:expected_url) { "#{ENV.fetch('FRONTEND_URL', 'http://www.chatwoot.test')}/webhooks/whatsapp/#{whatsapp_channel.phone_number}" }
+
+      def register
+        post "/api/v1/accounts/#{account.id}/inboxes/#{whatsapp_inbox.id}/register_webhook",
+             headers: admin.create_new_auth_token, as: :json
+        response.parsed_body
+      end
+
+      it 'reads the routing back when Meta refused the write, and answers what it found' do
+        stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")
+          .to_return(status: 403, body: { error: { message: '(#200) Permissions error', code: 200 } }.to_json)
+        stub_health_read(elsewhere_url)
+
+        body = register
+
+        expect(response).to have_http_status(:success)
+        expect(body['callback_override_applied']).to be(false)
+        expect(body['routing_read_back']).to be(true)
+        expect(body.dig('health', 'webhook_configuration', 'phone_number')).to eq(elsewhere_url)
+      end
+
+      # The case this endpoint could not describe: Meta stored the override and then answered 500.
+      # The write is not confirmed and the routing did change, so an answer derived from the write
+      # alone contradicts the card that is rendered from the read.
+      it 'answers the routing the write actually left, even though the write was not confirmed' do
+        # The fake Meta stores the override and only then fails, and the read answers what is
+        # stored at the moment it is asked. So a read taken before the write would answer the old
+        # URL, and this example is what pins the order rather than only the value.
+        stored = elsewhere_url
+        stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")
+          .to_return do
+            stored = expected_url
+            { status: 500, body: { error: { message: 'An unexpected error has occurred.', code: 1 } }.to_json }
+          end
+        stub_request(:get, %r{graph\.facebook\.com/#{health_api_version}/#{phone_number_id}})
+          .to_return do
+            { status: 200, headers: { 'Content-Type' => 'application/json' },
+              body: { id: phone_number_id, webhook_configuration: { phone_number: stored } }.to_json }
+          end
+
+        body = register
+
+        expect(body['callback_override_applied']).to be(false)
+        expect(body['routing_read_back']).to be(true)
+        expect(body.dig('health', 'webhook_configuration', 'phone_number')).to eq(expected_url)
+        expect(body.dig('health', 'routed_by_app_callback_only')).to be(false)
+      end
+
+      # The read is the addition, so it is the thing that must not cost anything: a write that
+      # landed cannot be reported as a failure because the read after it did not come back.
+      it 'says the routing is unknown when it could not be read back, and still answers 2xx' do
+        stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")
+          .to_return(status: 200, body: { success: true }.to_json, headers: { 'Content-Type' => 'application/json' })
+        stub_request(:get, %r{graph\.facebook\.com/#{health_api_version}/}).to_return(status: 500, body: '{}')
+
+        body = register
+
+        expect(response).to have_http_status(:success)
+        expect(body['callback_override_applied']).to be(true)
+        expect(body['routing_read_back']).to be(false)
+        expect(body).not_to have_key('health')
+      end
+
+      # Two arrangements that differ only in what Meta did with the write, and a consumer that is
+      # not the dashboard has to be able to tell them apart.
+      it 'answers differently for a refused write and one that landed before the error' do
+        stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")
+          .to_return(status: 403, body: { error: { message: '(#200) Permissions error', code: 200 } }.to_json)
+        stub_health_read(elsewhere_url)
+        refused = register
+
+        stub_request(:post, "https://graph.facebook.com/#{api_version}/#{phone_number_id}")
+          .to_return(status: 500, body: { error: { message: 'An unexpected error has occurred.', code: 1 } }.to_json)
+        stub_health_read(expected_url)
+        landed = register
+
+        expect(refused['callback_override_applied']).to eq(landed['callback_override_applied'])
+        expect(refused.dig('health', 'webhook_configuration', 'phone_number'))
+          .not_to eq(landed.dig('health', 'webhook_configuration', 'phone_number'))
       end
     end
 


### PR DESCRIPTION
## Closes

- Fixes #585

## What was wrong

`Whatsapp::FacebookApiClient#callback_override_applied?` answers through a bare `rescue StandardError`, and that width is deliberate: the same refusal reaches it as a 403 carrying Meta's code 200, as a plain 500, and as a connection that closes with nothing to read, and a guard that recognizes one shape leaves the other two killing the channel (#568). So `false` means **this write was not confirmed**, and nothing narrower.

Two things were built on top of it that said something narrower.

- `POST .../register_webhook` answered `callback_override_applied: false` and nothing else, so two very different outcomes came back byte-identical: Meta refusing the write, and Meta storing the override and then failing on the way back.
- The dashboard turned that flag into "so this number's own routing was not changed", which under a 5xx the application cannot know. In the arrangement where Meta stores and then errors, that sentence sat directly above a card showing the new URL.

## What changed

The answer carries a reading taken **after** the write:

```json
{
  "message": "Webhook registered successfully",
  "callback_override_applied": false,
  "routing_read_back": true,
  "health": { "webhook_configuration": { "phone_number": "…" }, "routed_by_app_callback_only": false, "…": "…" }
}
```

- `routing_read_back` is stated rather than implied. The read is the addition, so it must not cost anything: the write may well have landed, and a read that did not come back cannot turn a registration into an error, nor be answered as a routing nobody read. When it is `false` there is no `health` key at all, rather than a stale or invented one.
- `health` is the same payload `GET .../health` answers, `routed_by_app_callback_only` included, so a consumer that is not the dashboard gets the routing question answered in the same round trip that asked for the write.
- The toast stops claiming what the routing is and points at the card, which the dashboard now renders from this answer instead of asking again. One press is one write and one read, where it used to be one write and two reads.

Additive throughout: no field removed, no field changed type, and `callback_override_applied` keeps meaning exactly what it meant.

## Validation scope

Proven by test: the routing is read back and answered for a refused write; for a write Meta stored before failing, where the answer carries the URL the write actually left while `callback_override_applied` is still `false`; the read failing answers 2xx with `routing_read_back: false` and no `health`; and the two arrangements that were byte-identical now differ in a field a consumer can use. One example pins the **order** rather than only the value: the fake Meta stores the override and only then fails, and its read answers whatever is stored at the moment it is asked, so a read taken before the write would answer the old URL and fail the example.

Red before the change: 4 failing at `5483cd49`. Eight mutations were run and all eight failed a spec, including declaring an unread routing as read, letting the failed read take the registration down, dropping the routing from the answer, dropping the level from `health`, moving the read to before the write, removing `routing_read_back`, and the two guards #583 left behind.

Not covered by a spec harness: `Settings.vue`, an options-API component with no spec in the repo. Its two branches (render the card from the answer, fall back to fetching when the read did not come back) are covered by the browser evidence instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/587)
<!-- Reviewable:end -->
