### PR TITLE
fix(linear): pôr teto nas quatro chamadas, e trancar a varredura inteira

### DIFF
--- a/lib/integrations/linear/access_token_service.rb
+++ b/lib/integrations/linear/access_token_service.rb
@@ -1,4 +1,6 @@
 class Integrations::Linear::AccessTokenService
+  include Integrations::Linear::RequestOptions
+
   TOKEN_URL = 'https://api.linear.app/oauth/token'.freeze
   MIGRATE_OLD_TOKEN_URL = 'https://api.linear.app/oauth/migrate_old_token'.freeze
   TOKEN_EXPIRY_BUFFER = 1.minute
@@ -24,7 +26,8 @@ class Integrations::Linear::AccessTokenService
         refresh_token: refresh_token,
         client_id: client_id,
         client_secret: client_secret
-      }
+      },
+      **LINEAR_REQUEST_OPTIONS
     )
 
     return fallback_access_token unless response.success?
@@ -44,7 +47,8 @@ class Integrations::Linear::AccessTokenService
         access_token: hook.access_token,
         client_id: client_id,
         client_secret: client_secret
-      }
+      },
+      **LINEAR_REQUEST_OPTIONS
     )
 
     return fallback_access_token unless response.success?

--- a/lib/integrations/linear/request_options.rb
+++ b/lib/integrations/linear/request_options.rb
@@ -1,0 +1,16 @@
+# Every HTTParty call to Linear, with the number and the reason it is that number.
+#
+# One ceiling for the four, because they all wait on the same thing: Linear answering out
+# of its own state. Two of them exchange a token, one revokes it and one is the GraphQL
+# endpoint every issue action goes through. None of them hands Linear a body to go fetch,
+# which is what would justify waiting longer.
+#
+# Fifteen and not ten because the GraphQL one is in the group: an agent clicked something
+# in the dashboard and is waiting on the issue to exist, and a query that reads a team's
+# issues is more work for Linear than handing back a token.
+#
+# `max_retries: 0`: `Net::HTTP` repeats an idempotent request once by default, and on a
+# token exchange a silent second attempt is a second token.
+module Integrations::Linear::RequestOptions
+  LINEAR_REQUEST_OPTIONS = { timeout: 15, max_retries: 0 }.freeze
+end

--- a/lib/linear.rb
+++ b/lib/linear.rb
@@ -1,4 +1,6 @@
 class Linear
+  include Integrations::Linear::RequestOptions
+
   BASE_URL = 'https://api.linear.app/graphql'.freeze
   REVOKE_URL = 'https://api.linear.app/oauth/revoke'.freeze
   PRIORITY_LEVELS = (0..4).to_a
@@ -86,7 +88,8 @@ class Linear
     response = HTTParty.post(
       REVOKE_URL,
       headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-      body: { token: token, token_type_hint: token_type_hint }
+      body: { token: token, token_type_hint: token_type_hint },
+      **LINEAR_REQUEST_OPTIONS
     )
     response.success?
   end
@@ -151,7 +154,8 @@ class Linear
     HTTParty.post(
       BASE_URL,
       headers: { 'Authorization' => "Bearer #{@access_token}", 'Content-Type' => 'application/json' },
-      body: payload.to_json
+      body: payload.to_json,
+      **LINEAR_REQUEST_OPTIONS
     )
   end
 

--- a/spec/lib/request_ceilings_spec.rb
+++ b/spec/lib/request_ceilings_spec.rb
@@ -59,5 +59,108 @@ RSpec.describe 'the ceilings of the one-off integrations' do
     expect(Channel::Sms::BANDWIDTH_SEND_OPTIONS).to include(max_retries: 0)
     expect(Channel::Sms::BANDWIDTH_REQUEST_OPTIONS).to include(max_retries: 0)
   end
