### PR TITLE
fix(instagram): pôr teto nas oito chamadas da família Instagram

### DIFF
--- a/app/builders/messages/instagram/message_builder.rb
+++ b/app/builders/messages/instagram/message_builder.rb
@@ -1,4 +1,6 @@
 class Messages::Instagram::MessageBuilder < Messages::Instagram::BaseMessageBuilder
+  include Instagram::RequestOptions
+
   def initialize(messaging, inbox, outgoing_echo: false)
     super(messaging, inbox, outgoing_echo: outgoing_echo)
   end
@@ -8,7 +10,7 @@ class Messages::Instagram::MessageBuilder < Messages::Instagram::BaseMessageBuil
   def get_story_object_from_source_id(source_id)
     url = "#{base_uri}/#{source_id}?fields=story,from&access_token=#{@inbox.channel.access_token}"
 
-    response = HTTParty.get(url)
+    response = HTTParty.get(url, **INSTAGRAM_SHORT_REQUEST_OPTIONS)
 
     return JSON.parse(response.body).with_indifferent_access if response.success?
 

--- a/app/controllers/concerns/instagram_concern.rb
+++ b/app/controllers/concerns/instagram_concern.rb
@@ -51,7 +51,8 @@ module InstagramConcern
     response = HTTParty.get(
       endpoint,
       query: params,
-      headers: { 'Accept' => 'application/json' }
+      headers: { 'Accept' => 'application/json' },
+      **Instagram::RequestOptions::INSTAGRAM_SHORT_REQUEST_OPTIONS
     )
 
     unless response.success?

--- a/app/models/channel/instagram.rb
+++ b/app/models/channel/instagram.rb
@@ -17,6 +17,7 @@
 class Channel::Instagram < ApplicationRecord
   include Channelable
   include Reauthorizable
+  include Instagram::RequestOptions
   self.table_name = 'channel_instagram'
 
   # TODO: Remove guard once encryption keys become mandatory (target 3-4 releases out).
@@ -49,7 +50,8 @@ class Channel::Instagram < ApplicationRecord
       query: {
         subscribed_fields: %w[messages message_reactions messaging_seen],
         access_token: access_token
-      }
+      },
+      **INSTAGRAM_SHORT_REQUEST_OPTIONS
     )
   rescue StandardError => e
     Rails.logger.debug { "Rescued: #{e.inspect}" }
@@ -61,7 +63,8 @@ class Channel::Instagram < ApplicationRecord
       "#{base_uri}/#{instagram_id}/subscribed_apps",
       query: {
         access_token: access_token
-      }
+      },
+      **INSTAGRAM_SHORT_REQUEST_OPTIONS
     )
     true
   rescue StandardError => e

--- a/app/services/instagram/message_text.rb
+++ b/app/services/instagram/message_text.rb
@@ -1,4 +1,6 @@
 class Instagram::MessageText < Instagram::BaseMessageText
+  include Instagram::RequestOptions
+
   attr_reader :messaging
 
   def ensure_contact(ig_scope_id)
@@ -10,7 +12,7 @@ class Instagram::MessageText < Instagram::BaseMessageText
     fields = 'name,username,profile_pic,follower_count,is_user_follow_business,is_business_follow_user,is_verified_user'
     url = "#{base_uri}/#{ig_scope_id}?fields=#{fields}&access_token=#{@inbox.channel.access_token}"
 
-    response = HTTParty.get(url)
+    response = HTTParty.get(url, **INSTAGRAM_SHORT_REQUEST_OPTIONS)
 
     return process_successful_response(response) if response.success?
 

--- a/app/services/instagram/messenger/send_on_instagram_service.rb
+++ b/app/services/instagram/messenger/send_on_instagram_service.rb
@@ -1,4 +1,6 @@
 class Instagram::Messenger::SendOnInstagramService < Instagram::BaseSendService
+  include Instagram::RequestOptions
+
   private
 
   def channel_class
@@ -16,7 +18,8 @@ class Instagram::Messenger::SendOnInstagramService < Instagram::BaseSendService
     response = HTTParty.post(
       'https://graph.facebook.com/v11.0/me/messages',
       body: message_content,
-      query: query
+      query: query,
+      **INSTAGRAM_REQUEST_OPTIONS
     )
 
     process_response(response, message_content)

--- a/app/services/instagram/refresh_oauth_token_service.rb
+++ b/app/services/instagram/refresh_oauth_token_service.rb
@@ -2,6 +2,8 @@
 # Instagram tokens are valid for 60 days and can be refreshed to extend validity
 # This service implements the refresh logic per official Instagram API guidelines
 class Instagram::RefreshOauthTokenService
