### PR TITLE
fix(whatsapp): pôr o teto da Graph em toda chamada à Meta, não só nas duas primeiras

### DIFF
--- a/app/services/whatsapp/business_management_token_validation_service.rb
+++ b/app/services/whatsapp/business_management_token_validation_service.rb
@@ -1,4 +1,6 @@
 class Whatsapp::BusinessManagementTokenValidationService
+  include Whatsapp::GraphRequestOptions
+
   REQUIRED_PERMISSION = 'whatsapp_business_management'.freeze
 
   def initialize(business_management_token, business_account_id)
@@ -7,7 +9,7 @@ class Whatsapp::BusinessManagementTokenValidationService
   end
 
   def perform
-    response = HTTParty.get(permissions_url, headers: { 'Authorization' => "Bearer #{@business_management_token}" })
+    response = HTTParty.get(permissions_url, headers: { 'Authorization' => "Bearer #{@business_management_token}" }, **GRAPH_REQUEST_OPTIONS)
 
     raise ArgumentError, response_error(response) unless response.success?
     raise ArgumentError, "Business management token must grant the #{REQUIRED_PERMISSION} permission" unless required_permission_granted?(response)
@@ -40,7 +42,8 @@ class Whatsapp::BusinessManagementTokenValidationService
   def validate_business_account_access!
     response = HTTParty.get(
       business_account_templates_url,
-      headers: { 'Authorization' => "Bearer #{@business_management_token}" }
+      headers: { 'Authorization' => "Bearer #{@business_management_token}" },
+      **GRAPH_REQUEST_OPTIONS
     )
 
     raise ArgumentError, response_error(response) unless response.success?

--- a/app/services/whatsapp/csat_template_service.rb
+++ b/app/services/whatsapp/csat_template_service.rb
@@ -1,4 +1,6 @@
 class Whatsapp::CsatTemplateService
+  include Whatsapp::GraphRequestOptions
+
   DEFAULT_BUTTON_TEXT = 'Please rate us'.freeze
   DEFAULT_LANGUAGE = 'en'.freeze
   WHATSAPP_API_VERSION = 'v14.0'.freeze
@@ -22,13 +24,14 @@ class Whatsapp::CsatTemplateService
     template_name ||= CsatTemplateNameService.csat_template_name(@whatsapp_channel.inbox.id)
     response = HTTParty.delete(
       "#{business_account_path}/message_templates?name=#{template_name}",
-      headers: api_headers
+      headers: api_headers,
+      **GRAPH_REQUEST_OPTIONS
     )
     { success: response.success?, response_body: response.body }
   end
 
   def get_template_status(template_name)
-    response = HTTParty.get("#{business_account_path}/message_templates?name=#{template_name}", headers: api_headers)
+    response = HTTParty.get("#{business_account_path}/message_templates?name=#{template_name}", headers: api_headers, **GRAPH_REQUEST_OPTIONS)
 
     if response.success? && response['data']&.any?
       template_data = response['data'].first
@@ -141,7 +144,8 @@ class Whatsapp::CsatTemplateService
     HTTParty.post(
       "#{business_account_path}/message_templates",
       headers: api_headers,
-      body: request_body.to_json
+      body: request_body.to_json,
+      **GRAPH_REQUEST_OPTIONS
     )
   end
 

--- a/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
@@ -3,6 +3,7 @@
 
 class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageBaseService
   include Events::Types
+  include Whatsapp::GraphRequestOptions
 
   def perform
     return if processed_params.blank?
@@ -26,7 +27,8 @@ class Whatsapp::IncomingMessageWhatsappCloudService < Whatsapp::IncomingMessageB
   def download_attachment_file(attachment_payload)
     url_response = HTTParty.get(
       inbox.channel.media_url(attachment_payload[:id]),
-      headers: inbox.channel.api_headers
+      headers: inbox.channel.api_headers,
+      **GRAPH_REQUEST_OPTIONS
     )
 
     # This url response will be failure if the access token has expired.

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -1,4 +1,6 @@
 class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseService # rubocop:disable Metrics/ClassLength
