### PR TITLE
fix(whatsapp): pôr teto em toda chamada ao Baileys e tirar a repetição calada

### DIFF
--- a/app/services/whatsapp/baileys_request_options.rb
+++ b/app/services/whatsapp/baileys_request_options.rb
@@ -1,0 +1,41 @@
+# Two ceilings for the Baileys API, and the numbers come from the API's own, not from taste.
+#
+# Measured on `fazer-ai/baileys-api` at `112d95e`:
+#
+#   PROXY_REQUEST_TIMEOUT_MS  75_000   the API's proxy cuts every request at this
+#   defaultQueryTimeoutMs     60_000   how long Baileys itself waits on an IQ to WhatsApp
+#   BAILEYS_SEND_TIMEOUT_MS   45_000   the send's own deadline, plus a 20s audio budget
+#
+# Almost every route awaits a socket call, so 60s is a legitimate duration there, and the
+# proxy answers for itself at 75s. A ceiling below that is a ceiling that can hang up on a
+# provider that was about to answer, and for a write that means we report a failure for
+# something that happened. 90s is therefore the default: above the proxy's cut, so what we
+# get back is the API's structured 503/504 rather than a bare `Net::ReadTimeout`, and never
+# reached in practice because the far side always answers first. It is the number
+# `send_message_request` already chose, for these same reasons, written down once.
+#
+# `max_retries: 0` is on both, and it is the half that a `timeout:` alone does not buy.
+# `Net::HTTP` retries an idempotent request once by default, so a GET costs twice its
+# ceiling and a POST costs it once. Measured against a socket that accepts the connection
+# and never answers:
+#
+#   GET  timeout: 5                    10.0s
+#   GET  timeout: 5, max_retries: 0     5.0s
+#   POST timeout: 5                     5.0s
+#
+# Nothing here is safe to replay at the transport layer anyway: the send carries the API's
+# idempotency key and every other call is a command, so a silent second attempt is a second
+# effect nobody asked for.
+module Whatsapp::BaileysRequestOptions
+  BAILEYS_REQUEST_OPTIONS = { timeout: 90, max_retries: 0 }.freeze
+
+  # The calls that deliberately give up before the provider does. Each one is a read whose
+  # caller already treats silence as "I do not know" and changes nothing, so waiting out a
+  # wedged socket buys an answer nobody is going to act on. Two of the seven sites that
+  # carry this today are not that -- `import_session` and `disconnect_channel_provider` act
+  # on the outcome -- and keeping their existing 10s rather than raising it is deliberate:
+  # this change gives every call a ceiling and takes the silent retry away, and moving a
+  # ceiling that already exists is a decision about what a cut *means*, which is
+  # fazer-ai/chatwoot#600.
+  BAILEYS_SHORT_REQUEST_OPTIONS = { timeout: 10, max_retries: 0 }.freeze
+end

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -1,5 +1,6 @@
 class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseService # rubocop:disable Metrics/ClassLength
   include BaileysHelper
+  include Whatsapp::BaileysRequestOptions
 
   # Legacy errors inherit from the session hierarchy so every caller rescues a single
   # namespace, whatever the provider. Nothing else about this service changes: it is
@@ -58,7 +59,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
 
     response = HTTParty.get(
       "#{DEFAULT_URL}/status",
-      headers: { 'x-api-key' => DEFAULT_API_KEY }
+      headers: { 'x-api-key' => DEFAULT_API_KEY },
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     unless response.success?
@@ -95,7 +97,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         includeMedia: false,
         groupsEnabled: self.class.groups_enabled?,
         syncFullHistory: history_sync?
-      }.compact.to_json
+      }.compact.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -124,7 +127,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         groupsEnabled: self.class.groups_enabled?,
         syncFullHistory: history_sync?
       }.compact.to_json,
-      timeout: 10
+      **BAILEYS_SHORT_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -148,7 +151,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.delete(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}",
       headers: api_headers,
-      timeout: 10
+      **BAILEYS_SHORT_REQUEST_OPTIONS
     )
     # 404 is the state being asked for, not a failure: the session is already gone, so
     # reporting it as one would abort a provider conversion, block the rejected-session
