### PR TITLE
fix(whatsapp): ask for reauthorization on an answer about the credentials, not on silence

### DIFF
--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -433,10 +433,38 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
     perform_webhook_setup
   rescue StandardError => e
     Rails.logger.error "[WHATSAPP] Webhook setup failed: #{e.message}"
+    return unless credentials_refused?(e)
+
+    Rails.logger.error "[WHATSAPP] Meta refused the credentials for inbox #{inbox&.id}; asking for reauthorization"
     prompt_reauthorization!
   end
 
   private
+
+  # `prompt_reauthorization!` is not a log line: it writes the marker, runs the handler that emails
+  # the operator, invalidates the inbox cache and fires the event, and `Webhooks::WhatsappEventsJob`
+  # discards every inbound webhook while the marker stands. Nothing clears it but a human. So it
+  # takes an answer that says the credentials are the problem, and a Meta that accepts the
+  # connection and stays quiet is not one: measured on `main`, three ceiling-capped calls in a row
+  # marked a perfectly good channel in 30s.
+  #
+  # `ArgumentError` is the opposite case rather than an exception to the rule. It is what
+  # `Whatsapp::WebhookSetupService` raises when the access token or the WABA id is blank, and a
+  # credential that is not there is as definite an answer as one Meta rejected.
+  #
+  # The walk down `cause` is what makes this survive the layers in between: the setup service
+  # re-raises with a prefix so the operator can see which step failed, and Ruby keeps the original
+  # underneath. Asking only the outermost error would read every one of those as silence.
+  def credentials_refused?(error)
+    while error
+      return true if error.is_a?(ArgumentError)
+      return true if error.is_a?(Whatsapp::ApiError) && error.authorization_error?
+
+      error = error.cause
+    end
+
+    false
+  end
 
   # Whether anything on the way in will read the marker back. Written by exactly the two
   # inbound paths that can mistake our own receipt for a device read: the canonical session

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -456,8 +456,12 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
   # re-raises with a prefix so the operator can see which step failed, and Ruby keeps the original
   # underneath. Asking only the outermost error would read every one of those as silence.
   def credentials_refused?(error)
+    # Read at the top and not down the chain, unlike Meta's answer: the setup service raises this one
+    # from `perform` and nothing wraps it, while an `ArgumentError` coming from inside the Graph call
+    # path would be about something else entirely and has no business speaking for the credentials.
+    return true if error.is_a?(ArgumentError)
+
     while error
-      return true if error.is_a?(ArgumentError)
       return true if error.is_a?(Whatsapp::ApiError) && error.authorization_error?
 
       error = error.cause

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -455,16 +455,6 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
   # The walk down `cause` is what makes this survive the layers in between: the setup service
   # re-raises with a prefix so the operator can see which step failed, and Ruby keeps the original
   # underneath. Asking only the outermost error would read every one of those as silence.
-  # Named by what happened, not by "Meta refused": the blank-credential branch reaches this line
-  # without a single call having left, and a log that says Meta spoke is the same trade this class
-  # of bug is about. The channel id rather than the inbox's, because the `after_commit on: :create`
-  # path runs before the inbox exists and was printing "for inbox ;".
-  def reauthorization_reason(error)
-    return 'the setup could not run without a credential' if error.is_a?(ArgumentError)
-
-    'Meta answered that the credentials are the problem'
-  end
-
   def credentials_refused?(error)
     # Read at the top and not down the chain, unlike Meta's answer: the setup service raises this one
     # from `perform` and nothing wraps it, while an `ArgumentError` coming from inside the Graph call
@@ -478,6 +468,16 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
     end
 
     false