+  include Instagram::RequestOptions
+
   attr_reader :channel
 
   def initialize(channel:)
@@ -55,7 +57,8 @@ class Instagram::RefreshOauthTokenService
       access_token: channel[:access_token]
     }
 
-    response = HTTParty.get(endpoint, query: params, headers: { 'Accept' => 'application/json' })
+    response = HTTParty.get(endpoint, query: params, headers: { 'Accept' => 'application/json' },
+                                      **INSTAGRAM_SHORT_REQUEST_OPTIONS)
 
     unless response.success?
       Rails.logger.error "Failed to refresh Instagram token: #{response.body}"

--- a/app/services/instagram/request_options.rb
+++ b/app/services/instagram/request_options.rb
@@ -1,0 +1,19 @@
+# Every HTTParty call to Instagram, with the two numbers this integration has and the
+# reason each one is what it is.
+#
+# `max_retries: 0` on both: `Net::HTTP` repeats an idempotent request once by default, so
+# a ceiling on a GET is worth half of what it reads as, and six of these eight are GETs.
+#
+# `timeout:` is a per-socket-operation ceiling and not a request deadline: it bounds how
+# long one read may block, not how long the whole exchange may take. What sizes it is the
+# far side's thinking time before the first byte comes back.
+module Instagram::RequestOptions
+  # Reading a story or a profile while an incoming message is being built, exchanging and
+  # refreshing a token, and telling Instagram which events to send us. None of these has
+  # a body for the far side to go fetch: they answer out of Instagram's own state.
+  INSTAGRAM_SHORT_REQUEST_OPTIONS = { timeout: 10, max_retries: 0 }.freeze
+
+  # Outbound. An attachment travels as a URL that Instagram fetches from us before it
+  # answers, so this one waits on Instagram waiting on us.
+  INSTAGRAM_REQUEST_OPTIONS = { timeout: 90, max_retries: 0 }.freeze
+end

--- a/app/services/instagram/send_on_instagram_service.rb
+++ b/app/services/instagram/send_on_instagram_service.rb
@@ -1,4 +1,6 @@
 class Instagram::SendOnInstagramService < Instagram::BaseSendService
+  include Instagram::RequestOptions
+
   private
 
   def channel_class
@@ -15,7 +17,8 @@ class Instagram::SendOnInstagramService < Instagram::BaseSendService
     response = HTTParty.post(
       "https://graph.instagram.com/#{GlobalConfigService.load('INSTAGRAM_API_VERSION', 'v22.0')}/#{instagram_id}/messages",
       body: message_content,
-      query: query
+      query: query,
+      **INSTAGRAM_REQUEST_OPTIONS
     )
 
     process_response(response, message_content)

--- a/spec/controllers/concerns/instagram_concern_spec.rb
+++ b/spec/controllers/concerns/instagram_concern_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe InstagramConcern do
             access_token: short_lived_token,
             client_id: client_id
           },
-          headers: { 'Accept' => 'application/json' }
+          headers: { 'Accept' => 'application/json' },
+          timeout: 10,
+          max_retries: 0
         }
       )
 
@@ -109,7 +111,9 @@ RSpec.describe InstagramConcern do
             fields: 'id,username,user_id,name,profile_picture_url,account_type',
             access_token: access_token
           },
-          headers: { 'Accept' => 'application/json' }
+          headers: { 'Accept' => 'application/json' },
+          timeout: 10,
+          max_retries: 0
         }
       )
 

