### PR TITLE
fix(groups): recusar a leitura da lista como toda outra rota de grupo recusa

### DIFF
--- a/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
+++ b/app/controllers/api/v1/accounts/contacts/group_members_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
     @page = [(params[:page] || 1).to_i, 1].max
     @per_page = (params[:per_page] || DEFAULT_PER_PAGE).to_i.clamp(1, 100)
     @inbox_phone_number = inbox_phone_number
-    @own_member = Whatsapp::Session::Owner.group_member(channel_if_any, @contact)
+    @own_member = Whatsapp::Session::Owner.group_member(channel, @contact)
     @is_inbox_admin = @own_member&.role == 'admin'
 
     paginated = base_query.order(role: :desc, id: :asc)
@@ -88,7 +88,7 @@ class Api::V1::Accounts::Contacts::GroupMembersController < Api::V1::Accounts::C
   end
 
   def inbox_phone_number
-    channel_if_any&.phone_number
+    channel.phone_number
   end
 
   def pin_own_member_on_first_page(paginated)

--- a/app/controllers/concerns/group_channel_resolver.rb
+++ b/app/controllers/concerns/group_channel_resolver.rb
@@ -12,23 +12,23 @@ module GroupChannelResolver
 
   private
 
-  # The channel a group action runs as. Every action that actually talks to WhatsApp needs a real
-  # one, so this refuses rather than handing back nil for the provider call to raise on: an agent
-  # with no claim to any of this group's inboxes was answered 500 for a request that is simply not
-  # theirs. Use `channel_if_any` in the few reads that are meant to work without one.
+  # The channel a group action runs as, and the only way to get one. It refuses rather than handing
+  # back nil for the provider call to raise on: an agent with no claim to any of this group's
+  # inboxes was answered 500 for a request that is simply not theirs.
+  #
+  # There used to be a nil-tolerant reader beside this one, for the roster read, on the grounds
+  # that `ContactPolicy` and not inbox membership governs it. What that produced was one endpoint
+  # answering the same question two ways: 200 with the roster when the caller left `inbox_id` out,
+  # 404 when they named an inbox they are not on. The verdict may not depend on whether an
+  # optional parameter was typed, and refusing is what the other eleven group routes already
+  # answer (fazer-ai/chatwoot#535).
+  #
+  # What that costs, said out loud: the roster of a group contact that is in no inbox at all stops
+  # being readable. Nothing in the dashboard asks for one -- every caller passes the inbox of the
+  # conversation it has open, and an administrator gets every inbox of the account -- so the case
+  # is reachable through the API and not through the product.
   def channel
-    channel_if_any || raise(ActiveRecord::RecordNotFound)
-  end
-
-  # Returns nil rather than refusing, which is the very shape the bug above had, so reach for it
-  # only where nil is a real answer. Today that is `GroupMembersController#index`, which is a read
-  # governed by `ContactPolicy` rather than by inbox membership and shows the roster without the
-  # "am I an admin here" flag. Anything that acts on the group needs `channel` and must not borrow
-  # this because it happens to be nearby.
-  def channel_if_any
-    return @channel_if_any if defined?(@channel_if_any)
-
-    @channel_if_any = group_contact_inbox&.inbox&.channel
+    group_contact_inbox&.inbox&.channel || raise(ActiveRecord::RecordNotFound)
   end
 
   def group_contact_inbox
@@ -54,8 +54,9 @@ module GroupChannelResolver
     candidates = @contact.contact_inboxes.includes(:inbox).where(inbox: Current.user.assigned_inboxes)
     return candidates.find_by!(inbox_id: params[:inbox_id]) if params[:inbox_id].present?
 
-    # None and one both answer nil here, and that is the honest answer: whether nil is fatal is
-    # the caller's question, not this one's. `channel` refuses on it, `channel_if_any` does not.
+    # None and one both answer nil here, and `channel` is what turns that into the refusal. Kept
+    # as nil rather than raised here because this method answers which inbox, not whether one
+    # exists to answer with.
     return candidates.first if candidates.size <= 1
 
     raise ActionController::BadRequest, I18n.t('contacts.group.inbox_id_required')

--- a/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_channel_resolver_spec.rb
@@ -126,18 +126,53 @@ RSpec.describe 'group actions and the inbox they run as', type: :request do
     expect(response).to have_http_status(:not_found)
   end
 