+  end
+
+  # Named by what happened, not by "Meta refused": the blank-credential branch reaches this line
+  # without a single call having left, and a log that says Meta spoke is the same trade this class
+  # of bug is about. The channel id rather than the inbox's, because the `after_commit on: :create`
+  # path runs before the inbox exists and was printing "for inbox ;".
+  def reauthorization_reason(error)
+    return 'the setup could not run without a credential' if error.is_a?(ArgumentError)
+
+    'Meta answered that the credentials are the problem'
   end
 
   # Whether anything on the way in will read the marker back. Written by exactly the two

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -435,7 +435,7 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
     Rails.logger.error "[WHATSAPP] Webhook setup failed: #{e.message}"
     return unless credentials_refused?(e)
 
-    Rails.logger.error "[WHATSAPP] Meta refused the credentials for inbox #{inbox&.id}; asking for reauthorization"
+    Rails.logger.error("[WHATSAPP] Asking for reauthorization on channel #{id}: #{reauthorization_reason(e)}")
     prompt_reauthorization!
   end
 
@@ -455,6 +455,16 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
   # The walk down `cause` is what makes this survive the layers in between: the setup service
   # re-raises with a prefix so the operator can see which step failed, and Ruby keeps the original
   # underneath. Asking only the outermost error would read every one of those as silence.
+  # Named by what happened, not by "Meta refused": the blank-credential branch reaches this line
+  # without a single call having left, and a log that says Meta spoke is the same trade this class
+  # of bug is about. The channel id rather than the inbox's, because the `after_commit on: :create`
+  # path runs before the inbox exists and was printing "for inbox ;".
+  def reauthorization_reason(error)
+    return 'the setup could not run without a credential' if error.is_a?(ArgumentError)
+
+    'Meta answered that the credentials are the problem'
+  end
+
   def credentials_refused?(error)
     # Read at the top and not down the chain, unlike Meta's answer: the setup service raises this one
     # from `perform` and nothing wraps it, while an `ArgumentError` coming from inside the Graph call

--- a/app/services/whatsapp/api_error.rb
+++ b/app/services/whatsapp/api_error.rb
@@ -1,0 +1,40 @@
+# Meta answers a refusal with a body carrying a numeric code, and exactly one of those codes is a
+# statement about the credentials. Everything else is a refusal of this request: `(#200) Permissions
+# error` for a WABA in someone else's portfolio, a rate limit, a plain 500. The difference is not
+# cosmetic, because it decides whether the operator gets an alarm they have to act on by hand.
+#
+# So the error carries what it takes to tell the two apart, and the question is asked in exactly one
+# place: two classes each deciding what `190` means is how the two answers drift apart.
+class Whatsapp::ApiError < StandardError
+  AUTHORIZATION_ERROR_CODE = 190
+
+  attr_reader :http_status, :code, :subcode
+
+  def initialize(message:, http_status:, code: nil, subcode: nil)
+    super(message)
+    @http_status = http_status
+    @code = code
+    @subcode = subcode
+  end
+
+  # `message:` is for a caller that prefixes the step that failed ("Phone registration failed: ...")
+  # and needs Meta's body in the line; without it the error speaks Meta's own message.
+  #
+  # A body that is not a Hash is Meta not answering in the vocabulary it documents (an HTML page from
+  # something in front of it), and it leaves the code nil, which is the honest reading: no answer
+  # about the credentials.
+  def self.from_response(response, message: nil)
+    error = response.parsed_response.is_a?(Hash) ? response.parsed_response['error'].to_h : {}
+
+    new(
+      message: message || error['message'].presence || 'WhatsApp API request failed',
+      http_status: response.code,
+      code: error['code'],
+      subcode: error['error_subcode']
+    )
+  end
+
+  def authorization_error?
+    code.to_i == AUTHORIZATION_ERROR_CODE
+  end
+end

--- a/app/services/whatsapp/facebook_api_client.rb
+++ b/app/services/whatsapp/facebook_api_client.rb
@@ -193,8 +193,11 @@ class Whatsapp::FacebookApiClient
     "#{app_id}|#{app_secret}"
   end
 
+  # The message is unchanged, because it is what reaches the operator through the register-webhook
+  # endpoint. What is new is that the error also carries Meta's code, which is the only thing that
+  # separates "this token is no good" from "this request was refused" for whoever rescues it.
   def handle_response(response, error_message)
