### PR TITLE
fix(groups): resolver a caixa antes de decidir que a escrita não tem nada a fazer

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/group_metadata_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_metadata_controller.rb
@@ -3,6 +3,12 @@ class Api::V1::Accounts::Contacts::GroupMetadataController < Api::V1::Accounts::
 
   def update
     authorize @contact, :update?
+    # Before deciding there is nothing to do, and not after. Resolving only when a field was sent
+    # meant an empty request was never refused: an agent on none of this group's inboxes, or one
+    # naming an inbox they are not on, got a 200 for a request that would have been refused the
+    # moment it carried a single field. Whether the answer is 404 or 200 is not the caller's to
+    # decide by leaving the body out.
+    channel
     refuse_description_removal!
     update_subject if metadata_params[:subject].present?
     update_description if metadata_params[:description].present?

--- a/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
@@ -140,6 +140,56 @@ RSpec.describe 'group actions and the inbox they run as', type: :request do
                           'app/controllers/api/v1/accounts/contacts/group_members_controller.rb')
   end
 
+  # A metadata write resolved the channel only when it had a field to write, so a request with no
+  # subject, description or avatar never reached the refusal: it answered 200 to a caller the very
+  # same request would have been refused for the moment it carried one field.
+  describe 'a metadata write with nothing in it' do
+    it 'refuses an inbox the agent is not on, as it does with a field' do
+      agent = create(:user, account: account, role: :agent)
+      create(:inbox_member, user: agent, inbox: looking_at.inbox)
+
+      patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_metadata",
+            params: { inbox_id: other.inbox.id }, headers: agent.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'refuses an agent on none of this group\'s inboxes' do
+      outsider = create(:user, account: account, role: :agent)
+      create(:inbox_member, user: outsider,
+                            inbox: create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false,
+                                                             sync_templates: false, account: account).inbox)
+
+      patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_metadata",
+            headers: outsider.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    # Before the body is read at all, not merely before the fields are written. A description sent
+    # empty is refused with a 422 that explains the rule, and answering that to a caller with no
+    # claim to any of this group's inboxes tells them about a group they were not to be told about,
+    # in a request that should have ended one line earlier.
+    it 'refuses before it explains why an empty description is not allowed' do
+      outsider = create(:user, account: account, role: :agent)
+      create(:inbox_member, user: outsider,
+                            inbox: create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false,
+                                                             sync_templates: false, account: account).inbox)
+
+      patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_metadata",
+            params: { description: '' }, headers: outsider.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'is still a no-op success for a caller who could have written' do
+      patch "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_metadata",
+            params: { inbox_id: looking_at.inbox.id }, headers: admin.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   # The endpoints predate the parameter and are documented without it, so a group that is
   # in one inbox still answers on its own.
   it 'needs no inbox when the group is in only one' do


### PR DESCRIPTION
Metade da #535, a que não depende de decisão de contrato.

Um `PATCH /contacts/:id/group_metadata` sem `subject`, `description` nem `avatar` nunca chegava à recusa. A caixa só era resolvida quando havia campo para escrever, então um agente que não está em nenhuma das caixas deste grupo, ou que nomeia uma caixa em que não está, recebia **200** para exatamente o pedido que seria recusado com 404 no instante em que carregasse um campo. Se a resposta é 404 ou 200 não é coisa que o chamador decida deixando o corpo de fora.

```ruby
def update
  authorize @contact, :update?
  channel                      # <- aqui, e não mais embaixo
  refuse_description_removal!
  update_subject if metadata_params[:subject].present?
  ...
```

A ordem dentro da ação também é parte do conserto: a recusa vem **antes** de `refuse_description_removal!`. Aquele 422 explica uma regra sobre um grupo (descrição vazia não pode ser removida, medido contra os dois provedores na #542), e responder isso a quem não tinha o que ser respondido conta sobre um grupo que não era para ser contado.

## O que foi medido

Bateria de mutação, `group_channel_resolver_spec.rb` inteira em cada rodada:

| mutante | resultado |
| --- | --- |
| m1 sem resolver antes (o defeito) | 2 falhas |
| m2 resolvendo depois da recusa de descrição | 1 falha |
| m3 resolvendo sem recusar no nil (`group_contact_inbox` no lugar de `channel`) | 1 falha |
| restaurado | 0 falhas |

m2 só passou a morrer depois do exemplo que fixa a ordem; antes dele os dois arranjos davam o mesmo resultado em toda entrada testada, que é precisamente o buraco que ele fecha.

85 exemplos em `spec/controllers/api/v1/accounts/contacts`, verdes. RuboCop limpo.

## O que esta PR não faz

A outra metade da #535 é a leitura da lista de participantes, e ela é decisão de contrato, não defeito:

| pedido | hoje |
| --- | --- |
| sem `inbox_id`, agente em nenhuma caixa do grupo | 200 com a lista |
| `inbox_id` de uma caixa em que o agente não está | 404 |
| `inbox_id` de uma caixa em que o grupo não está | 404 |

Medi o custo das duas saídas antes de escolher não escolher sozinho:

- **Recusar também na leitura** alinha o endpoint com as outras onze rotas de grupo depois da #533, e não custa nada ao painel: todo chamador do dashboard manda a caixa da conversa aberta (`MessagesView`, `ReplyBox`, `GroupContactInfo`), e `GroupContactInfo` só é renderizado dentro do `ContactPanel` da conversa. Administrador recebe todas as caixas da conta em `assigned_inboxes`, então nunca cai no caso. O que sai de pé é a leitura da lista de um contato de grupo que não está em caixa nenhuma: cinco exemplos existentes fixam esse comportamento hoje, todos com contato de grupo sem `contact_inbox`.
- **Manter permissivo** preserva a leitura e mantém o que o próprio `GroupChannelResolver` documenta: a lista é dado de contato, governada por `ContactPolicy` e não por participação na caixa.

Reverter uma decisão escrita e testada assim quer uma linha de quem decide o produto, então implementei a metade sem ambiguidade e deixei a análise na issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/604)
<!-- Reviewable:end -->
