### PR TITLE
fix(whatsapp): fechar o segundo eixo do teto no cliente uazapi

### DIFF
--- a/app/services/whatsapp/session/backends/uazapi/client.rb
+++ b/app/services/whatsapp/session/backends/uazapi/client.rb
@@ -16,6 +16,13 @@ class Whatsapp::Session::Backends::Uazapi::Client
   UPLOAD_TIMEOUT = 60
   OPEN_TIMEOUT = 5
 
+  # `Net::HTTP` retries an idempotent request once by default, so every ceiling above
+  # buys half of what it reads as: measured here, a GET at `read_timeout: 3` against a
+  # socket that accepts and never answers took 6.0s, and 3.0s with this. The `get`s are
+  # the status reads, one of which runs inside the pairing poll, so the doubling landed
+  # on the loop that is already waiting.
+  MAX_RETRIES = 0
+
   # HTTP status -> contract error code, resolved to a class at raise time by
   # `Errors.build`. Codes rather than classes on purpose: a frozen hash of class objects
   # keeps the ones from before the last reload, and a `rescue` in a caller that did
@@ -100,7 +107,7 @@ class Whatsapp::Session::Backends::Uazapi::Client
   # large body (a group photo travels as base64) would otherwise hold a worker for
   # Net::HTTP's own write default, well past the ceiling this class advertises.
   def filtered(method, path, query, payload, timeout)
-    options = { open_timeout: OPEN_TIMEOUT, read_timeout: timeout, write_timeout: timeout }
+    options = { open_timeout: OPEN_TIMEOUT, read_timeout: timeout, write_timeout: timeout, max_retries: MAX_RETRIES }
     response = SsrfFilter.public_send(method, url(path), headers: headers, body: payload, params: query.presence,
                                                          sensitive_headers: [TOKEN_HEADER], http_options: options)
     [response.code.to_i, response.body]
@@ -120,7 +127,7 @@ class Whatsapp::Session::Backends::Uazapi::Client
   # a misconfiguration or somebody standing in front of it, and both read better as the
   # provider being unreachable.
   def direct(method, path, query, payload, timeout)
-    options = { headers: headers, timeout: timeout, open_timeout: OPEN_TIMEOUT, no_follow: true }
+    options = { headers: headers, timeout: timeout, open_timeout: OPEN_TIMEOUT, no_follow: true, max_retries: MAX_RETRIES }
     options[:query] = query if query.present?
     options[:body] = payload if payload.present?
     response = HTTParty.public_send(method, url(path), **options)

--- a/spec/services/whatsapp/session/backends/uazapi/client_spec.rb
+++ b/spec/services/whatsapp/session/backends/uazapi/client_spec.rb
@@ -73,6 +73,54 @@ RSpec.describe Whatsapp::Session::Backends::Uazapi::Client do
     expect(WebMock).not_to have_requested(:post, 'https://evil.test/x')
   end
 
+  # `Net::HTTP` retries an idempotent request once by default, so the ceilings this class
+  # advertises were worth half of what they read as on every `get`: measured against a
+  # socket that accepts and never answers, a GET at `read_timeout: 3` took 6.0s, and 3.0s
+  # once the retry was closed. One of those `get`s runs inside the pairing poll, so the
+  # doubling landed on a loop that is already waiting.
+  #
+  # Both transports, because which one runs is decided by a deployment variable and the
+  # ceiling cannot depend on that.
+  describe 'the second axis of the ceiling' do
+    it 'closes the retry on the filtered transport' do
+      options = nil
+      allow(SsrfFilter).to receive(:get) do |_uri, **kwargs|
+        options = kwargs[:http_options]
+        instance_double(Net::HTTPOK, code: '200', body: '{}')
+      end
+
+      client.get('/instance/status')
+
+      expect(options).to include(max_retries: 0)
+    end
+
+    it 'closes the retry on the private-network transport' do
+      options = nil
+      allow(HTTParty).to receive(:get) do |_url, **kwargs|
+        options = kwargs
+        instance_double(HTTParty::Response, code: 200, body: '{}')
+      end
+
+      allow(Resolv).to receive(:getaddresses).with('uazapi.test').and_return(['10.0.0.5'])
+      with_modified_env SAFE_FETCH_ALLOW_PRIVATE_NETWORK: 'true' do
+        client.get('/instance/status')
+      end
+
+      expect(options).to include(max_retries: 0)
+    end
+
+    # A fence, not a checklist. The two examples above each hold one transport, and they
+    # hold nothing about a third: this class picks its transport from a deployment
+    # variable, so a call added outside `direct` and `filtered` would carry neither
+    # ceiling and no example here would notice.
+    it 'reaches the network in those two places and nowhere else' do
+      source = File.read(Rails.root.join('app/services/whatsapp/session/backends/uazapi/client.rb'))
+
+      expect(source.scan('HTTParty.').size).to eq(1)
+      expect(source.scan('SsrfFilter.public_send').size).to eq(1)
+    end
+  end
+
   describe 'what it makes of a failure' do
     # The class decides what the caller does next: a retryable error keeps an outbound
     # message in the queue, a non-retryable one puts the reason in front of the agent.


### PR DESCRIPTION
O provedor `uazapi` anuncia um teto de espera por chamada, mas todo `GET` custava o dobro dele: `Net::HTTP` repete uma requisição idempotente uma vez por padrão. Na prática, uma instância que aceita a conexão e para de responder segurava um worker por 40s onde a classe dizia 20s, e o pior caso é a leitura de status que roda dentro do laço de pareamento, que já é espera.

Medido aqui, contra um socket que aceita e nunca responde:

| chamada | hoje | com `max_retries: 0` |
| --- | --- | --- |
| GET `read_timeout: 3` (transporte filtrado, `Net::HTTP.start`) | 6,0s | 3,0s |
| GET `timeout: 3` (transporte direto, HTTParty) | 6,0s | 3,0s |
| POST `timeout: 3` (controle, não é idempotente) | 3,0s | 3,0s |

Os dois transportes ganham a opção, porque quem escolhe entre eles é `SAFE_FETCH_ALLOW_PRIVATE_NETWORK` e um teto não pode depender de variável de deployment. No caminho filtrado a opção viaja no `http_options` do `SsrfFilter`, que o repassa inteiro para o `Net::HTTP.start`, e o `start` aplica qualquer chave que tenha escritor: conferido que `max_retries: 0` chega no objeto.

## Closes

Fecha a família `uazapi` da #589. A issue continua aberta para as demais famílias (Telegram, Instagram, TikTok, Twilio, Linear, Dyte, Cloudflare, Clearbit, Firecrawl, Captain e o crawler), que são 50 pontos de chamada sem teto nenhum.

## What changed

- `MAX_RETRIES = 0` ao lado dos tetos que já existiam, com a medição escrita no comentário.
- A opção entra nos dois construtores de opções, `filtered` e `direct`.
- Três exemplos no spec: um por transporte, mais uma cerca de que a classe alcança a rede nesses dois lugares e em nenhum outro. Um transporte novo entra sem teto e sem ninguém perceber, que é o que a cerca impede.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/614)
<!-- Reviewable:end -->