+  include Whatsapp::GraphRequestOptions
+
   # The types WhatsApp accepts for a voice message, taken from its own rejection message:
   # "Please use one of audio/ogg; codecs=opus, audio/mpeg, audio/amr, audio/mp4, audio/aac."
   # Measured live in #520: a phone renders every one of them as a voice bubble, and only opus
@@ -41,7 +43,8 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     response = HTTParty.post(
       "#{phone_id_path}/messages",
       headers: api_headers,
-      body: request_body.to_json
+      body: request_body.to_json,
+      **GRAPH_REQUEST_OPTIONS
     )
 
     process_response(response, message)
@@ -62,7 +65,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   def fetch_whatsapp_templates(after: nil)
     options = { headers: { 'Authorization' => "Bearer #{whatsapp_channel.template_access_token}" } }
     options[:query] = { after: after } if after.present?
-    response = HTTParty.get("#{business_account_path}/message_templates", options)
+    response = HTTParty.get("#{business_account_path}/message_templates", **options, **GRAPH_REQUEST_OPTIONS)
     unless response.success?
       Rails.logger.warn "[WHATSAPP] Template sync failed for account #{whatsapp_channel.account_id} " \
                         "inbox #{whatsapp_channel.inbox&.id}: #{response.code} #{error_message(response)}"
@@ -78,12 +81,15 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
 
   def validate_provider_config?
     config = whatsapp_channel.provider_config
-    response = HTTParty.get("#{business_account_path}/message_templates?access_token=#{config['api_key']}")
+    response = HTTParty.get("#{business_account_path}/message_templates?access_token=#{config['api_key']}", **GRAPH_REQUEST_OPTIONS)
     return log_transfer_failure('waba_or_token_check', response) unless response.success?
     # The templates check only proves the WABA/token pair, so verify the phone_number_id belongs to this WABA when it changes.
     return true unless whatsapp_channel.provider_config_changed?
 
-    phone_response = HTTParty.get("#{business_account_path}/phone_numbers?fields=id&limit=100&access_token=#{config['api_key']}")
+    phone_response = HTTParty.get(
+      "#{business_account_path}/phone_numbers?fields=id&limit=100&access_token=#{config['api_key']}",
+      **GRAPH_REQUEST_OPTIONS
+    )
     ids = phone_response.parsed_response.is_a?(Hash) ? Array(phone_response.parsed_response['data']) : []
     return true if phone_response.success? && ids.any? { |number| number['id'] == config['phone_number_id'].to_s }
 
@@ -147,7 +153,8 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         status: 'read',
         # NOTE: API currently only supports "typing", no "recording" status.
         typing_indicator: { type: 'text' }
-      }.to_json
+      }.to_json,
+      **GRAPH_REQUEST_OPTIONS
     )
 
     Rails.logger.error(response.parsed_response) unless response.success?
@@ -165,7 +172,8 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         messaging_product: 'whatsapp',
         message_id: message.source_id,
         status: 'read'
-      }.to_json
+      }.to_json,
+      **GRAPH_REQUEST_OPTIONS
     )
 
     Rails.logger.error(response.parsed_response) unless response.success?
@@ -212,7 +220,8 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         **recipient_params(phone_number),
         text: { body: message.outgoing_content },
         type: 'text'
-      }.to_json
+      }.to_json,
+      **GRAPH_REQUEST_OPTIONS
     )
 
     process_response(response, message)
@@ -231,7 +240,8 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         **recipient_params(phone_number),
         'type' => type,
         type.to_s => type_content
-      }.to_json
+      }.to_json,
+      **GRAPH_REQUEST_OPTIONS
     )
 
     process_response(response, message)
@@ -348,7 +358,8 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         **recipient_params(phone_number),
         interactive: payload,
         type: 'interactive'
-      }.to_json
+      }.to_json,
+      **GRAPH_REQUEST_OPTIONS
     )
 
     process_response(response, message)
@@ -367,7 +378,8 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
           message_id: message.content_attributes[:in_reply_to_external_id],
           emoji: message.outgoing_content
         }
-      }.to_json
+      }.to_json,
+      **GRAPH_REQUEST_OPTIONS
     )
 
     process_response(response, message)

