### PR TITLE
fix(whatsapp): pôr teto nas chamadas de Z-API e 360dialog

### DIFF
--- a/app/services/whatsapp/dialog360_request_options.rb
+++ b/app/services/whatsapp/dialog360_request_options.rb
@@ -1,0 +1,13 @@
+# One ceiling for 360dialog, and one is enough because its bodies are all the same size class.
+#
+# It is a BSP in front of Meta's Cloud API, and `send_attachment_message` passes a `link` rather
+# than the file: no call in this provider carries media in the body. So every request here is a
+# small JSON document answered by the same upstream the Graph family talks to directly, whose
+# ceiling this repo already chose and wrote down in Whatsapp::GraphRequestOptions. The extra hop
+# is 360dialog's own, and it is not the part that stalls.
+#
+# `max_retries: 0` for the reason the other families carry it: `Net::HTTP` retries an idempotent
+# request once by default, so the template sync GET cost twice what its ceiling said.
+module Whatsapp::Dialog360RequestOptions
+  DIALOG360_REQUEST_OPTIONS = { timeout: 10, max_retries: 0 }.freeze
+end

--- a/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
@@ -1,5 +1,6 @@
 class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseService
   include Whatsapp::TransportFailure
+  include Whatsapp::Dialog360RequestOptions
 
   def send_message(phone_number, message)
     @message = message
@@ -29,7 +30,7 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
   def sync_templates
     # ensuring that channels with wrong provider config wouldn't keep trying to sync templates
     whatsapp_channel.mark_message_templates_updated
-    response = HTTParty.get("#{api_base_path}/configs/templates", headers: api_headers)
+    response = HTTParty.get("#{api_base_path}/configs/templates", headers: api_headers, **DIALOG360_REQUEST_OPTIONS)
     whatsapp_channel.update!(message_templates: response['waba_templates'], message_templates_last_updated: Time.now.utc) if response.success?
   end
 
@@ -39,7 +40,8 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
       headers: { 'D360-API-KEY': whatsapp_channel.provider_config['api_key'], 'Content-Type': 'application/json' },
       body: {
         url: "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/whatsapp/#{whatsapp_channel.phone_number}"
-      }.to_json
+      }.to_json,
+      **DIALOG360_REQUEST_OPTIONS
     )
     response.success?
   end
@@ -131,7 +133,7 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
   # Every HTTP call that puts a message on its way out goes through here, and nothing else does.
   # One line inside the `rescue`, on purpose: see Whatsapp::TransportFailure.
   def post_outgoing(url, **)
-    HTTParty.post(url, **)
+    HTTParty.post(url, **, **DIALOG360_REQUEST_OPTIONS)
   rescue StandardError => e
     raise_transport_failure(e)
   end

--- a/app/services/whatsapp/providers/whatsapp_zapi_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_zapi_service.rb
@@ -1,5 +1,6 @@
 class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseService # rubocop:disable Metrics/ClassLength
   include Whatsapp::TransportFailure
+  include Whatsapp::ZapiRequestOptions
 
   # See the note in WhatsappBaileysService: legacy errors share the session hierarchy.
   class ProviderUnavailableError < Whatsapp::Session::Errors::ProviderUnavailable; end
@@ -31,7 +32,8 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   def validate_provider_config?
     response = HTTParty.get(
       "#{api_instance_path_with_token}/status",
-      headers: api_headers
+      headers: api_headers,
+      **ZAPI_REQUEST_OPTIONS
     )
 
     process_response(response)
@@ -44,7 +46,8 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
       body: {
         value: whatsapp_channel.inbox.callback_webhook_url,
         notifySentByMe: true
-      }.to_json
+      }.to_json,
+      **ZAPI_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -59,7 +62,8 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   def disconnect_channel_provider
     response = HTTParty.get(
       "#{api_instance_path_with_token}/disconnect",
-      headers: api_headers
+      headers: api_headers,
+      **ZAPI_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -70,7 +74,8 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   def qr_code_image
     response = HTTParty.get(
       "#{api_instance_path_with_token}/qr-code/image",
-      headers: api_headers
+      headers: api_headers,
+      **ZAPI_REQUEST_OPTIONS
     )
 
     if response.parsed_response['connected']
@@ -102,7 +107,8 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
       body: {
         phone: phone,
         messageId: message_source_id
-      }.to_json
+      }.to_json,
+      **ZAPI_REQUEST_OPTIONS
     )
 
     process_response(response)