-    raise "#{error_message}: #{response.body}" unless response.success?
+    raise Whatsapp::ApiError.from_response(response, message: "#{error_message}: #{response.body}") unless response.success?
 
     response.parsed_response
   end

--- a/app/services/whatsapp/health_service.rb
+++ b/app/services/whatsapp/health_service.rb
@@ -1,18 +1,8 @@
 class Whatsapp::HealthService
-  class ApiError < StandardError
-    attr_reader :http_status, :code, :subcode
-
-    def initialize(message:, http_status:, code: nil, subcode: nil)
-      super(message)
-      @http_status = http_status
-      @code = code
-      @subcode = subcode
-    end
-
-    def authorization_error?
-      code.to_i == 190
-    end
-  end
+  # Kept as a name of its own so `rescue Whatsapp::HealthService::ApiError` still means "reading the
+  # health failed" and not "any Graph call failed". What it is, including what counts as an
+  # authorization error, lives in the parent.
+  class ApiError < Whatsapp::ApiError; end
 
   BASE_URI = 'https://graph.facebook.com'.freeze
   MINIMUM_HEALTH_API_VERSION = 24.0
@@ -126,14 +116,7 @@ class Whatsapp::HealthService
   def handle_response(response)
     return response.parsed_response if response.success?
 
-    parsed_response = response.parsed_response
-    error_data = parsed_response.is_a?(Hash) ? parsed_response['error'].to_h : {}
-    error = ApiError.new(
-      message: error_data['message'].presence || 'WhatsApp API request failed',
-      http_status: response.code,
-      code: error_data['code'],
-      subcode: error_data['error_subcode']
-    )
+    error = ApiError.from_response(response)
 
     Rails.logger.error(
       "[WHATSAPP HEALTH] WhatsApp API request failed: http_status=#{error.http_status} " \

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -226,6 +226,36 @@ RSpec.describe Channel::Whatsapp do
       end
     end
 
+    # The line is the only place a diagnosis starts from, and the two ways in are not the same fact:
+    # one of them never reached Meta at all. Saying Meta refused there would be the same trade this
+    # change exists to stop, one layer down.
+    describe 'the line that says why reauthorization was asked for' do
+      it 'says Meta answered, when Meta answered' do
+        stub_request(:post, %r{graph\.facebook\.com/.*/#{waba_id}/subscribed_apps})
+          .to_return(status: 401, body: { error: { message: 'Error validating access token', code: 190 } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+        allow(Rails.logger).to receive(:error)
+
+        channel.setup_webhooks
+
+        expect(Rails.logger).to have_received(:error)
+          .with("[WHATSAPP] Asking for reauthorization on channel #{channel.id}: " \
+                'Meta answered that the credentials are the problem')
+      end
+
+      it 'says the setup could not run, when nothing ever left' do
+        channel.provider_config = channel.provider_config.merge('api_key' => '')
+        channel.save!(validate: false)
+        allow(Rails.logger).to receive(:error)
+
+        channel.setup_webhooks
+
+        expect(Rails.logger).to have_received(:error)
+          .with("[WHATSAPP] Asking for reauthorization on channel #{channel.id}: " \
+                'the setup could not run without a credential')
+      end
+    end
+
     context 'when the setup cannot run because there is no access token' do
       before do
         channel.provider_config = channel.provider_config.merge('api_key' => '')

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -124,14 +124,92 @@ RSpec.describe Channel::Whatsapp do
       end
     end
 
-    context 'when the WABA subscription itself fails' do
+    context 'when Meta answers that the credentials are the problem' do
       before do
         stub_request(:post, %r{graph\.facebook\.com/.*/#{waba_id}/subscribed_apps})
-          .to_return(status: 400, body: { error: { message: 'App subscription to WABA failed' } }.to_json,
+          .to_return(status: 401,
+                     body: { error: { message: 'Error validating access token', type: 'OAuthException', code: 190 } }.to_json,
                      headers: { 'Content-Type' => 'application/json' })
       end
 
       it 'marks the channel for reauthorization' do
+        channel.setup_webhooks
+
+        expect(channel.reauthorization_required?).to be(true)
+      end
+
+      it 'tells the operator, because a revoked token only gets fixed by hand' do
+        admin_mailer = double
+        mailer_double = double
+        allow(AdministratorNotifications::ChannelNotificationsMailer).to receive(:with).and_return(admin_mailer)
+        allow(admin_mailer).to receive(:whatsapp_disconnect).and_return(mailer_double)
+        allow(mailer_double).to receive(:deliver_later)
+
+        channel.setup_webhooks
+
+        expect(admin_mailer).to have_received(:whatsapp_disconnect).with(channel.inbox)
+      end
+    end
+
+    # A ceiling that stops the wait says nothing about the credentials, and `prompt_reauthorization!`
+    # is not a log line: it writes the marker, runs the handler that emails the operator, invalidates
+    # the inbox cache and fires the event, and `Webhooks::WhatsappEventsJob` discards every inbound
+    # webhook while the marker stands. So the alarm has to come from an answer, never from silence.
+    context 'when the WABA subscription never answers' do
+      before do
+        stub_request(:post, %r{graph\.facebook\.com/.*/#{waba_id}/subscribed_apps}).to_timeout
+      end
+
+      it 'leaves the channel authorized' do
+        channel.setup_webhooks
+
+        expect(channel.reauthorization_required?).to be(false)
+      end
+
+      it 'does not email the operator about a disconnection that was never established' do
+        expect(AdministratorNotifications::ChannelNotificationsMailer).not_to receive(:with)
+
+        channel.setup_webhooks
+      end
+    end
+
+    context 'when the WABA subscription answers with a server error' do
+      before do
+        stub_request(:post, %r{graph\.facebook\.com/.*/#{waba_id}/subscribed_apps})
+          .to_return(status: 500, body: { error: { message: 'Internal error', code: 1 } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'leaves the channel authorized, because a bad minute at Meta is not a bad credential' do
+        channel.setup_webhooks
+
+        expect(channel.reauthorization_required?).to be(false)
+      end
+    end
+
+    # The refusal a coexistence number gets every time its WABA sits in the customer's own Business
+    # Manager. The optional half already survives it; the required half used to mark the channel.
+    context 'when Meta refuses the WABA subscription with a permissions error' do
+      before do
+        stub_request(:post, %r{graph\.facebook\.com/.*/#{waba_id}/subscribed_apps})
+          .to_return(status: 403, body: { error: { message: '(#200) Permissions error', code: 200 } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'leaves the channel authorized' do
+        channel.setup_webhooks
+
+        expect(channel.reauthorization_required?).to be(false)
+      end
+    end
+
+    context 'when the setup cannot run because there is no access token' do
+      before do
+        channel.provider_config = channel.provider_config.merge('api_key' => '')
+        channel.save!(validate: false)
+      end
+
+      it 'marks the channel for reauthorization, because a missing credential is not silence' do
         channel.setup_webhooks
 
         expect(channel.reauthorization_required?).to be(true)

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -203,6 +203,29 @@ RSpec.describe Channel::Whatsapp do
       end
     end
 
+    # `cause` is only set by raising inside a rescue, which is what the setup service does when it
+    # re-raises with a prefix. Built here rather than provoked, because provoking it would mean
+    # stubbing the Graph client instance the service builds for itself.
+    def wrapped(inner)
+      raise inner
+    rescue StandardError => e
+      begin
+        raise "Webhook setup failed: #{e.message}"
+      rescue StandardError => wrapper
+        wrapper
+      end
+    end
+
+    context 'when something inside the Graph call path raises ArgumentError' do
+      it 'leaves the channel authorized, because that one is not about a credential' do
+        allow(channel).to receive(:perform_webhook_setup).and_raise(wrapped(ArgumentError.new('bad callback url')))
+
+        channel.setup_webhooks
+
+        expect(channel.reauthorization_required?).to be(false)
+      end
+    end
+
     context 'when the setup cannot run because there is no access token' do
       before do
         channel.provider_config = channel.provider_config.merge('api_key' => '')

--- a/spec/services/whatsapp/api_error_spec.rb
+++ b/spec/services/whatsapp/api_error_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+describe Whatsapp::ApiError do
+  # Meta's own shape: the code lives in `error.code`, and the subcode, when there is one, in
+  # `error.error_subcode`.
+  let(:refusal) do
+    instance_double(
+      HTTParty::Response,
+      code: 401,
+      parsed_response: { 'error' => { 'message' => 'Error validating access token', 'type' => 'OAuthException',
+                                      'code' => 190, 'error_subcode' => 463 } }
+    )
+  end
+
+  describe '.from_response' do
+    it "speaks Meta's message when the caller has nothing to add" do
+      error = described_class.from_response(refusal)
+
+      expect(error.message).to eq('Error validating access token')
+      expect([error.http_status, error.code, error.subcode]).to eq([401, 190, 463])
+    end
+
+    it 'keeps the code when the caller prefixes the step that failed' do
+      error = described_class.from_response(refusal, message: 'App subscription to WABA failed: {...}')
+
+      expect(error.message).to eq('App subscription to WABA failed: {...}')
+      expect(error).to be_authorization_error
+    end
+
+    # Something in front of Meta answering with an HTML page. It is still a failure, and it is still
+    # not an answer about the credentials.
+    it 'leaves the code nil when the body is not the shape Meta documents' do
+      response = instance_double(HTTParty::Response, code: 502, parsed_response: '<html>502 Bad Gateway</html>')
+
+      error = described_class.from_response(response)
+
+      expect(error.message).to eq('WhatsApp API request failed')
+      expect(error.code).to be_nil
+      expect(error).not_to be_authorization_error
+    end
+  end
+
+  describe '#authorization_error?' do
+    it 'is true only for the code that talks about the credentials' do
+      expect(described_class.new(message: 'x', http_status: 401, code: 190)).to be_authorization_error
+    end
+
+    it 'is false for a refusal of this particular request' do
+      expect(described_class.new(message: 'x', http_status: 403, code: 200)).not_to be_authorization_error
+    end
+
+    it 'is false when there is no code at all, which is what silence leaves behind' do
+      expect(described_class.new(message: 'x', http_status: 500)).not_to be_authorization_error
+    end
+  end
+
+  # The health card asks the same question through its own name, and it has to keep getting the same
+  # answer: `Whatsapp::HealthService::ApiError` exists so `rescue` reads as "the health read failed",
+  # not so it can decide on its own what 190 means.
+  describe Whatsapp::HealthService::ApiError do
+    it 'is this error under another name' do
+      expect(described_class.new(message: 'x', http_status: 401, code: 190)).to be_authorization_error
+    end
+  end
+
+  describe 'the one place the question is asked' do
+    # A second `def authorization_error?`, or a second literal 190, is the failure this guards: the
+    # two copies agree on the day they are written and drift the first time Meta adds a code. The
+    # scan is over the WhatsApp tree, which is where the question belongs.
+    def askers(pattern, sources)
+      sources.select { |path| Rails.root.join(path).read.match?(pattern) }
+    end
+
+    let(:sources) do
+      Dir.glob(Rails.root.join('app/{services/whatsapp,models/channel}/**/*.rb'))
+         .map { |path| Pathname.new(path).relative_path_from(Rails.root).to_s }
+    end
+
+    it 'scans files that exist, so an empty result cannot pass as a clean one' do
+      expect(sources).to include('app/services/whatsapp/api_error.rb', 'app/models/channel/whatsapp.rb')
+    end
+
+    it 'finds what it is looking for when it is there' do
+      # Against the guarded tree the scan is expected to answer "one file", and it would answer the
+      # same for a pattern that matches nothing at all. This pins the scan to a pattern that does.
+      expect(askers(/AUTHORIZATION_ERROR_CODE/, sources)).to eq(['app/services/whatsapp/api_error.rb'])
+    end
+
+    it 'has one definition of the question' do
+      expect(askers(/def authorization_error\?/, sources)).to eq(['app/services/whatsapp/api_error.rb'])
+    end
+
+    it 'has one place that knows the number' do
+      expect(askers(/\b190\b/, sources)).to eq(['app/services/whatsapp/api_error.rb'])
+    end
+  end
+end

--- a/spec/services/whatsapp/api_error_spec.rb
+++ b/spec/services/whatsapp/api_error_spec.rb
@@ -71,8 +71,34 @@ describe Whatsapp::ApiError do
     # A second `def authorization_error?`, or a second literal 190, is the failure this guards: the
     # two copies agree on the day they are written and drift the first time Meta adds a code. The
     # scan is over the WhatsApp tree, which is where the question belongs.
-    def askers(pattern, sources)
-      sources.select { |path| Rails.root.join(path).read.match?(pattern) }
+    #
+    # Measured, because a fence is worth exactly what it catches: a second `authorization_error?`
+    # added to `HealthService::ApiError` with today's semantics fails this group and passes all 1909
+    # examples of the behavioural suite, since a copy that agrees changes no output. That is the case
+    # no behavioural spec can reach, and it is why this group exists.
+    #
+    # Two things it got wrong and that the same measurement showed. `select` answers per file, so two
+    # definitions inside one file came back as "one file" and passed -- exactly the drift being
+    # forbidden, admitted through the counting. And the scan read comment lines, so a neighbouring
+    # file that merely mentions the code in prose failed the group, which teaches the next reader to
+    # delete the spec instead of reading it. Occurrences now, over code only.
+    def without_comment_lines(text)
+      text.gsub(/^[[:space:]]*#.*$/, '')
+    end
+
+    def code_of(path)
+      without_comment_lines(Rails.root.join(path).read)
+    end
+
+    # Per file: for asking whether the scan reaches a file at all.
+    def files_with(pattern, sources)
+      sources.select { |path| code_of(path).match?(pattern) }
+    end
+
+    # Per occurrence: for asking how many times something is written, which is the actual question
+    # when the failure mode is a duplicate.
+    def occurrences(pattern, sources)
+      sources.flat_map { |path| code_of(path).scan(pattern).map { path } }
     end
 
     let(:sources) do
@@ -87,15 +113,22 @@ describe Whatsapp::ApiError do
     it 'finds what it is looking for when it is there' do
       # Against the guarded tree the scan is expected to answer "one file", and it would answer the
       # same for a pattern that matches nothing at all. This pins the scan to a pattern that does.
-      expect(askers(/AUTHORIZATION_ERROR_CODE/, sources)).to eq(['app/services/whatsapp/api_error.rb'])
+      expect(files_with(/AUTHORIZATION_ERROR_CODE/, sources)).to eq(['app/services/whatsapp/api_error.rb'])
+    end
+
+    it 'reads code and not prose, so a comment naming the code is not a second place that knows it' do
+      # Pinned on the helper itself: if it ever strips more than comment lines, every scan below
+      # would pass over an empty file and this group would report a clean tree it never read.
+      expect(without_comment_lines("# 190 is the authorization code\ncode.to_i == 190\n"))
+        .to eq("\ncode.to_i == 190\n")
     end
 
     it 'has one definition of the question' do
-      expect(askers(/def authorization_error\?/, sources)).to eq(['app/services/whatsapp/api_error.rb'])
+      expect(occurrences(/def authorization_error\?/, sources)).to eq(['app/services/whatsapp/api_error.rb'])
     end
 
     it 'has one place that knows the number' do
-      expect(askers(/\b190\b/, sources)).to eq(['app/services/whatsapp/api_error.rb'])
+      expect(occurrences(/\b190\b/, sources)).to eq(['app/services/whatsapp/api_error.rb'])
     end
   end
 end

--- a/spec/services/whatsapp/api_error_spec.rb
+++ b/spec/services/whatsapp/api_error_spec.rb
@@ -49,6 +49,10 @@ describe Whatsapp::ApiError do
       expect(described_class.new(message: 'x', http_status: 403, code: 200)).not_to be_authorization_error
     end
 
+    it 'reads a code that arrived as a string, which is what the cast is there for' do
+      expect(described_class.new(message: 'x', http_status: 401, code: '190')).to be_authorization_error
+    end
+
     it 'is false when there is no code at all, which is what silence leaves behind' do
       expect(described_class.new(message: 'x', http_status: 500)).not_to be_authorization_error
     end

--- a/spec/services/whatsapp/embedded_signup_service_spec.rb
+++ b/spec/services/whatsapp/embedded_signup_service_spec.rb
@@ -121,28 +121,34 @@ describe Whatsapp::EmbeddedSignupService do
         expect { service.perform }.to raise_error('Token error')
       end
 
-      it 'prompts reauthorization when webhook setup fails' do
-        # Create a real channel to test the actual webhook failure behavior
+      # Signup is where a wrong token is most likely, so the failure that says so has to arrive.
+      # What it must not do is answer for the failures that say nothing about the token: the service
+      # completes either way, and the difference is whether the operator is sent to fix a credential.
+      def channel_whose_setup_raises(error)
         real_channel = create(:channel_whatsapp, account: account, phone_number: '+1234567890',
                                                  validate_provider_config: false, sync_templates: false)
-
-        # Mock the channel creation to return our real channel
         channel_creation = instance_double(Whatsapp::ChannelCreationService)
         allow(Whatsapp::ChannelCreationService).to receive(:new).and_return(channel_creation)
         allow(channel_creation).to receive(:perform).and_return(real_channel)
+        allow(real_channel).to receive(:perform_webhook_setup).and_raise(error)
+        real_channel
+      end
 
-        # Mock webhook setup to fail
-        allow(real_channel).to receive(:perform_webhook_setup).and_raise('Webhook setup error')
+      it 'prompts reauthorization when Meta says the token is the problem' do
+        refused = Whatsapp::ApiError.new(message: 'App subscription to WABA failed', http_status: 401, code: 190)
+        real_channel = channel_whose_setup_raises(refused)
 
-        # Verify channel is not marked for reauthorization initially
         expect(real_channel.reauthorization_required?).to be false
 
-        # The service completes successfully even if webhook fails (webhook error is rescued in setup_webhooks)
-        result = service.perform
-        expect(result).to eq(real_channel)
-
-        # Verify the channel is now marked for reauthorization
+        expect(service.perform).to eq(real_channel)
         expect(real_channel.reauthorization_required?).to be true
+      end
+
+      it 'leaves the channel alone when the webhook setup failed without an answer from Meta' do
+        real_channel = channel_whose_setup_raises(Net::ReadTimeout.new)
+
+        expect(service.perform).to eq(real_channel)
+        expect(real_channel.reauthorization_required?).to be false
       end
     end
 


### PR DESCRIPTION
A WhatsApp Cloud inbox no longer gets marked as needing reauthorization because Meta went quiet. Only an answer from Meta saying the credentials are the problem does that, which is what the operator can actually act on: a revoked or expired token still raises the alarm on the first failure, while a call that never came back, a `500`, or a refusal of that one request logs what happened and leaves the inbox working.

That marker is not a log line. It emails the account admins that the WhatsApp channel disconnected, invalidates the inbox cache and fires the reauthorization event, and nothing clears it but a human.

What it costs depends on how the inbox was set up, and both halves are bad in their own way. On an embedded-signup inbox, `Webhooks::WhatsappEventsJob#channel_is_inactive?` discards every inbound webhook while the marker stands, so a number that Meta keeps delivering to goes quiet. On a manual inbox the webhooks keep arriving, but `_inbox.json.jbuilder` only exposes `reauthorization_required` for embedded signup, so the alarm is invisible in the dashboard and reaches the operator as an email about a channel that never disconnected.

Closes #595

## How to reproduce

On `main`, point `Whatsapp::FacebookApiClient::BASE_URI` at a socket that accepts the connection and never answers, then run `channel.setup_webhooks` on a `whatsapp_cloud` channel. Measured on `421586e0a5`:

```
antes: reauthorization_required=false contador=0
setup_webhooks: voltou em 10.03s
depois: reauthorization_required=true contador=0
```

Two details that do not appear in the issue. `Reauthorizable::AUTHORIZATION_ERROR_THRESHOLD` is 2, but the counter stayed at `0`: this site calls `prompt_reauthorization!` directly rather than `authorization_error!`, so a single quiet minute is enough, with no second chance. And the same run enqueues one `ChannelNotificationsMailer` job, so the operator is told the channel disconnected.

The same reproduction also covers the refusal a coexistence number gets every time its WABA sits in the customer's own Business Manager: on `main`, `(#200) Permissions error` on the WABA subscription marks the channel too.

## What changed

`Whatsapp::FacebookApiClient#handle_response` raised a `RuntimeError` built from a string, so by the time a failure reached `Channel::Whatsapp#setup_webhooks` there was nothing left to ask: no status, no code. The message is unchanged (it reaches the operator through the register-webhook endpoint), but the error now carries Meta's `code` and `error_subcode` as `Whatsapp::ApiError`.

The question "is this about the credentials" is defined once, in that class, and `Whatsapp::HealthService::ApiError` inherits it instead of asking it again with its own copy of `190`. The name stays so `rescue Whatsapp::HealthService::ApiError` still reads as "reading the health failed". A spec fences both: one definition of `authorization_error?`, one place that knows the number.

`setup_webhooks` then prompts only on an answer:

- Meta answers `190`, on any HTTP status: prompt, as before.
- The access token or WABA id is blank (`ArgumentError` from `Whatsapp::WebhookSetupService`): prompt. That is the absence of a credential, which is as definite as a refusal.
- Anything else: log and leave the channel alone.

The check walks `cause` rather than looking only at the exception it was handed. `Whatsapp::WebhookSetupService#setup_webhook` re-raises with a prefix so the operator can see which step failed, and Ruby keeps the original underneath; asking only the outermost error would read every wrapped refusal as silence. This is also why the verdict never comes from matching text in a message.

## Validation scope

Proven by spec (`spec/models/channel/whatsapp_spec.rb`, `spec/services/whatsapp/api_error_spec.rb`, `spec/services/whatsapp/embedded_signup_service_spec.rb`): silence, `500` and `(#200)` leave the channel authorized and send no email; `190` marks it and emails the operator; a blank access token marks it; the error class carries Meta's code across a prefixing re-raise; one definition of the authorization question in the WhatsApp tree.

Two green specs asserted the old behaviour and were rewritten rather than deleted, because both were about a real requirement stated with the wrong stimulus: `'when the WABA subscription itself fails'` used a `400` with no code, and the embedded-signup one raised a bare string. Both now use the answer that actually says the credentials are bad, and each gained a sibling for the failure that says nothing.

Proven live, against a socket rather than a stub (same fake Graph, same channel, same single hanging call at the 10s ceiling, `base` = `421586e0a5`):

| Meta answers | base | this branch |
| --- | --- | --- |
| accepts and never answers | marked, 10.03s | not marked, 10.01s |
| `401` with `code: 190` | marked | marked |
| `403` with `(#200) Permissions error` | marked | not marked |

Not covered: the `after_commit` path on channel creation was exercised through `setup_webhooks` directly rather than through a real signup, and no screenshot of the inbox banner is included, because the change is about not producing the state the banner reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/602)
<!-- Reviewable:end -->
