### PR TITLE
fix(whatsapp): put a ceiling on the Graph calls, on both axes

### DIFF
--- a/app/services/whatsapp/facebook_api_client.rb
+++ b/app/services/whatsapp/facebook_api_client.rb
@@ -1,4 +1,6 @@
 class Whatsapp::FacebookApiClient
+  include Whatsapp::GraphRequestOptions
+
   BASE_URI = 'https://graph.facebook.com'.freeze
   # Base webhook fields resent on every subscribe so Meta won't reset to defaults. `calls` is added by callers only when voice is enabled.
   WEBHOOK_DEFAULT_FIELDS = %w[messages smb_message_echoes].freeze
@@ -11,6 +13,7 @@ class Whatsapp::FacebookApiClient
   def exchange_code_for_token(code)
     response = HTTParty.get(
       "#{BASE_URI}/#{@api_version}/oauth/access_token",
+      **GRAPH_REQUEST_OPTIONS,
       query: {
         client_id: GlobalConfigService.load('WHATSAPP_APP_ID', ''),
         client_secret: GlobalConfigService.load('WHATSAPP_APP_SECRET', ''),
@@ -24,6 +27,7 @@ class Whatsapp::FacebookApiClient
   def fetch_phone_numbers(waba_id)
     response = HTTParty.get(
       "#{BASE_URI}/#{@api_version}/#{waba_id}/phone_numbers",
+      **GRAPH_REQUEST_OPTIONS,
       query: { access_token: @access_token }
     )
 
@@ -33,6 +37,7 @@ class Whatsapp::FacebookApiClient
   def debug_token(input_token)
     response = HTTParty.get(
       "#{BASE_URI}/#{@api_version}/debug_token",
+      **GRAPH_REQUEST_OPTIONS,
       query: {
         input_token: input_token,
         access_token: build_app_access_token
@@ -45,6 +50,7 @@ class Whatsapp::FacebookApiClient
   def register_phone_number(phone_number_id, pin)
     response = HTTParty.post(
       "#{BASE_URI}/#{@api_version}/#{phone_number_id}/register",
+      **GRAPH_REQUEST_OPTIONS,
       headers: request_headers,
       body: { messaging_product: 'whatsapp', pin: pin.to_s }.to_json
     )
@@ -57,6 +63,7 @@ class Whatsapp::FacebookApiClient
   def deregister_phone_number(phone_number_id)
     response = HTTParty.post(
       "#{BASE_URI}/#{@api_version}/#{phone_number_id}/deregister",
+      **GRAPH_REQUEST_OPTIONS,
       headers: request_headers
     )
 
@@ -66,6 +73,7 @@ class Whatsapp::FacebookApiClient
   def phone_number_verified?(phone_number_id)
     response = HTTParty.get(
       "#{BASE_URI}/#{@api_version}/#{phone_number_id}",
+      **GRAPH_REQUEST_OPTIONS,
       headers: request_headers
     )
 
@@ -101,6 +109,7 @@ class Whatsapp::FacebookApiClient
   def subscribe_app_to_waba(waba_id, subscribed_fields: WEBHOOK_DEFAULT_FIELDS)
     response = HTTParty.post(
       "#{BASE_URI}/#{@api_version}/#{waba_id}/subscribed_apps",
+      **GRAPH_REQUEST_OPTIONS,
       headers: request_headers,
       body: { subscribed_fields: subscribed_fields }.to_json
     )
@@ -111,6 +120,7 @@ class Whatsapp::FacebookApiClient
   def override_phone_number_callback(phone_number_id, callback_url, verify_token)
     response = HTTParty.post(
       "#{BASE_URI}/#{@api_version}/#{phone_number_id}",
+      **GRAPH_REQUEST_OPTIONS,
       headers: request_headers,
       body: {
         webhook_configuration: {
@@ -126,6 +136,7 @@ class Whatsapp::FacebookApiClient
   def clear_phone_number_callback_override(phone_number_id)
     response = HTTParty.post(
       "#{BASE_URI}/#{@api_version}/#{phone_number_id}",
+      **GRAPH_REQUEST_OPTIONS,
       headers: request_headers,
       body: {
         webhook_configuration: {
@@ -141,6 +152,7 @@ class Whatsapp::FacebookApiClient
   def unsubscribe_app_from_waba(waba_id)
     response = HTTParty.delete(
       "#{BASE_URI}/#{@api_version}/#{waba_id}/subscribed_apps",
+      **GRAPH_REQUEST_OPTIONS,
       headers: request_headers
     )
 

--- a/app/services/whatsapp/graph_request_options.rb
+++ b/app/services/whatsapp/graph_request_options.rb
@@ -1,0 +1,20 @@
+# Meta accepts the connection and can then stay quiet. Without a ceiling, one request occupies a
+# Puma thread for as long as Meta feels like staying quiet, and nothing in the app ever decides to
+# stop waiting.
+#
+# There are two axes here and a ceiling alone only closes the first. `Net::HTTP` retries an
+# idempotent request once by default, so a read costs twice the ceiling while a write costs it once.
+# Measured against a socket that accepts the connection and never answers:
+#
+#   GET  timeout: 5                    10.0s
+#   GET  timeout: 5, max_retries: 0     5.0s
+#   POST timeout: 5                     5.0s
+#
+# The value is 10s because that is what the Baileys provider in this repo already uses for the same
+# kind of call, and because the failure of a ceiling that is too low is not a slow page: it is the
+# health screen reporting "could not read the routing" for a Meta that was going to answer. That
+# screen exists to stop false reassurance, so inventing a false alarm in its place is not a trade
+# worth making.
+module Whatsapp::GraphRequestOptions
+  GRAPH_REQUEST_OPTIONS = { timeout: 10, max_retries: 0 }.freeze
+end

--- a/app/services/whatsapp/health_service.rb
+++ b/app/services/whatsapp/health_service.rb
@@ -87,6 +87,7 @@ class Whatsapp::HealthService
   def fetch_graph_data(resource_id, fields)
     response = HTTParty.get(
       "#{BASE_URI}/#{@api_version}/#{resource_id}",
+      **Whatsapp::GraphRequestOptions::GRAPH_REQUEST_OPTIONS,
       query: {
         fields: fields,
         access_token: @access_token

--- a/spec/services/whatsapp/facebook_api_client_spec.rb
+++ b/spec/services/whatsapp/facebook_api_client_spec.rb
@@ -334,4 +334,25 @@ describe Whatsapp::FacebookApiClient do
       end
     end
   end
+
+  describe 'the ceiling on every Graph call' do
+    # Meta accepting the connection and then staying quiet is the arrangement this is about, and
+    # webmock cannot show it: it answers instantly, so a missing ceiling passes every stub in this
+    # file. What the ceiling is made of is therefore asserted on the call itself.
+    it 'passes the wait ceiling and switches the retry off, on a read' do
+      allow(HTTParty).to receive(:get).and_return(instance_double(HTTParty::Response, success?: true, parsed_response: {}))
+
+      api_client.fetch_phone_numbers('test_waba_id')
+
+      expect(HTTParty).to have_received(:get).with(anything, hash_including(timeout: 10, max_retries: 0))
+    end
+
+    it 'passes the same ceiling on a write' do
+      allow(HTTParty).to receive(:post).and_return(instance_double(HTTParty::Response, success?: true, parsed_response: {}))
+
+      api_client.subscribe_app_to_waba('test_waba_id')
+
+      expect(HTTParty).to have_received(:post).with(anything, hash_including(timeout: 10, max_retries: 0))
+    end
+  end
 end

--- a/spec/services/whatsapp/graph_request_options_spec.rb
+++ b/spec/services/whatsapp/graph_request_options_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe Whatsapp::GraphRequestOptions do
+  # The two files that talk to Meta's Graph API. A call added to either of them without the ceiling
+  # is the whole failure this fence exists for: the alternative was a line in a review checklist,
+  # and a checklist is read once.
+  let(:guarded_sources) do
+    %w[
+      app/services/whatsapp/facebook_api_client.rb
+      app/services/whatsapp/health_service.rb
+    ]
+  end
+
+  # Reads a call the way the parser would, not the way a line-oriented grep would: `HTTParty.get(`
+  # opens a call that runs for several lines, and only the text up to its matching paren says
+  # whether the options are in THIS call or in the next one further down the file.
+  def graph_calls(source)
+    calls = []
+    source.to_enum(:scan, /HTTParty\.(?:get|post|put|patch|delete)\(/).each do
+      start = Regexp.last_match.begin(0)
+      depth = 0
+      source[start..].each_char.with_index do |char, offset|
+        depth += 1 if char == '('
+        next unless char == ')'
+
+        depth -= 1
+        next unless depth.zero?
+
+        calls << source[start, offset + 1]
+        break
+      end
+    end
+    calls
+  end
+
+  it 'caps the wait and the retry, because a ceiling alone still costs twice on a read' do
+    expect(described_class::GRAPH_REQUEST_OPTIONS).to eq(timeout: 10, max_retries: 0)
+  end
+
+  it 'leaves no Graph call in the guarded files without the ceiling' do
+    without_ceiling = guarded_sources.flat_map do |path|
+      graph_calls(Rails.root.join(path).read)
+        .reject { |call| call.include?('GRAPH_REQUEST_OPTIONS') }
+        .map { |call| "#{path}: #{call.lines.first.strip} #{call.lines[1].to_s.strip}" }
+    end
+
+    expect(without_ceiling).to be_empty
+  end
+
+  it 'reads every call in the guarded files, so an empty result cannot pass as a clean one' do
+    # The check above answers "nothing without a ceiling", and it answers that for zero calls too.
+    # This one measures that the scan actually reached the calls it was supposed to inspect.
+    counts = guarded_sources.index_with { |path| graph_calls(Rails.root.join(path).read).size }
+
+    expect(counts).to eq(
+      'app/services/whatsapp/facebook_api_client.rb' => 10,
+      'app/services/whatsapp/health_service.rb' => 1
+    )
+  end
+end

--- a/spec/services/whatsapp/graph_request_options_spec.rb
+++ b/spec/services/whatsapp/graph_request_options_spec.rb
@@ -33,6 +33,22 @@ describe Whatsapp::GraphRequestOptions do
     calls
   end
 
+  it 'reads a call to its own closing paren, not to the first one it meets' do
+    # Every call in the guarded files happens to carry the options right after the URL, so a scanner
+    # that stopped at the first `)` would still find them and this fence would pass for the wrong
+    # reason. It would then report a false offender the day a call carries the options after an
+    # argument that has parens of its own, which is what this arrangement is.
+    source = <<~RUBY
+      HTTParty.get(
+        "\#{BASE_URI}/\#{@api_version}/x",
+        query: { token: GlobalConfigService.load('A', '') },
+        **GRAPH_REQUEST_OPTIONS
+      )
+    RUBY
+
+    expect(graph_calls(source).first).to include('GRAPH_REQUEST_OPTIONS')
+  end
+
   it 'caps the wait and the retry, because a ceiling alone still costs twice on a read' do
     expect(described_class::GRAPH_REQUEST_OPTIONS).to eq(timeout: 10, max_retries: 0)
   end

--- a/spec/services/whatsapp/health_service_spec.rb
+++ b/spec/services/whatsapp/health_service_spec.rb
@@ -339,4 +339,19 @@ RSpec.describe Whatsapp::HealthService do
       end
     end
   end
+
+  describe 'the ceiling on the health read' do
+    # The register endpoint reads the routing back through this service (#585), so a Meta that
+    # accepts and stays quiet holds the request here too. Webmock answers instantly and can never
+    # show that, so the ceiling is asserted on the call.
+    it 'passes the wait ceiling and switches the retry off' do
+      allow(HTTParty).to receive(:get).and_return(
+        instance_double(HTTParty::Response, success?: true, parsed_response: { 'id' => 'test_phone_number_id' })
+      )
+
+      service.sync_health_status!
+
+      expect(HTTParty).to have_received(:get).with(anything, hash_including(timeout: 10, max_retries: 0)).at_least(:once)
+    end
+  end
 end


### PR DESCRIPTION
Pressing **Register webhook** on a WhatsApp Cloud inbox can no longer hold a request for two minutes when Meta accepts the connection and then goes quiet. The same press that took 120s now answers in 10s, with the same answer.

## Closes

- Fixes #588

## How to reproduce

Point the Graph API at something that accepts the TCP connection and never replies (a socket that holds it open, not one that refuses or closes), then press **Register webhook** on a WhatsApp Cloud inbox.

Before, against `4379f0970f`: the request takes **120.0s** and answers `200` with `routing_read_back: false`. The fake Graph's log shows **two** GETs for one press.

After: the same request takes **10.0s**, with the same status and the same body, and the log shows **one** GET.

`GET .../inboxes/:id/health` on its own moves the same way: 120.6s to 10.3s.

## What changed

There are two axes here and a timeout alone only closes the first. `Net::HTTP` retries an idempotent request once by default, so a read costs twice the ceiling while a write costs it once:

```
GET  timeout: 5                    10.0s
GET  timeout: 5, max_retries: 0     5.0s
POST timeout: 5                     5.0s
```

That is also where the 60s and 120s in #588 come from: `Net::HTTP`'s own default read timeout is 60s, and the read was paying it twice.

Both options now live in one place, `Whatsapp::GraphRequestOptions`, and are merged into all 11 Graph calls across `Whatsapp::FacebookApiClient` and `Whatsapp::HealthService`. The declared budget is **10s per Graph call**, and for this endpoint **4 x that, 40s**, because it makes up to four Graph calls and only the first one ends the request when it fails.

Measured on the endpoint, against a fake Graph:

| arrangement | time | answer |
| --- | --- | --- |
| every call hangs | 10.03s | `422`, the required write raised first |
| the required write answers, the override and the read hang | 20.03s | `200`, `callback_override_applied: false`, `routing_read_back: false` |
| four calls: write fast, override hangs, phone read answers **correctly in 9s**, business read hangs | 29.05s | `200`, `routing_read_back: true`, health present |
| the same four calls on `4379f0970f` | **180.05s** | the same `200` |

The third row is why the budget is 4x and not 2x: a call that answers correctly in 9s is under the ceiling and still spends 9s, so counting only the calls that hang understates the worst case. A budget for the whole request, rather than per call, is what would bound this independently of how many calls the endpoint makes, and that is filed as #592.

10s is the value the Baileys provider in this repo already uses for the same kind of call, and it sits inside the range the repo already spans for outbound HTTP (5s for push, 10s for Baileys, 30s for data imports). It is deliberately not lower, for the reason below.

The fence is a spec, not a review note. It parses both files, finds every `HTTParty` call by balancing parens, and fails if one of them is missing the options. It also counts the calls it found, so an empty scan cannot pass as a clean one, and it pins its own balancing, because every call today carries the options early enough that a scanner stopping at the first `)` would pass for the wrong reason.

## The cost this introduces, and why the value is 10s

A ceiling's failure mode is not a slow page. `Whatsapp::WebhookSetupService#perform` decides whether to re-register the phone number from `phone_number_verified?`, which turns **any** error into "not verified", and re-registering is a real write to Meta plus a PIN stored on the channel. So a ceiling low enough to fire on a healthy-but-slow Meta converts latency into a spurious write.

That branch already existed and already fired at 60s; this change moves the threshold to 10s. Meta publishes a p99 under 5s for the Cloud API, which leaves 2x of headroom, and headroom is not a guard, so the underlying swallow is filed as #590. It is not on this endpoint's path: `register_webhook` calls `register_callback`, which does not run those predicates.

The rest of the repo is filed as #589: 136 HTTParty call sites, 10 with a timeout, **zero** with `max_retries`, so even the ten that look protected still pay double on a GET.

## Validation scope

Proven end to end against a fake Graph, with a real Puma on both the base commit and this one: every row of the table above, and that the retry disappears from the request log (two GETs per press before, one after).

Exercised independently by the holdout scenarios sealed on the issue before the diff existed, including the shapes I had not thought to check: every one of the client's eleven public methods returns in 10.00s to 10.02s with all Graph routes hanging; a ceiling that fires leaves `phone_number_health` intact rather than blanking the card; and the screen, measured from the click rather than from the request, settles in 20.25s, because the dashboard fires its own `GET .../health` when `routing_read_back` comes back false and both halves are now capped.

One known piece of friction, taken deliberately: the fence hardcodes how many Graph calls each file has (10 and 1). Adding a capped call site turns the ceiling check green but leaves the count check red until the number is bumped. That is the intended trade: deriving the count would give back the hole the check exists to close, which is an empty scan passing as a clean one, and adding a Graph call to these two files is exactly when someone should reread the ceiling.

Not proven against Meta itself. The 10s value is argued from Meta's published p99 and from what this repo already uses, not from latency measured on our own traffic; if a production number turns out to sit above it, the symptom would be a health card reporting "could not read the routing" rather than a hung request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/591)
<!-- Reviewable:end -->
