### PR TITLE
fix(messages): deixar a recusa por anexo vencer a marca de áudio da mensagem

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -113,8 +113,19 @@ class Messages::MessageBuilder # rubocop:disable Metrics/ClassLength
     blob_for(uploaded_attachment)&.filename&.to_s
   end
 
+  # The top-level flag is about the message and the metadata entry is about one attachment, so the
+  # entry is the more specific of the two and wins. It used to lose: this ran after the metadata
+  # merge and wrote `true` over a refusal that had just been read and cast, which left a caller
+  # sending several attachments with no way at all to say "this one is not a voice note".
+  #
+  # Said as a skip rather than by moving the call, because `should_transcode?` reads the same
+  # `file_type` this does and moving one of them changes the order they see. Only the key decides:
+  # an entry that mentions the flag has answered, whatever it answered, and the absence of the key
+  # is what leaves the message-level flag standing -- which is the dashboard's case, one recording
+  # with the flag on the message.
   def tag_voice_message(attachment)
     return unless @is_voice_message && attachment.file_type == 'audio'
+    return if attachment.meta.to_h.key?('is_voice_message')
 
     attachment.meta = (attachment.meta || {}).merge('is_voice_message' => true)
   end

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -218,6 +218,47 @@ describe Messages::MessageBuilder do
         expect(message.attachments.first.meta).to include('is_recorded_audio' => false)
       end
 
+      # The same sentence for the sibling flag, and it was not true for it. `tag_voice_message` ran
+      # after the metadata merge and wrote `true` over the refusal that had just been read and cast,
+      # so the two flags disagreed about who wins with nothing saying so. An audio attachment,
+      # because the top-level flag only reaches one.
+      it 'lets a per-attachment refusal beat the top-level voice flag too' do
+        params[:attachments] = [Rack::Test::UploadedFile.new('spec/assets/sample.mp3', 'audio/mpeg')]
+        params[:is_voice_message] = true
+        params[:attachments_metadata] = { 'sample.mp3' => { is_voice_message: 'false' } }
+
+        message = message_builder
+
+        expect(message.attachments.first.meta).to include('is_voice_message' => false)
+      end
+
+      # Mentioning the key is answering, whatever the answer is. An explicit null is the case that
+      # separates "the entry has an opinion" from "the entry refuses", and it goes the same way as
+      # the sibling flag: there the entry merges last, so a null lands on top of the message-level
+      # value. Reading only a `false` here would put the two flags back out of step on exactly the
+      # input nobody thinks about.
+      it 'treats an explicit null in the entry as the entry having answered' do
+        params[:attachments] = [Rack::Test::UploadedFile.new('spec/assets/sample.mp3', 'audio/mpeg')]
+        params[:is_voice_message] = true
+        params[:attachments_metadata] = { 'sample.mp3' => { is_voice_message: nil } }
+
+        message = message_builder
+
+        expect(message.attachments.first.meta['is_voice_message']).to be_nil
+      end
+
+      # And the top-level flag still reaches an attachment whose metadata says nothing about it,
+      # which is the case the dashboard sends: one recording, the flag on the message.
+      it 'still tags an attachment whose metadata does not mention the voice flag' do
+        params[:attachments] = [Rack::Test::UploadedFile.new('spec/assets/sample.mp3', 'audio/mpeg')]
+        params[:is_voice_message] = true
+        params[:attachments_metadata] = { 'sample.mp3' => { description: 'recado' } }
+
+        message = message_builder
+
+        expect(message.attachments.first.meta).to include('is_voice_message' => true, 'description' => 'recado')
+      end
+
       # What the cast covers is `ActiveModel::Type::Boolean`'s own list, and no more. Widening it
       # would be inventing a second truth table one line from the sibling parameter that uses the
       # standard one, which is the inconsistency this exists to remove.
@@ -407,6 +448,19 @@ describe Messages::MessageBuilder do
           message = message_builder
 
           expect(message.attachments.first.meta).to include('is_recorded_audio' => false)