--- a/enterprise/app/services/enterprise/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/enterprise/app/services/enterprise/whatsapp/providers/whatsapp_cloud_service.rb
@@ -1,4 +1,6 @@
 module Enterprise::Whatsapp::Providers::WhatsappCloudService
+  include Whatsapp::GraphRequestOptions
+
   # Calls API + the call_permission_request interactive message both require Graph
   # API v17+; OSS phone_id_path is locked at v13.0 for legacy /messages compatibility.
   # Use the configured global version (defaulting to v22.0) for call-flow endpoints.
@@ -22,7 +24,8 @@ module Enterprise::Whatsapp::Providers::WhatsappCloudService
 
   def send_call_permission_request(to_phone_number, body_text = I18n.t('conversations.messages.whatsapp.call_permission_request_body'))
     response = HTTParty.post(
-      "#{calls_phone_id_path}/messages", headers: api_headers, body: permission_request_body(to_phone_number, body_text)
+      "#{calls_phone_id_path}/messages", headers: api_headers, body: permission_request_body(to_phone_number, body_text),
+                                         **GRAPH_REQUEST_OPTIONS
     )
 
     unless response.success?
@@ -35,7 +38,8 @@ module Enterprise::Whatsapp::Providers::WhatsappCloudService
 
   def initiate_call(to_phone_number, sdp_offer)
     response = HTTParty.post(
-      "#{calls_phone_id_path}/calls", headers: api_headers, body: initiate_call_body(to_phone_number, sdp_offer)
+      "#{calls_phone_id_path}/calls", headers: api_headers, body: initiate_call_body(to_phone_number, sdp_offer),
+                                      **GRAPH_REQUEST_OPTIONS
     )
     process_initiate_call_response(response)
   end
@@ -46,7 +50,8 @@ module Enterprise::Whatsapp::Providers::WhatsappCloudService
     response = HTTParty.post(
       "#{calls_phone_id_path}/settings",
       headers: api_headers,
-      body: { calling: { status: status } }.to_json
+      body: { calling: { status: status } }.to_json,
+      **GRAPH_REQUEST_OPTIONS
     )
     return true if response.success?
 
@@ -73,7 +78,7 @@ module Enterprise::Whatsapp::Providers::WhatsappCloudService
   def call_api(action_name, body)
     url = "#{calls_phone_id_path}/calls"
     Rails.logger.info "[WHATSAPP CALL] #{action_name} POST #{url} body=#{body.except(:session).to_json}"
-    response = HTTParty.post(url, headers: api_headers, body: body.to_json)
+    response = HTTParty.post(url, headers: api_headers, body: body.to_json, **GRAPH_REQUEST_OPTIONS)
     Rails.logger.error "[WHATSAPP CALL] #{action_name} failed: status=#{response.code} body=#{response.body}" unless response.success?
     response.success?
   end

--- a/spec/services/whatsapp/csat_template_service_spec.rb
+++ b/spec/services/whatsapp/csat_template_service_spec.rb
@@ -195,7 +195,12 @@ RSpec.describe Whatsapp::CsatTemplateService do
           'Authorization' => "Bearer #{whatsapp_channel.provider_config['api_key']}",
           'Content-Type' => 'application/json'
         },
-        body: expected_body.to_json
+        body: expected_body.to_json,
+        # Named here rather than splatted from the constant: what this pins is that a Graph call
+        # cannot wait forever and cannot be retried behind the caller's back, and a splat would
+        # keep agreeing with itself if the constant were emptied.
+        timeout: 10,
+        max_retries: 0
       )
 
       service.create_template(template_config)
@@ -256,7 +261,9 @@ RSpec.describe Whatsapp::CsatTemplateService do
         headers: {
           'Authorization' => "Bearer #{whatsapp_channel.provider_config['api_key']}",
           'Content-Type' => 'application/json'
-        }
+        },
+        timeout: 10,
+        max_retries: 0
       ).and_return(mock_response)
 
       result = service.delete_template('test_template')
@@ -304,7 +311,9 @@ RSpec.describe Whatsapp::CsatTemplateService do
         headers: {
           'Authorization' => "Bearer #{whatsapp_channel.provider_config['api_key']}",
           'Content-Type' => 'application/json'
-        }
+        },
+        timeout: 10,
+        max_retries: 0
       ).and_return(mock_response)
 
       service.get_template_status('test_template')

