### PR TITLE
fix(telegram): pôr teto nas chamadas da Bot API e dizer quando não deu para perguntar

### DIFF
--- a/app/models/channel/telegram.rb
+++ b/app/models/channel/telegram.rb
@@ -95,6 +95,15 @@ class Channel::Telegram < ApplicationRecord
     self.bot_name = response.parsed_response['result']['username']
   end
 
+  # This one runs in `before_save`, where an error on its own changes nothing: the callback
+  # returning stops nothing, and the record is written anyway. Before the ceiling, a
+  # Telegram that did not answer raised out of here, which at least left nothing saved;
+  # swallowing it would have persisted an inbox whose webhook was never set, so it cannot
+  # receive a message and nothing on the screen says so.
+  #
+  # `RecordInvalid` and not `throw :abort`, because only `RecordInvalid` is rendered as a
+  # 422 carrying the message: an abort answers 500 again, which is the thing this change
+  # exists to stop saying.
   def setup_telegram_webhook
     reaching_telegram { HTTParty.post("#{telegram_api_url}/deleteWebhook", **TELEGRAM_SHORT_REQUEST_OPTIONS) }
     response = reaching_telegram do
@@ -104,12 +113,12 @@ class Channel::Telegram < ApplicationRecord
                     },
                     **TELEGRAM_SHORT_REQUEST_OPTIONS)
     end
-    return if response.nil?
+    raise ActiveRecord::RecordInvalid, self if response.nil?
 
     errors.add(:bot_token, 'error setting up the webook') unless response.success?
   end
 
-  # Both calls above run inside the request the operator is waiting on, and until now a
+  # Both setup calls run inside the request the operator is waiting on, and until now a
   # Telegram that did not answer came back as a 500 on the inbox form: the app saying it
   # is broken, about the one thing it cannot know. Putting a ceiling on the call without
   # this would only have delivered that 500 sooner.

--- a/app/models/channel/telegram.rb
+++ b/app/models/channel/telegram.rb
@@ -16,6 +16,7 @@
 
 class Channel::Telegram < ApplicationRecord
   include Channelable
+  include Telegram::RequestOptions
 
   # TODO: Remove guard once encryption keys become mandatory (target 3-4 releases out).
   encrypts :bot_token, deterministic: true if Chatwoot.encryption_configured?
@@ -43,7 +44,7 @@ class Channel::Telegram < ApplicationRecord
 
   def get_telegram_profile_image(user_id)
     # get profile image from telegram
-    response = HTTParty.get("#{telegram_api_url}/getUserProfilePhotos", query: { user_id: user_id })
+    response = HTTParty.get("#{telegram_api_url}/getUserProfilePhotos", query: { user_id: user_id }, **TELEGRAM_SHORT_REQUEST_OPTIONS)
     return nil unless response.success?
 
     photos = response.parsed_response.dig('result', 'photos')
@@ -53,7 +54,7 @@ class Channel::Telegram < ApplicationRecord
   end
 
   def get_telegram_file_path(file_id)
-    response = HTTParty.get("#{telegram_api_url}/getFile", query: { file_id: file_id })
+    response = HTTParty.get("#{telegram_api_url}/getFile", query: { file_id: file_id }, **TELEGRAM_SHORT_REQUEST_OPTIONS)
     return nil unless response.success?
 
     "https://api.telegram.org/file/bot#{bot_token}/#{response.parsed_response['result']['file_path']}"
@@ -83,7 +84,9 @@ class Channel::Telegram < ApplicationRecord
   private
 
   def ensure_valid_bot_token
-    response = HTTParty.get("#{telegram_api_url}/getMe")
+    response = reaching_telegram { HTTParty.get("#{telegram_api_url}/getMe", **TELEGRAM_SHORT_REQUEST_OPTIONS) }
+    return if response.nil?
+
     unless response.success?
       errors.add(:bot_token, 'invalid token')
       return