-  # A fence, not a checklist. `channel` refusing is what keeps a new group endpoint from
-  # answering 500 the way this one did, and the tolerant reader exists for the two reads
-  # that are meant to degrade. Adding a third without meaning to is the way back in.
-  it 'is read tolerantly in exactly the two places that mean to' do
+  # A fence, not a checklist. There used to be a nil-tolerant reader beside `channel`, for the
+  # roster read, and what it produced was one endpoint answering the same question two ways
+  # depending on whether an optional parameter was typed. Its absence is what keeps the next
+  # group endpoint from reaching for one because it happens to be nearby.
+  it 'has no nil-tolerant way to resolve the channel' do
     roots = %w[app enterprise lib].select { |dir| Rails.root.join(dir).directory? }
-    readers = Dir.glob(Rails.root.join("{#{roots.join(',')}}/**/*.rb")).select do |path|
-      File.read(path).include?('channel_if_any')
+    sources = Dir.glob(Rails.root.join("{#{roots.join(',')}}/**/*.rb"))
+    readers = sources.select { |path| File.read(path).include?('channel_if_any') }
+
+    expect(sources).not_to be_empty
+    expect(readers.map { |path| Pathname.new(path).relative_path_from(Rails.root).to_s }).to be_empty
+  end
+
+  # The half of #535 this closes: same caller, same contact, same authorisation question, and
+  # until now two answers depending on whether `inbox_id` was typed.
+  describe 'the roster read' do
+    let(:outsider) do
+      agent = create(:user, account: account, role: :agent)
+      create(:inbox_member, user: agent,
+                            inbox: create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false,
+                                                             sync_templates: false, account: account).inbox)
+      agent
     end
 
-    expect(readers.map { |path| Pathname.new(path).relative_path_from(Rails.root).to_s })
-      .to contain_exactly('app/controllers/concerns/group_channel_resolver.rb',
-                          'app/controllers/api/v1/accounts/contacts/group_members_controller.rb')
+    it 'answers an agent on none of this group\'s inboxes the same way, named or not' do
+      get "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+          headers: outsider.create_new_auth_token, as: :json
+      unnamed = [response.status, response.parsed_body]
+
+      get "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+          params: { inbox_id: looking_at.inbox.id }, headers: outsider.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(unnamed).to eq([response.status, response.parsed_body])
+    end
+
+    # And it still answers the agent who has a claim, without being told which inbox to use, which
+    # is the case the parameter was made optional for.
+    it 'still answers an agent who is on one of them, without being told which' do
+      insider = create(:user, account: account, role: :agent)
+      create(:inbox_member, user: insider, inbox: looking_at.inbox)
+
+      get "/api/v1/accounts/#{account.id}/contacts/#{group_contact.id}/group_members",
+          headers: insider.create_new_auth_token, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   # A metadata write resolved the channel only when it had a field to write, so a request with no

--- a/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/contacts/group_members_controller_spec.rb
@@ -16,8 +16,16 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
     end
 
     context 'when user is logged in' do
+      # The roster read resolves the inbox it would act as, like every other group route, so a
+      # group that is in no inbox at all is refused rather than listed (#535). These examples are
+      # about what the roster contains, so they get an inbox and go on measuring that.
+      let(:whatsapp_channel) do
+        create(:channel_whatsapp, provider: 'baileys', validate_provider_config: false, sync_templates: false, account: account)
+      end
+
       it 'returns active group members' do
         contact = create(:contact, account: account, group_type: :group, identifier: 'group@g.us')
+        create(:contact_inbox, contact: contact, inbox: whatsapp_channel.inbox, source_id: '120363041234567890')
         create(:group_member, group_contact: contact, contact: contact)
         create(:group_member, group_contact: contact, contact: create(:contact, account: account))
 
@@ -51,6 +59,7 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
 
       it 'does not return inactive group members' do
         contact = create(:contact, account: account, group_type: :group, identifier: 'group@g.us')
+        create(:contact_inbox, contact: contact, inbox: whatsapp_channel.inbox, source_id: '120363041234567890')
         create(:group_member, group_contact: contact, contact: contact)
         create(:group_member, :inactive, group_contact: contact, contact: create(:contact, account: account))
 
@@ -63,6 +72,7 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
 
       it 'does not return group members from another account' do
         contact = create(:contact, account: account, group_type: :group, identifier: 'group@g.us')
+        create(:contact_inbox, contact: contact, inbox: whatsapp_channel.inbox, source_id: '120363041234567890')
         create(:group_member, group_contact: contact, contact: contact)
         other_account = create(:account)
         other_group_contact = create(:contact, account: other_account, group_type: :group, identifier: 'other@g.us')