--- a/spec/services/whatsapp/graph_request_options_spec.rb
+++ b/spec/services/whatsapp/graph_request_options_spec.rb
@@ -84,8 +84,18 @@ describe Whatsapp::GraphRequestOptions do
     expect(described_class::GRAPH_REQUEST_OPTIONS).to eq(timeout: 10, max_retries: 0)
   end
 
+  # The CE suite runs with `rm -rf enterprise spec/enterprise` in front of it, so a guarded path in
+  # that tree is legitimately absent there and reading it would fail the fence for a reason that has
+  # nothing to do with a missing ceiling. Absence is only ever expected for that tree: a CE file that
+  # has gone missing is a real change and reads as one.
+  def present_sources(paths)
+    present, missing = paths.partition { |path| Rails.root.join(path).exist? }
+    expect(missing.grep_v(%r{\Aenterprise/})).to be_empty
+    present
+  end
+
   it 'leaves no Graph call in the guarded files without the ceiling' do
-    without_ceiling = guarded_sources.flat_map do |path|
+    without_ceiling = present_sources(guarded_sources).flat_map do |path|
       graph_calls(Rails.root.join(path).read)
         .reject { |call| call.include?('GRAPH_REQUEST_OPTIONS') }
         .map { |call| "#{path}: #{call.lines.first.strip} #{call.lines[1].to_s.strip}" }
@@ -97,9 +107,7 @@ describe Whatsapp::GraphRequestOptions do
   it 'reads every call in the guarded files, so an empty result cannot pass as a clean one' do
     # The check above answers "nothing without a ceiling", and it answers that for zero calls too.
     # This one measures that the scan actually reached the calls it was supposed to inspect.
-    counts = guarded_sources.index_with { |path| graph_calls(Rails.root.join(path).read).size }
-
-    expect(counts).to eq(
+    expected = {
       'app/services/whatsapp/facebook_api_client.rb' => 10,
       'app/services/whatsapp/health_service.rb' => 1,
       'app/services/whatsapp/providers/whatsapp_cloud_service.rb' => 10,
@@ -107,7 +115,11 @@ describe Whatsapp::GraphRequestOptions do
       'app/services/whatsapp/csat_template_service.rb' => 3,
       'app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb' => 1,
       'enterprise/app/services/enterprise/whatsapp/providers/whatsapp_cloud_service.rb' => 4
-    )
+    }
+    present = present_sources(guarded_sources)
+    counts = present.index_with { |path| graph_calls(Rails.root.join(path).read).size }
+
+    expect(counts).to eq(expected.slice(*present))
   end
 
   # The list above is written by hand, and a hand-written list has one failure mode: a new file that

--- a/spec/services/whatsapp/graph_request_options_spec.rb
+++ b/spec/services/whatsapp/graph_request_options_spec.rb
@@ -1,14 +1,45 @@
 require 'rails_helper'
 
 describe Whatsapp::GraphRequestOptions do
-  # The two files that talk to Meta's Graph API. A call added to either of them without the ceiling
-  # is the whole failure this fence exists for: the alternative was a line in a review checklist,
-  # and a checklist is read once.
+  # Every file that talks to Meta's Graph API. A call added to any of them without the ceiling is the
+  # whole failure this fence exists for: the alternative was a line in a review checklist, and a
+  # checklist is read once.
   let(:guarded_sources) do
     %w[
       app/services/whatsapp/facebook_api_client.rb
       app/services/whatsapp/health_service.rb
+      app/services/whatsapp/providers/whatsapp_cloud_service.rb
+      app/services/whatsapp/business_management_token_validation_service.rb
+      app/services/whatsapp/csat_template_service.rb
+      app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb
+      enterprise/app/services/enterprise/whatsapp/providers/whatsapp_cloud_service.rb
     ]