@@ -111,7 +117,8 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   def on_whatsapp(phone_number)
     response = HTTParty.get(
       "#{api_instance_path_with_token}/phone-exists/#{phone_number.delete('+')}",
-      headers: api_headers
+      headers: api_headers,
+      **ZAPI_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -131,7 +138,8 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
         messageId: message.source_id,
         phone: phone,
         owner: message.message_type == 'outgoing'
-      }
+      },
+      **ZAPI_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -306,7 +314,7 @@ class Whatsapp::Providers::WhatsappZapiService < Whatsapp::Providers::BaseServic
   # Every HTTP call that puts a message on its way out goes through here, and nothing else does.
   # One line inside the `rescue`, on purpose: see Whatsapp::TransportFailure.
   def post_outgoing(url, **)
-    HTTParty.post(url, **)
+    HTTParty.post(url, **, **ZAPI_SEND_OPTIONS)
   rescue StandardError => e
     raise_transport_failure(e)
   end

--- a/app/services/whatsapp/zapi_request_options.rb
+++ b/app/services/whatsapp/zapi_request_options.rb
@@ -1,0 +1,28 @@
+# Ceilings for the Z-API provider. Z-API publishes no deadline of its own, so unlike the Baileys
+# ones these numbers come from this side, and saying so is part of them: what is measured here is
+# what a stall costs us, not what the far side promises.
+#
+# What a `timeout:` actually bounds is one socket operation, not the request. Measured against a
+# server that answers one byte every 300ms with `read_timeout = 1`: the request completed in 11.8
+# seconds. So a ceiling does not cap how long a send takes; it caps how long the socket may sit
+# still. That is why the size of a body does not decide the number, and why the think time of the
+# far side does.
+#
+# `max_retries: 0` on both. `Net::HTTP` retries GET, HEAD, PUT, DELETE, OPTIONS and TRACE once by
+# default, so half of this provider's calls silently cost twice their ceiling, and a repeated
+# DELETE of a message or PUT of the webhook set is a second effect nobody asked for.
+module Whatsapp::ZapiRequestOptions
+  # Control and reads: connection status, webhook setup, disconnect, QR code, read receipts,
+  # phone-exists, message delete. Small bodies, and Z-API answers them out of its own state, so
+  # ten seconds of silence is already a wedged socket rather than a slow answer.
+  ZAPI_REQUEST_OPTIONS = { timeout: 10, max_retries: 0 }.freeze
+
+  # Sends. The long wait here is not the upload -- that is many writes, each bounded by this same
+  # number -- it is the single blocked read while Z-API forwards the message to WhatsApp and only
+  # then answers. Media travels base64 inside the body (up to 5 MB for an image, 16 for audio and
+  # video, 100 for a document), so that forward can legitimately take tens of seconds. 90s is the
+  # number the Baileys provider already uses for a media-bearing send, for the same reason; there
+  # it is tied to a published 75s proxy cut, and here it is not tied to anything the far side
+  # states, which is the honest difference between the two.
+  ZAPI_SEND_OPTIONS = { timeout: 90, max_retries: 0 }.freeze
+end