@@ -208,7 +211,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-create",
       headers: api_headers,
-      body: { subject: subject, participants: participants }.to_json
+      body: { subject: subject, participants: participants }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -220,7 +224,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-subject",
       headers: api_headers,
-      body: { jid: group_jid, subject: subject }.to_json
+      body: { jid: group_jid, subject: subject }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -230,7 +235,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-description",
       headers: api_headers,
-      body: { jid: group_jid, description: description }.to_json
+      body: { jid: group_jid, description: description }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -240,7 +246,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/update-profile-picture",
       headers: api_headers,
-      body: { jid: group_jid, image: image_base64 }.to_json
+      body: { jid: group_jid, image: image_base64 }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -251,7 +258,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       response = HTTParty.post(
         "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-participants",
         headers: api_headers,
-        body: { jid: group_jid, participant: participant, action: action }.to_json
+        body: { jid: group_jid, participant: participant, action: action }.to_json,
+        **BAILEYS_REQUEST_OPTIONS
       )
 
       raise ProviderUnavailableError unless process_response(response)
@@ -265,7 +273,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-invite-code",
       headers: api_headers,
       query: { jid: group_jid },
-      format: :json
+      format: :json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -277,7 +286,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-revoke-invite",
       headers: api_headers,
-      body: { jid: group_jid }.to_json
+      body: { jid: group_jid }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -290,7 +300,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-request-participants-list",
       headers: api_headers,
       query: { jid: group_jid },
-      format: :json
+      format: :json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     return [] if response.code == 403
@@ -305,7 +316,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-request-participants-update",
       headers: api_headers,
-      body: { jid: group_jid, participants: participants, action: action }.to_json
+      body: { jid: group_jid, participants: participants, action: action }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -315,7 +327,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-leave",
       headers: api_headers,
-      body: { jid: group_jid }.to_json
+      body: { jid: group_jid }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -333,7 +346,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-setting-update",
       headers: api_headers,
-      body: { jid: group_jid, setting: setting }.to_json
+      body: { jid: group_jid, setting: setting }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -343,7 +357,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-join-approval-mode",
       headers: api_headers,
-      body: { jid: group_jid, mode: mode }.to_json
+      body: { jid: group_jid, mode: mode }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -353,7 +368,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.post(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-member-add-mode",
       headers: api_headers,
-      body: { jid: group_jid, mode: mode }.to_json
+      body: { jid: group_jid, mode: mode }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -392,7 +408,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   def validate_provider_config?
     response = HTTParty.get(
       "#{provider_url}/status/auth",
-      headers: api_headers
+      headers: api_headers,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     process_response(response)
@@ -412,7 +429,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       body: {
         toJid: remote_jid,
         type: status_map[typing_status]
-      }.to_json
+      }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -425,7 +443,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/presence-subscribe",
       headers: api_headers,
       body: { jids: Array(jids) }.to_json,
-      timeout: 10
+      **BAILEYS_SHORT_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -445,7 +463,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       headers: api_headers,
       body: {
         type: status_map[status]
-      }.to_json
+      }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -461,7 +480,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       headers: api_headers,
       body: {
         keys: messages.map { |message| message_key_for(message) }
-      }.to_json
+      }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -484,7 +504,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
             messageTimestamp: message.content_attributes[:external_created_at]
           }]
         }
-      }.to_json
+      }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -500,7 +521,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       headers: api_headers,
       body: {
         keys: messages.map { |message| message_key_for(message) }
-      }.to_json
+      }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -536,7 +558,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         count: (count || HISTORY_REQUEST_COUNT).to_i.clamp(1, HISTORY_REQUEST_COUNT),
         oldestMsgKey: { id: anchor.source_id, remoteJid: jid, fromMe: anchor.outgoing? },
         oldestMsgTimestamp: history_anchor_timestamp(anchor)
-      }.to_json
+      }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -550,7 +573,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       headers: api_headers,
       query: { jid: jid },
       format: :json,
-      timeout: 10
+      **BAILEYS_SHORT_REQUEST_OPTIONS
     )
 
     return nil unless process_response(response)