+  end
+
+  # The WhatsApp services that speak to something other than the Graph API. They are listed rather
+  # than skipped so that a file is never simply absent: absent is how the first sweep missed most of
+  # the repo, and it is the state the check below refuses. Each of these is a family of its own with
+  # its own ceiling to decide, which is fazer-ai/chatwoot#589.
+  let(:other_families) do
+    {
+      # Its own API, not Meta's, and the one place in the repo that already reasoned about a number:
+      # 10s for the control calls and 90s for the send, tied to the API's own 45s deadline and to the
+      # per-channel outgoing lock. One family constant would be wrong for it.
+      'app/services/whatsapp/providers/whatsapp_baileys_service.rb' => 'Baileys API, ceilings already reasoned per call',
+      'app/services/whatsapp/providers/whatsapp_zapi_service.rb' => 'Z-API, no ceiling decided yet',
+      'app/services/whatsapp/providers/whatsapp_360_dialog_service.rb' => '360dialog, no ceiling decided yet',
+      # uazapi, and already the most careful caller in the repo: its own TIMEOUT constant, a separate
+      # open_timeout, and read and write timeouts set apart because HTTParty's `timeout` sets all
+      # three. It is also the one file a scan for `HTTParty.<verb>(` cannot see, because it dispatches
+      # the verb -- which is why this check looks for the string and not for the call shape.
+      'app/services/whatsapp/session/backends/uazapi/client.rb' => 'uazapi session client, ceilings already set per axis'
+    }
+  end
+
+  # Where a WhatsApp service lives. Both trees, because the enterprise one is not a copy of the other
+  # and has Graph calls of its own.
+  let(:whatsapp_service_trees) do
+    %w[app/services/whatsapp enterprise/app/services/enterprise/whatsapp]
   end
 
   # Reads a call the way the parser would, not the way a line-oriented grep would: `HTTParty.get(`
@@ -70,7 +101,31 @@ describe Whatsapp::GraphRequestOptions do
 
     expect(counts).to eq(
       'app/services/whatsapp/facebook_api_client.rb' => 10,
-      'app/services/whatsapp/health_service.rb' => 1
+      'app/services/whatsapp/health_service.rb' => 1,
+      'app/services/whatsapp/providers/whatsapp_cloud_service.rb' => 10,
+      'app/services/whatsapp/business_management_token_validation_service.rb' => 2,
+      'app/services/whatsapp/csat_template_service.rb' => 3,
+      'app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb' => 1,
+      'enterprise/app/services/enterprise/whatsapp/providers/whatsapp_cloud_service.rb' => 4
     )
+  end
+
+  # The list above is written by hand, and a hand-written list has one failure mode: a new file that
+  # nobody adds to it. That is not hypothetical -- this fence guarded two files while twenty more
+  # Graph calls sat outside it, and the only thing that found them was somebody counting by hand.
+  # So a WhatsApp service that reaches the network is either guarded or declared to be another
+  # family, and being absent from both is what fails.
+  it 'leaves no WhatsApp service unaccounted for, guarded or declared another family' do
+    sources = whatsapp_service_trees.flat_map { |tree| Dir.glob(Rails.root.join(tree, '**/*.rb')) }
+    reaching_the_network = sources
+                           .select { |path| File.read(path).include?('HTTParty.') }
+                           .map { |path| Pathname.new(path).relative_path_from(Rails.root).to_s }
+
+    expect(reaching_the_network).not_to be_empty
+    expect(reaching_the_network - guarded_sources - other_families.keys).to be_empty
+  end
+
+  it 'declares a reason for every family it does not guard' do
+    expect(other_families.values).to all(be_present)
   end
 end


### PR DESCRIPTION
Primeira fatia da #589, pelo recorte que a própria issue pede (uma família por PR, começando pelo que fica no caminho de uma requisição web).

## O que faltava

A #591 pôs teto e corte de retry nas chamadas da Graph de dois arquivos. **Outras vinte chamadas falavam com os mesmos servidores da Meta sem nenhum dos dois eixos**, com o mesmo modo de falha medido lá: a conexão é aceita, a resposta nunca vem, e o processo espera 60s, ou 120s num GET, porque o `Net::HTTP` repete requisição idempotente uma vez.

O pior está no caminho de request web: **`validate_provider_config?` faz dois GET sem teto e roda na validação do modelo**, ou seja na criação e na atualização de inbox. Com a Meta calada, a thread ficava presa por até 240s e só então levantava. Agora levanta em 20s, com o mesmo desfecho.

