### PR TITLE
fix(whatsapp): classificar o envio que não recebe resposta nenhuma

### DIFF
--- a/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
@@ -1,4 +1,6 @@
 class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseService
+  include Whatsapp::TransportFailure
+
   def send_message(phone_number, message)
     @message = message
     if message.attachments.present?
@@ -11,7 +13,7 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
   end
 
   def send_template(phone_number, template_info, message)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_base_path}/messages",
       headers: api_headers,
       body: {
@@ -58,7 +60,7 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
   end
 
   def send_text_message(phone_number, message)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_base_path}/messages",
       headers: api_headers,
       body: {
@@ -80,7 +82,7 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
     type_content['caption'] = message.outgoing_content unless %w[audio sticker].include?(type)
     type_content['filename'] = attachment.file.filename if type == 'document'
 
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_base_path}/messages",
       headers: api_headers,
       body: {
@@ -113,7 +115,7 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
   def send_interactive_text_message(phone_number, message)
     payload = create_payload_based_on_items(message)
 
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_base_path}/messages",
       headers: api_headers,
       body: {
@@ -124,5 +126,13 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
     )
 
     process_response(response, message)
+  end
+
+  # Every HTTP call that puts a message on its way out goes through here, and nothing else does.
+  # One line inside the `rescue`, on purpose: see Whatsapp::TransportFailure.
+  def post_outgoing(url, **)
+    HTTParty.post(url, **)
+  rescue StandardError => e
+    raise_transport_failure(e)
   end
 end

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -1,6 +1,7 @@
 class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseService # rubocop:disable Metrics/ClassLength
   include BaileysHelper
   include Whatsapp::BaileysRequestOptions
+  include Whatsapp::TransportFailure
 
   # Legacy errors inherit from the session hierarchy so every caller rescues a single
   # namespace, whatever the provider. Nothing else about this service changes: it is
@@ -15,9 +16,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
   # resending could deliver the message twice, and only the operator can tell. Reached
   # only when the send did not reserve a message id, since with one a resend reuses the
   # same WhatsApp key.id and WhatsApp itself dedupes it.
-  class SendOutcomeUnknownError < Whatsapp::Session::Errors::Error
-    CODE = 'send_outcome_unknown'.freeze
-  end
+  class SendOutcomeUnknownError < Whatsapp::Session::Errors::SendOutcomeUnknown; end
 
   # The API knows this connection is not accepting sends at all (its send-stall circuit
   # breaker is open) and refused without touching the socket. Retryable: the provider
@@ -907,25 +906,17 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     raise_transport_error(e)
   end
 
-  # Failures that cannot have put a single byte of the request on the wire. Everything
-  # else defaults to indeterminate, and the asymmetry is deliberate: calling a
-  # possibly-delivered send "the provider is down" marks the channel closed, which drops
-  # the inbox out of the health-check cycle, while calling a never-sent one indeterminate
-  # costs one retry that the reserved message id makes duplicate-safe anyway.
-  NEVER_TRANSMITTED_ERRORS = [
-    Net::OpenTimeout, SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH
-  ].freeze
-
+  # The list of failures that cannot have put a byte on the wire, and the predicate that reads
+  # it, come from Whatsapp::TransportFailure. What stays here is what to raise, because this
+  # provider answers differently from the other three: a possibly-delivered send here is
+  # retryable, since the reserved message id makes a second attempt duplicate-safe, and the
+  # providers that reserve nothing must not retry one at all.
   def raise_transport_error(error)
     Rails.logger.error "[WHATSAPP][BAILEYS] transport failure on send: #{error.class}: #{error.message}"
 
     raise ProviderUnavailableError, outgoing_error(:provider_unreachable) if never_transmitted?(error)
 
     raise SendTimeoutError, outgoing_error(:send_timed_out)