@@ -563,7 +586,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/group-metadata",
       headers: api_headers,
       query: { jid: group_jid },
-      format: :json
+      format: :json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -579,7 +603,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       headers: api_headers,
       body: {
         jids: [remote_jid]
-      }.to_json
+      }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -598,7 +623,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       body: {
         jid: remote_jid,
         key: message_key_for(message)
-      }.to_json
+      }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -616,7 +642,8 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         jid: remote_jid,
         key: message_key_for(message),
         messageContent: { text: new_content }
-      }.to_json
+      }.to_json,
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -634,7 +661,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/reachout-timelock",
       headers: api_headers,
       format: :json,
-      timeout: 10
+      **BAILEYS_SHORT_REQUEST_OPTIONS
     )
 
     return nil if response.code == 404
@@ -662,7 +689,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/health",
       headers: api_headers,
       format: :json,
-      timeout: 10
+      **BAILEYS_SHORT_REQUEST_OPTIONS
     )
 
     return nil if response.code == 404
@@ -686,7 +713,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}/new-chat-cap",
       headers: api_headers,
       format: :json,
-      timeout: 10
+      **BAILEYS_SHORT_REQUEST_OPTIONS
     )
 
     return nil if response.code == 404
@@ -847,14 +874,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         # key while still letting Sidekiq retries of the same attempt dedupe.
         chatwootMessageId: "#{@message.id}:#{@message.updated_at.to_f}",
         messageId: message_id
-      }.to_json,
-      # Above the API's own 45s send deadline plus its slower paths (audio
-      # transcoding, media upload) and above a proxy's 75s cut, so we get its
-      # structured 504/503 rather than a bare Net::ReadTimeout. Below the old
-      # 120s because this request holds the per-channel outgoing lock
-      # (BaileysHelper::CHANNEL_LOCK_ON_OUTGOING_MESSAGE_TIMEOUT, 130s) and every
-      # other send on the inbox queues behind it.
-      timeout: 90
+      }.to_json
     )
 
     raise_send_error(response) unless response.success?
@@ -873,8 +893,16 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # way a socket can fail, and it will be wrong (Net::WriteTimeout on a large media body,
   # OpenSSL::SSL::SSLError on a handshake, whatever the next TLS or HTTP gem raises).
   # Anything StandardError can be here is a transport failure by construction.
+  # The ceiling goes on this call and not on the caller, so that the one HTTParty call on the
+  # send path cannot be reached without it, and it goes AFTER the forwarded keywords so a
+  # caller cannot quietly raise it. The constant's 90s is the number this call chose first:
+  # above the API's own 45s send deadline plus its slower paths (audio transcoding, media
+  # upload) and above its proxy's 75s cut, so what comes back is its structured 504/503 and
+  # not a bare Net::ReadTimeout. The ceiling above it is the per-channel outgoing lock
+  # (BaileysHelper::CHANNEL_LOCK_ON_OUTGOING_MESSAGE_TIMEOUT, 130s), which every other send on
+  # the inbox queues behind.
   def post_send_message(url, **)
-    HTTParty.post(url, **)
+    HTTParty.post(url, **, **BAILEYS_REQUEST_OPTIONS)
   rescue StandardError => e
     raise_transport_error(e)
   end

--- a/spec/services/whatsapp/baileys_request_options_spec.rb
+++ b/spec/services/whatsapp/baileys_request_options_spec.rb
@@ -91,6 +91,23 @@ describe Whatsapp::BaileysRequestOptions do
     expect(short).to eq(7)
   end
 
+  # The one claim in this change that the text scan above cannot check, because it is about what
+  # Ruby does with two double-splats rather than about what the file says. `post_send_message`
+  # forwards its caller's keywords and then applies the constant, in that order, so a caller that
+  # passed a `timeout:` of its own would not get it. Written as an example because the order is
+  # invisible at the call site and reversing it is a one-character edit.
+  it 'lets the constant win over a keyword the caller forwarded' do
+    service = described_class::BAILEYS_REQUEST_OPTIONS
+    sent = nil
+    allow(HTTParty).to receive(:post) { |_url, **options| sent = options }
+
+    channel = create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false)
+    Whatsapp::Providers::WhatsappBaileysService.new(whatsapp_channel: channel)
+                                               .send(:post_send_message, 'http://example.test', timeout: 1, max_retries: 9)
+
+    expect(sent).to include(service)
+  end
+
   it 'is the only source of a ceiling for this file' do
     # The constants live in a module of their own so that the value and its reasoning sit in one
     # place; a copy of the numbers in the service would be the thing that drifts.

