### PR TITLE
fix(integrations): write to the row, not to the copy read before the call

### DIFF
--- a/app/models/channel/email.rb
+++ b/app/models/channel/email.rb
@@ -37,6 +37,7 @@
 
 class Channel::Email < ApplicationRecord
   include Channelable
+  include JsonColumnMerge
   include Reauthorizable
 
   AUTHORIZATION_ERROR_THRESHOLD = 10

--- a/app/models/concerns/json_column_merge.rb
+++ b/app/models/concerns/json_column_merge.rb
@@ -62,6 +62,37 @@ module JsonColumnMerge
     false
   end
 
+  # The case the merge above cannot cover: the key being written is the key another writer just
+  # wrote. Two OAuth refreshes of the same row both write `refresh_token`, both exchanged the same
+  # one, and a provider that rotates refresh tokens invalidates the old one, so only one of the two
+  # pairs is live. Merging leaves whichever wrote last, which can be the dead one, and then the row
+  # holds a token the provider will not honour. Last writer wins is the wrong rule here, and no
+  # amount of merging changes that: the loser has to notice.
+  #
+  # `expect` is read under the same lock as the write, so it is a compare-and-set and not a check
+  # followed by a hope: each key's stored value has to still be what the caller based its call on.
+  # An empty `expect` is a write with no precondition, which is what `merge_json_column!` already is.
+  #
+  # Answers what happened, unlike the merge, which answers only whether it wrote. A caller that has
+  # to log a rotation it spent and hand back the value that won needs the three cases apart, and a
+  # boolean would collapse "someone else got there first" into "there was nothing to write".
+  def swap_json_column!(column, expect:, merge: {}, attributes: {})
+    self.class.transaction do
+      row = self.class.lock.find(id)
+      current = row[column] || {}
+
+      next :stale unless expect.deep_stringify_keys.all? { |key, value| current[key] == value }
+
+      params = attributes.to_h.merge(column => merged_attributes(current, merge: merge, remove: [], under: nil))
+      next :unchanged if params.all? { |name, value| row[name] == value }
+
+      row.update!(params)
+      :written
+    end
+  rescue ActiveRecord::RecordNotFound
+    :gone
+  end
+
   private
 
   def merged_attributes(current, merge:, remove:, under:)

--- a/app/models/integrations/hook.rb
+++ b/app/models/integrations/hook.rb
@@ -15,6 +15,7 @@
 #  reference_id :string
 #
 class Integrations::Hook < ApplicationRecord
+  include JsonColumnMerge
   include Reauthorizable
 
   attr_readonly :app_id, :account_id, :inbox_id, :hook_type

--- a/app/services/base_refresh_oauth_token_service.rb
+++ b/app/services/base_refresh_oauth_token_service.rb
@@ -34,13 +34,26 @@ class BaseRefreshOauthTokenService
     channel.reload.provider_config
   end
 
+  # The three keys the refresh owns, merged into the row rather than assigned over it. What used to
+  # happen is that the whole column was replaced: anything else stored in `provider_config` was
+  # erased on the first refresh, silently. Not hypothetical -- `Platform::Api::V1::EmailChannelMigrationsController`
+  # writes this column from a payload that permits an open hash, so a migrated channel can hold keys
+  # that nobody here knows about.
+  #
+  # This does NOT make two concurrent refreshes safe, and the merge is not what would make them
+  # safe: both exchanged the same refresh token before either wrote, so both hold a token the
+  # provider issued, and the row cannot tell which one the provider still honours. That needs one
+  # refresh in flight per channel, which is a lock held across a network round trip, and it is
+  # filed separately.
   def update_channel_provider_config(new_tokens)
-    channel.provider_config = {
-      access_token: new_tokens[:access_token],
-      refresh_token: new_tokens[:refresh_token],
-      expires_on: Time.at(new_tokens[:expires_at]).utc.to_s
-    }
-    channel.save!
+    channel.merge_json_column!(
+      :provider_config,
+      merge: {
+        access_token: new_tokens[:access_token],
+        refresh_token: new_tokens[:refresh_token],
+        expires_on: Time.at(new_tokens[:expires_at]).utc.to_s
+      }
+    )
   end
 
   private

--- a/app/services/base_refresh_oauth_token_service.rb
+++ b/app/services/base_refresh_oauth_token_service.rb
@@ -23,15 +23,22 @@ class BaseRefreshOauthTokenService
   # Refresh the access tokens using the refresh token
   # Refer: https://github.com/microsoftgraph/msgraph-sample-rubyrailsapp/tree/b4a6869fe4a438cde42b161196484a929f1bee46
   def refresh_tokens
-    raise 'A refresh_token is not available' if provider_config[:refresh_token].blank?
+    spent_refresh_token = provider_config[:refresh_token]
+    raise 'A refresh_token is not available' if spent_refresh_token.blank?
 
     oauth_strategy = build_oauth_strategy
     token_service = build_token_service(oauth_strategy)
 
     new_tokens = token_service.refresh!.to_hash.slice(:access_token, :refresh_token, :expires_at)
 
