### PR TITLE
fix(tiktok): pôr teto nas oito chamadas da Business API e no upload

### DIFF
--- a/app/services/tiktok/auth_client.rb
+++ b/app/services/tiktok/auth_client.rb
@@ -1,4 +1,10 @@
 class Tiktok::AuthClient
+  # `extend` and not `include`: every call in this class runs on the singleton, inside
+  # `class << self`, and a module included into the class is not in the singleton's
+  # ancestors, so the constant does not resolve there. It raises `NameError` at the call,
+  # which no count of the constant in the source can notice.
+  extend Tiktok::RequestOptions
+
   REQUIRED_SCOPES = %w[user.info.basic user.info.username user.info.stats user.info.profile user.account.type user.insights message.list.read
                        message.list.send message.list.manage].freeze
 
@@ -40,7 +46,8 @@ class Tiktok::AuthClient
       response = HTTParty.post(
         endpoint,
         body: body.to_json,
-        headers: headers
+        headers: headers,
+        **TIKTOK_REQUEST_OPTIONS
       )
 
       json = process_json_response(response, 'Failed to obtain TikTok short-term access token')
@@ -68,7 +75,8 @@ class Tiktok::AuthClient
       response = HTTParty.post(
         endpoint,
         body: body.to_json,
-        headers: headers
+        headers: headers,
+        **TIKTOK_REQUEST_OPTIONS
       )
 
       json = process_json_response(response, 'Failed to renew TikTok short-term access token')
@@ -89,7 +97,7 @@ class Tiktok::AuthClient
         secret: client_secret,
         event_type: 'DIRECT_MESSAGE'
       }
-      response = HTTParty.get(endpoint, query: params, headers: headers)
+      response = HTTParty.get(endpoint, query: params, headers: headers, **TIKTOK_REQUEST_OPTIONS)
 
       process_json_response(response, 'Failed to fetch TikTok webhook callback')
     end
@@ -103,7 +111,7 @@ class Tiktok::AuthClient
         event_type: 'DIRECT_MESSAGE',
         callback_url: webhook_url
       }
-      response = HTTParty.post(endpoint, body: body.to_json, headers: headers)
+      response = HTTParty.post(endpoint, body: body.to_json, headers: headers, **TIKTOK_REQUEST_OPTIONS)
 
       process_json_response(response, 'Failed to update TikTok webhook callback')
     end

--- a/app/services/tiktok/client.rb
+++ b/app/services/tiktok/client.rb
@@ -2,6 +2,8 @@ require 'faraday'
 require 'faraday/multipart'
 
 class Tiktok::Client
+  include Tiktok::RequestOptions
+
   # Always use Tiktok::TokenService to get a valid access token
   pattr_initialize [:business_id!, :access_token!]
 
@@ -9,7 +11,7 @@ class Tiktok::Client
     endpoint = "#{api_base_url}/business/get/"
     headers = { 'Access-Token': access_token }
     params = { business_id: business_id, fields: %w[username display_name profile_image].to_s }
-    response = HTTParty.get(endpoint, query: params, headers: headers)
+    response = HTTParty.get(endpoint, query: params, headers: headers, **TIKTOK_REQUEST_OPTIONS)
 
     json = process_json_response(response, 'Failed to fetch TikTok user details')
     {
@@ -28,7 +30,7 @@ class Tiktok::Client
              media_id: media_id,
              media_type: media_type }
 
-    response = HTTParty.post(endpoint, body: body.to_json, headers: headers)
+    response = HTTParty.post(endpoint, body: body.to_json, headers: headers, **TIKTOK_REQUEST_OPTIONS)
     json = process_json_response(response, 'Failed to fetch TikTok media download URL')
 
     json['data']['download_url']
@@ -44,7 +46,7 @@ class Tiktok::Client
       capability_types: ['IMAGE_SEND'].to_json
     }
 