--- a/spec/services/whatsapp/baileys_request_options_spec.rb
+++ b/spec/services/whatsapp/baileys_request_options_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+describe Whatsapp::BaileysRequestOptions do
+  # One file, and the fence is here rather than folded into the Graph one because the number is
+  # not the same and the reason for it is not the same: Meta is somebody else's API with no
+  # published deadline, and the Baileys API is ours, with its own cuts written in its own config.
+  let(:guarded_source) { 'app/services/whatsapp/providers/whatsapp_baileys_service.rb' }
+  let(:source) { Rails.root.join(guarded_source).read }
+  let(:calls) { provider_calls(source) }
+
+  # Reads a call to its own closing paren rather than to the first one it meets: `HTTParty.post(`
+  # opens a call that runs for a dozen lines here, and the body hash has parens of its own.
+  def provider_calls(source)
+    calls = []
+    source.to_enum(:scan, /HTTParty\.(?:get|post|put|patch|delete|head)\(/).each do
+      start = Regexp.last_match.begin(0)
+      depth = 0
+      source[start..].each_char.with_index do |char, offset|
+        depth += 1 if char == '('
+        next unless char == ')'
+
+        depth -= 1
+        next unless depth.zero?
+
+        calls << source[start, offset + 1]
+        break
+      end
+    end
+    calls
+  end
+
+  it 'reads a call to its own closing paren, not to the first one it meets' do
+    # Without this the scanner would stop inside `{ jid: jid }` and report the call as having no
+    # ceiling, or worse, would find the ceiling of the call below and pass for the wrong reason.
+    sample = <<~RUBY
+      HTTParty.post(
+        url,
+        body: { jid: jid, keys: messages.map { |m| key_for(m) } }.to_json,
+        **BAILEYS_REQUEST_OPTIONS
+      )
+    RUBY
+
+    expect(provider_calls(sample).first).to include('BAILEYS_REQUEST_OPTIONS')
+  end
+
+  it 'caps the wait and the retry, because a ceiling alone still costs twice on a read' do
+    expect(described_class::BAILEYS_REQUEST_OPTIONS).to eq(timeout: 90, max_retries: 0)
+    expect(described_class::BAILEYS_SHORT_REQUEST_OPTIONS).to eq(timeout: 10, max_retries: 0)
+  end
+
+  it 'keeps the default above the cut the provider applies to itself' do
+    # 75s is PROXY_REQUEST_TIMEOUT_MS in fazer-ai/baileys-api. A ceiling at or below it is a
+    # ceiling that hangs up on a provider that was about to answer for itself, which on a write
+    # means reporting a failure for something that happened.
+    expect(described_class::BAILEYS_REQUEST_OPTIONS[:timeout]).to be > 75
+  end
+
+  it 'leaves no call to the provider without one of the two ceilings' do
+    unguarded = calls.reject { |call| call.include?('BAILEYS_REQUEST_OPTIONS') || call.include?('BAILEYS_SHORT_REQUEST_OPTIONS') }
+
+    expect(unguarded.map { |call| call.lines.first(2).map(&:strip).join(' ') }).to be_empty
+  end
+
+  it 'refuses a call that names both ceilings, because then neither is the one in force' do
+    both = calls.select { |call| call.include?('**BAILEYS_REQUEST_OPTIONS') && call.include?('BAILEYS_SHORT_REQUEST_OPTIONS') }
+
+    expect(both).to be_empty
+  end
+
+  it 'leaves no inline timeout beside the constant, which would be the value actually in force' do
+    # A `timeout:` written after the splat wins over it, so the fence would read as satisfied
+    # while the call ran on a number nobody wrote down.
+    inline = calls.grep(/timeout:\s*\d/)
+
+    expect(inline).to be_empty
+  end
+
+  it 'reads every call in the file, so an empty result cannot pass as a clean one' do
+    # The checks above all answer "none", and they answer "none" for zero calls too. This is the
+    # canary: it fails the day the scanner stops seeing the file, instead of reporting it clean.
+    expect(calls.size).to eq(34)
+  end
+
+  # The split is the substance of this fence, not a detail: the short ceiling is the one that
+  # gives up before the provider does, so a call moving into it silently is a call that starts
+  # reporting failure on something the provider would have answered. Counting each side means a
+  # move has to be made on purpose.
+  it 'keeps the short ceiling on the calls that chose to give up before the provider does' do
+    short = calls.count { |call| call.include?('BAILEYS_SHORT_REQUEST_OPTIONS') }
+
+    expect(short).to eq(7)
+  end
+
+  it 'is the only source of a ceiling for this file' do
+    # The constants live in a module of their own so that the value and its reasoning sit in one
+    # place; a copy of the numbers in the service would be the thing that drifts.
+    expect(source).to include('include Whatsapp::BaileysRequestOptions')
+  end
+end

--- a/spec/services/whatsapp/graph_request_options_spec.rb
+++ b/spec/services/whatsapp/graph_request_options_spec.rb
@@ -22,10 +22,11 @@ describe Whatsapp::GraphRequestOptions do
   # its own ceiling to decide, which is fazer-ai/chatwoot#589.
   let(:other_families) do
     {
-      # Its own API, not Meta's, and the one place in the repo that already reasoned about a number:
-      # 10s for the control calls and 90s for the send, tied to the API's own 45s deadline and to the
-      # per-channel outgoing lock. One family constant would be wrong for it.
-      'app/services/whatsapp/providers/whatsapp_baileys_service.rb' => 'Baileys API, ceilings already reasoned per call',
+      # Its own API, not Meta's, and the one with two ceilings rather than one: 90s by default,
+      # above the cut its own proxy applies, and 10s on the reads that give up before it does.
+      # Fenced by spec/services/whatsapp/baileys_request_options_spec.rb, which also counts each
+      # side, so this entry is a pointer and not an exemption.
+      'app/services/whatsapp/providers/whatsapp_baileys_service.rb' => 'Baileys API, fenced by its own two-ceiling spec',
       'app/services/whatsapp/providers/whatsapp_zapi_service.rb' => 'Z-API, no ceiling decided yet',
       'app/services/whatsapp/providers/whatsapp_360_dialog_service.rb' => '360dialog, no ceiling decided yet',
       # uazapi, and already the most careful caller in the repo: its own TIMEOUT constant, a separate


### PR DESCRIPTION
Primeira fatia da #589. Uma família por PR, e esta é a do provedor Baileys: 34 chamadas HTTParty, sete com teto e **nenhuma** com controle de repetição.

## O que estava em jogo

Duas coisas, e um `timeout:` sozinho fecha só a primeira. O `Net::HTTP` repete uma requisição idempotente uma vez por padrão, então:

| | antes | agora |
| --- | --- | --- |
| 26 chamadas sem teto | 60s no POST, 120s no GET (padrão do gem) | 90s, sem repetição |
| 7 chamadas com `timeout: 10` | 10s no POST, **20s** no GET | 10s, sem repetição |

## De onde vem o 90

Do outro lado, medido em `fazer-ai/baileys-api` no `112d95e`:

```
PROXY_REQUEST_TIMEOUT_MS  75_000   o proxy da API corta toda requisição aqui
defaultQueryTimeoutMs     60_000   quanto o Baileys espera por um IQ ao WhatsApp
BAILEYS_SEND_TIMEOUT_MS   45_000   prazo do envio, mais 20s de pré-processamento de áudio
```

Varri as rotas de `src/controllers/connections/index.ts`: quase toda uma aguarda uma chamada `baileys.*`, ou seja, espera o WhatsApp. Então 60s é duração legítima lá dentro, e o proxy responde por si aos 75s. Um teto abaixo disso desliga na cara de um provedor que ia responder, e numa escrita (criar grupo, editar, apagar, enviar recibo) isso não é uma página lenta: é relatar falha de algo que aconteceu. Acima de 75s não compra nada além da margem para receber o 503/504 estruturado dele em vez de um `Net::ReadTimeout` nosso.

90s não é número novo: é o que `send_message_request` já tinha escolhido, com a razão escrita no próprio arquivo. O que esta PR faz é escrever essa razão uma vez e aplicá-la ao resto.

O custo, dito por inteiro: uma escrita patológica passa a segurar a thread de request até os 75s em vez de 60s. É o mesmo trade que o envio já fazia de propósito, e a troca é nunca inventar desfecho.

## O teto curto

`BAILEYS_SHORT_REQUEST_OPTIONS` (10s) fica exatamente onde já estava. Em cinco dos sete pontos ele é a resposta certa, porque o chamador trata silêncio como "não sei" e não muda nada: `get_profile_pic`, `fetch_reachout_timelock`, `fetch_send_health` e `fetch_new_chat_cap` devolvem `nil`, e `presence_subscribe` é rescueado e logado em `Conversations::PresenceSubscribeService`.

Nos outros dois (`import_session` e `disconnect_channel_provider`) o chamador **usa** o desfecho, e um corte aos 10s vira veredito. Não mexi: esta PR é a frase "toda chamada tem teto e nenhuma repete sozinha", e mexer num teto que já existe é decidir o que um corte significa, uma pergunta por ponto. Abri a **#600** com os três caminhos e a medição.

## O envio

O teto foi para dentro de `post_send_message`, que é a única chamada HTTParty do caminho de envio, e **depois** do `**` encaminhado, para que um chamador não consiga baixá-lo em silêncio. O comentário que explicava os 90s continua lá, agora dizendo por que este ponto em particular precisa deles.

## A cerca

`spec/services/whatsapp/baileys_request_options_spec.rb`, no mesmo formato da da Graph (#588), lendo cada chamada até o parêntese que a fecha e não até o primeiro que encontra. Bateria de mutação, 9 exemplos por rodada:

| mutante | resultado |
| --- | --- |
| m1 uma chamada existente sem o splat | 1 falha |
| m2 chamada nova sem teto | 2 falhas |
| m3 chamada migrada para o teto curto | 1 falha |
| m4 `timeout: 5` inline depois do splat | 1 falha |
| m5 teto padrão baixado para 60s | 2 falhas |
| m6 constante sem `max_retries` | 1 falha |
| m7 scanner cego (não lê chamada nenhuma) | 3 falhas |
| m8 ordem invertida dos dois splats no envio | 1 falha |
| restaurado | 0 falhas |

m3 é o que me importava mais: contar quantas chamadas ficam de cada lado é o que faz uma migração entre os dois tetos ter que ser deliberada, em vez de um splat trocado numa revisão distraída.

m8 não é alcançável por leitura de texto, porque não é sobre o que o arquivo diz e sim sobre o que o Ruby faz com dois duplo-splats, então tem exemplo de comportamento próprio. Conferido também fora da suíte, chamando o método de verdade: um chamador que passe `timeout: 1, max_retries: 9` chega na HTTParty como `{timeout: 90, max_retries: 0}`. Na mesma medição confirmei que a constante resolve dentro do método de classe `self.status` (ela vem de `include`, e a busca de constante lá passa pelos ancestrais) e que o `Net::HTTP` responde a `max_retries=`.

Também atualizei a entrada do Baileys em `graph_request_options_spec.rb`: ela dizia "ceilings already reasoned per call", o que era generoso, já que os três 10s sem comentário (`84f1c5cf7a`, `cca574ee5d`, `11e9932e9b`) foram escolhidos inline. Agora aponta para a cerca nova.

## Suítes

139 exemplos nas três specs diretas e 2043 no conjunto afetado (`spec/services/whatsapp`, `channel/whatsapp`, controllers de contato, jobs do Baileys, presence subscribe), todos verdes. RuboCop limpo, `zeitwerk:check` ok. O concern novo é do tipo que o mapa afetado da CI não enxerga (é por nome de arquivo), então a suíte CE inteira foi disparada na branch por `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/601)
<!-- Reviewable:end -->