@@ -77,6 +87,7 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
 
       it 'returns expected attributes in the response' do
         contact = create(:contact, account: account, group_type: :group, identifier: 'group@g.us')
+        create(:contact_inbox, contact: contact, inbox: whatsapp_channel.inbox, source_id: '120363041234567890')
         create(:group_member, group_contact: contact, contact: contact)
 
         get "/api/v1/accounts/#{account.id}/contacts/#{contact.id}/group_members",
@@ -94,6 +105,7 @@ RSpec.describe '/api/v1/accounts/{account.id}/contacts/:id/group_members', type:
 
       it 'returns empty payload when contact is not a group' do
         contact = create(:contact, account: account, group_type: :individual)
+        create(:contact_inbox, contact: contact, inbox: whatsapp_channel.inbox, source_id: '5511999999999')
 
         get "/api/v1/accounts/#{account.id}/contacts/#{contact.id}/group_members",
             headers: admin.create_new_auth_token


### PR DESCRIPTION
Fecha a metade que faltava da #535. A outra foi na #604.

A leitura da lista de participantes era a única rota de grupo que resolvia a caixa de forma tolerante:

| pedido | antes | agora |
| --- | --- | --- |
| sem `inbox_id`, agente em nenhuma caixa do grupo | 200 com a lista | 404 |
| `inbox_id` de uma caixa em que o agente não está | 404 | 404 |
| `inbox_id` de uma caixa em que o grupo não está | 404 | 404 |
| sem `inbox_id`, agente em uma das caixas | 200 | 200 |

Mesmo chamador, mesmo contato, mesma pergunta de autorização, e o veredito dependia de o cliente ter digitado ou não um parâmetro opcional. O `group_channel_resolver_spec` já dizia o princípio em texto, escrito quando as outras rotas foram alinhadas na #533: "answering differently would tell an agent whether that number is in the group".

O leitor tolerante (`channel_if_any`) sai junto. Ele existia por causa desta leitura, e a cerca que contava em quantos arquivos ele aparecia virou a que exige que não apareça em nenhum, para a próxima rota de grupo não pegar um emprestado só porque estava por perto.

## O que isso custa, dito por inteiro

A lista de um contato de grupo que não está em **caixa nenhuma** deixa de ser legível, para qualquer um, inclusive administrador.

Medi antes de escolher: nada no painel pede uma. Todos os chamadores do dashboard mandam a caixa da conversa aberta (`MessagesView.vue:517`, `ReplyBox.vue:718`, `GroupContactInfo.vue:52`), e o `GroupContactInfo` só é renderizado dentro do `ContactPanel` da conversa, então nunca existe sem conversa aberta. Administrador recebe todas as caixas da conta em `User#assigned_inboxes`. Agente só abre conversa de caixa em que está, e essa caixa tem o grupo por construção. O caso perdido é alcançável pela API, não pelo produto.

Isto reverte uma decisão que estava escrita e testada, e é honesto dizer isso: o comentário do `channel_if_any` defendia a tolerância com o argumento de que a lista é dado de contato, governada por `ContactPolicy` e não por participação na caixa. O argumento continua verdadeiro sobre os dados; o que ele não resolve é o endpoint responder duas coisas para a mesma pergunta. A análise completa das duas saídas está em https://github.com/fazer-ai/chatwoot/issues/535#issuecomment-5642295592.

## Os cinco exemplos que quebraram

Todos em `group_members_controller_spec.rb`, e todos criavam o contato de grupo **sem `contact_inbox`**, por descuido e não por desenho: são sobre o conteúdo da lista (ativos, inativos, outra conta, atributos, contato que não é grupo). Ganharam uma caixa e seguem medindo o que mediam. Foram exatamente esses cinco, nenhum outro.

## O que foi medido

Bateria de mutação, os 15 exemplos de `group_channel_resolver_spec.rb` em cada rodada:

| mutante | resultado |
| --- | --- |
| m1 `channel` sem a recusa (o defeito) | 5 falhas |
| m2 os dois pontos do `index` voltando a tolerar nil | 1 falha |
| restaurado | 0 falhas |

m2 mereceu uma segunda rodada: mutar só um dos dois pontos do `index` não falha, porque `inbox_phone_number` roda antes e a recusa vem de lá. Mutados os dois juntos, a cerca pega. Registro porque uma bateria que só mutasse o ponto "principal" teria dito que o outro não está coberto quando está, e o contrário também é possível.

87 exemplos em `spec/controllers/api/v1/accounts/contacts`, verdes. RuboCop limpo. Suíte CE disparada na branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/610)
<!-- Reviewable:end -->
