### PR TITLE
fix(enterprise): pôr teto nas onze chamadas da árvore enterprise

### DIFF
--- a/enterprise/app/models/enterprise/concerns/article.rb
+++ b/enterprise/app/models/enterprise/concerns/article.rb
@@ -70,7 +70,9 @@ module Enterprise::Concerns::Article
     headers = { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{openai_api_key}" }
     body = { model: 'gpt-4o', messages: messages, response_format: { type: 'json_object' } }.to_json
     Rails.logger.info "Requesting Chat GPT with body: #{body}"
-    response = HTTParty.post(openai_api_url, headers: headers, body: body)
+    # A chat completion: the thinking time before the first byte is the point of the call.
+    # `max_retries: 0` because a repeat is a second answer and a second bill.
+    response = HTTParty.post(openai_api_url, headers: headers, body: body, timeout: 120, max_retries: 0)
     Rails.logger.info "Chat GPT response: #{response.body}"
     JSON.parse(response.parsed_response['choices'][0]['message']['content'])['search_terms']
   end

--- a/enterprise/app/services/captain/tools/firecrawl_service.rb
+++ b/enterprise/app/services/captain/tools/firecrawl_service.rb
@@ -12,11 +12,17 @@ class Captain::Tools::FirecrawlService
     raise 'Missing API key' if @api_key.blank?
   end
 
+  # `crawl` only registers the job and answers, so it waits on Firecrawl's own state.
+  # `scrape` fetches the page before answering, so it waits on whatever site was named.
+  CRAWL_REQUEST_OPTIONS = { timeout: 20, max_retries: 0 }.freeze
+  SCRAPE_REQUEST_OPTIONS = { timeout: 60, max_retries: 0 }.freeze
+
   def perform(url, webhook_url, crawl_limit = 10)
     HTTParty.post(
       "#{BASE_URL}/crawl",
       body: crawl_payload(url, webhook_url, crawl_limit),
-      headers: headers
+      headers: headers,
+      **CRAWL_REQUEST_OPTIONS
     )
   rescue StandardError => e
     raise "Failed to crawl URL: #{e.message}"
@@ -26,7 +32,8 @@ class Captain::Tools::FirecrawlService
     HTTParty.post(
       "#{BASE_URL}/scrape",
       body: scrape_payload(url),
-      headers: headers
+      headers: headers,
+      **SCRAPE_REQUEST_OPTIONS
     )
   end
 

--- a/enterprise/app/services/cloudflare/check_custom_hostname_service.rb
+++ b/enterprise/app/services/cloudflare/check_custom_hostname_service.rb
@@ -6,7 +6,8 @@ class Cloudflare::CheckCustomHostnameService < Cloudflare::BaseCloudflareZoneSer
     return { errors: ['No custom domain found'] } if @portal.custom_domain.blank?
 
     response = HTTParty.get(
-      "#{BASE_URI}/zones/#{zone_id}/custom_hostnames?hostname=#{@portal.custom_domain}", headers: headers
+      "#{BASE_URI}/zones/#{zone_id}/custom_hostnames?hostname=#{@portal.custom_domain}", headers: headers,
+                                                                                         timeout: 10, max_retries: 0
     )
 
     return { errors: response.parsed_response['errors'] } unless response.success?

--- a/enterprise/app/services/cloudflare/create_custom_hostname_service.rb
+++ b/enterprise/app/services/cloudflare/create_custom_hostname_service.rb
@@ -31,7 +31,9 @@ class Cloudflare::CreateCustomHostnameService < Cloudflare::BaseCloudflareZoneSe
           method: 'http',
           type: 'dv'
         }
-      }.to_json
+      }.to_json,
+      timeout: 10,
+      max_retries: 0
     )
   end
 end

--- a/enterprise/app/services/enterprise/clearbit_lookup_service.rb
+++ b/enterprise/app/services/enterprise/clearbit_lookup_service.rb
@@ -34,12 +34,13 @@ class Enterprise::ClearbitLookupService
   # @param email [String] The email address to lookup.
   # @return [HTTParty::Response] The response from the Clearbit API.
   def self.perform_request(email)
-    options = {
+    HTTParty.get(
+      CLEARBIT_ENDPOINT,
       headers: { 'Authorization' => "Bearer #{clearbit_token}" },
-      query: { email: email }
-    }
-
-    HTTParty.get(CLEARBIT_ENDPOINT, options)
+      query: { email: email },
+      timeout: 10,
+      max_retries: 0
+    )
   end
 
   # Handles an error response from the Clearbit API.