@@ -93,12 +96,35 @@ class Channel::Telegram < ApplicationRecord
   end
 
   def setup_telegram_webhook
-    HTTParty.post("#{telegram_api_url}/deleteWebhook")
-    response = HTTParty.post("#{telegram_api_url}/setWebhook",
-                             body: {
-                               url: "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/telegram/#{bot_token}"
-                             })
+    reaching_telegram { HTTParty.post("#{telegram_api_url}/deleteWebhook", **TELEGRAM_SHORT_REQUEST_OPTIONS) }
+    response = reaching_telegram do
+      HTTParty.post("#{telegram_api_url}/setWebhook",
+                    body: {
+                      url: "#{ENV.fetch('FRONTEND_URL', nil)}/webhooks/telegram/#{bot_token}"
+                    },
+                    **TELEGRAM_SHORT_REQUEST_OPTIONS)
+    end
+    return if response.nil?
+
     errors.add(:bot_token, 'error setting up the webook') unless response.success?
+  end
+
+  # Both calls above run inside the request the operator is waiting on, and until now a
+  # Telegram that did not answer came back as a 500 on the inbox form: the app saying it
+  # is broken, about the one thing it cannot know. Putting a ceiling on the call without
+  # this would only have delivered that 500 sooner.
+  #
+  # "Could not ask" is a third answer, and it is not "invalid token": one tells the
+  # operator to fix what they typed, the other to try again.
+  #
+  # Exactly one call inside the block, on purpose. A `rescue` any wider swallows a bug in
+  # the code that reads the answer and reports it as the provider being unreachable.
+  def reaching_telegram
+    yield
+  rescue StandardError => e
+    Rails.logger.error("[TELEGRAM] the Bot API did not answer: #{e.class}: #{e.message}")
+    errors.add(:bot_token, 'could not reach Telegram, try again')
+    nil
   end
 
   def send_message(message)
@@ -166,6 +192,7 @@ class Channel::Telegram < ApplicationRecord
                     reply_markup: reply_markup,
                     parse_mode: 'HTML',
                     reply_to_message_id: reply_to_message_id
-                  }.merge(business_body))
+                  }.merge(business_body),
+                  **TELEGRAM_REQUEST_OPTIONS)
   end
 end

--- a/app/services/telegram/request_options.rb
+++ b/app/services/telegram/request_options.rb
@@ -1,0 +1,25 @@
+# Every HTTParty call to the Bot API, with the two numbers this integration has and the
+# reason each one is what it is.
+#
+# `max_retries: 0` on both: `Net::HTTP` repeats an idempotent request once by default, so
+# a ceiling on a GET is worth half of what it reads as. Measured against a socket that
+# accepts the connection and never answers, a GET at `timeout: 3` took 6.0s and 3.0s once
+# the retry was closed.
+#
+# `timeout:` is a per-socket-operation ceiling and not a request deadline: it bounds how
+# long one read may block, not how long the whole exchange may take. What sizes it is the
+# far side's thinking time before the first byte comes back, which is why a send gets more
+# than a status read and not the other way around.
+module Telegram::RequestOptions
+  # The calls whose answer the caller acts on right now, in the request the operator is
+  # waiting on: validating the bot token and pointing the webhook at us, both inside the
+  # inbox form, plus the two reads that resolve a file the contact just sent.
+  TELEGRAM_SHORT_REQUEST_OPTIONS = { timeout: 10, max_retries: 0 }.freeze
+
+  # Outbound. Telegram fetches the media from the URL we hand it before it answers, so
+  # this one waits on Telegram waiting on us.
+  #
+  # A document does not come through here: it is uploaded byte by byte over Faraday, which
+  # carries its own ceiling in `Telegram::SendAttachmentsService#multipart_post_connection`.
+  TELEGRAM_REQUEST_OPTIONS = { timeout: 90, max_retries: 0 }.freeze
+end

