### PR TITLE
feat(whatsapp): dizer ao conector, uma vez, quais inboxes nativas deveriam estar no ar

### DIFF
--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -408,6 +408,7 @@ class Channel::Whatsapp < ApplicationRecord # rubocop:disable Metrics/ClassLengt
 
   delegate :setup_channel_provider, to: :provider_service
   delegate :import_session, to: :provider_service
+  delegate :reassert_desired_state, to: :provider_service
   delegate :presence_subscribe, to: :provider_service
   delegate :send_message, to: :provider_service
   delegate :send_template, to: :provider_service

--- a/app/services/whatsapp/session/facade.rb
+++ b/app/services/whatsapp/session/facade.rb
@@ -59,6 +59,34 @@ class Whatsapp::Session::Facade
     backend.import_session(session: session, candidate_index: candidate_index)
   end
 
+  # Says again that this account should be connected, without touching what the dashboard
+  # shows. It exists for the one-time re-assert after a connector upgrade
+  # (fazer-ai/whatsapp-connector#194), where the point is the record the connector keeps of
+  # having been asked, and not a new pairing.
+  #
+  # Deliberately NOT `setup_channel_provider`. That one claims a pairing attempt, which writes
+  # `connecting` over the stored state, and turns a refusal into `close` with `connect_failure`.
+  # For a bulk re-assert those writes are the wrong shape twice over: the inbox this asked for
+  # is the one that was recorded as `open`, so erasing that on a failure makes the retry skip
+  # exactly the inboxes that still need it, and a fleet being re-asserted has nothing to fence,
+  # because there is no QR on anybody's screen to go stale.
+  #
+  # What the dashboard ends up showing is the connector's own doing, which is the arrangement
+  # this backend already relies on: it pushes every transition it sees, which is why it declares
+  # no state polling.
+  #
+  # Always `resume`: this is only ever asked of an account that is already paired. One that is
+  # not gets the provider's own refusal, which the caller reports rather than turning into a QR
+  # nobody is watching.
+  def reassert_desired_state
+    backend.connect(
+      model::Commands::SessionConnect.new(
+        pairing: 'resume', phone: channel.phone_number.to_s.delete('+'),
+        groups: capability?('groups'), calls: call_policy, history_sync: history_sync?
+      )
+    )
+  end
+
   # The channel calls this when an inbox is destroyed or converted to another provider,
   # so it is a teardown, not a pause: the Baileys service answers it with
   # `DELETE /connections/<phone>`. Merely disconnecting would leave the pairing and its

--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -252,7 +252,11 @@ namespace :whatsapp do
         # process that has just started.
         sleep(pause) unless index.zero?
         slice.each do |channel|
-          channel.setup_channel_provider
+          # `reassert_desired_state`, not `setup_channel_provider`: the latter writes `connecting`
+          # over the stored state and turns a refusal into `close`, so an inbox this could not
+          # reach would stop matching the selection above and the rerun below would skip exactly
+          # the ones that still need asking.
+          channel.reassert_desired_state
           puts "  inbox #{channel.inbox&.id}: asked"
         rescue StandardError => e
           failures += 1
@@ -265,7 +269,6 @@ namespace :whatsapp do
       puts failures.zero? ? 'done' : "done, #{failures} inbox(es) could not be asked; run again for those"
     end
   end
-
 end
 # rubocop:enable Metrics/BlockLength
 

--- a/lib/tasks/whatsapp_session.rake
+++ b/lib/tasks/whatsapp_session.rake
@@ -208,6 +208,64 @@ namespace :whatsapp do
       end
     end
   end