--- a/enterprise/app/services/enterprise/website_branding_service.rb
+++ b/enterprise/app/services/enterprise/website_branding_service.rb
@@ -28,7 +28,9 @@ module Enterprise::WebsiteBrandingService
       headers: {
         'Authorization' => "Bearer #{context_dev_api_key}",
         'Content-Type' => 'application/json'
-      }
+      },
+      timeout: 10,
+      max_retries: 0
     )
   end
 

--- a/enterprise/app/services/internal/account_analysis/discord_notifier_service.rb
+++ b/enterprise/app/services/internal/account_analysis/discord_notifier_service.rb
@@ -8,7 +8,9 @@ class Internal::AccountAnalysis::DiscordNotifierService
     HTTParty.post(
       webhook_url,
       body: build_message(account).to_json,
-      headers: { 'Content-Type' => 'application/json' }
+      headers: { 'Content-Type' => 'application/json' },
+      timeout: 10,
+      max_retries: 0
     )
 
     Rails.logger.info("Discord notification sent for flagged account #{account.id}")

--- a/enterprise/app/services/internal/account_analysis/website_scraper_service.rb
+++ b/enterprise/app/services/internal/account_analysis/website_scraper_service.rb
@@ -9,7 +9,9 @@ class Internal::AccountAnalysis::WebsiteScraperService
     Rails.logger.info("Scraping website: #{external_link}")
 
     begin
-      response = HTTParty.get(external_link, follow_redirects: true)
+      # Whatever address the account put on its own record, so the wait is on a site
+      # nobody here controls and the ceiling is the only thing bounding it.
+      response = HTTParty.get(external_link, follow_redirects: true, timeout: 15, max_retries: 0)
       response.to_s
     rescue StandardError => e
       Rails.logger.error("Error scraping website for domain #{@domain}: #{e.message}")

--- a/enterprise/app/services/internal/accounts/marketing_conversion_tracking_service.rb
+++ b/enterprise/app/services/internal/accounts/marketing_conversion_tracking_service.rb
@@ -33,7 +33,9 @@ class Internal::Accounts::MarketingConversionTrackingService
       body: {
         destinations: [destination_payload],
         events: [conversion_payload]
-      }.to_json
+      }.to_json,
+      timeout: 10,
+      max_retries: 0
     )
 
     raise "Marketing conversion upload failed: #{response.body}" unless response.success?

--- a/enterprise/app/services/page_crawler_service.rb
+++ b/enterprise/app/services/page_crawler_service.rb
@@ -3,7 +3,9 @@ class PageCrawlerService
 
   def initialize(external_link)
     @external_link = external_link
-    @doc = Nokogiri::HTML(HTTParty.get(external_link).body)
+    # An address nobody here controls, fetched in the constructor, so every caller pays
+    # this wait before it has a chance to do anything about it.
+    @doc = Nokogiri::HTML(HTTParty.get(external_link, timeout: 15, max_retries: 0).body)
   end
 
   def page_links