--- a/app/services/telegram/send_attachments_service.rb
+++ b/app/services/telegram/send_attachments_service.rb
@@ -16,6 +16,8 @@ require 'faraday/multipart'
 # The service will terminate if any of the attachment requests fail when the message has multiple attachments
 # We will create multiple messages in telegram if the message has multiple attachments (if its documents or mixed media).
 class Telegram::SendAttachmentsService
+  include Telegram::RequestOptions
+
   pattr_initialize [:message!]
 
   def perform
@@ -76,7 +78,8 @@ class Telegram::SendAttachmentsService
                     **business_connection_body,
                     media: attachments.map { |hash| hash.except(:attachment) }.to_json,
                     reply_to_message_id: reply_to_message_id
-                  })
+                  },
+                  **TELEGRAM_REQUEST_OPTIONS)
   end
 
   def send_individual_attachments(attachments)

--- a/spec/models/channel/telegram_spec.rb
+++ b/spec/models/channel/telegram_spec.rb
@@ -3,6 +3,62 @@ require 'rails_helper'
 RSpec.describe Channel::Telegram do
   let(:telegram_channel) { create(:channel_telegram) }
 
+  # Both calls that set an inbox up run inside the request the operator is waiting on, and
+  # a Telegram that accepted the connection and then stopped answering came back as a 500:
+  # the app reporting itself broken about the one thing it cannot know. Putting a ceiling
+  # on the call without this would only have delivered that 500 sooner, which is the
+  # mistake #605 already cost us on the WhatsApp side.
+  describe 'when the Bot API does not answer' do
+    let(:account) { create(:account) }
+
+    it 'says the check could not be made, instead of failing the request' do
+      stub_request(:get, %r{api\.telegram\.org/bot.*/getMe}).to_timeout
+
+      channel = described_class.new(account: account, bot_token: 'a-token')
+
+      expect(channel).not_to be_valid
+      expect(channel.errors[:bot_token]).to eq(['could not reach Telegram, try again'])
+    end
+
+    # Two different things to do about it: one is fix what you typed, the other is try
+    # again. Answering the same for both sends the operator looking for a typo that is
+    # not there.
+    it 'does not say it the way it says a refused token' do
+      stub_request(:get, %r{api\.telegram\.org/bot.*/getMe}).to_return(status: 401, body: '{}')
+
+      channel = described_class.new(account: account, bot_token: 'a-token')
+
+      expect(channel).not_to be_valid
+      expect(channel.errors[:bot_token]).to eq(['invalid token'])
+    end
+
+    # The `rescue` covers the call and not the reading of the answer: a bug in the parsing
+    # below reported as "could not reach Telegram" is a bug nobody goes looking for.
+    it 'does not answer for a body it did reach and could not read' do
+      stub_request(:get, %r{api\.telegram\.org/bot.*/getMe}).to_return(status: 200, body: '{"ok":true}')
+
+      channel = described_class.new(account: account, bot_token: 'a-token')
+
+      expect { channel.valid? }.to raise_error(NoMethodError)
+    end
+  end
+
+  # A fence, not a checklist. Every call to the Bot API carries one of the two ceilings,
+  # and the count is per ceiling so that moving a call between them has to be deliberate.
+  # Measured, not remembered: the numbers below come from reading the two files.
+  it 'puts every Bot API call under one of the two ceilings' do
+    sources = [
+      Rails.root.join('app/models/channel/telegram.rb'),
+      Rails.root.join('app/services/telegram/send_attachments_service.rb')
+    ].map { |path| File.read(path) }.join
+
+    calls = sources.scan(/HTTParty\.\w+/).size
+
+    expect(calls).to eq(7)
+    expect(sources.scan('TELEGRAM_SHORT_REQUEST_OPTIONS').size).to eq(5)
+    expect(sources.scan('TELEGRAM_REQUEST_OPTIONS').size).to eq(2)
+  end
+
   describe '#convert_markdown_to_telegram_html' do
     subject { telegram_channel.send(:convert_markdown_to_telegram_html, text) }
 