-  end
-
-  def never_transmitted?(error)
-    NEVER_TRANSMITTED_ERRORS.any? { |klass| error.is_a?(klass) }
   end
 
   # Every non-2xx used to collapse into a bare ProviderUnavailableError, which made it

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -1,5 +1,6 @@
 class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseService # rubocop:disable Metrics/ClassLength
   include Whatsapp::GraphRequestOptions
+  include Whatsapp::TransportFailure
 
   # The types WhatsApp accepts for a voice message, taken from its own rejection message:
   # "Please use one of audio/ogg; codecs=opus, audio/mpeg, audio/amr, audio/mp4, audio/aac."
@@ -40,11 +41,10 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
       template: template_body
     }
 
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{phone_id_path}/messages",
       headers: api_headers,
-      body: request_body.to_json,
-      **GRAPH_REQUEST_OPTIONS
+      body: request_body.to_json
     )
 
     process_response(response, message)
@@ -211,7 +211,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def send_text_message(phone_number, message)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{phone_id_path}/messages",
       headers: api_headers,
       body: {
@@ -220,8 +220,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         **recipient_params(phone_number),
         text: { body: message.outgoing_content },
         type: 'text'
-      }.to_json,
-      **GRAPH_REQUEST_OPTIONS
+      }.to_json
     )
 
     process_response(response, message)
@@ -231,7 +230,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     attachment = message.attachments.first
     type = %w[image audio video].include?(attachment.file_type) ? attachment.file_type : 'document'
     type_content = build_attachment_content(type, attachment, message)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{phone_id_path('v24.0')}/messages",
       headers: api_headers,
       body: {
@@ -240,8 +239,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         **recipient_params(phone_number),
         'type' => type,
         type.to_s => type_content
-      }.to_json,
-      **GRAPH_REQUEST_OPTIONS
+      }.to_json
     )
 
     process_response(response, message)
@@ -350,7 +348,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   def send_interactive_text_message(phone_number, message)
     payload = create_payload_based_on_items(message)
 
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{phone_id_path}/messages",
       headers: api_headers,
       body: {
@@ -358,15 +356,14 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
         **recipient_params(phone_number),
         interactive: payload,
         type: 'interactive'
-      }.to_json,
-      **GRAPH_REQUEST_OPTIONS
+      }.to_json
     )
 
     process_response(response, message)
   end
 
   def send_reaction_message(phone_number, message)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{phone_id_path('v23.0')}/messages",
       headers: api_headers,
       body: {
@@ -378,11 +375,22 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
           message_id: message.content_attributes[:in_reply_to_external_id],
           emoji: message.outgoing_content
         }
-      }.to_json,
-      **GRAPH_REQUEST_OPTIONS
+      }.to_json
     )
 
     process_response(response, message)
+  end
+
+  # Every HTTP call that puts a message on its way out goes through here, and nothing else does.
+  # One line inside the `rescue`, on purpose: see Whatsapp::TransportFailure.
+  #
+  # The ceiling lives here rather than at each call site, and AFTER the forwarded keywords, so a
+  # send cannot be added without one and a caller cannot quietly raise it. Same arrangement as the
+  # Baileys provider's `post_send_message`.
+  def post_outgoing(url, **)
+    HTTParty.post(url, **, **GRAPH_REQUEST_OPTIONS)
+  rescue StandardError => e
+    raise_transport_failure(e)
   end
 end
 

--- a/app/services/whatsapp/providers/whatsapp_zapi_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_zapi_service.rb
@@ -1,4 +1,6 @@
 class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseService # rubocop:disable Metrics/ClassLength
+  include Whatsapp::TransportFailure
+
   # See the note in WhatsappBaileysService: legacy errors share the session hierarchy.
   class ProviderUnavailableError < Whatsapp::Session::Errors::ProviderUnavailable; end
 