--- a/spec/enterprise/lib/request_ceilings_spec.rb
+++ b/spec/enterprise/lib/request_ceilings_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass -- the subject is eleven calls across eight unrelated
+# services, and what they have in common is the number each one does not share.
+#
+# This file lives under `spec/enterprise`, which the CE suite deletes before it runs
+# (`run_foss_spec.yml` does `rm -rf enterprise spec/enterprise`). So nothing here is
+# covered by CI in this repo: it runs in the Pro repo, and locally. The fence below reads
+# files from `enterprise/`, which is exactly why it cannot live in `spec/lib`.
+RSpec.describe 'the ceilings of the enterprise integrations' do
+  # Two calls to the same service with different numbers, because they wait on different
+  # things: `crawl` registers a job and answers, `scrape` fetches the page first.
+  it 'waits longer on a scrape than on registering a crawl' do
+    expect(Captain::Tools::FirecrawlService::SCRAPE_REQUEST_OPTIONS[:timeout])
+      .to be > Captain::Tools::FirecrawlService::CRAWL_REQUEST_OPTIONS[:timeout]
+    expect(Captain::Tools::FirecrawlService::CRAWL_REQUEST_OPTIONS).to include(max_retries: 0)
+    expect(Captain::Tools::FirecrawlService::SCRAPE_REQUEST_OPTIONS).to include(max_retries: 0)
+  end
+
+  # The one call in this tree that is a chat completion. The thinking time before the first
+  # byte is the point of the call, so it gets the long ceiling, and `max_retries: 0` matters
+  # here more than elsewhere because a repeat is a second answer and a second bill.
+  it 'gives the model room to think, and never asks twice' do
+    source = File.read(Rails.root.join('enterprise/app/models/enterprise/concerns/article.rb'))
+
+    expect(source).to include('timeout: 120, max_retries: 0')
+  end
+
+  # A fence, not a checklist: every HTTParty call in the enterprise tree carries both axes.
+  #
+  # Parsed rather than grepped, because four of these calls carry their options as
+  # `**GRAPH_REQUEST_OPTIONS` and a count of the word `timeout:` reads those as bare. That
+  # is the same mistake in miniature that this whole sweep exists to undo: counting the
+  # text instead of reading the call.
+  it 'leaves no call in the enterprise tree without both axes' do
+    require 'prism'
+
+    constants = {}
+    sources = Dir.glob(Rails.root.join('{app,lib,enterprise}/**/*.rb'))
+    sources.each do |path|
+      File.read(path).scan(/^\s*([A-Z][A-Z0-9_]*)\s*=\s*(\{.*?\})\.freeze/m) do |name, literal|
+        constants[name] = { timeout: literal.include?('timeout'), retries: literal.include?('max_retries') }
+      end
+    end
+
+    bare = []
+    Dir.glob(Rails.root.join('enterprise/**/*.rb')).each do |path|
+      body = File.read(path)
+      next unless body.include?('HTTParty')
+
+      stack = [Prism.parse(body).value]
+      until stack.empty?
+        node = stack.pop
+        stack.concat(node.compact_child_nodes)
+        next unless node.is_a?(Prism::CallNode)
+        next unless node.receiver.is_a?(Prism::ConstantReadNode) && node.receiver.name == :HTTParty
+
+        text = (node.arguments&.arguments || []).map { |arg| body.byteslice(arg.location.start_offset, arg.location.length) }.join(', ')
+        timeout = text.include?('timeout')
+        retries = text.include?('max_retries')
+        text.scan(/\*\*(?:[A-Z][A-Za-z0-9_]*::)*([A-Z][A-Z0-9_]*)/).flatten.each do |name|
+          next unless constants[name]
+
+          timeout ||= constants[name][:timeout]
+          retries ||= constants[name][:retries]
+        end
+        bare << "#{Pathname.new(path).relative_path_from(Rails.root)}:#{node.location.start_line}" unless timeout && retries
+      end
+    end
+
+    expect(bare).to be_empty
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
As onze chamadas HTTP da árvore `enterprise/` iam sem teto de espera e sem controle de repetição. Cada uma recebeu o número dela, porque elas não compartilham cliente nem semântica:

| chamada | teto | por quê |
| --- | --- | --- |
| termos de busca do artigo (chat completion) | 120s | do outro lado um modelo está compondo a resposta; o tempo de pensar é o ponto da chamada |
| Firecrawl `scrape` | 60s | busca a página antes de responder |
| Firecrawl `crawl` | 20s | só registra o trabalho e responde; o resultado vem por webhook |
| scraper de site e crawler de página | 15s | buscam um endereço que ninguém aqui controla, e o crawler faz isso no construtor, então todo chamador paga antes de poder reagir |
| Cloudflare (2), Clearbit, branding, Discord, conversão de marketing | 10s | API administrativa, respondida do estado do próprio terceiro |

`max_retries: 0` em todas. Na do modelo ele pesa mais que o teto: repetir ali é uma segunda resposta e uma segunda cobrança.

## A cerca lê, não conta

A cerca usa Prism e percorre as chamadas de verdade, resolvendo também opção que chega por `**CONSTANTE`. Contar a palavra `timeout:` leria como descobertas as quatro chamadas que carregam `**GRAPH_REQUEST_OPTIONS`, que é o mesmo erro em miniatura que esta varredura existe para desfazer.

Ela pegou um caso real enquanto eu escrevia: as opções do Clearbit moravam numa variável local e eram invisíveis no ponto de chamada. Foram para a chamada.

## Sem cobertura de CI neste repo

`run_foss_spec.yml` roda `rm -rf enterprise spec/enterprise` antes da suíte, então **nem o código desta PR nem o spec dela são executados pela CI do CE**. A verificação foi local: `bundle exec rspec spec/enterprise`, 2451 exemplos, 0 falhas, excluindo um spec que já estava vermelho antes (detalhes abaixo). A cobertura de verdade vem quando isto chegar ao repo Pro.

## Um vermelho que eu encontrei e não causei

`spec/enterprise/jobs/enterprise/internal/check_new_versions_job_spec.rb` falha com `WebMock::NetConnectNotAllowedError`. Conferi em quatro pontos da história, incluindo a tag `v4.17.0-fazer-ai.112`: já falhava em todos. Nenhuma CI deste repo roda esse arquivo, que é por isso que ninguém viu. Vai virar issue à parte.

## Closes

Avança a #589. Depois desta e da #624 e #625, resta só a família Linear (4 pontos), segurada porque a #616 está em voo no mesmo diretório.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/626)
<!-- Reviewable:end -->
