### PR TITLE
fix(twilio): pôr teto nas cinco chamadas da Content API

### DIFF
--- a/app/services/twilio/csat_template_api_client.rb
+++ b/app/services/twilio/csat_template_api_client.rb
@@ -1,4 +1,6 @@
 class Twilio::CsatTemplateApiClient
+  include Twilio::RequestOptions
+
   def initialize(twilio_channel)
     @twilio_channel = twilio_channel
   end
@@ -7,7 +9,8 @@ class Twilio::CsatTemplateApiClient
     HTTParty.post(
       "#{api_base_path}/v1/Content",
       headers: api_headers,
-      body: request_body.to_json
+      body: request_body.to_json,
+      **TWILIO_REQUEST_OPTIONS
     )
   end
 
@@ -20,28 +23,32 @@ class Twilio::CsatTemplateApiClient
     HTTParty.post(
       approval_url,
       headers: api_headers,
-      body: request_body.to_json
+      body: request_body.to_json,
+      **TWILIO_REQUEST_OPTIONS
     )
   end
 
   def delete_template(content_sid)
     HTTParty.delete(
       "#{api_base_path}/v1/Content/#{content_sid}",
-      headers: api_headers
+      headers: api_headers,
+      **TWILIO_REQUEST_OPTIONS
     )
   end
 
   def fetch_template(content_sid)
     HTTParty.get(
       "#{api_base_path}/v1/Content/#{content_sid}",
-      headers: api_headers
+      headers: api_headers,
+      **TWILIO_REQUEST_OPTIONS
     )
   end
 
   def fetch_approval_status(content_sid)
     HTTParty.get(
       "#{api_base_path}/v1/Content/#{content_sid}/ApprovalRequests",
-      headers: api_headers
+      headers: api_headers,
+      **TWILIO_REQUEST_OPTIONS
     )
   end
 

--- a/app/services/twilio/request_options.rb
+++ b/app/services/twilio/request_options.rb
@@ -1,0 +1,17 @@
+# Every HTTParty call to Twilio's Content API, which is all five of the CSAT template
+# ones, with the number and the reason it is that number.
+#
+# `max_retries: 0`: `Net::HTTP` repeats an idempotent request once by default, so the two
+# reads below would otherwise cost twice what this says.
+#
+# One ceiling and not two, because these five are the same kind of call: they create,
+# delete and read a template definition, and Twilio answers each out of its own state.
+# None of them hands Twilio a body to go fetch, which is what would justify a longer wait.
+#
+# The number matters most on the read: `CsatSurveyService` asks whether the template is
+# approved before sending a survey, and that runs once per conversation resolved, inside
+# a job. A Twilio that accepts the connection and stops answering held a worker for a
+# minute there, per conversation.
+module Twilio::RequestOptions
+  TWILIO_REQUEST_OPTIONS = { timeout: 10, max_retries: 0 }.freeze
+end

--- a/spec/services/twilio/request_options_spec.rb
+++ b/spec/services/twilio/request_options_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+# The ceiling for Twilio's Content API, and the call that pays for it most.
+RSpec.describe Twilio::RequestOptions do
+  let(:channel) { create(:channel_twilio_sms) }
+  let(:client) { Twilio::CsatTemplateApiClient.new(channel) }
+
+  # `CsatSurveyService` reads this before sending a survey, once per conversation
+  # resolved, inside a job. A Twilio that accepts the connection and then stops answering
+  # held a worker for a minute there, per conversation, and the caller reads the failure
+  # as "not approved", so nothing on the screen ever said why the survey stopped going
+  # out. The ceiling does not fix that reading; it bounds what it costs.
+  it 'bounds the read the survey path depends on' do
+    options = nil
+    allow(HTTParty).to receive(:get) do |_url, **kwargs|
+      options = kwargs
+      instance_double(HTTParty::Response, success?: true, body: '{}')
+    end
+
+    client.fetch_approval_status('HX123')
+
+    expect(options).to include(timeout: 10, max_retries: 0)
+  end
+
+  # A fence, not a checklist. One ceiling for this family, so the count is the count of
+  # calls: a sixth call arriving without it fails here rather than in production.
+  it 'puts every call to the Content API under the one ceiling' do
+    source = File.read(Rails.root.join('app/services/twilio/csat_template_api_client.rb'))
+
+    expect(source.scan(/HTTParty\.\w+/).size).to eq(5)
+    expect(source.scan('TWILIO_REQUEST_OPTIONS').size).to eq(5)
+  end
+end


### PR DESCRIPTION
As cinco chamadas HTTP ao Content API do Twilio, que são as de template do CSAT, iam sem teto de espera e sem controle de repetição. Um Twilio que aceitava a conexão e parava de responder segurava a thread por um minuto, e duas minutos nas duas que são GET.

Um teto só, e não dois como nas famílias anteriores, porque as cinco são o mesmo tipo de chamada: criam, apagam e leem uma definição de template, e o Twilio responde cada uma do estado dele. Nenhuma entrega um corpo para o Twilio ir buscar, que é o que justificaria esperar mais.

O número pesa mais numa delas. O `CsatSurveyService` pergunta se o template está aprovado antes de mandar a pesquisa, e isso roda **uma vez por conversa resolvida, dentro de um job**. Era um worker por minuto por conversa, num provedor quieto.

## O que esta PR não conserta

`Twilio::CsatTemplateService#get_template_status` tem `rescue StandardError` e responde `{ success: false }`, e o chamador no `CsatSurveyService` responde `false` de novo. Ou seja, um estouro de teto é lido como "o template não está aprovado" e a pesquisa simplesmente não sai, sem nada que o operador veja. O teto não muda essa leitura, só limita o que ela custa. Isso é classificação faltando, tem decisão própria, e vira issue em vez de entrar aqui de carona.

## Closes

Fecha a família Twilio da #589 (5 pontos). Restam TikTok (8), Linear (4) e os avulsos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/622)
<!-- Reviewable:end -->