+        end
+
+        # Same sentence for the voice flag, measured here too rather than inferred from multipart:
+        # the defect was in `tag_voice_message`, which both upload paths run, so both wrote `true`
+        # over the refusal.
+        it 'lets a per-attachment refusal beat the top-level voice flag, as multipart does' do
+          params[:attachments] = [get_blob_for('spec/assets/sample.ogg', 'audio/ogg').signed_id]
+          params[:is_voice_message] = true
+          params[:attachments_metadata] = { 'sample.ogg' => { is_voice_message: 'false' } }
+
+          message = message_builder
+
+          expect(message.attachments.first.meta).to include('is_voice_message' => false)
         end
 
         # The sibling reader in the same `process_metadata` has no `respond_to?` guard at all, so


### PR DESCRIPTION
Fecha #561.

`is_voice_message` como parâmetro fala da mensagem inteira; a entrada correspondente em `attachments_metadata` fala de um anexo só. A entrada é a mais específica das duas, então é ela que vale. Valia o contrário: `tag_voice_message` roda depois do merge dos metadados e escrevia `true` por cima de uma recusa que tinha acabado de ser lida e convertida, o que deixava quem manda vários anexos sem nenhuma forma de dizer "esse aqui não é recado de voz".

```ruby
def tag_voice_message(attachment)
  return unless @is_voice_message && attachment.file_type == 'audio'
  return if attachment.meta.to_h.key?('is_voice_message')

  attachment.meta = (attachment.meta || {}).merge('is_voice_message' => true)
end
```

Quem decide é a chave, não o valor: citar `is_voice_message` já é responder, qualquer que seja a resposta, e é a ausência da chave que deixa a marca da mensagem de pé, que é o caso do painel (uma gravação só, marca na mensagem). Escrito como desvio em vez de mudar a chamada de lugar porque `should_transcode?` lê o mesmo `file_type` que este método lê, e mover uma das duas muda a ordem que elas enxergam, que é justamente a ressalva registrada na issue.

Isso põe as duas marcas irmãs de acordo. Em `is_recorded_audio` a entrada do anexo já merge por último e a recusa já vencia (#532, cenário s15 do holdout); agora `is_voice_message` responde igual, inclusive no nulo explícito, onde a entrada fala e o valor guardado fica `nil` nas duas.

## O que foi medido

Bateria de mutação no desvio novo, `spec/builders/messages/message_builder_spec.rb` inteira em cada rodada:

| mutante | resultado |
| --- | --- |
| m1 sem o desvio (defeito original) | 3 falhas |
| m2 desvio só quando o valor é `false` | 1 falha |
| m3 desvio com qualquer metadado presente | 1 falha |
| m4 desvio pela chave símbolo | 3 falhas |
| m5 desvio repetindo `file_type == 'audio'` | **0 falhas, equivalente** |
| restaurado | 0 falhas |

m5 sobrevive por ser equivalente de verdade: a linha acima já garante `attachment.file_type == 'audio'`, então a conjunção extra não muda nenhuma entrada. Registrado como sobrevivente explicado em vez de inventar um observador para matá-lo.

m2 é o mutante que exigiu exemplo novo. `key?` e `== false` só divergem quando o valor guardado não é nem `true` nem `false`, e o nulo explícito é exatamente esse caso: `cast_metadata_flags` converte `nil` para `nil`, a entrada continua presente, e ler só o `false` poria as duas marcas irmãs de novo fora de compasso na entrada em que ninguém pensa.

Suítes: 67 exemplos em `message_builder_spec.rb`, e 293 no conjunto afetado (`spec/builders/messages`, `messages_controller`, `reactions_controller`, `send_scheduled_message_job`, `automation_rules/action_service`, `whatsapp_cloud_service`, `active_storage_opus_fix`, `slack/incoming_message_builder`, `webhooks_request`), todos verdes. RuboCop limpo. O mapa afetado da CI é por nome de arquivo, então a suíte CE inteira foi disparada na branch por `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/599)
<!-- Reviewable:end -->