--- a/spec/services/instagram/request_options_spec.rb
+++ b/spec/services/instagram/request_options_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+# The ceilings for the Instagram family, and the two places that cannot report their own
+# absence.
+RSpec.describe Instagram::RequestOptions do
+  # Three of this family's call sites sit inside a `rescue StandardError` that answers with
+  # something plausible: `subscribe` and `unsubscribe` answer `true`, and a failed token
+  # refresh answers the token it already had. A constant that does not resolve raises
+  # `NameError`, which is a `StandardError`, so forgetting the `include` in one of those
+  # files produces a channel that never subscribed and a token that is never refreshed,
+  # with nothing in the logs above debug level. That is not a hypothesis: writing this
+  # slice, the two files that needed the `include` were exactly the two that swallow, and
+  # only the token-refresh spec noticed.
+  describe 'the calls whose failure is swallowed' do
+    let(:channel) { create(:channel_instagram, access_token: 'a-token', expires_at: 20.days.from_now) }
+    let(:answer) do
+      instance_double(HTTParty::Response, success?: true, body: '{"access_token":"x","expires_in":1}',
+                                          parsed_response: { 'access_token' => 'x', 'expires_in' => 1 })
+    end
+
+    it 'sends the ceiling when telling Instagram what to notify us about' do
+      options = nil
+      allow(HTTParty).to receive(:post) { |_url, **kwargs| options = kwargs and answer }
+
+      channel.subscribe
+
+      expect(options).to include(timeout: 10, max_retries: 0)
+    end
+
+    it 'sends the ceiling when it stops asking to be notified' do
+      options = nil
+      allow(HTTParty).to receive(:delete) { |_url, **kwargs| options = kwargs and answer }
+
+      channel.unsubscribe
+
+      expect(options).to include(timeout: 10, max_retries: 0)
+    end
+
+    # This one answers with the token it already had on any failure, so a ceiling that
+    # never applied would show up as a token quietly never refreshed. Answered as a
+    # refusal on purpose: what is under test is the options the call went out with, and a
+    # refusal keeps the example out of the whole token-rotation chain that follows a
+    # successful answer.
+    it 'sends the ceiling when refreshing the long-lived token' do
+      options = nil
+      refused = instance_double(HTTParty::Response, success?: false, body: '{}')
+      allow(HTTParty).to receive(:get) { |_url, **kwargs| options = kwargs and refused }
+      channel.update!(expires_at: 5.days.from_now)
+      allow(channel).to receive(:updated_at).and_return(25.hours.ago)
+
+      expect(Instagram::RefreshOauthTokenService.new(channel: channel).access_token).to eq('a-token')
+      expect(options).to include(timeout: 10, max_retries: 0)
+    end
+  end
+
+  # A fence, not a checklist. Counted per ceiling so that moving a call between them has to
+  # be deliberate, and the total counted separately so a new call cannot arrive without one.
+  it 'puts every Instagram call under one of the two ceilings' do
+    sources = %w[
+      app/models/channel/instagram.rb
+      app/controllers/concerns/instagram_concern.rb
+      app/builders/messages/instagram/message_builder.rb
+      app/services/instagram/message_text.rb
+      app/services/instagram/refresh_oauth_token_service.rb
+      app/services/instagram/send_on_instagram_service.rb
+      app/services/instagram/messenger/send_on_instagram_service.rb
+    ].map { |path| File.read(Rails.root.join(path)) }.join
+
+    expect(sources.scan(/HTTParty\.\w+/).size).to eq(8)
+    expect(sources.scan('INSTAGRAM_SHORT_REQUEST_OPTIONS').size).to eq(6)
+    expect(sources.scan('INSTAGRAM_REQUEST_OPTIONS').size).to eq(2)
+  end
+end


### PR DESCRIPTION
As oito chamadas HTTP da família Instagram iam sem teto de espera e sem controle de repetição, então um Instagram quieto podia segurar uma thread por um minuto, e dois nas seis que são GET.

**Teto.** Dois números, porque são dois tipos de chamada:

| chamada | teto | por quê |
| --- | --- | --- |
| ler story e perfil ao montar a mensagem recebida, trocar e renovar token, assinar e desassinar os eventos | 10s | o Instagram responde do estado dele, não tem corpo nosso para ir buscar |
| enviar mensagem (login do Instagram e caminho Messenger) | 90s | o anexo viaja como URL que o Instagram busca em nós antes de responder |

**O que esta PR não conserta, e por quê está escrito aqui.** Três desses pontos ficam dentro de um `rescue StandardError` que responde algo plausível: `subscribe` e `unsubscribe` respondem `true`, e `attempt_token_refresh` responde o token que já tinha. Baixar o teto ali faz a falha chegar mais cedo, mas ela continua chegando como sucesso. Isso é classificação faltando e não teto faltando, tem custo e blast radius próprios, e vai virar issue em vez de entrar aqui de carona.

Vale registrar como isso apareceu: enquanto eu escrevia esta slice, os dois arquivos que precisavam do `include` eram exatamente os dois que engolem, o `NameError` foi engolido com eles, e a única coisa que percebeu foi um spec de renovação de token que já existia. Por isso três exemplos medem as opções que efetivamente saem nesses pontos, em vez de confiar que a constante resolveu.

## Closes

Fecha a família Instagram da #589 (8 pontos). Restam TikTok (8), Twilio (5), Linear (4) e os avulsos: 41 pontos sem teto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/620)
<!-- Reviewable:end -->