-    update_channel_provider_config(new_tokens)
-    channel.reload.provider_config
+    update_channel_provider_config(new_tokens, spent_refresh_token: spent_refresh_token)
+    # Re-read, and replace the memo with it. Two things depend on this being the row rather than the
+    # copy this object started with: the caller reads `[:access_token]` off what comes back, and when
+    # the write did not land, what comes back has to be the token set that did. `with_indifferent_access`
+    # because the column is a jsonb read back with String keys, and every reader here asks with symbols;
+    # handing the raw hash up made `access_token` answer nil, which is what
+    # `Imap::MicrosoftFetchEmailService` passes as the IMAP password.
+    @provider_config = channel.reload.provider_config.with_indifferent_access
   end
 
   # The three keys the refresh owns, merged into the row rather than assigned over it. What used to
@@ -40,20 +47,33 @@ class BaseRefreshOauthTokenService
   # writes this column from a payload that permits an open hash, so a migrated channel can hold keys
   # that nobody here knows about.
   #
-  # This does NOT make two concurrent refreshes safe, and the merge is not what would make them
-  # safe: both exchanged the same refresh token before either wrote, so both hold a token the
-  # provider issued, and the row cannot tell which one the provider still honours. That needs one
-  # refresh in flight per channel, which is a lock held across a network round trip, and it is
-  # filed separately.
-  def update_channel_provider_config(new_tokens)
-    channel.merge_json_column!(
+  # The merge alone does not make two concurrent refreshes safe, and it never could: both exchanged
+  # the same refresh token before either wrote, so the keys the loser writes are the keys the winner
+  # already wrote and there is nothing to merge them with. A provider that rotates refresh tokens
+  # invalidates the one it just replaced, so only one of the two pairs is live, and last writer wins
+  # can leave the row holding the dead one. The channel then stops fetching until somebody reconnects
+  # it by hand.
+  #
+  # So the write is conditional on the row still holding the refresh token this call spent. Losing is
+  # not an error and does not raise: the other refresh already stored a live pair, the caller re-reads
+  # and gets it. What losing must not be is silent, because the rotation this call spent is gone and
+  # the provider has seen a token the row never held.
+  def update_channel_provider_config(new_tokens, spent_refresh_token:)
+    result = channel.swap_json_column!(
       :provider_config,
+      expect: { refresh_token: spent_refresh_token },
       merge: {
         access_token: new_tokens[:access_token],
         refresh_token: new_tokens[:refresh_token],
         expires_on: Time.at(new_tokens[:expires_at]).utc.to_s
       }
     )
+
+    return result unless result == :stale
+
+    Rails.logger.warn("[OAUTH] Refresh for #{channel.class.name} #{channel.id} was not stored: the row no longer " \
+                      'holds the refresh token this call spent, so another refresh rotated it first')
+    result
   end
 
   private

--- a/lib/integrations/linear/access_token_service.rb
+++ b/lib/integrations/linear/access_token_service.rb
@@ -60,22 +60,29 @@ class Integrations::Linear::AccessTokenService
     fallback_access_token
   end
 
+  # Only the keys this response carries, merged into the row. It used to read `hook.settings` off
+  # this object -- loaded before the token call -- and write that copy back, so anything written to
+  # the hook while Linear was answering was erased. The `|| current_settings[...]` fallbacks are
+  # gone with it: a key the response does not carry is simply not in the merge, which leaves the
+  # stored one standing without having to read it first.
+  #
+  # `merge_json_column!` deliberately leaves this object untouched, so the reload is what lets the
+  # callers read the token they just persisted.
   def persist_tokens(token_data)
     raise ArgumentError, 'Missing access token in Linear token response' if token_data['access_token'].blank?
 
-    current_settings = hook_settings
-    updated_settings = current_settings.merge(
-      token_type: token_data['token_type'] || current_settings[:token_type],
-      expires_in: token_data['expires_in'] || current_settings[:expires_in],
-      expires_on: expires_on(token_data['expires_in']),
-      scope: token_data['scope'] || current_settings[:scope],
-      refresh_token: token_data['refresh_token'] || current_settings[:refresh_token]
-    ).compact
-
-    hook.update!(
-      access_token: token_data['access_token'],
-      settings: updated_settings
+    hook.merge_json_column!(
+      :settings,
+      merge: {
+        token_type: token_data['token_type'],
+        expires_in: token_data['expires_in'],
+        expires_on: (expires_on(token_data['expires_in']) if token_data['expires_in'].present?),
+        scope: token_data['scope'],
+        refresh_token: token_data['refresh_token']
+      }.compact,
+      attributes: { access_token: token_data['access_token'] }
     )
+    hook.reload
   end
 
   def token_valid?

--- a/lib/integrations/linear/access_token_service.rb
+++ b/lib/integrations/linear/access_token_service.rb
@@ -18,12 +18,14 @@ class Integrations::Linear::AccessTokenService
   private
 
   def refresh_access_token
+    spent_refresh_token = refresh_token
+
     response = HTTParty.post(
       TOKEN_URL,
       headers: url_encoded_headers,
       body: {
         grant_type: 'refresh_token',
-        refresh_token: refresh_token,
+        refresh_token: spent_refresh_token,
         client_id: client_id,
         client_secret: client_secret
       },
@@ -32,7 +34,7 @@ class Integrations::Linear::AccessTokenService
 
     return fallback_access_token unless response.success?
 
-    persist_tokens(response.parsed_response)
+    persist_tokens(response.parsed_response, spent_refresh_token: spent_refresh_token)
     hook.access_token
   rescue StandardError => e
     Rails.logger.error("Linear token refresh failed for hook #{hook.id}: #{e.message}")
@@ -66,13 +68,21 @@ class Integrations::Linear::AccessTokenService
   # gone with it: a key the response does not carry is simply not in the merge, which leaves the
   # stored one standing without having to read it first.
   #
-  # `merge_json_column!` deliberately leaves this object untouched, so the reload is what lets the
-  # callers read the token they just persisted.
-  def persist_tokens(token_data)
+  # `swap_json_column!` deliberately leaves this object untouched, so the reload is what lets the
+  # callers read the token that is now in the row.
+  #
+  # `spent_refresh_token` is the precondition of a refresh: the row has to still hold the token this
+  # call exchanged. When it does not, an OAuth reconnection landed while Linear was answering, and
+  # its tokens are the live ones because an admin just authorised them. Writing over them would undo
+  # the reconnection and leave the integration on a token Linear invalidated when it issued the new
+  # pair. The legacy migration passes nothing, because it exchanges the access token rather than a
+  # rotating refresh token, and there is no earlier value of it to compare against here.
+  def persist_tokens(token_data, spent_refresh_token: nil)
     raise ArgumentError, 'Missing access token in Linear token response' if token_data['access_token'].blank?
 
-    hook.merge_json_column!(
+    result = hook.swap_json_column!(
       :settings,
+      expect: spent_refresh_token.present? ? { refresh_token: spent_refresh_token } : {},
       merge: {
         token_type: token_data['token_type'],
         expires_in: token_data['expires_in'],
@@ -82,6 +92,12 @@ class Integrations::Linear::AccessTokenService
       }.compact,
       attributes: { access_token: token_data['access_token'] }
     )
+
+    if result == :stale
+      Rails.logger.warn("[LINEAR] Token refresh for hook #{hook.id} was not stored: the row no longer holds the " \
+                        'refresh token this call spent, so a reconnection or another refresh replaced it first')
+    end
+
     hook.reload
   end
 

--- a/lib/integrations/slack/channel_builder.rb
+++ b/lib/integrations/slack/channel_builder.rb
@@ -14,8 +14,15 @@ class Integrations::Slack::ChannelBuilder
     return if channel.blank?
 
     slack_client.conversations_join(channel: channel[:id]) if channel[:is_private] == false
-    @hook.update!(reference_id: channel[:id], settings: { channel_name: channel[:name] }, status: 'enabled')
-    @hook
+    # `channel_name` is the only settings key this owns. Replacing the column, which is what this
+    # did, erased every other key a hook had -- and `PATCH .../integrations/hooks/:id` permits
+    # `settings` as an open hash, so there is a supported way to put keys there.
+    @hook.merge_json_column!(
+      :settings,
+      merge: { channel_name: channel[:name] },
+      attributes: { reference_id: channel[:id], status: 'enabled' }
+    )
+    @hook.reload
   end
 
   private

--- a/spec/lib/integrations/linear/access_token_service_spec.rb
+++ b/spec/lib/integrations/linear/access_token_service_spec.rb
@@ -174,5 +174,100 @@ describe Integrations::Linear::AccessTokenService do
         expect(hook.settings['token_type']).to eq('Bearer')
       end
     end
+
+    context 'when another writer lands on the hook settings during the token call' do
+      let(:hook) do
+        create(
+          :integrations_hook,
+          :linear,
+          account: account,
+          access_token: 'old_access_token',
+          settings: {
+            refresh_token: 'refresh_token',
+            token_type: 'Bearer',
+            expires_on: 1.minute.from_now.utc.to_s
+          }
+        )
+      end
+
+      before do
+        stub_request(:post, 'https://api.linear.app/oauth/token').to_return do
+          # O outro escritor e a API publica de hooks (`PATCH .../integrations/hooks/:id`, que
+          # aceita `settings` como hash aberto). Gravado direto na linha porque a copia que o
+          # servico vai escrever de volta foi lida antes desta chamada.
+          Integrations::Hook.where(id: hook.id)
+                            .update_all("settings = settings || '{\"project_id\":\"ENG\"}'::jsonb")  # rubocop:disable Rails/SkipsModelValidations
+          {
+            status: 200,
+            body: { access_token: 'new_access_token', refresh_token: 'new_refresh_token', expires_in: 3600 }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          }
+        end
+      end
+
+      it 'keeps the key that landed while Linear was answering' do
+        described_class.new(hook: hook).access_token
+
+        expect(hook.reload.settings['project_id']).to eq('ENG')
+      end
+
+      it 'still writes the token it went to fetch' do
+        described_class.new(hook: hook).access_token
+
+        expect(hook.reload.access_token).to eq('new_access_token')
+        expect(hook.reload.settings['refresh_token']).to eq('new_refresh_token')
+      end
+
+      # The merge is taken on a separate row object, so this object still holds the old token until
+      # it is read again, and the callers return `hook.access_token`.
+      it 'hands the caller the token it just persisted' do
+        expect(described_class.new(hook: hook).access_token).to eq('new_access_token')
+      end
+    end
+
+    context 'when the response leaves out the keys the hook already has' do
+      let(:hook) do
+        create(
+          :integrations_hook,
+          :linear,
+          account: account,
+          access_token: 'old_access_token',
+          settings: {
+            refresh_token: 'refresh_token',
+            token_type: 'Bearer',
+            scope: 'read,write',
+            expires_on: 1.minute.from_now.utc.to_s
+          }
+        )
+      end
+
+      before do
+        stub_request(:post, 'https://api.linear.app/oauth/token').to_return(
+          status: 200,
+          body: { access_token: 'new_access_token' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'leaves the stored scope standing rather than writing nil over it' do
+        described_class.new(hook: hook).access_token
+
+        expect(hook.reload.settings['scope']).to eq('read,write')
+      end
+
+      # No `expires_in` in the response means the expiry this service can speak about did not
+      # change, so it writes nothing there. Rewriting it from the copy read before the call is how
+      # an expiry set during the call would be undone.
+      it 'does not rewrite the expiry it was not told about' do
+        stored = hook.settings['expires_on']
+        Integrations::Hook.where(id: hook.id)
+                          .update_all("settings = settings || '{\"expires_on\":\"2030-01-01 00:00:00 UTC\"}'::jsonb") # rubocop:disable Rails/SkipsModelValidations
+
+        described_class.new(hook: hook).access_token
+
+        expect(hook.reload.settings['expires_on']).to eq('2030-01-01 00:00:00 UTC')
+        expect(hook.reload.settings['expires_on']).not_to eq(stored)
+      end
+    end
   end
 end

--- a/spec/lib/integrations/linear/access_token_service_spec.rb
+++ b/spec/lib/integrations/linear/access_token_service_spec.rb
@@ -225,6 +225,63 @@ describe Integrations::Linear::AccessTokenService do
       end
     end
 
+    # Same shape, other axis, and the one the merge cannot reach: the writer that lands during the
+    # POST is an OAuth reconnection, so it writes the very keys this refresh is about to write. Its
+    # tokens are the live ones, because the admin just authorised them, and the refresh is holding a
+    # pair derived from a refresh token the row no longer has. Writing it back undoes the
+    # reconnection and leaves the integration on a token Linear has already invalidated.
+    context 'when an OAuth reconnection lands on the hook during the token call' do
+      let(:hook) do
+        create(
+          :integrations_hook,
+          :linear,
+          account: account,
+          access_token: 'old_access_token',
+          settings: {
+            refresh_token: 'refresh_token',
+            token_type: 'Bearer',
+            expires_on: 1.minute.from_now.utc.to_s
+          }
+        )
+      end
+
+      before do
+        allow(Rails.logger).to receive(:warn)
+        stub_request(:post, 'https://api.linear.app/oauth/token').to_return do
+          # `Linear::CallbacksController#handle_response`: the admin reconnected, so the row gets a
+          # new access token in its column and a new refresh token in its settings. Through its own
+          # AR object, which is what the controller does, and `access_token` is an encrypted column,
+          # so a raw UPDATE would write something the reader cannot decrypt.
+          reconnected = Integrations::Hook.find(hook.id)
+          reconnected.access_token = 'reconnected_access_token'
+          reconnected.settings = reconnected.settings.merge('refresh_token' => 'reconnected_refresh_token')
+          reconnected.save!
+          {
+            status: 200,
+            body: { access_token: 'new_access_token', refresh_token: 'new_refresh_token', expires_in: 3600 }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          }
+        end
+      end
+
+      it 'does not undo the reconnection' do
+        described_class.new(hook: hook).access_token
+
+        expect(hook.reload.access_token).to eq('reconnected_access_token')
+        expect(hook.reload.settings['refresh_token']).to eq('reconnected_refresh_token')
+      end
+
+      it 'hands the caller the token that is in the row' do
+        expect(described_class.new(hook: hook).access_token).to eq('reconnected_access_token')
+      end
+
+      it 'says the rotation it spent was not stored' do
+        described_class.new(hook: hook).access_token
+
+        expect(Rails.logger).to have_received(:warn).with(/refresh token this call spent/)
+      end
+    end
+
     context 'when the response leaves out the keys the hook already has' do
       let(:hook) do
         create(

--- a/spec/lib/integrations/slack/channel_builder_spec.rb
+++ b/spec/lib/integrations/slack/channel_builder_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe Integrations::Slack::ChannelBuilder do
+  let(:account) { create(:account) }
+  let(:hook) { create(:integrations_hook, account: account, settings: { channel_name: 'old-name', unfurl_links: true }) }
+  let(:slack_client) { instance_double(Slack::Web::Client) }
+
+  let(:channel) { { 'id' => 'C123', 'name' => 'support', 'is_private' => false } }
+
+  # Slack::Messages::Message e um Hashie::Mash, entao instance_double nao verifica o metodo:
+  # a resposta de verdade responde por chave, nao por metodo declarado na classe.
+  def conversations_list_response(channels)
+    Slack::Messages::Message.new(channels: channels, response_metadata: { next_cursor: nil })
+  end
+
+  before do
+    allow(Slack::Web::Client).to receive(:new).and_return(slack_client)
+    allow(slack_client).to receive(:conversations_list)
+      .with(hash_including(types: 'private_channel')).and_return(conversations_list_response([]))
+    allow(slack_client).to receive(:conversations_list)
+      .with(hash_including(types: 'public_channel')).and_return(conversations_list_response([channel]))
+  end
+
+  describe '#update_reference_id' do
+    context 'when the channel is joinable' do
+      before { allow(slack_client).to receive(:conversations_join).and_return(true) }
+
+      it 'writes the channel it was pointed at' do
+        described_class.new(hook: hook).update_reference_id('C123')
+
+        expect(hook.reload.reference_id).to eq('C123')
+        expect(hook.reload.settings['channel_name']).to eq('support')
+        expect(hook.reload.status).to eq('enabled')
+      end
+
+      it 'leaves the settings it does not own alone' do
+        described_class.new(hook: hook).update_reference_id('C123')
+
+        expect(hook.reload.settings['unfurl_links']).to be(true)
+      end
+
+      # The merge is taken on a separate row object on purpose, so the hook handed back has to be
+      # read again: the controller renders what this returns.
+      it 'hands back a hook that carries what was written' do
+        returned = described_class.new(hook: hook).update_reference_id('C123')
+
+        expect(returned.settings['channel_name']).to eq('support')
+        expect(returned.reference_id).to eq('C123')
+      end
+    end
+
+    # A escrita de terceiro que entra DURANTE a chamada de rede. O outro escritor e a API publica
+    # de hooks (`PATCH .../integrations/hooks/:id`, que aceita `settings` como hash aberto), e a
+    # gravacao direta na linha e o que torna o defeito reproduzivel sem thread: a copia que o
+    # builder escreve de volta nao e nem lida, ela e substituida por uma chave so.
+    context 'when another writer lands on the settings while Slack is answering' do
+      before do
+        allow(slack_client).to receive(:conversations_join) do
+          Integrations::Hook.where(id: hook.id)
+                            .update_all("settings = settings || '{\"alert_channel\":\"ops\"}'::jsonb") # rubocop:disable Rails/SkipsModelValidations
+          true
+        end
+      end
+
+      it 'keeps the key that landed during the join' do
+        described_class.new(hook: hook).update_reference_id('C123')
+
+        expect(hook.reload.settings['alert_channel']).to eq('ops')
+      end
+    end
+
+    context 'when the reference id names no channel' do
+      it 'writes nothing' do
+        expect(described_class.new(hook: hook).update_reference_id('C999')).to be_nil
+        expect(hook.reload.settings['channel_name']).to eq('old-name')
+      end
+    end
+  end
+end

--- a/spec/models/concerns/json_column_merge_spec.rb
+++ b/spec/models/concerns/json_column_merge_spec.rb
@@ -131,4 +131,88 @@ RSpec.describe JsonColumnMerge do
       end
     end
   end
+
+  describe '#swap_json_column!' do
+    let(:contact) { create(:contact, additional_attributes: { 'token' => 'T1', 'city' => 'Curitiba' }) }
+
+    it 'writes when the row still holds what the caller based its call on' do
+      expect(contact.swap_json_column!(:additional_attributes, expect: { 'token' => 'T1' }, merge: { 'token' => 'T2' }))
+        .to be(:written)
+      expect(contact.reload.additional_attributes).to eq('token' => 'T2', 'city' => 'Curitiba')
+    end
+
+    # The whole point: not an error, not a raise, and above all not a write. The caller has to be
+    # able to tell this apart from "there was nothing to write", which is why the answer is a symbol
+    # and not a boolean.
+    it 'writes nothing when another writer got there first' do
+      contact.update!(additional_attributes: { 'token' => 'T_OTHER', 'city' => 'Curitiba' })
+
+      expect(contact.swap_json_column!(:additional_attributes, expect: { 'token' => 'T1' }, merge: { 'token' => 'T2' }))
+        .to be(:stale)
+      expect(contact.reload.additional_attributes['token']).to eq('T_OTHER')
+    end
+
+    it 'compares the stored value whether the caller asked with a symbol or a string' do
+      expect(contact.swap_json_column!(:additional_attributes, expect: { token: 'T1' }, merge: { 'token' => 'T2' }))
+        .to be(:written)
+    end
+
+    it 'answers that it did not write when the write would change nothing' do
+      expect(contact.swap_json_column!(:additional_attributes, expect: { 'token' => 'T1' }, merge: { 'token' => 'T1' }))
+        .to be(:unchanged)
+    end
+
+    # A key the row does not have is not the value the caller expected, so an `expect` on it is a
+    # precondition that fails rather than one that is vacuously true.
+    it 'does not write when the key it expected is not there at all' do
+      contact.update!(additional_attributes: { 'city' => 'Curitiba' })
+
+      expect(contact.swap_json_column!(:additional_attributes, expect: { 'token' => 'T1' }, merge: { 'token' => 'T2' }))
+        .to be(:stale)
+    end
+
+    # The compare and the write have to come from the same locked read, or this is a check followed
+    # by a hope: another writer lands in between and the loser overwrites it anyway, which is the
+    # whole defect. Nothing a single connection can do shows the difference, and a mutation that
+    # moves the read out of the lock survives every example above, so what is asserted here is the
+    # property itself: inside the swap, no read of this row happens without the lock.
+    it 'compares a value it read under the lock' do
+      contact.id
+
+      reads = []
+      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+        reads << payload[:sql] if payload[:sql].match?(/SELECT .+ FROM "contacts"/i)
+      end
+
+      begin
+        contact.swap_json_column!(:additional_attributes, expect: { 'token' => 'T1' }, merge: { 'token' => 'T2' })
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(reads).to be_present
+      expect(reads.grep_v(/FOR UPDATE/i)).to be_empty
+    end
+
+    it 'writes with no precondition when nothing is expected' do
+      expect(contact.swap_json_column!(:additional_attributes, expect: {}, merge: { 'token' => 'T2' })).to be(:written)
+    end
+
+    it 'writes the other columns that belong to the same write' do
+      expect(contact.swap_json_column!(:additional_attributes, expect: { 'token' => 'T1' },
+                                                               merge: { 'token' => 'T2' }, attributes: { name: 'Equipe' }))
+        .to be(:written)
+      expect(contact.reload.name).to eq('Equipe')
+    end
+
+    # Same reason as the merge: every caller is enrichment after a network round trip, so a row that
+    # went away during the call ends the work instead of raising into a retry loop.
+    it 'answers that the row is gone instead of raising' do
+      id = contact.id
+      contact.destroy!
+
+      expect(Contact.new(id: id).swap_json_column!(:additional_attributes, expect: {}, merge: { 'token' => 'T2' }))
+        .to be(:gone)
+    end
+  end
 end

--- a/spec/services/microsoft/refresh_oauth_token_service_spec.rb
+++ b/spec/services/microsoft/refresh_oauth_token_service_spec.rb
@@ -86,4 +86,55 @@ RSpec.describe Microsoft::RefreshOauthTokenService do
       end
     end
   end
+
+  # A escrita de terceiro que entra DURANTE a chamada de rede. Sem thread: a copia em memoria
+  # ja esta velha quando volta para a linha, e e por isso que o defeito reproduz com um stub.
+  describe 'when another writer lands on provider_config during the refresh' do
+    let(:channel) do
+      create(:channel_email, :microsoft_email, provider_config: {
+               expires_on: Time.zone.now - 3600,
+               access_token: SecureRandom.hex,
+               refresh_token: SecureRandom.hex,
+               imap_login_hint: 'someone@example.com'
+             })
+    end
+
+    before do
+      stub_request(:post, 'https://login.microsoftonline.com/common/oauth2/v2.0/token').to_return do
+        # Uma chave que nenhum dos dois lados do refresh escreve, gravada direto na linha para
+        # simular o outro escritor: a API de migracao de canal de e-mail (que aceita
+        # `provider_config` como hash aberto) e o unico caminho por onde ela chega hoje.
+        Channel::Email.where(id: channel.id)
+                      .update_all("provider_config = provider_config || '{\"migrated_by\":\"platform-api\"}'::jsonb")  # rubocop:disable Rails/SkipsModelValidations
+        { status: 200, body: new_tokens.to_json, headers: { 'Content-Type' => 'application/json' } }
+      end
+    end
+
+    it 'keeps the key that landed while the provider was answering' do
+      with_modified_env AZURE_APP_ID: SecureRandom.uuid, AZURE_APP_SECRET: SecureRandom.hex do
+        described_class.new(channel: channel).access_token
+      end
+
+      expect(channel.reload.provider_config['migrated_by']).to eq('platform-api')
+    end
+
+    it 'keeps the keys the refresh does not own' do
+      with_modified_env AZURE_APP_ID: SecureRandom.uuid, AZURE_APP_SECRET: SecureRandom.hex do
+        described_class.new(channel: channel).access_token
+      end
+
+      expect(channel.reload.provider_config['imap_login_hint']).to eq('someone@example.com')
+    end
+
+    it 'still writes the three keys it does own' do
+      with_modified_env AZURE_APP_ID: SecureRandom.uuid, AZURE_APP_SECRET: SecureRandom.hex do
+        described_class.new(channel: channel).access_token
+      end
+
+      config = channel.reload.provider_config
+      expect(config['access_token']).to eq(new_tokens[:access_token])
+      expect(config['refresh_token']).to eq(new_tokens[:refresh_token])
+      expect(config['expires_on']).to eq(Time.at(new_tokens[:expires_at]).utc.to_s)
+    end
+  end
 end

--- a/spec/services/microsoft/refresh_oauth_token_service_spec.rb
+++ b/spec/services/microsoft/refresh_oauth_token_service_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe Microsoft::RefreshOauthTokenService do
     end
   end
 
+  # Os dois exemplos abaixo cobram o VALOR que o refresh devolve, nao a diferenca em relacao ao
+  # token velho. `not_to eq(o token velho)` passa com nil, e passava: `refresh_tokens` devolvia a
+  # coluna crua, de chaves String, para um leitor que pede `[:access_token]`. Quem consome esse
+  # retorno e `Imap::MicrosoftFetchEmailService#imap_password`, ou seja a senha do IMAP era nil
+  # sempre que o token tinha expirado.
   describe 'on expired token or invalid expiry' do
     before do
       stub_request(:post, 'https://login.microsoftonline.com/common/oauth2/v2.0/token').with(
@@ -40,9 +45,8 @@ RSpec.describe Microsoft::RefreshOauthTokenService do
     context 'when token is invalid' do
       it 'fetches new access token and refresh tokens' do
         with_modified_env AZURE_APP_ID: SecureRandom.uuid, AZURE_APP_SECRET: SecureRandom.hex do
-          provider_config = microsoft_channel_with_expired_token.provider_config
           service = described_class.new(channel: microsoft_channel_with_expired_token)
-          expect(service.access_token).not_to eq(provider_config['access_token'])
+          expect(service.access_token).to eq(new_tokens[:access_token])
 
           new_provider_config = microsoft_channel_with_expired_token.reload.provider_config
           expect(new_provider_config['access_token']).to eq(new_tokens[:access_token])
@@ -57,9 +61,8 @@ RSpec.describe Microsoft::RefreshOauthTokenService do
         with_modified_env AZURE_APP_ID: SecureRandom.uuid, AZURE_APP_SECRET: SecureRandom.hex do
           microsoft_channel_with_expired_token.provider_config['expires_on'] = nil
           microsoft_channel_with_expired_token.save!
-          provider_config = microsoft_channel_with_expired_token.provider_config
           service = described_class.new(channel: microsoft_channel_with_expired_token)
-          expect(service.access_token).not_to eq(provider_config['access_token'])
+          expect(service.access_token).to eq(new_tokens[:access_token])
 
           new_provider_config = microsoft_channel_with_expired_token.reload.provider_config
           expect(new_provider_config['access_token']).to eq(new_tokens[:access_token])
@@ -135,6 +138,63 @@ RSpec.describe Microsoft::RefreshOauthTokenService do
       expect(config['access_token']).to eq(new_tokens[:access_token])
       expect(config['refresh_token']).to eq(new_tokens[:refresh_token])
       expect(config['expires_on']).to eq(Time.at(new_tokens[:expires_at]).utc.to_s)
+    end
+  end
+
+  # O outro eixo, e o que o merge nao alcanca: o outro escritor e outro refresh, entao as chaves que
+  # ele escreveu sao as mesmas que este vai escrever. Os dois trocaram o MESMO refresh token antes de
+  # qualquer um gravar, e um provedor que rota o refresh token invalida o antigo, logo so um dos dois
+  # pares e vivo. Gravar por cima deixa a linha com um token que o provedor ja nao honra, e o canal
+  # para de buscar e-mail ate alguem reconectar a mao (issue #557, que nomeia o conserto: quem perdeu
+  # tem que perceber, em vez de sobrescrever).
+  describe 'when another refresh of the same channel rotated the token during this one' do
+    let(:winner) do
+      { access_token: 'AT_WINNER', refresh_token: 'RT_WINNER', expires_on: (Time.zone.now + 7200).utc.to_s }
+    end
+
+    let(:channel) do
+      create(:channel_email, :microsoft_email, provider_config: {
+               expires_on: Time.zone.now - 3600,
+               access_token: SecureRandom.hex,
+               refresh_token: SecureRandom.hex
+             })
+    end
+
+    before do
+      allow(Rails.logger).to receive(:warn)
+      stub_request(:post, 'https://login.microsoftonline.com/common/oauth2/v2.0/token').to_return do
+        Channel::Email.where(id: channel.id)
+                      .update_all(['provider_config = provider_config || ?::jsonb', winner.to_json])  # rubocop:disable Rails/SkipsModelValidations
+        { status: 200, body: new_tokens.to_json, headers: { 'Content-Type' => 'application/json' } }
+      end
+    end
+
+    it 'leaves the row with the token set that won' do
+      with_modified_env AZURE_APP_ID: SecureRandom.uuid, AZURE_APP_SECRET: SecureRandom.hex do
+        described_class.new(channel: channel).access_token
+      end
+
+      config = channel.reload.provider_config
+      expect(config['refresh_token']).to eq('RT_WINNER')
+      expect(config['access_token']).to eq('AT_WINNER')
+    end
+
+    it 'hands the caller the token that is in the row, not the one it could not store' do
+      token = with_modified_env AZURE_APP_ID: SecureRandom.uuid, AZURE_APP_SECRET: SecureRandom.hex do
+        described_class.new(channel: channel).access_token
+      end
+
+      expect(token).to eq('AT_WINNER')
+    end
+
+    # Perceber e o requisito, e uma rotacao gasta e depois descartada e justamente o evento que
+    # ninguem reconstroi depois: o provedor viu um token que esta linha nunca teve.
+    it 'says the rotation it spent was not stored' do
+      with_modified_env AZURE_APP_ID: SecureRandom.uuid, AZURE_APP_SECRET: SecureRandom.hex do
+        described_class.new(channel: channel).access_token
+      end
+
+      expect(Rails.logger).to have_received(:warn).with(/refresh token this call spent/)
     end
   end
 end


### PR DESCRIPTION
An e-mail channel whose OAuth token was refreshed, a Linear integration whose token was renewed, and a Slack integration whose channel was picked all lost whatever else was stored alongside: the three writers read a JSON column into memory, went to the network, and wrote the column back from the copy they had read before the call. Anything that landed in the row while the provider was answering was erased, and in two of the three the column was not merged at all, it was replaced.

## Closes

Fixes #557
Fixes #619

Not #617. What separates them is measured below.

## How to reproduce

Not a database race, and it needs no threads: the copy is simply old.

1. Create an e-mail channel through `POST /platform/api/v1/email_channel_migrations` with an extra key in `provider_config` (the endpoint permits an open hash). Let the IMAP fetcher refresh the token. The extra key is gone, and so is anything else that was not one of `access_token`, `refresh_token`, `expires_on`.
2. `PATCH /api/v1/accounts/:id/integrations/hooks/:id` with any key in `settings` on a Slack hook (also an open hash), then pick a channel in the Slack integration screen. Every key except `channel_name` is gone.
3. On a Linear hook, write a key to `settings` while the token refresh is in flight. It is erased when the refresh persists.

## What changed

The three writers now go through `JsonColumnMerge#merge_json_column!`, which re-reads the row under its lock and merges only the keys being written. The concern was already column-agnostic, so this adds no primitive: it includes it in `Channel::Email` and `Integrations::Hook` and rewrites three call sites.

The Linear site lost its `|| current_settings[...]` fallbacks along the way. They existed to keep a stored value when the response did not carry one, and they needed the pre-call read to do it; a key that is not in the merge leaves the stored one standing without reading anything first.

`merge_json_column!` deliberately leaves the receiver untouched, since it takes the lock on a separately loaded row. Two of the three sites hand state back to their caller (the Linear service returns `hook.access_token`, the Slack builder returns the hook the controller renders), so both read the row again, and there is an example on each that fails without it.

## The second axis, which the first round of this PR wrongly parked

The holdout scenarios for #557 failed four of fourteen, and they were right. This PR had fixed the staleness and declared the token race out of scope, but the issue names that race and names the shape of its fix: "the losing refresh has to notice it lost rather than overwrite". Parking it was narrowing the issue against its own text.

The merge cannot reach that axis, because the keys the loser writes are the keys the winner already wrote. `JsonColumnMerge#swap_json_column!` is the compare-and-set for it: `expect` is read under the same lock as the write, so the row has to still hold what the caller based its call on. It answers `:written`, `:unchanged`, `:stale` or `:gone`, since a boolean would collapse "someone else got there first" into "there was nothing to write", and the caller has to log a rotation it spent and hand back the value that won. `merge_json_column!` keeps its contract, because the six callers that do not race need no precondition.

Losing is not an error and does not raise: the other writer already stored a live pair, so the caller re-reads and gets it. What losing must not be is silent, because the provider has seen a token the row never held and nothing else records that.

Also fixed here, and it is what the sealed scenario for the plain refresh was failing on: `refresh_tokens` handed the raw jsonb hash, with String keys, to a caller that reads `[:access_token]`, so the refresh answered `nil`, and `Imap::MicrosoftFetchEmailService` passes that value as the IMAP password. The two examples meant to cover it asserted `not_to eq(the old token)`, which `nil` satisfies; they now charge for the value.

## Validation scope

Exercised live for the OAuth site, against a socket rather than a stub: a fake token endpoint on `127.0.0.1:4600`, the strategy's `site` repointed by a throwaway initializer, Rails in development, and the third-party write performed from inside the network window by the fake server itself (its own Postgres connection, outside Rails) before it answers. On the base code the two keys that are not the refresh's own are gone and the write that landed during the call is gone; on this HEAD all five keys stand, the third-party key stands, and the new token pair is in the row. Both sides measured on the same channel through the same socket.

Proven by spec, with the third-party write landing during the network call for each of the three sites, plus the halves a careless merge would break: the three keys the refresh does own are still written, the token the Linear service went to fetch is still persisted and still handed to the caller, and the `channel_name` the Slack builder owns still lands with the `reference_id` and the `enabled` status.

Measured before implementing, and two claims in the issue did not survive it. The issue says the OAuth site "costs nothing extra by luck" because only two places write that column and both write the same three keys; there is a third (`Platform::Api::V1::EmailChannelMigrationsController`, open hash from the payload), so this is data loss today rather than a guard against a future writer. The Slack site has the same shape through `HooksController#update`, which the issue does not mention, and the repo's own factory exhibits it: `:integrations_hook` is born with `settings { { test: 'test' } }`, and that key used to die on the first `update_reference_id`.

The race examples drive the losing writer through the real service, with the winner landing from inside the network window: another refresh that rotated the pair, and on the Linear side an OAuth reconnection through its own AR object, because `access_token` is an encrypted column and a raw UPDATE would write something the reader cannot decrypt.

One survivor in the mutation battery was not an equivalent, and it is worth naming because no behavioural example could reach it: moving the guard's read out of the lock, so it reads the row and then locks it, passed everything. That is a check followed by a hope rather than a compare-and-set, and nothing a single database connection does shows the difference. The property is now asserted directly, and measured: the mutant dies on that one example and on nothing else. Battery at 16 mutants, no survivors.

The holdout verifier reproduced that measurement against the mutant in its own tree, ran the three sealed race scenarios against it with separate processes and a real database (all three pass, so the mutant survives behaviour at its level of arrangement too), and then designed the sibling mutant to find the fence's edge: a guard comparing the receiver's in-memory copy issues no new SELECT and therefore walks past the fence, while dying on six behavioural examples. So the two axes are complementary and neither is redundant, which is the difference between this and a fence that guards vocabulary.

Two caveats on that assertion, from the same verification and worth stating rather than discovering later. It is coupled to the **form** of the lock: the check looks for `FOR UPDATE` in the SQL, so moving to an advisory lock or `FOR NO KEY UPDATE` would fail it with the property intact. And it asserts something stronger than the property, that no read of the table happens in the method without the lock, so a legitimate read added later (a counter, a log that re-reads) fails it with nothing wrong. Both are maintenance cost with a known shape, not holes in the guard.

**What this does not close is #617**, and the line between them is the measurement that issue carries. Where one side is authoritative the guard is decisive: a reconnection an admin just authorised, or a refresh that spent a token the row no longer held. Where both refreshes exchanged the same token before either wrote, both lost, and nothing in the row says which pair the provider still honours, because that fact exists only on the provider's side. The row then keeps the first write instead of the last, which is not better. What changes for #617 is smaller and still worth having: the loss stops being silent. Its three ways out (one refresh in flight per channel, closing the owner-check hole in `MutexApplicationJob`, or marking for reauthorization on `invalid_grant`) are all still open, and reaching that order still needs a fetch that outlives the 5-minute mutex TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/616)
<!-- Reviewable:end -->