Os cinco arquivos: `providers/whatsapp_cloud_service.rb` (10), o `enterprise/` equivalente (4), `csat_template_service.rb` (3), `business_management_token_validation_service.rb` (2) e o GET de metadados de mídia do `incoming_message_whatsapp_cloud_service.rb` (1), que é leitura de JSON: os bytes vão pelo `Down` e são outra família.

O número não foi escolhido de novo. É o `GRAPH_REQUEST_OPTIONS` da #591, que já carrega a medição e o argumento.

## A cerca virou prestação de contas

Antes era uma lista de arquivos guardados, e uma lista escrita à mão tem um modo de falha só: o arquivo que ninguém acrescenta. Não é hipotético, é exatamente o estado destes vinte.

Agora todo arquivo de `app/services/whatsapp/` e do equivalente no `enterprise/` que alcance a rede tem que estar **ou na lista de guardados, ou numa lista de outras famílias com o motivo escrito**. Ausente passa a ser o que falha. O baileys, o zapi e o 360dialog ficam registrados como outra família com decisão pendente da #589, em vez de escaparem por omissão, e a próxima fatia fica impossível de esquecer.

## O que a cerca nova achou

`app/services/whatsapp/session/backends/uazapi/client.rb` chama `HTTParty.public_send(verb, ...)`, então **uma busca por `HTTParty.<verbo>(` não enxerga o arquivo** e ele não aparece no inventário da #589. É o chamador mais cuidadoso do repositório (constante própria, `open_timeout` separado, `read` e `write` apartados porque o `timeout` do HTTParty mexe nos três), e entra na lista de outras famílias pelo que é. A conta de 136 call sites da issue é, por isso, um piso.

## O que eu procurei antes de apertar

O modo de falha de um teto não é página lenta: é latência virando escrita, onde alguém consome o resultado dentro de um `rescue`. Nos cinco arquivos:

- `validate_provider_config?` não tem `rescue` nenhum, então o timeout continua subindo e o desfecho é o mesmo, doze vezes mais rápido.
- `csat_template_service.rb` tem `rescue StandardError` que devolve `{ success: false, error: e.message }`, que é relatar, não decidir.
- `business_management_token_validation_service.rb` **já** trata `Net::OpenTimeout, Net::ReadTimeout, SocketError` e responde "não deu para validar, tente de novo", que é a resposta certa.
- A varredura pós-conversão de templates zera as colunas num `rescue` para o agendador tentar de novo: um timeout ali não afirma nada.

O caso em que latência **vira** escrita está fora desta PR e virou a #595: `setup_webhooks` transforma qualquer `StandardError` em `prompt_reauthorization!`, que persiste no Redis, invalida o cache da inbox e chega ao operador. É consequência viva do teto da #591 e é do dono daquele arquivo.

Um sobrou como follow-up e não fiz aqui para não misturar: um timeout em `validate_provider_config?` vira 500 e não erro de validação. Não é escrita errada, é resposta errada.

## Verificação

- `spec/services/whatsapp`, `spec/models/channel/whatsapp_spec.rb` e `spec/enterprise`: 4341 exemplos, 2 falhas **anteriores a esta branch** (`check_new_versions_job_spec` bate em `api.github.com` sem stub; confere na árvore limpa também).
- Seis mutantes na cerca, todos mortos: uma chamada perde o teto, um arquivo guardado sai da lista, um serviço novo aparece sem ser declarado, uma família é declarada sem motivo, o scanner de chamadas fica cego nos arquivos de verdade, e a varredura de arquivos não acha nada. Os dois últimos são o caso que o dono da #591 avisou que costuma passar: cerca cega concorda com cerca sã num arquivo limpo, e só o exemplo que **conta** o que foi lido mata.
- Os três exemplos do `csat_template_service_spec` que fixavam os argumentos exatos passaram a fixar `timeout: 10, max_retries: 0` por extenso, e não por splat da constante: um splat continuaria concordando consigo mesmo se a constante fosse esvaziada.
- rubocop limpo nos sete arquivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/597)
<!-- Reviewable:end -->
