### PR TITLE
fix(whatsapp): keep the register webhook control on the screen when the health read fails

### DIFF
--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -656,7 +656,11 @@ export default {
         // from it instead of a second round trip. When that read did not come back the field says
         // so, and then the card is fetched rather than left showing what it had before the press.
         if (data?.routing_read_back) {
+          // The error has to go with it. Until #593 the screen could not be repaired from the error
+          // state at all, so nothing ever reached this line holding a stale failure; now it can,
+          // and leaving `healthError` set would keep the error card over a reading that came back.
           this.healthData = data.health;
+          this.healthError = null;
         } else {
           await this.fetchHealthData();
         }

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -610,9 +610,15 @@ export default {
 
       try {
         this.isLoadingHealth = true;
-        this.healthError = null;
+        // Cleared with the answer, not before asking. Until #593 there was nothing to press in the
+        // error state, so the gap between the two never had a viewer; now the operator presses
+        // Register, the re-read starts, and clearing the error here would drop the screen into the
+        // "nothing is known" state for as long as the read takes, which with a quiet Meta is the
+        // whole 10s ceiling: the error card, the provider message and the button all disappear and
+        // come back.
         const response = await InboxHealthAPI.getHealthStatus(this.inbox.id);
         this.healthData = response.data;
+        this.healthError = null;
       } catch (error) {
         const apiError = error.response?.data?.error;
         this.healthError =

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/Settings.vue
@@ -656,11 +656,7 @@ export default {
         // from it instead of a second round trip. When that read did not come back the field says
         // so, and then the card is fetched rather than left showing what it had before the press.
         if (data?.routing_read_back) {
-          // The error has to go with it. Until #593 the screen could not be repaired from the error
-          // state at all, so nothing ever reached this line holding a stale failure; now it can,
-          // and leaving `healthError` set would keep the error card over a reading that came back.
           this.healthData = data.health;
-          this.healthError = null;
         } else {
           await this.fetchHealthData();
         }

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
@@ -373,6 +373,32 @@ const webhookUrlMismatch = computed(
     webhookUrl.value !== props.healthData?.expected_webhook_url
 );
 
+// Whether anything on this screen is an answer from Meta about where delivery is going right now.
+// A read that failed leaves the previous payload in place, and every line built from it is a claim
+// about a reading that did not happen.
+const hasReading = computed(
+  () => Boolean(props.healthData) && !errorState.value
+);
+
+// Registering a webhook needs the channel's `provider_config`, which the endpoint already has, and
+// never the health payload, so this control is not part of the card's state.
+//
+// A failed read is the case the issue is about: it says nothing about the wiring, and that is
+// exactly when the wiring is the most plausible thing to repair, so the control stays. The one
+// state that must stay quiet is "nothing is known yet", which is a different condition from "the
+// read failed": no data and no error.
+const showRegisterWebhook = computed(() => {
+  if (errorState.value) return true;
+  if (!props.healthData) return false;
+
+  return !webhookConfigured.value || webhookUrlMismatch.value;
+});
+
+const showWebhookCard = computed(
+  () =>
+    (hasReading.value && showWebhookSection.value) || showRegisterWebhook.value
+);
+
 // A number with no override of its own rides on the app's own callback, which belongs to the
 // installation and can be pointed elsewhere at any time. The chip above cannot say that: green
 // whenever the effective URL is ours, amber "mismatch" whenever it is not, and both readings are
@@ -492,116 +518,6 @@ const handleCopyWebhookUrl = async url => {
             </div>
           </div>
         </section>
-
-        <!-- Webhook configuration card -->
-        <div
-          v-if="showWebhookSection"
-          class="flex flex-col gap-2 p-4 rounded-lg border border-n-weak bg-n-solid-1"
-        >
-          <div class="flex gap-2 items-center">
-            <span class="text-body-main font-medium text-n-slate-11">
-              {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.TITLE') }}
-            </span>
-            <Icon
-              v-tooltip.top="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.DESCRIPTION')"
-              icon="i-lucide-info"
-              class="flex-shrink-0 w-4 h-4 cursor-help text-n-slate-9"
-            />
-          </div>
-          <div class="flex items-center justify-between gap-3">
-            <span
-              v-if="webhookConfigured && !webhookUrlMismatch"
-              class="inline-flex items-center gap-1.5 px-2 py-0.5 min-h-6 text-label-small rounded-md bg-n-alpha-2 text-n-teal-11"
-            >
-              <Icon icon="i-lucide-check-circle" class="w-3.5 h-3.5" />
-              {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.CONFIGURED_SUCCESS') }}
-            </span>
-            <span
-              v-else
-              class="inline-flex items-center gap-1.5 px-2 py-0.5 min-h-6 text-label-small rounded-md bg-n-alpha-2 text-n-amber-11"
-            >
-              <Icon icon="i-lucide-alert-triangle" class="w-3.5 h-3.5" />
-              {{
-                webhookUrlMismatch
-                  ? t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.URL_MISMATCH')
-                  : t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.ACTION_REQUIRED')
-              }}
-            </span>
-            <ButtonV4
-              v-if="!webhookConfigured || webhookUrlMismatch"
-              sm
-              solid
-              blue
-              :loading="isRegisteringWebhook"
-              :disabled="isRegisteringWebhook"
-              class="flex-shrink-0"
-              @click="handleRegisterWebhook"
-            >
-              {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_BUTTON') }}
-            </ButtonV4>
-          </div>
-          <div
-            v-if="appCallbackRoutingMessage"
-            class="flex gap-1.5 items-start text-label-small text-n-amber-11"
-          >
-            <Icon
-              icon="i-lucide-alert-triangle"
-              class="flex-shrink-0 mt-0.5 w-3.5 h-3.5"
-            />
-            <span>
-              {{ t(appCallbackRoutingMessage) }}
-            </span>
-          </div>
-          <div v-if="webhookConfigured" class="pt-1 space-y-2">
-            <div class="flex items-center gap-3 min-w-0">
-              <span class="flex-shrink-0 text-label-small text-n-slate-10">
-                {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.CONFIGURED_URL') }}
-              </span>
-              <span
-                v-tooltip.top="webhookUrl"
-                class="flex-1 min-w-0 font-mono text-label-small truncate text-n-slate-12"
-              >
-                {{ webhookUrl }}
-              </span>
-              <ButtonV4
-                v-tooltip.top="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.COPY_URL')"
-                type="button"
-                ghost
-                sm
-                slate
-                icon="i-lucide-copy"
-                class="flex-shrink-0"
-                :aria-label="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.COPY_URL')"
-                @click="handleCopyWebhookUrl(webhookUrl)"
-              />
-            </div>
-            <div
-              v-if="webhookUrlMismatch"
-              class="flex items-center gap-3 min-w-0"
-            >
-              <span class="flex-shrink-0 text-label-small text-n-slate-10">
-                {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.EXPECTED_URL') }}
-              </span>
-              <span
-                v-tooltip.top="healthData.expected_webhook_url"
-                class="flex-1 min-w-0 font-mono text-label-small truncate text-n-slate-12"
-              >
-                {{ healthData.expected_webhook_url }}
-              </span>
-              <ButtonV4
-                v-tooltip.top="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.COPY_URL')"
-                type="button"
-                ghost
-                sm
-                slate
-                icon="i-lucide-copy"
-                class="flex-shrink-0"
-                :aria-label="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.COPY_URL')"
-                @click="handleCopyWebhookUrl(healthData.expected_webhook_url)"
-              />
-            </div>
-          </div>
-        </div>
       </div>
 
       <div v-else-if="errorState" class="pt-2">
@@ -646,6 +562,126 @@ const handleCopyWebhookUrl = async url => {
               {{ t('INBOX_MGMT.ACCOUNT_HEALTH.NO_DATA') }}
             </p>
           </div>
+        </div>
+      </div>
+
+      <!-- Webhook configuration card. Outside the three states on purpose: registering a webhook
+           needs the channel's provider_config, which the endpoint already has, and never the health
+           payload. Inside the data branch, the control left the screen exactly when the health read
+           failed, which is when the wiring is the most plausible thing to repair (#593).
+
+           What the reading produced stays behind `hasReading`: the chip, the URLs and the app
+           callback lines are claims about where delivery is going now, and a read that did not
+           answer leaves them describing a moment that has passed. -->
+      <div
+        v-if="showWebhookCard"
+        class="flex flex-col gap-2 p-4 mt-6 rounded-lg border border-n-weak bg-n-solid-1"
+      >
+        <div class="flex gap-2 items-center">
+          <span class="text-body-main font-medium text-n-slate-11">
+            {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.TITLE') }}
+          </span>
+          <Icon
+            v-tooltip.top="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.DESCRIPTION')"
+            icon="i-lucide-info"
+            class="flex-shrink-0 w-4 h-4 cursor-help text-n-slate-9"
+          />
+        </div>
+        <div
+          v-if="hasReading && showWebhookSection"
+          class="flex items-center justify-between gap-3"
+        >
+          <span
+            v-if="webhookConfigured && !webhookUrlMismatch"
+            class="inline-flex items-center gap-1.5 px-2 py-0.5 min-h-6 text-label-small rounded-md bg-n-alpha-2 text-n-teal-11"
+          >
+            <Icon icon="i-lucide-check-circle" class="w-3.5 h-3.5" />
+            {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.CONFIGURED_SUCCESS') }}
+          </span>
+          <span
+            v-else
+            class="inline-flex items-center gap-1.5 px-2 py-0.5 min-h-6 text-label-small rounded-md bg-n-alpha-2 text-n-amber-11"
+          >
+            <Icon icon="i-lucide-alert-triangle" class="w-3.5 h-3.5" />
+            {{
+              webhookUrlMismatch
+                ? t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.URL_MISMATCH')
+                : t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.ACTION_REQUIRED')
+            }}
+          </span>
+        </div>
+        <div
+          v-if="hasReading && appCallbackRoutingMessage"
+          class="flex gap-1.5 items-start text-label-small text-n-amber-11"
+        >
+          <Icon
+            icon="i-lucide-alert-triangle"
+            class="flex-shrink-0 mt-0.5 w-3.5 h-3.5"
+          />
+          <span>
+            {{ t(appCallbackRoutingMessage) }}
+          </span>
+        </div>
+        <div v-if="hasReading && webhookConfigured" class="pt-1 space-y-2">
+          <div class="flex items-center gap-3 min-w-0">
+            <span class="flex-shrink-0 text-label-small text-n-slate-10">
+              {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.CONFIGURED_URL') }}
+            </span>
+            <span
+              v-tooltip.top="webhookUrl"
+              class="flex-1 min-w-0 font-mono text-label-small truncate text-n-slate-12"
+            >
+              {{ webhookUrl }}
+            </span>
+            <ButtonV4
+              v-tooltip.top="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.COPY_URL')"
+              type="button"
+              ghost
+              sm
+              slate
+              icon="i-lucide-copy"
+              class="flex-shrink-0"
+              :aria-label="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.COPY_URL')"
+              @click="handleCopyWebhookUrl(webhookUrl)"
+            />
+          </div>
+          <div
+            v-if="webhookUrlMismatch"
+            class="flex items-center gap-3 min-w-0"
+          >
+            <span class="flex-shrink-0 text-label-small text-n-slate-10">
+              {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.EXPECTED_URL') }}
+            </span>
+            <span
+              v-tooltip.top="healthData.expected_webhook_url"
+              class="flex-1 min-w-0 font-mono text-label-small truncate text-n-slate-12"
+            >
+              {{ healthData.expected_webhook_url }}
+            </span>
+            <ButtonV4
+              v-tooltip.top="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.COPY_URL')"
+              type="button"
+              ghost
+              sm
+              slate
+              icon="i-lucide-copy"
+              class="flex-shrink-0"
+              :aria-label="t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.COPY_URL')"
+              @click="handleCopyWebhookUrl(healthData.expected_webhook_url)"
+            />
+          </div>
+        </div>
+        <div v-if="showRegisterWebhook" class="pt-1">
+          <ButtonV4
+            sm
+            solid
+            blue
+            :loading="isRegisteringWebhook"
+            :disabled="isRegisteringWebhook"
+            @click="handleRegisterWebhook"
+          >
+            {{ t('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_BUTTON') }}
+          </ButtonV4>
         </div>
       </div>
     </div>

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -4,6 +4,12 @@ import AccountHealth from '../AccountHealth.vue';
 
 const { locale } = vi.hoisted(() => ({ locale: { value: 'en' } }));
 
+// jsdom has no `navigator.clipboard`, so the copy button's handler rejects and the run exits 1
+// even with every assertion green. The helper is the boundary this component talks to.
+vi.mock('shared/helpers/clipboard', () => ({
+  copyTextToClipboard: vi.fn(),
+}));
+
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: key => key,

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -186,6 +186,131 @@ describe('AccountHealth', () => {
     });
   });
 
+  // Found by the verifier agent while measuring the screen for #588: the control that exists to
+  // repair the webhook wiring left the screen exactly when the wiring was most likely to need
+  // repairing. Presence is asserted through the event, not through markup: the only button on this
+  // screen that asks for a registration is the one that emits it, whatever the layout does.
+  describe('the register webhook control', () => {
+    // Clicks every button on the screen and asks whether any of them asked for a registration.
+    // The other buttons are harmless here (one opens a mocked window, one emits a navigation), and
+    // this way the assertion survives any reshuffling of the markup.
+    const clickRegisterWebhook = async wrapper => {
+      await Promise.all(
+        wrapper
+          .findAllComponents(ButtonV4)
+          .map(button => button.trigger('click'))
+      );
+
+      return Boolean(wrapper.emitted('registerWebhook'));
+    };
+
+    it('stays on the screen when the health read failed', async () => {
+      const wrapper = mountComponent(null, {
+        healthError: { type: 'api', message: 'Net::ReadTimeout' },
+      });
+
+      expect(await clickRegisterWebhook(wrapper)).toBe(true);
+    });
+
+    it('stays on the screen when the read failed on credentials, over the stale card', async () => {
+      const wrapper = mountComponent(
+        { webhook_configuration: { phone_number: 'https://old.example.com' } },
+        {
+          healthError: {
+            type: 'authorization',
+            message: 'Session has expired',
+          },
+          isEmbeddedSignup: true,
+        }
+      );
+
+      expect(await clickRegisterWebhook(wrapper)).toBe(true);
+    });
+
+    it('is absent before the screen knows anything, which is not the same as a failed read', async () => {
+      const wrapper = mountComponent(null);
+
+      expect(await clickRegisterWebhook(wrapper)).toBe(false);
+    });
+
+    it('is absent when the webhook is configured and pointed here', async () => {
+      const wrapper = mountComponent({
+        webhook_configuration: {
+          phone_number: 'https://app.example.com/webhooks/whatsapp/+1',
+        },
+        expected_webhook_url: 'https://app.example.com/webhooks/whatsapp/+1',
+      });
+
+      expect(await clickRegisterWebhook(wrapper)).toBe(false);
+    });
+
+    it('is present when the health read came back without a webhook configured', async () => {
+      const wrapper = mountComponent({ webhook_configuration: {} });
+
+      expect(await clickRegisterWebhook(wrapper)).toBe(true);
+    });
+
+    // The read failed, so the payload underneath is from a moment that has passed. It cannot be
+    // read as "the webhook is fine" any more than it can be shown as the current routing.
+    it('is present when the failed read sits on top of a payload that looked fine', async () => {
+      const wrapper = mountComponent(
+        {
+          webhook_configuration: {
+            phone_number: 'https://app.example.com/webhooks/whatsapp/+1',
+          },
+          expected_webhook_url: 'https://app.example.com/webhooks/whatsapp/+1',
+        },
+        { healthError: { type: 'api', message: 'Net::ReadTimeout' } }
+      );
+
+      expect(await clickRegisterWebhook(wrapper)).toBe(true);
+    });
+
+    // The POST it fires writes to Meta, so the second click has to find the control locked. The
+    // lock is the `disabled` attribute: `loading` is not a prop of this button (the prop is
+    // `isLoading`), so it falls through as an attribute and paints nothing, here and where this
+    // control used to live.
+    it('keeps the lock that stops a second registration from leaving', () => {
+      const wrapper = mountComponent(null, {
+        healthError: { type: 'api', message: 'Net::ReadTimeout' },
+        isRegisteringWebhook: true,
+      });
+
+      const locked = wrapper
+        .findAllComponents(ButtonV4)
+        .filter(button => button.attributes('disabled') !== undefined);
+
+      expect(locked).toHaveLength(1);
+    });
+
+    // The button keeps its own name and explanation. What it must not bring along is the reading:
+    // the chip and the URLs are claims about where delivery is going now, and there was no answer.
+    it('carries its label but none of the lines built from a reading that did not happen', () => {
+      const wrapper = mountComponent(
+        {
+          webhook_configuration: {
+            phone_number: 'https://elsewhere.example.com/webhooks/whatsapp/+1',
+          },
+          expected_webhook_url: 'https://app.example.com/webhooks/whatsapp/+1',
+        },
+        { healthError: { type: 'api', message: 'Net::ReadTimeout' } }
+      );
+
+      expect(wrapper.text()).toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.TITLE'
+      );
+      expect(wrapper.text()).not.toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.URL_MISMATCH'
+      );
+      expect(wrapper.text()).not.toContain(
+        'INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.CONFIGURED_SUCCESS'
+      );
+      expect(wrapper.text()).not.toContain(
+        'https://elsewhere.example.com/webhooks/whatsapp/+1'
+      );
+    });
+  });
+
   it('shows the current error instead of stale health data', () => {
     const wrapper = mountComponent(
       { verified_name: 'Stale Business Name' },

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -284,9 +284,24 @@ describe('AccountHealth', () => {
 
       const locked = wrapper
         .findAllComponents(ButtonV4)
-        .filter(button => button.attributes('disabled') !== undefined);
+        .filter(button => button.attributes('disabled') === 'true');
 
       expect(locked).toHaveLength(1);
+    });
+
+    // The attribute is on the element in both states, so asking whether it exists says only that
+    // the binding was written. What has to be true is that it answers.
+    it('does not lock the control when no registration is in flight', () => {
+      const wrapper = mountComponent(null, {
+        healthError: { type: 'api', message: 'Net::ReadTimeout' },
+        isRegisteringWebhook: false,
+      });
+
+      const locked = wrapper
+        .findAllComponents(ButtonV4)
+        .filter(button => button.attributes('disabled') === 'true');
+
+      expect(locked).toHaveLength(0);
     });
 
     // The button keeps its own name and explanation. What it must not bring along is the reading:

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/specs/inboxHealthMethods.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/specs/inboxHealthMethods.spec.js
@@ -2,7 +2,7 @@ import Settings from '../Settings.vue';
 import InboxHealthAPI from 'dashboard/api/inboxHealth';
 
 vi.mock('dashboard/api/inboxHealth', () => ({
-  default: { registerWebhook: vi.fn() },
+  default: { registerWebhook: vi.fn(), getHealthStatus: vi.fn() },
 }));
 
 vi.mock('dashboard/composables', () => ({
@@ -64,5 +64,56 @@ describe('Settings registerWebhook', () => {
       message: 'Net::ReadTimeout',
     });
     expect(context.isRegisteringWebhook).toBe(false);
+  });
+});
+
+describe('Settings fetchHealthData', () => {
+  const contextWith = overrides => ({
+    inbox: { id: 7 },
+    isAWhatsAppCloudChannel: true,
+    isLoadingHealth: false,
+    healthData: null,
+    healthError: { type: 'api', message: 'Net::ReadTimeout' },
+    ...overrides,
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Clearing the error before asking drops the screen into the "nothing is known" state for the
+  // length of the read, which with a quiet Meta is the whole ceiling. Nobody could see that gap
+  // until #593 put a control in the error state for the operator to press.
+  it('keeps the error on the screen while the re-read is in flight', async () => {
+    let answer;
+    InboxHealthAPI.getHealthStatus.mockReturnValue(
+      new Promise(resolve => {
+        answer = resolve;
+      })
+    );
+    const context = contextWith({});
+
+    const pending = Settings.methods.fetchHealthData.call(context);
+
+    expect(context.healthError).not.toBeNull();
+    expect(context.healthData).toBeNull();
+
+    answer({ data: { status: 'CONNECTED' } });
+    await pending;
+
+    expect(context.healthError).toBeNull();
+    expect(context.healthData).toEqual({ status: 'CONNECTED' });
+  });
+
+  it('replaces the error when the re-read fails too', async () => {
+    InboxHealthAPI.getHealthStatus.mockRejectedValue(new Error('still quiet'));
+    const context = contextWith({});
+
+    await Settings.methods.fetchHealthData.call(context);
+
+    expect(context.healthError).toEqual({
+      type: 'generic',
+      message: 'still quiet',
+    });
   });
 });

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/specs/registerWebhook.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/specs/registerWebhook.spec.js
@@ -1,0 +1,68 @@
+import Settings from '../Settings.vue';
+import InboxHealthAPI from 'dashboard/api/inboxHealth';
+
+vi.mock('dashboard/api/inboxHealth', () => ({
+  default: { registerWebhook: vi.fn() },
+}));
+
+vi.mock('dashboard/composables', () => ({
+  useAlert: vi.fn(),
+}));
+
+// The method is exercised on its own rather than through a mount: this page pulls the whole inbox
+// settings screen in, and what is under test is one branch of one method.
+describe('Settings registerWebhook', () => {
+  const contextWith = overrides => ({
+    inbox: { id: 7 },
+    isRegisteringWebhook: false,
+    healthData: null,
+    healthError: { type: 'api', message: 'Net::ReadTimeout' },
+    $t: key => key,
+    fetchHealthData: vi.fn(),
+    ...overrides,
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Registering from the error state is what #593 made possible, so this branch is the first that
+  // can be reached while an error is on the screen. Leaving it set would keep the error card over a
+  // reading that came back, with the button still offered for a webhook that is already registered.
+  it('clears the error when the registration answers with the routing it read back', async () => {
+    InboxHealthAPI.registerWebhook.mockResolvedValue({
+      data: { routing_read_back: true, health: { status: 'CONNECTED' } },
+    });
+    const context = contextWith({});
+
+    await Settings.methods.registerWebhook.call(context);
+
+    expect(context.healthData).toEqual({ status: 'CONNECTED' });
+    expect(context.healthError).toBeNull();
+    expect(context.fetchHealthData).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a fresh read when the answer did not carry the routing', async () => {
+    InboxHealthAPI.registerWebhook.mockResolvedValue({
+      data: { routing_read_back: false },
+    });
+    const context = contextWith({});
+
+    await Settings.methods.registerWebhook.call(context);
+
+    expect(context.fetchHealthData).toHaveBeenCalled();
+  });
+
+  it('leaves the error alone when the registration itself failed', async () => {
+    InboxHealthAPI.registerWebhook.mockRejectedValue(new Error('boom'));
+    const context = contextWith({});
+
+    await Settings.methods.registerWebhook.call(context);
+
+    expect(context.healthError).toEqual({
+      type: 'api',
+      message: 'Net::ReadTimeout',
+    });
+    expect(context.isRegisteringWebhook).toBe(false);
+  });
+});


### PR DESCRIPTION
The Register Webhook button stays on the WhatsApp health screen when the health read fails. Before, it was rendered inside the branch that draws the health card's data, so a failed read replaced the card and the button together: a number whose health could not be read, which is a plausible candidate for a webhook that needs re-registering, left the operator with a reload and hope.

Closes #593

## How to reproduce

Point the Graph API at a socket that accepts the connection and never answers, open the inbox's Account Health tab, and wait for the ceiling to fire. The card goes to "WhatsApp health data is unavailable" with the provider error under it, and there is no way to ask for a registration from that screen.

## What changed

The webhook card moved out of the three-way state branch, because registering a webhook needs the channel's `provider_config`, which `POST .../register_webhook` already has, and never the health payload.

Two things in `Settings.vue` had to follow, and neither was reachable before, because until now there was nothing to press in the error state. `registerWebhook` wrote the health payload from the answer and left `healthError` set, so a successful repair kept the error card over a reading that had come back. And `fetchHealthData` cleared `healthError` before awaiting, which with no payload yet is neither an error nor a reading: the screen dropped into "nothing is known" for the length of the read, ten seconds at the ceiling, taking the error card, the provider message and the button with it, and then put them back.

What the reading produced stayed behind a reading: `hasReading` (there is health data and no error) now gates the status chip, the configured and expected URLs, and the app callback lines. Those are claims about where delivery is going right now, and a read that did not answer leaves them describing a moment that has passed. The section's own label and its tooltip stay with the button, because they are its name and its explanation.

The button is offered when the read failed, and otherwise when the reading says the webhook is missing or pointed elsewhere. The state that stays quiet is the one before anything is known, which is a different condition from a failed read: no data and no error.

## How to test

On the Account Health tab of a WhatsApp Cloud inbox:

- with Meta answering and the webhook pointed here: the green chip, both URLs, and no button;
- with Meta answering and the webhook pointed elsewhere: the amber chip, both URLs, and the button;
- with Meta not answering: the error card, then the webhook card with its label and the button, and no chip or URL;
- while a registration is in flight: the button is disabled.

## The authorization flavour

When the read fails with Meta's `190`, the error card offers `GO_TO_CONFIGURATION`, and that stays the first action on the screen: it is rendered above, inside the error card, and re-authorizing is the primary repair there. The register button is offered underneath it as well, because a credential that was refused does not say anything about where the webhook points, and once the credential is fixed the wiring may still need the registration. The decision is stated here because either choice is defensible on that flavour; on the generic one, which is what the issue is about, the button is not optional.

## Validation scope

Proven by spec (`AccountHealth.spec.js`, 20 examples, up from 11 on `main`): the button survives a generic failure, an authorization failure, and a failure sitting on top of a payload that looked fine; it is absent before anything is known and when the webhook is configured and pointed here; it keeps the `disabled` lock; and in the error state it carries its label without the chip or the URLs. Five of those fail on `main`.

Proven on the screen, against a socket rather than a stub: a fake Graph that hangs produces the error state, and a fake Graph answering a real payload produces the two success states.

The before/after pair for that state was measured rather than only described, on a fake Graph answering a real payload with a diverging webhook URL, and it is the pair worth looking at if you only look at one: the published prose covers the error state, which is not where the button moved.

One layout change to look at, and it is in the success state rather than the error one: the button used to sit at the top right of the webhook card, on the same row as the status chip. That row is now behind `hasReading`, so it cannot host the button any more, and the button sits at the foot of the card, under the URLs.

The repair loop was exercised end to end: a fake Graph that hangs produces the error state, the mode is switched to healthy mid-session, the button is pressed, and the card comes back with the green chip and the configured URL without a reload (`performance.getEntriesByType('navigation').length` stays at 1).

Not covered: pt_BR and es on screen, phone width, and dark theme. The button's position changed in the success state, so the first two are worth a look before this ships.

One thing found next door and deliberately left alone: `:loading` is not a prop of `ButtonV4` (the prop is `isLoading`), so it falls through as an attribute and paints no spinner. That was already true where this control used to live, the `disabled` half does lock the button, and fixing it is a separate change.

## Reviewed at 400px, in `es`, and in dark mode

Three things the six screenshots above did not cover, measured before merging and on both sides where a comparison exists.

**i18n**: the diff touches no locale file and creates or removes no key. `INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.TITLE` and `.REGISTER_BUTTON` exist in `en`, `pt_BR` and `es`, and in `es` their values are already the English strings on `main`, so the card read in English before this change too. Upstream's, not this PR's, and fixing it would be an override in the `fazer-ai` overlay.

**400px, error state, measured on the base and on the head**: on both, the widest container on the page is 676 CSS pixels inside a 400 viewport, and the document does not scroll horizontally (`scrollWidth == clientWidth == 400`). On the base the button does not exist at all, which is the defect; on the head the card sits at `x=44 w=588`, which is exactly the geometry the sibling error card already had. So the side cut at that width belongs to the whole Account Health page and predates this change.

**Dark mode**: lit deterministically rather than by emulating the media query, which is what made a first attempt at this inconclusive. The class goes on `document.body`, not on `documentElement`, and `localStorage.color_scheme = 'dark'` forces the theme regardless of the OS (`dashboard/helper/themeHelper.js`). With `body.dark` and `color-scheme: dark` confirmed: the error state renders, the button is visible with `rgb(255,255,255)` on `rgb(39,129,246)`, and the section label is `rgb(237,238,240)`. Screenshot: `ship-593-erro-400-escuro.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/606)
<!-- Reviewable:end -->


