### PR TITLE
fix(whatsapp): parar de desistir, nessas duas, antes do provedor responder por si

### DIFF
--- a/app/services/whatsapp/baileys_request_options.rb
+++ b/app/services/whatsapp/baileys_request_options.rb
@@ -29,13 +29,17 @@
 module Whatsapp::BaileysRequestOptions
   BAILEYS_REQUEST_OPTIONS = { timeout: 90, max_retries: 0 }.freeze
 
-  # The calls that deliberately give up before the provider does. Each one is a read whose
-  # caller already treats silence as "I do not know" and changes nothing, so waiting out a
-  # wedged socket buys an answer nobody is going to act on. Two of the seven sites that
-  # carry this today are not that -- `import_session` and `disconnect_channel_provider` act
-  # on the outcome -- and keeping their existing 10s rather than raising it is deliberate:
-  # this change gives every call a ceiling and takes the silent retry away, and moving a
-  # ceiling that already exists is a decision about what a cut *means*, which is
-  # fazer-ai/chatwoot#600.
+  # The calls that deliberately give up before the provider does. Every one is a read whose
+  # caller already treats silence as "I do not know" and changes nothing: `get_profile_pic`,
+  # `fetch_reachout_timelock`, `fetch_send_health` and `fetch_new_chat_cap` answer nil, and
+  # `presence_subscribe` is rescued and logged by Conversations::PresenceSubscribeService. For
+  # those, waiting out a wedged socket buys an answer nobody is going to act on.
+  #
+  # Two calls used to sit here and no longer do. `import_session` and
+  # `disconnect_channel_provider` have callers that act on the outcome, and between 10s and the
+  # provider's own 75s cut they were giving up on an operation still in progress: the disconnect
+  # left `provider_connection` untouched, so an inbox whose session had in fact ended stayed
+  # recorded as open with nothing to correct it later, and the import answered the operator
+  # "try again" for an import that may have completed (fazer-ai/chatwoot#600).
   BAILEYS_SHORT_REQUEST_OPTIONS = { timeout: 10, max_retries: 0 }.freeze
 end

--- a/app/services/whatsapp/providers/whatsapp_baileys_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_baileys_service.rb
@@ -126,7 +126,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
         groupsEnabled: self.class.groups_enabled?,
         syncFullHistory: history_sync?
       }.compact.to_json,
-      **BAILEYS_SHORT_REQUEST_OPTIONS
+      **BAILEYS_REQUEST_OPTIONS
     )
 
     raise ProviderUnavailableError unless process_response(response)
@@ -150,7 +150,7 @@ class Whatsapp::Providers::WhatsappBaileysService < Whatsapp::Providers::BaseSer
     response = HTTParty.delete(
       "#{provider_url}/connections/#{whatsapp_channel.phone_number}",
       headers: api_headers,
-      **BAILEYS_SHORT_REQUEST_OPTIONS
+      **BAILEYS_REQUEST_OPTIONS
     )
     # 404 is the state being asked for, not a failure: the session is already gone, so
     # reporting it as one would abort a provider conversion, block the rejected-session

--- a/spec/services/whatsapp/baileys_request_options_spec.rb
+++ b/spec/services/whatsapp/baileys_request_options_spec.rb
@@ -88,7 +88,20 @@ describe Whatsapp::BaileysRequestOptions do
   it 'keeps the short ceiling on the calls that chose to give up before the provider does' do
     short = calls.count { |call| call.include?('BAILEYS_SHORT_REQUEST_OPTIONS') }
 
-    expect(short).to eq(7)
+    expect(short).to eq(5)
+  end
+
+  # Named rather than counted, because the rule for this side is about the caller and not about
+  # the number: a call belongs here only when whoever asked treats silence as "I do not know" and
+  # changes nothing. `import_session` and `disconnect_channel_provider` were here and act on the
+  # outcome, which is what fazer-ai/chatwoot#600 was.
+  it 'keeps the two calls whose caller acts on the outcome off the short ceiling' do
+    %w[import_session disconnect_channel_provider].each do |method|
+      body = source[/  def #{method}\b.*?\n  end\n/m]
+
+      expect(body).to include('**BAILEYS_REQUEST_OPTIONS')
+      expect(body).not_to include('BAILEYS_SHORT_REQUEST_OPTIONS')
+    end
   end
 
   # The one claim in this change that the text scan above cannot check, because it is about what


### PR DESCRIPTION
Fecha a #600.

O teto curto de 10s do provedor Baileys existe para as leituras cujo chamador já trata silêncio como "não sei" e não muda nada: `get_profile_pic`, `fetch_reachout_timelock`, `fetch_send_health` e `fetch_new_chat_cap` devolvem `nil`, e `presence_subscribe` é rescueado e logado em `Conversations::PresenceSubscribeService`. Duas das sete chamadas que o usavam não são isso.

## `disconnect_channel_provider`

Roda numa ação de controller, e a ação é esta:

```ruby
channel.disconnect_channel_provider
channel.update_provider_connection!(connection: 'close') if ...
head :ok
rescue Whatsapp::Session::Errors::Error => e
  render_session_error(e)
```

Quando a chamada falha, o `update_provider_connection!` **não roda**. Como o provedor só responde por si aos 75s (`PROXY_REQUEST_TIMEOUT_MS` no baileys-api), qualquer desconectar que levasse entre 10 e 75 segundos era abandonado por nós: a inbox cuja sessão de fato terminou ficava registrada como `open`, e nada corrige isso depois.

A mensagem em si já era honesta, e eu tinha errado isso no primeiro relato da issue: o método separa `disconnect_refused` (o provedor respondeu não-2xx) de `disconnect_unreachable` (não houve resposta), e um estouro cai na segunda. O que estava errado não era a frase, era o registro.

## `import_session`

Também ação de controller, e um `ProviderUnavailable` vira 503 com "Please try again". Para um import que pode ter concluído, essa é a instrução errada: as credenciais vêm da extensão e reimportar não é grátis.

## A mudança

As duas passam para `BAILEYS_REQUEST_OPTIONS`, que fica acima do corte que o provedor aplica a si mesmo. O que volta passa a ser a resposta dele e não um palpite nosso.

O custo, dito por inteiro: num caso patológico o operador espera até 75s em vez de 10. A troca é não registrar como conectada uma sessão que já não existe, e é a mesma que o envio já fazia de propósito desde que aquele teto foi escolhido.

Vale lembrar o que um teto de fato limita, medido na #611: é uma operação de socket, não a requisição. Contra um servidor que responde um byte a cada 300ms com `read_timeout = 1s`, a requisição completou em 11,8s. Então o que muda aqui não é quanto a chamada pode levar, é quanto o provedor pode ficar pensando antes de começar a responder, que é exatamente a espera que os 75s dele ocupam.

## A cerca

Deixou de contar sete e passou a contar cinco, e ganhou um exemplo que **nomeia** as duas em vez de só contar, porque o critério deste lado é sobre o chamador e não sobre o número: uma sétima chamada entrando no teto curto amanhã passaria numa contagem ajustada e não passa numa que pergunta por estas duas.

| mutante | resultado |
| --- | --- |
| m1 `import_session` de volta ao teto curto | 1 falha |
| m2 `disconnect_channel_provider` de volta ao teto curto | 2 falhas |
| m3 teto curto igualado ao padrão | 1 falha |
| restaurado | 0 falhas |

1999 exemplos em `spec/services/whatsapp` mais o `inboxes_controller_spec`, verdes. RuboCop limpo. Suíte CE disparada na branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/613)
<!-- Reviewable:end -->