-    response = HTTParty.get(endpoint, query: query, headers: headers)
+    response = HTTParty.get(endpoint, query: query, headers: headers, **TIKTOK_REQUEST_OPTIONS)
     json = process_json_response(response, 'Failed to fetch TikTok message capabilities')
     capabilities = json.dig('data', 'capability_infos') || []
     image_send = capabilities.find { |capability| capability['capability_type'] == 'IMAGE_SEND' }
@@ -84,7 +86,7 @@ class Tiktok::Client
       body[:text] = { body: payload }
     end
 
-    response = HTTParty.post(endpoint, body: body.to_json, headers: headers)
+    response = HTTParty.post(endpoint, body: body.to_json, headers: headers, **TIKTOK_REQUEST_OPTIONS)
     json = process_json_response(response, 'Failed to send TikTok message')
 
     json['data']['message']['message_id']
@@ -112,6 +114,8 @@ class Tiktok::Client
   def multipart_connection
     @multipart_connection ||= Faraday.new do |faraday|
       faraday.request :multipart
+      faraday.options.timeout = TIKTOK_UPLOAD_TIMEOUT
+      faraday.options.open_timeout = TIKTOK_OPEN_TIMEOUT
     end
   end
 

--- a/app/services/tiktok/request_options.rb
+++ b/app/services/tiktok/request_options.rb
@@ -1,0 +1,21 @@
+# Every HTTParty call to the TikTok Business API, plus the one that does not go through
+# HTTParty at all, with the numbers and the reason each one is what it is.
+#
+# `max_retries: 0`: `Net::HTTP` repeats an idempotent request once by default, and three
+# of these eight are GETs, so their ceiling was worth half of what it read as.
+#
+# One ceiling for the eight, unlike the channels that send media by URL. TikTok never
+# fetches anything from us while answering: an image is uploaded first, separately, and
+# the send then names it by `media_id`. So every one of these eight answers out of
+# TikTok's own state, and none of them has a reason to wait longer than the others.
+module Tiktok::RequestOptions
+  TIKTOK_REQUEST_OPTIONS = { timeout: 10, max_retries: 0 }.freeze
+
+  # The upload is the exception, and it is the only call here that carries bytes: it is a
+  # multipart POST over Faraday, which defaults to no ceiling at all, so a TikTok that
+  # accepted the connection and stopped reading held the worker until the socket died on
+  # its own. Faraday names the same two things separately, and it has no retry of its own
+  # to close.
+  TIKTOK_UPLOAD_TIMEOUT = 120
+  TIKTOK_OPEN_TIMEOUT = 10
+end

--- a/spec/services/tiktok/client_spec.rb
+++ b/spec/services/tiktok/client_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe Tiktok::Client do
           conversation_type: 'SINGLE',
           capability_types: '["IMAGE_SEND"]'
         },
-        headers: { 'Access-Token': 'token-123' }
+        headers: { 'Access-Token': 'token-123' },
+        timeout: 10,
+        max_retries: 0
       )
     end
 