+  namespace :session do
+    # One-time, after upgrading to a connector that carries the resume sweep
+    # (fazer-ai/whatsapp-connector#183).
+    #
+    # That sweep brings back an account nobody is running, and it reads which ones should be up
+    # from `wac_session_desired`, a table written only when the connector executes a
+    # `session.connect` or a `session.disconnect`. The upgrade creates it empty and nothing seeds
+    # it: on the deploy that introduces the fix, every already-paired account has a device row
+    # and no desired row, so the sweep finds no candidate and the fleet stays orphaned exactly as
+    # before (fazer-ai/whatsapp-connector#194).
+    #
+    # The connector cannot seed it without deciding something it has no basis for: a
+    # `session.disconnect` keeps the device, so seeding from the pairing would dial back an
+    # account an operator deliberately stopped, and nothing in its store separates the two
+    # (`bound_at` is when the credential was bound, `wac_session_presence` is chat availability).
+    # This side does know: `provider_connection['connection']` is `open` for the accounts this
+    # installation wants in the air.
+    #
+    # Safe on a healthy fleet: the connector answers a resume for a session that is already up
+    # without dialling anything, and what it does do is write the row this exists to create.
+    desc 'Tell the connector again which native inboxes should be connected (one-time, after the connector upgrade)'
+    task :reassert, %i[batch pause] => :environment do |_task, args|
+      batch = (args[:batch] || 4).to_i
+      pause = (args[:pause] || 10).to_f
+      abort 'batch must be at least 1' if batch < 1
+
+      channels = Channel::Whatsapp.where(provider: 'native').select do |channel|
+        channel.provider_connection['connection'] == 'open'
+      end
+
+      if channels.empty?
+        puts 'no native inbox is recorded as connected; nothing to re-assert.'
+        next
+      end
+
+      puts "re-asserting #{channels.size} native inbox(es), #{batch} at a time, #{pause}s apart"
+      failures = 0
+      channels.each_slice(batch).with_index do |slice, index|
+        # Paced, and the pacing is the point: `wa:control` is one stream for the whole fleet, so
+        # a wake per inbox in the same second is the stampede its retention cannot absorb
+        # (fazer-ai/whatsapp-connector#170). Each account brought back also dials, in a connector
+        # process that has just started.
+        sleep(pause) unless index.zero?
+        slice.each do |channel|
+          channel.setup_channel_provider
+          puts "  inbox #{channel.inbox&.id}: asked"
+        rescue StandardError => e
+          failures += 1
+          # One inbox that cannot be reached is not a reason to leave the rest down, which is the
+          # whole failure mode this task exists to end.
+          puts "  inbox #{channel.inbox&.id}: #{e.class}: #{e.message}"
+        end
+      end
+
+      puts failures.zero? ? 'done' : "done, #{failures} inbox(es) could not be asked; run again for those"
+    end
+  end
+
 end
 # rubocop:enable Metrics/BlockLength
 

--- a/spec/lib/tasks/rake/task_whatsapp_session_reassert_spec.rb
+++ b/spec/lib/tasks/rake/task_whatsapp_session_reassert_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Rake::Task do
     open_channel = native_channel('open')
     closed_channel = native_channel('close')
     asked = []
-    allow_any_instance_of(Channel::Whatsapp).to receive(:setup_channel_provider) { |channel| asked << channel.id } # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Channel::Whatsapp).to receive(:reassert_desired_state) { |channel| asked << channel.id } # rubocop:disable RSpec/AnyInstance
 
     task.invoke
 
@@ -46,7 +46,7 @@ RSpec.describe Rake::Task do
     first = native_channel('open')
     second = native_channel('open')
     asked = []
-    allow_any_instance_of(Channel::Whatsapp).to receive(:setup_channel_provider) do |channel| # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Channel::Whatsapp).to receive(:reassert_desired_state) do |channel| # rubocop:disable RSpec/AnyInstance
       raise Whatsapp::Session::Errors::ProviderUnavailable, 'nope' if channel.id == first.id
 
       asked << channel.id
@@ -58,16 +58,32 @@ RSpec.describe Rake::Task do
 
   it 'says there is nothing to do rather than asking anything' do
     native_channel('close')
-    allow_any_instance_of(Channel::Whatsapp).to receive(:setup_channel_provider) # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Channel::Whatsapp).to receive(:reassert_desired_state) # rubocop:disable RSpec/AnyInstance
 
     expect { task.invoke }.to output(/nothing to re-assert/).to_stdout
+  end
+
+  # The failure this task runs in the middle of is a connector that is not answering, so what it
+  # must not do is destroy the very thing it selects on. Measured against the real facade, with
+  # no stub over its state writes: an inbox it could not reach is still recorded as `open`
+  # afterwards, and the rerun the task tells the operator to do finds it again.
+  it 'leaves an inbox it could not reach eligible for the next run' do
+    channel = native_channel('open')
+    backend = instance_double(Whatsapp::Session::Backends::Connector::Backend)
+    allow(backend).to receive(:connect).and_raise(Whatsapp::Session::Errors::ProviderUnavailable, 'down')
+    allow_any_instance_of(Whatsapp::Session::Facade).to receive(:backend).and_return(backend) # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Whatsapp::Session::Facade).to receive(:capability?).and_return(false) # rubocop:disable RSpec/AnyInstance
+
+    expect { task.invoke }.to output(/could not be asked/).to_stdout
+
+    expect(channel.reload.provider_connection['connection']).to eq('open')
   end
 
   # The control stream is one for the whole fleet, so the batch size is not a convenience: a wake
   # per inbox in the same second is the stampede it cannot absorb.
   it 'waits between batches, and not before the first one' do
     3.times { native_channel('open') }