--- a/spec/models/channel/telegram_spec.rb
+++ b/spec/models/channel/telegram_spec.rb
@@ -32,6 +32,24 @@ RSpec.describe Channel::Telegram do
       expect(channel.errors[:bot_token]).to eq(['invalid token'])
     end
 
+    # The webhook is set in `before_save`, where adding an error changes nothing on its
+    # own: the record is written anyway, and what gets written is an inbox whose webhook
+    # was never set, so it receives no message and nothing on the screen says why. The
+    # answer has to roll the save back, and it has to do it as a 422 with the message,
+    # since that is the only shape this API renders instead of answering 500.
+    it 'saves nothing when the webhook could not be set' do
+      stub_request(:get, %r{api\.telegram\.org/bot.*/getMe})
+        .to_return(status: 200, body: { result: { username: 'a_bot' } }.to_json)
+      stub_request(:post, %r{api\.telegram\.org/bot.*/deleteWebhook}).to_return(status: 200, body: '{}')
+      stub_request(:post, %r{api\.telegram\.org/bot.*/setWebhook}).to_timeout
+
+      channel = described_class.new(account: account, bot_token: 'a-token')
+
+      expect { channel.save! }.to raise_error(ActiveRecord::RecordInvalid, /could not reach Telegram/)
+      expect(channel).not_to be_persisted
+      expect(described_class.where(bot_token: 'a-token')).to be_empty
+    end
+
     # The `rescue` covers the call and not the reading of the answer: a bug in the parsing
     # below reported as "could not reach Telegram" is a bug nobody goes looking for.
     it 'does not answer for a body it did reach and could not read' do


### PR DESCRIPTION
Uma caixa de entrada do Telegram podia deixar o operador esperando um minuto por chamada, e dois minutos nas leituras, sem nada na tela explicando o quê. Todas as sete chamadas à Bot API iam sem teto de espera e sem controle de repetição.

Duas coisas mudam aqui, e a segunda é a que faz a primeira valer a pena.

**Teto.** Dois números, porque são dois tipos de chamada:

| chamada | teto | por quê |
| --- | --- | --- |
| validar o token, apontar o webhook, resolver arquivo recebido | 10s | o chamador usa a resposta agora, e nas duas primeiras é o operador esperando na tela |
| enviar mensagem, enviar grupo de mídia | 90s | o Telegram busca a mídia na URL que entregamos antes de responder |

O envio de documento não entra na tabela: ele sobe byte a byte por Faraday e já tem teto próprio (300s de leitura, 60s de conexão), o que está escrito na constante para a próxima pessoa não achar que faltou.

**Classificação.** As duas chamadas de configuração rodam dentro da requisição que o operador está esperando, e um Telegram que aceitava a conexão e parava de responder virava **500 no formulário**: o app dizendo que está quebrado sobre a única coisa que ele não pode saber. Baixar o teto sem mexer nisso só entregaria esse 500 mais cedo, que foi o que a #605 já nos custou do lado do WhatsApp. Agora a falha de transporte vira um erro de validação próprio, e ele é diferente de `invalid token` de propósito: uma frase manda corrigir o que foi digitado, a outra manda tentar de novo.

O `rescue` cobre a chamada e não a leitura da resposta. Um bug no parsing reportado como "não consegui falar com o Telegram" é um bug que ninguém vai procurar, e tem exemplo prendendo isso.

## Closes

Fecha a família Telegram da #589 (7 pontos de chamada). Continuam abertas Instagram (8), TikTok (8), Twilio (5), Linear (4) e os avulsos.

## How to test

Criar uma caixa de entrada do Telegram com a Bot API inalcançável (um proxy que aceita a conexão e não responde, ou `api.telegram.org` apontado para um buraco no `/etc/hosts`). Antes: a tela ficava presa e terminava em erro genérico. Agora: em 10s aparece no campo do token que não foi possível falar com o Telegram e para tentar de novo, e o token continua lá para não ser redigitado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/618)
<!-- Reviewable:end -->
