### PR TITLE
fix(http): fechar o segundo eixo onde o teto já tinha sido escolhido

### DIFF
--- a/app/jobs/internal/check_new_versions_job.rb
+++ b/app/jobs/internal/check_new_versions_job.rb
@@ -11,7 +11,9 @@ class Internal::CheckNewVersionsJob < ApplicationJob
   private
 
   def fetch_latest_github_release
-    response = HTTParty.get('https://api.github.com/repos/fazer-ai/chatwoot/releases/latest', timeout: 5)
+    # `max_retries: 0` alongside the ceiling: `Net::HTTP` repeats an idempotent request
+    # once by default, so 5 seconds was 10 against a GitHub that accepts and stalls.
+    response = HTTParty.get('https://api.github.com/repos/fazer-ai/chatwoot/releases/latest', timeout: 5, max_retries: 0)
     unless response.success?
       Rails.logger.error "Failed to fetch latest GitHub release: HTTP #{response.code} - #{response.body}"
       return nil

--- a/app/services/data_imports/freshdesk/client.rb
+++ b/app/services/data_imports/freshdesk/client.rb
@@ -91,12 +91,16 @@ class DataImports::Freshdesk::Client
   def request(path, query: {})
     response =
       begin
+        # `max_retries: 0` alongside the ceiling: `Net::HTTP` repeats an idempotent request
+        # once by default, so a page this import waits 30 seconds for cost 60 against a
+        # server that accepts the connection and then stops answering.
         HTTParty.get(
           "https://#{@domain}/api/v2#{path}",
           query: query,
           basic_auth: { username: @api_key, password: 'X' },
           headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' },
-          timeout: 30
+          timeout: 30,
+          max_retries: 0
         )
       rescue StandardError => e
         raise Error.new(

--- a/app/services/data_imports/intercom/client.rb
+++ b/app/services/data_imports/intercom/client.rb
@@ -53,11 +53,15 @@ class DataImports::Intercom::Client
   def get(path, query: {})
     response =
       begin
+        # `max_retries: 0` alongside the ceiling: `Net::HTTP` repeats an idempotent request
+        # once by default, so a page this import waits 30 seconds for cost 60 against a
+        # server that accepts the connection and then stops answering.
         HTTParty.get(
           "#{BASE_URL}#{path}",
           query: query,
           headers: headers,
-          timeout: 30
+          timeout: 30,
+          max_retries: 0
         )
       rescue StandardError => e
         raise Error.new(

--- a/spec/jobs/internal/check_new_versions_job_spec.rb
+++ b/spec/jobs/internal/check_new_versions_job_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe Internal::CheckNewVersionsJob do
       end
     end
 
+    # `Net::HTTP` repeats an idempotent request once by default, so this job's five seconds
+    # were ten against a GitHub that accepts the connection and then stalls, on a schedule.
+    it 'asks once, so the ceiling it advertises is the one it spends' do
+      options = nil
+      allow(HTTParty).to receive(:get) do |_url, **kwargs|
+        options = kwargs
+        instance_double(HTTParty::Response, success?: false, code: 500, body: '')
+      end
+      allow(Rails.logger).to receive(:error)
+
+      job
+
+      expect(options).to eq(timeout: 5, max_retries: 0)
+    end
+
     context 'when GitHub API returns failed response' do
       before do
         stub_request(:get, 'https://api.github.com/repos/fazer-ai/chatwoot/releases/latest')

--- a/spec/services/data_imports/freshdesk/client_spec.rb
+++ b/spec/services/data_imports/freshdesk/client_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe DataImports::Freshdesk::Client do
         },
         basic_auth: { username: 'secret', password: 'X' },
         headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' },
-        timeout: 30
+        timeout: 30,
+        max_retries: 0
       )
       expect(page.data).to eq([{ 'id' => 2001 }])
       expect(page.next_page).to eq(3)

--- a/spec/services/data_imports/intercom/client_spec.rb
+++ b/spec/services/data_imports/intercom/client_spec.rb
@@ -13,5 +13,21 @@ RSpec.describe DataImports::Intercom::Client do
         expect(error.body).to include(transport_error_class: 'SocketError')
       end
     end
+
+    # `Net::HTTP` repeats an idempotent request once by default, so the 30 seconds this
+    # client advertises were 60 against a server that accepts the connection and then
+    # stops answering, once per page of an import that pages.
+    it 'asks once, so the ceiling it advertises is the one it spends' do
+      response = instance_double(HTTParty::Response, success?: true, parsed_response: { 'data' => [] })
+      options = nil
+      allow(HTTParty).to receive(:get) do |_url, **kwargs|
+        options = kwargs
+        response
+      end
+
+      client.list_contacts
+
+      expect(options).to include(timeout: 30, max_retries: 0)
+    end
   end
 end


### PR DESCRIPTION
Três chamadas HTTP que já tinham escolhido um teto de espera gastavam o dobro dele, porque `Net::HTTP` repete uma requisição idempotente uma vez por padrão e as três são GET. O número escrito no código não muda nesta PR: o que muda é ele passar a ser o que se gasta.

| chamada | anunciava | gastava | onde dói |
| --- | --- | --- | --- |
| verificação de versão nova (GitHub) | 5s | 10s | job agendado |
| cliente do Freshdesk | 30s | 60s | por página, dentro da importação |
| cliente do Intercom | 30s | 60s | por página, dentro da importação |

Medido contra um socket que aceita a conexão e nunca responde: GET com `timeout: 3` leva 6,0s, e 3,0s com `max_retries: 0`. O POST de controle leva 3,0s nos dois casos, que é o motivo de só os GET estarem nesta lista.

## Closes

Avança a #589: depois desta e da #614, não sobra nenhum ponto de chamada com um eixo só. Continuam abertos os 49 sem teto nenhum, que precisam de decisão por família e não de varredura.

## What changed

- `max_retries: 0` ao lado do `timeout` já existente nos três pontos, com o porquê escrito onde a próxima pessoa vai ler.
- Um exemplo por ponto, prendendo as duas opções juntas. No Freshdesk o spec já conferia o hash inteiro de opções, então foi ele que passou a conferir a nova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/615)
<!-- Reviewable:end -->