-    allow_any_instance_of(Channel::Whatsapp).to receive(:setup_channel_provider) # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Channel::Whatsapp).to receive(:reassert_desired_state) # rubocop:disable RSpec/AnyInstance
     pauses = []
     allow_any_instance_of(Object).to receive(:sleep) { |_, seconds| pauses << seconds } # rubocop:disable RSpec/AnyInstance
 

--- a/spec/lib/tasks/rake/task_whatsapp_session_reassert_spec.rb
+++ b/spec/lib/tasks/rake/task_whatsapp_session_reassert_spec.rb
@@ -1,0 +1,78 @@
+require 'rake'
+require 'rails_helper'
+
+# The deploy step behind fazer-ai/whatsapp-connector#194. The connector's resume sweep reads
+# which accounts should be up from a table only a `session.connect` writes, and the upgrade that
+# introduces the sweep creates that table empty: the fleet it was built to recover is the one it
+# cannot see. This is the side that knows, saying so once.
+RSpec.describe Rake::Task do
+  subject(:task) { described_class['whatsapp:session:reassert'] }
+
+  let(:account) { create(:account) }
+
+  before do
+    described_class.clear
+    Chatwoot::Application.load_tasks
+    # The pacing is real and this is a spec: without this the examples would sit out the pause.
+    allow_any_instance_of(Object).to receive(:sleep) # rubocop:disable RSpec/AnyInstance
+  end
+
+  def native_channel(connection)
+    create(:channel_whatsapp, provider: 'native', account: account,
+                              validate_provider_config: false, sync_templates: false).tap do |channel|
+      # update_column rather than update!: provider_connection is written by the state writer in
+      # production, and going through validations here would drag a provider call into a fixture.
+      channel.update_column(:provider_connection, # rubocop:disable Rails/SkipsModelValidations
+                            { 'connection' => connection, 'phone_number' => '5511999999999' })
+    end
+  end
+
+  it 'asks only the native inboxes this installation records as connected' do
+    open_channel = native_channel('open')
+    closed_channel = native_channel('close')
+    asked = []
+    allow_any_instance_of(Channel::Whatsapp).to receive(:setup_channel_provider) { |channel| asked << channel.id } # rubocop:disable RSpec/AnyInstance
+
+    task.invoke
+
+    expect(asked).to eq([open_channel.id])
+    expect(asked).not_to include(closed_channel.id)
+  end
+
+  # A provider that will not answer for one inbox is the state this task runs in the middle of,
+  # so stopping at the first failure would leave the rest of the fleet down -- which is the very
+  # thing it exists to end.
+  it 'goes on to the next inbox when one cannot be asked' do
+    first = native_channel('open')
+    second = native_channel('open')
+    asked = []
+    allow_any_instance_of(Channel::Whatsapp).to receive(:setup_channel_provider) do |channel| # rubocop:disable RSpec/AnyInstance
+      raise Whatsapp::Session::Errors::ProviderUnavailable, 'nope' if channel.id == first.id
+
+      asked << channel.id
+    end
+
+    expect { task.invoke }.not_to raise_error
+    expect(asked).to eq([second.id])
+  end
+
+  it 'says there is nothing to do rather than asking anything' do
+    native_channel('close')
+    allow_any_instance_of(Channel::Whatsapp).to receive(:setup_channel_provider) # rubocop:disable RSpec/AnyInstance
+
+    expect { task.invoke }.to output(/nothing to re-assert/).to_stdout
+  end
+
+  # The control stream is one for the whole fleet, so the batch size is not a convenience: a wake
+  # per inbox in the same second is the stampede it cannot absorb.
+  it 'waits between batches, and not before the first one' do
+    3.times { native_channel('open') }
+    allow_any_instance_of(Channel::Whatsapp).to receive(:setup_channel_provider) # rubocop:disable RSpec/AnyInstance
+    pauses = []
+    allow_any_instance_of(Object).to receive(:sleep) { |_, seconds| pauses << seconds } # rubocop:disable RSpec/AnyInstance
+
+    task.invoke(1, 7)
+
+    expect(pauses).to eq([7.0, 7.0])
+  end
+end


### PR DESCRIPTION
A metade Chatwoot da **fazer-ai/whatsapp-connector#194**, que é um passo de deploy e não um conserto de código.

## O problema