@@ -157,7 +159,7 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   end
 
   def send_text_message(phone, message, **params)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_instance_path_with_token}/send-text",
       headers: api_headers,
       body: {
@@ -210,7 +212,7 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   end
 
   def send_image_message(phone, message, buffer, **params)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_instance_path_with_token}/send-image",
       headers: api_headers,
       body: {
@@ -227,7 +229,7 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   end
 
   def send_audio_message(phone, _message, buffer, **params)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_instance_path_with_token}/send-audio",
       headers: api_headers,
       body: {
@@ -250,7 +252,7 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
       file_extension = 'bin'
     end
 
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_instance_path_with_token}/send-document/#{file_extension}",
       headers: api_headers,
       body: {
@@ -268,7 +270,7 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   end
 
   def send_video_message(phone, message, buffer, **params)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_instance_path_with_token}/send-video",
       headers: api_headers,
       body: {
@@ -285,7 +287,7 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   end
 
   def send_reaction_message(phone, message, **params)
-    response = HTTParty.post(
+    response = post_outgoing(
       "#{api_instance_path_with_token}/send-reaction",
       headers: api_headers,
       body: {
@@ -299,5 +301,13 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
     raise ProviderUnavailableError unless process_response(response)
 
     response.parsed_response&.dig('messageId')
+  end
+
+  # Every HTTP call that puts a message on its way out goes through here, and nothing else does.
+  # One line inside the `rescue`, on purpose: see Whatsapp::TransportFailure.
+  def post_outgoing(url, **)
+    HTTParty.post(url, **)
+  rescue StandardError => e
+    raise_transport_failure(e)
   end
 end

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -18,13 +18,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
   end
 
   def send_template_message
-    processor = Whatsapp::TemplateProcessorService.new(
-      channel: channel,
-      template_params: template_params,
-      message: message
-    )
-
-    name, namespace, lang_code, processed_parameters = processor.call
+    name, namespace, lang_code, processed_parameters = resolved_template
 
     if name.blank?
       message.update_under_lock!(status: :failed, external_error: 'Template not found or invalid template name')
@@ -43,6 +37,18 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     # media could not be uploaded. Retrying can't fix either, so surface the reason on the message
     # instead of letting the job die silently.
     message.update_under_lock!(status: :failed, external_error: e.message)
+  rescue Whatsapp::Session::Errors::Error => e
+    # A template send reaches the provider the same way a session message does, so a transport
+    # failure here has the same two outcomes and the same rule decides between them.
+    fail_unless_retryable(e)
+  end
+
+  def resolved_template
+    Whatsapp::TemplateProcessorService.new(
+      channel: channel,
+      template_params: template_params,
+      message: message
+    ).call
   end
 
   def send_baileys_session_message
@@ -55,22 +61,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
       send_session_message
     end
   rescue Whatsapp::Session::Errors::Error => e
-    # A refusal the provider will repeat, or a send whose outcome nobody can determine.
-    # Letting it escape leaves the bubble reading "sent" while the job retries something
-    # that cannot work and then dies in the dead set, so the reason goes on the message
-    # instead — the agent sees it and can act. Only an error that might answer
-    # differently next time is worth raising for. Mirrors
-    # Whatsapp::Session::Outbound::MessageSender, which already does this for the
-    # session providers.
-    raise if e.retryable?
-    # A processing conflict is not retryable by the definition retryable? uses — the
-    # same command is not going to answer differently, because we are not the one
-    # running it. But the MESSAGE is still on its way out through the worker holding
-    # the lock, so failing it here would be a lie, and it would swallow the dedicated
-    # backoff SendReplyJob has for exactly this conflict.
-    raise if e.code == Whatsapp::Session::Errors::MessageAlreadyProcessing::CODE
-
-    fail_message(e)
+    fail_unless_retryable(e)
   end
 
   # Through StatusTransition, which owns the rule and applies it under the row lock.
@@ -113,9 +104,34 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     phone_a == phone_b || (phone_a.length >= 8 && phone_b.length >= 8 && phone_a[-8..] == phone_b[-8..])
   end
 
+  # The same rule the Baileys path has had since #391, now that the other three providers raise
+  # something it can read. Before this a transport failure escaped as whatever the HTTP stack
+  # raised, matched no `retry_on` in SendReplyJob, and left Sidekiq re-sending the message three
+  # more times with the bubble still on "sent" (fazer-ai/chatwoot#605).
+  #
+  # The session providers reach this too, and it costs them nothing: their own MessageSender
+  # already applies this rule, so what arrives here is only what it chose to re-raise.
   def send_session_message
     message_id = channel.send_message(recipient_id, message)
     persist_source_id(message_id)
+  rescue Whatsapp::Session::Errors::Error => e
+    fail_unless_retryable(e)
+  end
+
+  # A refusal the provider will repeat, or a send whose outcome nobody can determine. Letting it
+  # escape leaves the bubble reading "sent" while the job retries something that cannot work and
+  # then dies in the dead set, so the reason goes on the message instead — the agent sees it and
+  # can act. Only an error that might answer differently next time is worth raising for. Mirrors
+  # Whatsapp::Session::Outbound::MessageSender, which already does this for the session providers.
+  def fail_unless_retryable(error)
+    raise error if error.retryable?
+    # A processing conflict is not retryable by the definition retryable? uses — the same command
+    # is not going to answer differently, because we are not the one running it. But the MESSAGE
+    # is still on its way out through the worker holding the lock, so failing it here would be a
+    # lie, and it would swallow the dedicated backoff SendReplyJob has for exactly this conflict.
+    raise error if error.code == Whatsapp::Session::Errors::MessageAlreadyProcessing::CODE
+
+    fail_message(error)
   end
 
   # The message may have been deleted while this send was in flight — the DELETE endpoint found no

--- a/app/services/whatsapp/session/errors.rb
+++ b/app/services/whatsapp/session/errors.rb
@@ -118,6 +118,18 @@ module Whatsapp::Session::Errors
     CODE = 'group_participant_not_allowed'.freeze
   end
 
+  # A send that reached its deadline without an answer, and that may or may not have arrived.
+  # NOT retryable, and that is the whole point of the class: a retry of a send that did arrive
+  # puts a second copy in front of the customer, and nothing on this side can tell the two apart.
+  # The agent gets the sentence and decides.
+  #
+  # Deliberately absent from CLASSES below. It is raised here, never received: a connector that
+  # sent this code on the wire would be claiming something about our socket, and `build` must not
+  # be able to manufacture it out of a string.
+  class SendOutcomeUnknown < Error
+    CODE = 'send_outcome_unknown'.freeze
+  end
+
   # Another worker is already handling this provider message id.
   class MessageAlreadyProcessing < Error
     CODE = 'message_already_processing'.freeze

--- a/app/services/whatsapp/transport_failure.rb
+++ b/app/services/whatsapp/transport_failure.rb
@@ -1,0 +1,50 @@
+# What to raise when a send never got an answer at all.
+#
+# A response that comes back, whatever it says, is something the caller can classify: a 400 is a
+# refusal, a 503 is the provider saying it is down. This is the other case, where there is no
+# response to look at -- the socket timed out, the connection was reset, the handshake failed --
+# and the send escapes as whatever the HTTP stack raised. That class is not in the session error
+# hierarchy, so `SendReplyJob`'s `retry_on` never matched it: the block that marks the message
+# failed did not run, the exception reached Sidekiq, and its three retries sent the message again
+# each time, with nothing on the agent's screen to say so (fazer-ai/chatwoot#605).
+#
+# Rescued as a CLASS rather than as a list of exception types, which is why the caller must wrap
+# nothing but the HTTP call in it: an enumerated list is a promise to have thought of every way a
+# socket can fail, and it will be wrong (Net::WriteTimeout on a large media body,
+# OpenSSL::SSL::SSLError on a handshake, whatever the next TLS or HTTP gem raises). Anything
+# StandardError can be at that one line is a transport failure by construction.
+#
+# The shape is the Baileys provider's `post_send_message`, which has had it since #391. This is
+# that reasoning made shareable, so the three providers that still lacked it answer the same way.
+module Whatsapp::TransportFailure
+  # Failures that cannot have put a single byte of the request on the wire. Everything else
+  # defaults to indeterminate, and the asymmetry is deliberate: calling a possibly-delivered send
+  # "the provider is unreachable" makes it retryable, and a retry of a send that did arrive is a
+  # second copy in front of the customer. Calling a never-sent one indeterminate costs the agent
+  # one click to resend.
+  NEVER_TRANSMITTED = [
+    Net::OpenTimeout, SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH
+  ].freeze
+
+  OUTGOING_ERRORS_SCOPE = 'errors.inboxes.channel.outgoing'.freeze
+
+  private
+
+  def raise_transport_failure(error)
+    Rails.logger.error("[WHATSAPP] transport failure on send: #{error.class}: #{error.message}")
+
+    raise Whatsapp::Session::Errors::ProviderUnavailable, unreachable_message if never_transmitted?(error)
+
+    raise Whatsapp::Session::Errors::SendOutcomeUnknown, unknown_outcome_message
+  end
+
+  def never_transmitted?(error)
+    NEVER_TRANSMITTED.any? { |klass| error.is_a?(klass) }
+  end
+
+  # Resolved at raise time rather than in a constant: I18n.locale is per request, and a constant
+  # would freeze whichever locale booted the process. This sentence reaches the agent as the
+  # message's `external_error`.
+  def unreachable_message = I18n.t("#{OUTGOING_ERRORS_SCOPE}.provider_unreachable")
+  def unknown_outcome_message = I18n.t("#{OUTGOING_ERRORS_SCOPE}.send_outcome_unknown")
+end

--- a/spec/services/whatsapp/graph_request_options_spec.rb
+++ b/spec/services/whatsapp/graph_request_options_spec.rb
@@ -111,7 +111,11 @@ describe Whatsapp::GraphRequestOptions do
     expected = {
       'app/services/whatsapp/facebook_api_client.rb' => 10,
       'app/services/whatsapp/health_service.rb' => 1,
-      'app/services/whatsapp/providers/whatsapp_cloud_service.rb' => 10,
+      # Six rather than ten: the five sends now go through `post_outgoing`, which is the single
+      # HTTParty call on the outgoing path and carries the ceiling for all of them. That
+      # indirection is what fazer-ai/chatwoot#605 needed, and collapsing five inspected calls into
+      # one is the count moving for a reason, not a call losing its ceiling.
+      'app/services/whatsapp/providers/whatsapp_cloud_service.rb' => 6,
       'app/services/whatsapp/business_management_token_validation_service.rb' => 2,
       'app/services/whatsapp/csat_template_service.rb' => 3,
       'app/services/whatsapp/incoming_message_whatsapp_cloud_service.rb' => 1,

--- a/spec/services/whatsapp/transport_failure_spec.rb
+++ b/spec/services/whatsapp/transport_failure_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+# A send that never gets an answer at all: the socket timed out, the connection was reset, the
+# handshake failed. Until fazer-ai/chatwoot#605 those escaped as whatever the HTTP stack raised,
+# matched no `retry_on` in SendReplyJob, and Sidekiq re-sent the message three more times with the
+# bubble still reading "sent" -- up to four copies in front of the customer and nothing on the
+# agent's screen. Measured here through the real send service, because the value is in the whole
+# chain and not in the classifier alone.
+describe 'a send that gets no answer at all' do # rubocop:disable RSpec/DescribeClass
+  let(:account) { create(:account) }
+  let(:contact) { create(:contact, account: account, phone_number: '+5511999999999') }
+  let(:contact_inbox) { create(:contact_inbox, inbox: channel.inbox, contact: contact, source_id: '5511999999999') }
+  let(:conversation) { create(:conversation, contact_inbox: contact_inbox, contact: contact, inbox: channel.inbox, account: account) }
+  let(:message) { create(:message, message_type: :outgoing, content: 'oi', conversation: conversation, account: account) }
+
+  # The window a session message needs: without one the service answers "outside the messaging
+  # window" and never reaches a provider at all, which would make every example below pass for
+  # the wrong reason.
+  before { create(:message, message_type: :incoming, conversation: conversation, account: account) }
+
+  # Not a class: the value is the whole chain, from the provider raising to the bubble the agent
+  # reads, and no single class owns that.
+  #
+  # The three providers that lacked the classification. Baileys is not here: it has had it since
+  # #391 and its own spec covers it, and the point of this one is the three that did not.
+  {
+    'whatsapp_cloud' => :post,
+    'zapi' => :post,
+    'default' => :post
+  }.each do |provider, verb|
+    context "when the provider is #{provider}" do
+      let(:channel) do
+        create(:channel_whatsapp, provider: provider, account: account,
+                                  validate_provider_config: false, sync_templates: false)
+      end
+
+      # Never transmitted: the connection was refused, so nothing can have reached WhatsApp. The
+      # message stays sendable and the error is retryable, which is what lets SendReplyJob try
+      # again rather than telling the agent a send failed that never left.
+      it 'keeps a refused connection retryable, because nothing can have arrived' do
+        allow(HTTParty).to receive(verb).and_raise(Errno::ECONNREFUSED)
+
+        expect { described_class_for(message).perform }
+          .to raise_error(Whatsapp::Session::Errors::ProviderUnavailable) { |error| expect(error).to be_retryable }
+      end
+
+      # The other half, and the one the issue is about. A read timeout may or may not have been
+      # delivered, so re-sending is how the customer gets a second copy. The message is marked
+      # failed instead, which both ends the silence and stops the retry.
+      it 'marks the message failed on an answer that never came, instead of sending it again' do
+        allow(HTTParty).to receive(verb).and_raise(Net::ReadTimeout)
+
+        expect { described_class_for(message).perform }.not_to raise_error
+
+        expect(message.reload.status).to eq('failed')
+        expect(message.external_error).to eq(I18n.t('errors.inboxes.channel.outgoing.send_outcome_unknown'))
+      end
+
+      it 'does not record a source id for a send it could not confirm' do
+        allow(HTTParty).to receive(verb).and_raise(Net::ReadTimeout)
+
+        described_class_for(message).perform
+
+        expect(message.reload.source_id).to be_nil
+      end
+    end
+  end
+
+  def described_class_for(message)
+    Whatsapp::SendOnWhatsappService.new(message: message)
+  end
+end


### PR DESCRIPTION
Fecha a #605.

Um envio por WhatsApp Cloud, Z-API ou 360dialog que falha no transporte, sem resposta nenhuma para classificar, escapava como o que quer que a pilha HTTP levantasse. `Net::ReadTimeout` não está na hierarquia de erro de sessão, então:

- o `retry_on Whatsapp::Session::Errors::Error` do `SendReplyJob` não casava;
- o bloco dele que chama `fail_message` não rodava;
- a exceção subia para o Sidekiq, que tem `:max_retries: 3`;
- a guarda de reenvio é `Base::SendOnChannelService#outgoing_message_originated_from_channel?`, que só testa `source_id.present?`, e um envio que estourou nunca chegou ao `persist_source_id`.

Somando: **até quatro cópias da mesma mensagem no telefone do cliente**, com quatro carimbos de hora, e o operador vendo uma bolha só, presa em `sent`, sem nada na tela dizendo que houve retentativa. Nenhum dos três provedores carrega chave de idempotência (o Baileys carrega, `chatwootMessageId`, e é justamente o que faltava aqui).

## A forma

É a do `post_send_message` do provedor Baileys, que tem isso desde a #391, agora escrita uma vez para os três que não tinham:

```ruby
def post_outgoing(url, **)
  HTTParty.post(url, **, **GRAPH_REQUEST_OPTIONS)   # o teto só no Cloud
rescue StandardError => e
  raise_transport_failure(e)
end
```

`rescue StandardError` com **uma linha só** dentro, a chamada HTTP, e não uma lista de tipos: enumerar é prometer ter pensado em toda forma de um socket falhar, e a promessa quebra (`Net::WriteTimeout` num corpo de mídia grande, `OpenSSL::SSL::SSLError` num handshake, o que o próximo gem inventar). Naquela linha, tudo que `StandardError` pode ser é falha de transporte por construção.

A classificação tem dois lados e a assimetria é deliberada:

| | levanta | retentável | por quê |
| --- | --- | --- | --- |
| não pôs um byte na rede (`ECONNREFUSED`, `SocketError`, `OpenTimeout`, `EHOSTUNREACH`, `ENETUNREACH`) | `ProviderUnavailable` | sim | nada chegou, então tentar de novo não duplica nada |
| qualquer outra | `SendOutcomeUnknown` | **não** | pode ter chegado, e reenviar é exatamente como o cliente ganha a segunda cópia |

O `SendOutcomeUnknown` é novo na hierarquia e fica **fora** do `CLASSES`/`BY_CODE` de propósito: ele é levantado aqui, nunca recebido, e um conector que mandasse esse código no fio estaria afirmando algo sobre o nosso socket.

No `Whatsapp::SendOnWhatsappService`, a regra que o caminho Baileys já aplicava virou `fail_unless_retryable` e passou a valer também para `send_session_message` e `send_template_message`. Os provedores de sessão (native, uazapi) passam por lá também e não pagam nada: o `MessageSender` deles já aplica a mesma regra, então o que chega aqui é só o que ele escolheu relevantar.

A lista de falhas que não põem byte na rede saiu do provedor Baileys para o módulo compartilhado. O que **continua** lá é o que ele levanta, e é diferente de propósito: lá um envio possivelmente entregue é retentável, porque o id reservado torna a segunda tentativa segura, e os três provedores que não reservam nada não podem retentar.

## Efeito colateral no teto da Graph

As cinco chamadas de envio do Cloud carregavam `**GRAPH_REQUEST_OPTIONS` no ponto de chamada. Passaram para dentro do `post_outgoing`, **depois** das palavras-chave encaminhadas, pela mesma razão da #601: nenhum envio novo pode nascer sem teto e nenhum chamador pode baixá-lo. A cerca da #588 pegou isso na hora (a contagem do arquivo caiu de 10 para 5), que é ela fazendo o trabalho dela; atualizei a contagem esperada para 6 com a razão escrita ao lado, porque cinco chamadas inspecionadas viraram uma.

## O que foi medido

Bateria de mutação, os 9 exemplos de `spec/services/whatsapp/transport_failure_spec.rb` em cada rodada:

| mutante | resultado |
| --- | --- |
| m1 Z-API sem o `rescue` (o defeito original) | 3 falhas |
| m2 tudo classificado como nunca transmitido | 6 falhas |
| m3 tudo classificado como desfecho desconhecido | 3 falhas |
| m4 `send_session_message` sem o `rescue` | 6 falhas |
| m5 `fail_unless_retryable` sempre relevanta | 6 falhas |
| m6 `SendOutcomeUnknown` herdando de `ProviderUnavailable` (retentável) | 6 falhas |
| m7 `ECONNREFUSED` fora da lista | 3 falhas |
| restaurado | 0 falhas |

O spec mede pelo serviço de envio de verdade, nos três provedores, porque o valor está na cadeia inteira e não no classificador sozinho: da recusa do socket até o `external_error` que o agente lê na bolha. Ele também fixa que nenhum `source_id` é gravado para um envio que não deu para confirmar, que é a metade que decide se haverá reenvio.

2090 exemplos no conjunto afetado (`spec/services/whatsapp`, `send_reply_job`, `channel/whatsapp`, `spec/services/messages`), verdes. RuboCop limpo, `zeitwerk:check` ok. Suíte CE inteira disparada na branch.

## O que não faz

Não põe teto nas chamadas de Z-API e 360dialog: isso é o que falta da #589 e vem em seguida, agora que pôr teto ali deixou de aumentar a frequência de um silêncio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/609)
<!-- Reviewable:end -->