+
+  # Both token calls sit inside a `rescue StandardError` that answers with
+  # `fallback_access_token`, which rereads the row and hands back the token it already
+  # had. So a ceiling here does not surface a failure, it reaches a swallow faster: what
+  # it buys is the worker, not the diagnosis. Exercised through the real call for the
+  # usual reason, that a constant which does not resolve raises `NameError`, which is a
+  # `StandardError`, which this very `rescue` would eat.
+  it 'bounds the Linear token refresh, whose failure is swallowed' do
+    hook = create(:integrations_hook, app_id: 'linear', access_token: 'old-token',
+                                      settings: { refresh_token: 'r', expires_on: 1.hour.ago.to_s })
+    options = nil
+    allow(HTTParty).to receive(:post) do |_url, **kwargs|
+      options = kwargs
+      instance_double(HTTParty::Response, success?: false)
+    end
+
+    expect(Integrations::Linear::AccessTokenService.new(hook: hook).access_token).to eq('old-token')
+    expect(options).to include(timeout: 15, max_retries: 0)
+  end
+
+  it 'bounds the GraphQL endpoint every issue action goes through' do
+    options = nil
+    allow(HTTParty).to receive(:post) do |_url, **kwargs|
+      options = kwargs
+      instance_double(HTTParty::Response, success?: true, parsed_response: { 'data' => { 'teams' => {} } })
+    end
+
+    Linear.new('a-token').teams
+
+    expect(options).to include(timeout: 15, max_retries: 0)
+  end
+
+  # The fence the whole of #589 was for. Every HTTParty call in the tree carries both axes,
+  # read by parsing the call rather than counting the word, because options arrive three
+  # ways: written at the call, splatted from a constant, or built in a local first.
+  #
+  # `enterprise` is included only when it is there: the CE suite deletes that tree before
+  # it runs, and a fence that reads a file the suite deleted fails for the wrong reason.
+  it 'leaves no HTTParty call in the repo without a ceiling and without the retry closed' do
+    require 'prism'
+
+    roots = %w[app lib enterprise].select { |dir| Rails.root.join(dir).directory? }
+    sources = Dir.glob(Rails.root.join("{#{roots.join(',')}}/**/*.rb"))
+
+    constants = {}
+    sources.each do |path|
+      File.read(path).scan(/^\s*([A-Z][A-Z0-9_]*)\s*=\s*(\{.*?\})\.freeze/m) do |name, literal|
+        constants[name] = { timeout: literal.include?('timeout'), retries: literal.include?('max_retries') }
+      end
+    end
+
+    bare = sources.flat_map do |path|
+      body = File.read(path)
+      next [] unless body.include?('HTTParty')
+
+      calls = []
+      parsed = Prism.parse(body).value
+      defs = []
+      collect = lambda do |node|
+        defs << node if node.is_a?(Prism::DefNode)
+        node.compact_child_nodes.each { |child| collect.call(child) }
+      end
+      collect.call(parsed)
+
+      stack = [parsed]
+      until stack.empty?
+        node = stack.pop
+        stack.concat(node.compact_child_nodes)
+        next unless node.is_a?(Prism::CallNode)
+        next unless node.receiver.is_a?(Prism::ConstantReadNode) && node.receiver.name == :HTTParty
+
+        text = (node.arguments&.arguments || []).map { |arg| body.byteslice(arg.location.start_offset, arg.location.length) }.join(', ')
+        timeout = text.include?('timeout')
+        retries = text.include?('max_retries')
+        text.scan(/\*\*(?:[A-Z][A-Za-z0-9_]*::)*([A-Z][A-Z0-9_]*)/).flatten.each do |name|
+          next unless constants[name]
+
+          timeout ||= constants[name][:timeout]
+          retries ||= constants[name][:retries]
+        end
+
+        # A call that splats a local is judged by the method that built that local. Looser
+        # than the rest on purpose, and the looseness is bounded: it only applies where the
+        # options were assembled a few lines above, which is what the uazapi client does
+        # because it adds keys conditionally.
+        if text.match?(/\*\*[a-z_]/)
+          owner = defs.select { |d| d.location.start_offset <= node.location.start_offset && d.location.end_offset >= node.location.end_offset }
+                      .min_by { |d| d.location.length }
+          if owner
+            enclosing = body.byteslice(owner.location.start_offset, owner.location.length)
+            timeout ||= enclosing.include?('timeout')
+            retries ||= enclosing.include?('max_retries')
+          end
+        end
+
+        calls << "#{Pathname.new(path).relative_path_from(Rails.root)}:#{node.location.start_line}" unless timeout && retries
+      end
+      calls
+    end
+
+    expect(sources).not_to be_empty
+    expect(bare).to be_empty
+  end
 end
 # rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
As últimas quatro chamadas HTTP sem teto do repositório, todas para o Linear: duas trocas de token, a revogação, e o endpoint GraphQL por onde passa toda ação de issue.

Um teto só, porque as quatro esperam a mesma coisa: o Linear respondendo do estado dele. Nenhuma entrega um corpo para ele ir buscar. Quinze segundos e não dez porque a de GraphQL está no grupo, e ler as issues de um time é mais trabalho para o Linear do que devolver um token. `max_retries: 0` porque numa troca de token uma segunda tentativa silenciosa é um segundo token.

## O que este teto compra, e o que não compra

As duas chamadas de token ficam dentro de um `rescue StandardError` que responde `fallback_access_token`, que relê a linha e devolve o token que já estava lá. Então o teto aqui **não** faz a falha aparecer: ele alcança o engolimento mais rápido. O que ele compra é o worker, não o diagnóstico. Está escrito no código, ao lado da chamada, para quem for mexer nisso depois não descobrir sozinho.

Não abri issue para isso porque a orientação atual é fechar o que está aberto em vez de registrar coisa nova. Quando alguém for tratar a classificação da família Linear, o ponto de partida é esse `rescue` e o `fallback_access_token`.

## Closes #589

Com estas quatro, **125 de 125** chamadas HTTParty do repositório carregam teto de tempo e controle de repetição. A varredura que abriu a issue media 136 pontos com 10 tetos e zero `max_retries`.

A cerca nova afirma isso lendo as chamadas com Prism, e resolve opção das três formas que aparecem no código: escrita na própria chamada, vinda de constante (`**GRAPH_REQUEST_OPTIONS`) e montada numa variável local antes (o cliente do uazapi, que acrescenta chaves condicionalmente). Contar a palavra `timeout:` leria as duas últimas como descobertas, que é o mesmo erro em miniatura que esta issue existe para desfazer.

`enterprise/` entra na varredura só quando a árvore está presente, porque `run_foss_spec.yml` apaga ela antes de rodar e uma cerca que lê arquivo apagado falha pelo motivo errado.

## Famílias fechadas ao longo da issue

WhatsApp Cloud, Baileys, Z-API, 360dialog, uazapi, Telegram, Instagram, TikTok, Twilio, SMS/Bandwidth, hCaptcha, Dyte, Captain, Linear, e os onze pontos da árvore enterprise. Os números vão de 5s (hCaptcha, na frente do formulário de cadastro) a 120s (chamadas de modelo, onde o tempo de pensar é o ponto da chamada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/628)
<!-- Reviewable:end -->