--- a/spec/services/tiktok/request_options_spec.rb
+++ b/spec/services/tiktok/request_options_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+# The ceilings for the TikTok family, including the one call that does not go through
+# HTTParty and therefore does not show up in any scan of it.
+RSpec.describe Tiktok::RequestOptions do
+  let(:client) { Tiktok::Client.new(business_id: 'biz-123', access_token: 'token-123') }
+
+  # The send is the call an agent is waiting on, and it is also the one a scan of options
+  # is least likely to be written for, since it sits in a private method.
+  it 'bounds the send' do
+    options = nil
+    allow(HTTParty).to receive(:post) do |_url, **kwargs|
+      options = kwargs
+      instance_double(HTTParty::Response, success?: true,
+                                          body: { code: 0, data: { message: { message_id: 'm1' } } }.to_json)
+    end
+
+    client.send_text_message('tt-conv-1', 'hello')
+
+    expect(options).to include(timeout: 10, max_retries: 0)
+  end
+
+  # The upload is the only call in this family that carries bytes, and it is the only one
+  # a scan for `HTTParty` cannot see: it is a multipart POST over Faraday, which defaults
+  # to no ceiling at all. Asserting on the connection object rather than on a request,
+  # because what is missing is a default, not an argument.
+  it 'bounds the upload, which does not go through HTTParty' do
+    connection = client.send(:multipart_connection)
+
+    expect(connection.options.timeout).to eq(120)
+    expect(connection.options.open_timeout).to eq(10)
+  end
+
+  # The auth client keeps its calls behind `class << self`, and the constant reaches them
+  # through the lexical scope rather than through the ancestors of an instance. Counting
+  # the constant in the source proves the text is there, not that it resolves: dropping
+  # the `include` from this file left every count intact and every example green, because
+  # nothing here exercised it. So this one goes through the real call.
+  it 'bounds the auth client, whose calls run on the singleton' do
+    options = nil
+    allow(HTTParty).to receive(:get) do |_url, **kwargs|
+      options = kwargs
+      instance_double(HTTParty::Response, success?: true, body: { code: 0, data: {} }.to_json)
+    end
+
+    Tiktok::AuthClient.webhook_callback
+
+    expect(options).to include(timeout: 10, max_retries: 0)
+  end
+
+  # A fence, not a checklist. One ceiling for the eight HTTParty calls, so the count of
+  # calls and the count of ceilings have to match; the Faraday one is named separately
+  # above because it is a different mechanism with a different failure.
+  it 'puts every TikTok call under the ceiling' do
+    sources = %w[
+      app/services/tiktok/client.rb
+      app/services/tiktok/auth_client.rb
+    ].map { |path| File.read(Rails.root.join(path)) }.join
+
+    expect(sources.scan(/HTTParty\.\w+/).size).to eq(8)
+    expect(sources.scan('TIKTOK_REQUEST_OPTIONS').size).to eq(8)
+    expect(sources.scan('Faraday.new').size).to eq(1)
+  end
+end


### PR DESCRIPTION
As oito chamadas HTTP à Business API do TikTok iam sem teto de espera e sem controle de repetição, e o upload de mídia, que é o único ponto por onde bytes realmente saem, não tinha teto de espécie alguma.

**Um teto só para as oito**, diferente dos canais que mandam mídia por URL. O TikTok nunca busca nada em nós enquanto responde: a imagem sobe antes, separada, e o envio depois só nomeia ela por `media_id`. Então as oito respondem do estado dele e nenhuma tem motivo para esperar mais que as outras.

**O upload é a exceção, e não aparece em varredura de HTTParty.** Ele é um POST multipart por Faraday, que por padrão não tem teto: um TikTok que aceitava a conexão e parava de ler segurava o worker até o socket morrer sozinho. Ganhou 120s de leitura e 10s de conexão, e um exemplo que afirma nas opções da conexão, porque o que faltava ali era um default e não um argumento.

## Um erro que só o teste pegou

O `AuthClient` guarda as quatro chamadas dele dentro de `class << self`. Eu escrevi `include Tiktok::RequestOptions`, e módulo incluído na classe **não** entra nos ancestrais do singleton: a constante não resolvia e a chamada levantava `NameError`. Todos os contadores de cerca continuavam batendo, porque o texto da constante estava lá, nas oito. O que pegou foi o exemplo que passa pela chamada de verdade e captura as opções que saem.

É a segunda vez nesta sequência que a mesma forma aparece (a #620 teve a versão dela), e é por isso que estas PRs medem o que sai da chamada em vez de conferir que a constante existe.

## Closes

Fecha a família TikTok da #589 (8 pontos HTTParty, mais o upload por Faraday). Restam Linear (4) e os avulsos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/624)
<!-- Reviewable:end -->