--- a/spec/services/whatsapp/dialog360_request_options_spec.rb
+++ b/spec/services/whatsapp/dialog360_request_options_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe Whatsapp::Dialog360RequestOptions do
+  let(:guarded_source) { 'app/services/whatsapp/providers/whatsapp_360_dialog_service.rb' }
+  let(:source) { Rails.root.join(guarded_source).read }
+  let(:calls) { provider_calls(source) }
+
+  # Reads a call to its own closing paren rather than to the first one it meets. This provider
+  # writes some calls on one line and some across several, so a line-oriented scan would answer
+  # differently for the same shape.
+  def provider_calls(text)
+    calls = []
+    text.to_enum(:scan, /HTTParty\.(?:get|post|put|patch|delete|head)\(/).each do
+      start = Regexp.last_match.begin(0)
+      depth = 0
+      text[start..].each_char.with_index do |char, offset|
+        depth += 1 if char == '('
+        next unless char == ')'
+
+        depth -= 1
+        next unless depth.zero?
+
+        calls << text[start, offset + 1]
+        break
+      end
+    end
+    calls
+  end
+
+  it 'caps the wait and the retry, because a ceiling alone still costs twice on a read' do
+    expect(described_class::DIALOG360_REQUEST_OPTIONS).to eq(timeout: 10, max_retries: 0)
+  end
+
+  it 'leaves no call to the provider without the ceiling' do
+    unguarded = calls.reject { |call| call.include?('DIALOG360_REQUEST_OPTIONS') }
+
+    expect(unguarded.map { |call| call.lines.first(2).map(&:strip).join(' ') }).to be_empty
+  end
+
+  it 'leaves no inline timeout beside the constant, which would be the value actually in force' do
+    expect(calls.grep(/timeout:\s*\d/)).to be_empty
+  end
+
+  it 'reads every call in the file, so an empty result cannot pass as a clean one' do
+    expect(calls.size).to eq(3)
+  end
+
+  # One ceiling is right here only while no call carries media in the body. `send_attachment_message`
+  # passes a `link`, which is what keeps every request in the same size class as the Graph family's
+  # and lets this provider share that family's number. A call that started uploading a file would
+  # need its own, so the absence of one is worth failing on.
+  it 'carries no media in a body, which is why one ceiling covers every call' do
+    expect(source).to include("'link': attachment.download_url")
+    expect(source).not_to include('base64')
+  end
+
+  it 'sends only through the helper that also classifies a transport failure' do
+    expect(source.scan(/HTTParty\.post\(url, \*\*, \*\*DIALOG360_REQUEST_OPTIONS\)/).size).to eq(1)
+    expect(source).to include('include Whatsapp::Dialog360RequestOptions')
+  end
+end

--- a/spec/services/whatsapp/dialog360_request_options_spec.rb
+++ b/spec/services/whatsapp/dialog360_request_options_spec.rb
@@ -55,7 +55,7 @@ describe Whatsapp::Dialog360RequestOptions do
   end
 
   it 'sends only through the helper that also classifies a transport failure' do
-    expect(source.scan(/HTTParty\.post\(url, \*\*, \*\*DIALOG360_REQUEST_OPTIONS\)/).size).to eq(1)
+    expect(source.scan('HTTParty.post(url, **, **DIALOG360_REQUEST_OPTIONS)').size).to eq(1)
     expect(source).to include('include Whatsapp::Dialog360RequestOptions')
   end
 end

--- a/spec/services/whatsapp/graph_request_options_spec.rb
+++ b/spec/services/whatsapp/graph_request_options_spec.rb
@@ -27,8 +27,8 @@ describe Whatsapp::GraphRequestOptions do
       # Fenced by spec/services/whatsapp/baileys_request_options_spec.rb, which also counts each
       # side, so this entry is a pointer and not an exemption.
       'app/services/whatsapp/providers/whatsapp_baileys_service.rb' => 'Baileys API, fenced by its own two-ceiling spec',
-      'app/services/whatsapp/providers/whatsapp_zapi_service.rb' => 'Z-API, no ceiling decided yet',
-      'app/services/whatsapp/providers/whatsapp_360_dialog_service.rb' => '360dialog, no ceiling decided yet',
+      'app/services/whatsapp/providers/whatsapp_zapi_service.rb' => 'Z-API, fenced by its own two-ceiling spec',
+      'app/services/whatsapp/providers/whatsapp_360_dialog_service.rb' => '360dialog, fenced by its own spec',
       # uazapi, and already the most careful caller in the repo: its own TIMEOUT constant, a separate
       # open_timeout, and read and write timeouts set apart because HTTParty's `timeout` sets all
       # three. It is also the one file a scan for `HTTParty.<verb>(` cannot see, because it dispatches

--- a/spec/services/whatsapp/zapi_request_options_spec.rb
+++ b/spec/services/whatsapp/zapi_request_options_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+describe Whatsapp::ZapiRequestOptions do
+  let(:guarded_source) { 'app/services/whatsapp/providers/whatsapp_zapi_service.rb' }
+  let(:source) { Rails.root.join(guarded_source).read }
+  let(:calls) { provider_calls(source) }
+
+  # Reads a call to its own closing paren rather than to the first one it meets: the bodies here
+  # are hashes with parens of their own, several lines down from the verb.
+  def provider_calls(text)
+    calls = []
+    text.to_enum(:scan, /HTTParty\.(?:get|post|put|patch|delete|head)\(/).each do
+      start = Regexp.last_match.begin(0)
+      depth = 0
+      text[start..].each_char.with_index do |char, offset|
+        depth += 1 if char == '('
+        next unless char == ')'
+
+        depth -= 1
+        next unless depth.zero?
+
+        calls << text[start, offset + 1]
+        break
+      end
+    end
+    calls
+  end
+
+  it 'caps the wait and the retry on both, because a ceiling alone still costs twice on a read' do
+    expect(described_class::ZAPI_REQUEST_OPTIONS).to eq(timeout: 10, max_retries: 0)
+    expect(described_class::ZAPI_SEND_OPTIONS).to eq(timeout: 90, max_retries: 0)
+  end
+
+  it 'gives a send more room than a control call, because a send waits on WhatsApp too' do
+    expect(described_class::ZAPI_SEND_OPTIONS[:timeout]).to be > described_class::ZAPI_REQUEST_OPTIONS[:timeout]
+  end
+
+  it 'leaves no call to the provider without one of the two ceilings' do
+    unguarded = calls.reject { |call| call.include?('ZAPI_REQUEST_OPTIONS') || call.include?('ZAPI_SEND_OPTIONS') }
+
+    expect(unguarded.map { |call| call.lines.first(2).map(&:strip).join(' ') }).to be_empty
+  end
+
+  it 'refuses a call that names both ceilings, because then neither is the one in force' do
+    expect(calls.select { |call| call.include?('**ZAPI_REQUEST_OPTIONS') && call.include?('ZAPI_SEND_OPTIONS') }).to be_empty
+  end
+
+  it 'leaves no inline timeout beside the constant, which would be the value actually in force' do
+    expect(calls.grep(/timeout:\s*\d/)).to be_empty
+  end
+
+  it 'reads every call in the file, so an empty result cannot pass as a clean one' do
+    # The canary. Every check above answers "none", and answers it for zero calls too.
+    expect(calls.size).to eq(8)
+  end
+
+  # The split is the substance: the send ceiling is the one that waits out a forward to WhatsApp,
+  # and the control one is deliberately impatient. A call moving between them silently is a call
+  # that starts failing on something the provider would have answered, or one that starts holding
+  # a worker for a minute and a half.
+  it 'keeps exactly one call on the send ceiling, the helper every send goes through' do
+    expect(calls.count { |call| call.include?('ZAPI_SEND_OPTIONS') }).to eq(1)
+  end
+
+  it 'sends only through that helper' do
+    # `post_outgoing` is where the ceiling and the transport classification both live, so a send
+    # written straight against HTTParty would miss both at once.
+    expect(source.scan(/HTTParty\.post\(url, \*\*, \*\*ZAPI_SEND_OPTIONS\)/).size).to eq(1)
+    expect(source).to include('include Whatsapp::ZapiRequestOptions')
+  end
+end

--- a/spec/services/whatsapp/zapi_request_options_spec.rb
+++ b/spec/services/whatsapp/zapi_request_options_spec.rb
@@ -65,7 +65,7 @@ describe Whatsapp::ZapiRequestOptions do
   it 'sends only through that helper' do
     # `post_outgoing` is where the ceiling and the transport classification both live, so a send
     # written straight against HTTParty would miss both at once.
-    expect(source.scan(/HTTParty\.post\(url, \*\*, \*\*ZAPI_SEND_OPTIONS\)/).size).to eq(1)
+    expect(source.scan('HTTParty.post(url, **, **ZAPI_SEND_OPTIONS)').size).to eq(1)
     expect(source).to include('include Whatsapp::ZapiRequestOptions')
   end
 end


### PR DESCRIPTION
Últimas duas famílias da #589 que estavam sem teto nenhum: **13 chamadas no Z-API e 6 no 360dialog**, nenhuma com controle de repetição.

| | antes | agora |
| --- | --- | --- |
| Z-API, controle e leituras (7) | 60s no POST, **120s** no GET/DELETE/PUT | 10s, sem repetição |
| Z-API, envios (6) | 60s | 90s, sem repetição |
| 360dialog (6) | 60s no POST, 120s no GET | 10s, sem repetição |

Os 120s não são exagero de retórica: o `Net::HTTP` repete GET, HEAD, PUT, DELETE, OPTIONS e TRACE uma vez por padrão, então metade das chamadas destes dois provedores custava o dobro do que o teto delas dizia, e um DELETE repetido de mensagem ou um PUT repetido do conjunto de webhooks é um segundo efeito que ninguém pediu.

## O que decide o número, medido

Um `timeout:` não limita a requisição, limita **uma operação de socket**. Medi contra um servidor que aceita a conexão, lê o pedido inteiro e responde um byte a cada 300ms:

```
read_timeout = 1s  ->  completou em 11,8s, corpo de 40 bytes
```

Ou seja, o tamanho do corpo não decide o teto: uma subida de 100 MB são muitas escritas, cada uma limitada pelo mesmo número. O que decide é **quanto o outro lado pode demorar para começar a responder**, porque essa espera é uma leitura bloqueada só.

## 360dialog: um teto

Ele é BSP na frente da Cloud API da Meta, e o `send_attachment_message` passa um `link`, nunca o arquivo. Nenhuma chamada dele carrega mídia no corpo, então toda requisição é um JSON pequeno respondido pelo mesmo upstream com que o `Whatsapp::GraphRequestOptions` já fala direto, e cuja escolha (10s) este repositório já fez e escreveu. O salto extra é o do próprio 360dialog, e não é ele que trava.

A cerca falha se isso deixar de valer: um exemplo fixa que o anexo vai por `link` e que o arquivo não contém `base64`, porque uma chamada que passasse a subir arquivo precisaria de teto próprio.

## Z-API: dois tetos, e de onde vêm

O Z-API **não publica prazo nenhum** (procurei na documentação deles e não há), então estes números vêm deste lado e a cerca diz isso em vez de fingir o contrário:

- **10s no controle** (status, webhooks, disconnect, QR, recibo de leitura, phone-exists, delete): corpos pequenos, respondidos do estado dele. Dez segundos de silêncio aí já é socket travado, não resposta lenta.
- **90s no envio**: a espera longa não é a subida, é a leitura bloqueada enquanto o Z-API encaminha ao WhatsApp e só então responde. A mídia sobe em base64 dentro do corpo (5 MB numa imagem, 16 em áudio e vídeo, 100 num documento), então esse encaminhamento pode levar dezenas de segundos. 90 é o número que o provedor Baileys já usa num envio com mídia; lá ele está amarrado a um corte publicado de 75s e **aqui não está amarrado a nada que o outro lado afirme**, que é a diferença honesta entre os dois.

O teto de envio fica dentro do `post_outgoing`, que é o mesmo ponto onde a #605 pôs a classificação da falha de transporte: um envio novo não nasce sem teto nem sem classificação, e as duas cercas assertam que só existe um `post_outgoing` por arquivo.

## O que foi medido

| mutante | resultado |
| --- | --- |
| m1 Z-API: uma chamada de controle sem teto | 1 falha |
| m2 Z-API: envio caindo no teto de controle | 2 falhas |
| m3 Z-API: teto de envio igual ao de controle | 2 falhas |
| m4 Z-API: constante sem `max_retries` | 1 falha |
| m5 360dialog: chamada de uma linha sem teto | 1 falha |
| m6 360dialog: mídia passando a ir no corpo | 1 falha |
| restaurado | 0 falhas |

m5 existe porque este provedor escreve umas chamadas em uma linha e outras em várias, e uma varredura por linha responderia diferente para a mesma forma; as duas cercas leem cada chamada até o parêntese que a fecha.

1839 exemplos em `spec/services/whatsapp`, verdes. RuboCop limpo, `zeitwerk:check` ok. Suíte CE disparada na branch.

## O que sobra da #589

O restante são famílias que não são WhatsApp (Telegram, Instagram, TikTok, Twilio, Cloudflare, Clearbit, Linear, Dyte, Firecrawl, Captain e o crawler), cada uma com a sua decisão a tomar. A entrada do Z-API e do 360dialog em `graph_request_options_spec.rb` deixou de dizer "no ceiling decided yet" e passou a apontar para as cercas novas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/611)
<!-- Reviewable:end -->