A varredura de retomada do conector (whatsapp-connector#183, mergeada) traz de volta a conta que ninguém está rodando, e é ela que fecha a janela órfã da #577. Só que ela lê quais contas deveriam estar de pé em `wac_session_desired`, uma tabela escrita **só** quando o conector executa um `session.connect` ou um `session.disconnect`. O `CREATE TABLE IF NOT EXISTS` do upgrade a cria vazia e nada a semeia, e o `Wanted` é inner join com a tabela de device.

No deploy que estreia a correção, então: toda conta já pareada tem linha de device e nenhuma tem linha de desired, a varredura não encontra candidato, e a frota fica órfã do mesmo jeito, em silêncio, até alguém abrir cada inbox e apertar conectar. A correção da #577 entra e não alcança ninguém.

## Por que o conserto não é do lado do conector

Semear a partir do pareamento parece a saída óbvia e decide algo que o conector não tem base para decidir: um `session.disconnect` mantém o device (só o logout apaga), então semear `connected` para toda linha discaria de volta a conta que o operador mandou parar. Conferi as quatro tabelas do store dele e nenhuma separa as duas: `wac_session_device.bound_at` é a hora do vínculo da credencial, e `wac_session_presence` é presença de chat (`available`/`unavailable`), como o comentário do `availability.go` diz com todas as letras.

Este lado sabe. `provider_connection['connection']` é `open` para as contas que a instalação quer no ar e `close` para as que ela parou, e o `ConnectionStateWriter` é o único que escreve ali. É a mesma conclusão a que a connector#170 já tinha chegado por outro caminho: "esta sessão deveria estar rodando só existe na cabeça do cliente".

## A tarefa

```
bin/rails "whatsapp:session:reassert"           # 4 por vez, 10s entre lotes
bin/rails "whatsapp:session:reassert[2,20]"     # mais devagar
```

Três decisões, com a razão de cada uma:

- **Em ritmo.** O `wa:control` é um stream só para a frota inteira, então um wake por inbox no mesmo segundo é exatamente a estampida que a connector#170 descreve. E cada conta trazida de volta **disca**, num processo de conector que acabou de subir.
- **Uma inbox que falha não interrompe as outras, e continua elegível.** Parar no primeiro erro deixaria o resto da frota no chão, que é a falha que isto existe para acabar. E a reafirmação não passa pelo `setup_channel_provider`: aquele reivindica uma tentativa de pareamento, escreve `connecting` por cima do estado guardado e transforma uma recusa em `close` com `connect_failure`, o que faria a reexecução pular exatamente as inboxes que ainda precisam ser pedidas. Num lote não há o que cercar, porque não existe QR na tela de ninguém para ficar velho, e quem mostra o resultado é o próprio conector, que empurra toda transição que vê (é por isso que este backend não declara polling de estado).
- **Seguro numa frota saudável.** Li o lado do conector antes de afirmar: `resume` devolve cedo quando o estado é `open`, `connecting` ou `reconnecting` (`internal/engine/whatsmeow/session.go:1427`), justamente para não discar ao lado do laço de retentativa do whatsmeow. Então uma sessão que já está no ar não é rediscada; o que acontece é o `PutDesired`, que é a linha que falta.

## O que foi medido

| mutante | resultado |
| --- | --- |
| m1 pedindo para toda inbox nativa, não só as `open` | 2 falhas |
| m2 `rescue` estreito (só `NotSupported`) | 1 falha |
| m3 pausando antes do primeiro lote | 1 falha |
| m4 provedor errado (`baileys` no lugar de `native`) | 3 falhas |
| m5 voltando a usar `setup_channel_provider` | 3 falhas |
| restaurado | 0 falhas |

m3 existe porque uma pausa antes do primeiro lote não quebra nada e só torna o passo mais lento, que é o tipo de coisa que ninguém nota e ninguém conserta.

m5 é o achado do codex nesta PR, e valeu a rodada: o primeiro desenho usava `setup_channel_provider` e destruía o próprio critério de seleção numa falha. O exemplo que o mata mede contra a facade de verdade, sem stub por cima das escritas de estado.

37 exemplos em `spec/lib/tasks`, verdes. RuboCop limpo. Suíte CE disparada na branch.

## O que isto não resolve

A whatsapp-connector#190: a linha de desired guarda `desired` e `asked_at` e mais nada, e o connect que a varredura sintetiza é `{"pairing":"resume"}` literal, então uma conta retomada **pela varredura** volta sem o que o cliente pediu, por exemplo `groups`. Uma conta retomada por esta tarefa não tem esse problema, porque aqui o connect é o de verdade, com as capacidades da inbox. As duas issues são a mesma lacuna vista de ângulos diferentes e quem for mexer na tabela decide as duas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/612)
<!-- Reviewable:end -->
