### PR TITLE
fix(instagram): parar de responder sucesso quando a inscrição não aconteceu

### DIFF
--- a/app/controllers/instagram/callbacks_controller.rb
+++ b/app/controllers/instagram/callbacks_controller.rb
@@ -106,13 +106,21 @@ class Instagram::CallbacksController < ApplicationController
 
     if channel_instagram
       update_channel(channel_instagram, user_details)
+      # A reconnection used to replace the credentials and stop there, so an inbox that was
+      # reconnected precisely because it had stopped receiving went on not receiving: the
+      # subscription is what had failed, and nothing here asked for it again.
+      subscribed = channel_instagram.subscribe
     else
       channel_instagram = create_channel_with_inbox(user_details)
+      # A new channel subscribes through `after_create_commit`, and the only mark it leaves
+      # when that fails is the flag below.
+      subscribed = !channel_instagram.reauthorization_required?
     end
 
-    # reauthorize channel, this code path only triggers when instagram auth is successful
-    # reauthorized will also update cache keys for the associated inbox
-    channel_instagram.reauthorized!
+    # Only when the channel can actually receive. Authorizing and being subscribed are two
+    # different things, and clearing the flag on the strength of the first would hide
+    # exactly what the flag exists to show: this is the one place that clears it.
+    channel_instagram.reauthorized! if subscribed
 
     [channel_instagram.inbox, channel_exists]
   end

--- a/app/models/channel/instagram.rb
+++ b/app/models/channel/instagram.rb
@@ -45,7 +45,7 @@ class Channel::Instagram < ApplicationRecord
 
   def subscribe
     # ref https://developers.facebook.com/docs/instagram-platform/webhooks#enable-subscriptions
-    HTTParty.post(
+    response = HTTParty.post(
       "#{base_uri}/#{instagram_id}/subscribed_apps",
       query: {
         subscribed_fields: %w[messages message_reactions messaging_seen],
@@ -53,22 +53,51 @@ class Channel::Instagram < ApplicationRecord
       },
       **INSTAGRAM_SHORT_REQUEST_OPTIONS
     )
+    return true if response.success?
+
+    subscription_failed("Instagram answered #{response.code}")
   rescue StandardError => e
-    Rails.logger.debug { "Rescued: #{e.inspect}" }
-    true
+    subscription_failed("the request did not complete: #{e.class}")
   end
 
+  # An inbox that did not subscribe exists and receives nothing, and it used to say so
+  # nowhere: the answer was never read, every failure answered `true`, and the only trace
+  # was a `debug` line. The operator saw a working inbox and no messages.
+  #
+  # There is no third state worth reporting here. Instagram refusing and Instagram not
+  # answering leave the same inbox in the same condition, and they have the same remedy,
+  # which is the one the reauthorization banner already asks for: reconnect, which runs
+  # this again. `authorization_error!` rather than `prompt_reauthorization!` so the
+  # channel's own threshold decides, which for this channel is one.
+  def subscription_failed(reason)
+    Rails.logger.error("[INSTAGRAM] inbox #{inbox&.id} did not subscribe to webhooks, so it will receive nothing: #{reason}")
+    authorization_error!
+    false
+  end
+
+  # Failing to unsubscribe must not stop the channel from being removed: the operator
+  # asked for it to go, and Instagram's copy of the subscription is not ours to hold it
+  # hostage. But it cannot be silent either, because we go on receiving webhooks for an
+  # inbox that no longer exists, and the only way anyone finds out is by reading logs.
   def unsubscribe
-    HTTParty.delete(
+    response = HTTParty.delete(
       "#{base_uri}/#{instagram_id}/subscribed_apps",
       query: {
         access_token: access_token
       },
       **INSTAGRAM_SHORT_REQUEST_OPTIONS
     )
-    true
+    return true if response.success?
+
+    log_unsubscribe_failure("Instagram answered #{response.code}")
   rescue StandardError => e
-    Rails.logger.debug { "Rescued: #{e.inspect}" }
+    log_unsubscribe_failure("the request did not complete: #{e.class}")
+  end
+
+  def log_unsubscribe_failure(reason)
+    Rails.logger.error(
+      "[INSTAGRAM] account #{account_id} removed instagram id #{instagram_id} and it is still subscribed there: #{reason}"
+    )
     true
   end
 

--- a/spec/controllers/instagram/callbacks_controller_spec.rb
+++ b/spec/controllers/instagram/callbacks_controller_spec.rb
@@ -34,6 +34,64 @@ RSpec.describe Instagram::CallbacksController do
       .to_return(status: 200, body: '', headers: {})
   end
 
+  # Authorizing and being subscribed are two different things. The callback used to clear
+  # the reauthorization flag on the strength of the first, which erased the only mark a
+  # failed subscription leaves, and a reconnection replaced the credentials without ever
+  # asking to be subscribed again. So the inbox that was reconnected precisely because it
+  # had stopped receiving went on not receiving, now looking connected.
+  #
+  # Through the real callback rather than a stub on the channel: the flag is cleared in
+  # the controller and set in the model, and only the two together show the hole.
+  describe 'when the webhook subscription fails during the callback' do
+    let(:subscription_url) do
+      'https://graph.instagram.com/v22.0/12345/subscribed_apps?access_token=long_lived_test_token' \
+        '&subscribed_fields%5B%5D=messages&subscribed_fields%5B%5D=message_reactions&subscribed_fields%5B%5D=messaging_seen'
+    end
+
+    before do
+      allow(auth_code_object).to receive(:get_token).and_return(access_token)
+      stub_request(:post, subscription_url).to_return(status: 400, body: '{}')
+    end
+
+    it 'leaves the new inbox asking to be reconnected' do
+      get :show, params: valid_params
+
+      channel = Channel::Instagram.find_by(instagram_id: '12345')
+      expect(channel).to be_present
+      expect(channel.reauthorization_required?).to be(true)
+    end
+
+    it 'keeps asking after a reconnection that could not subscribe either' do
+      channel = create(:channel_instagram, account: account, instagram_id: '12345')
+      channel.prompt_reauthorization!
+
+      get :show, params: valid_params
+
+      expect(channel.reload.reauthorization_required?).to be(true)
+    end
+  end
+
+  # And the other half: a reconnection has to actually subscribe again, because the
+  # subscription is usually the thing that broke.
+  describe 'when reconnecting an inbox that is already there' do
+    before do
+      allow(auth_code_object).to receive(:get_token).and_return(access_token)
+    end
+
+    it 'subscribes again instead of only replacing the credentials' do
+      channel = create(:channel_instagram, account: account, instagram_id: '12345')
+      channel.prompt_reauthorization!
+
+      get :show, params: valid_params
+
+      # Matched on the new token, because creating the channel above already subscribed
+      # once with the old one.
+      expect(WebMock).to have_requested(:post, %r{graph\.instagram\.com/.*/12345/subscribed_apps})
+        .with(query: hash_including('access_token' => 'long_lived_test_token'))
+      expect(channel.reload.reauthorization_required?).to be(false)
+    end
+  end
+
   describe '#show' do
     context 'when authorization is successful' do
       before do

--- a/spec/models/channel/instagram_spec.rb
+++ b/spec/models/channel/instagram_spec.rb
@@ -16,6 +16,49 @@ RSpec.describe Channel::Instagram do
     expect(channel.name).to eq('Instagram')
   end
 
+  # An inbox that did not subscribe exists and receives nothing. Until now the answer was
+  # never read and every failure answered `true`, so the operator saw a working inbox and
+  # no messages, with a `debug` line as the only trace.
+  describe 'when the webhook subscription does not go through' do
+    let(:unsaved) { build(:channel_instagram) }
+
+    it 'asks for the inbox to be reconnected when Instagram refuses' do
+      allow(HTTParty).to receive(:post).and_return(instance_double(HTTParty::Response, success?: false, code: 400))
+
+      expect(unsaved).to receive(:authorization_error!)
+      expect(unsaved.subscribe).to be(false)
+    end
+
+    # Refused and not answered leave the same inbox in the same condition, and the remedy
+    # is the same, so they are reported the same way.
+    it 'asks for the same thing when the request does not complete at all' do
+      allow(HTTParty).to receive(:post).and_raise(Net::ReadTimeout)
+
+      expect(unsaved).to receive(:authorization_error!)
+      expect(unsaved.subscribe).to be(false)
+    end
+
+    it 'says nothing when it worked' do
+      allow(HTTParty).to receive(:post).and_return(instance_double(HTTParty::Response, success?: true))
+
+      expect(unsaved).not_to receive(:authorization_error!)
+      expect(unsaved.subscribe).to be(true)
+    end
+  end
+
+  # Failing to unsubscribe must not stop the removal the operator asked for, but it cannot
+  # be silent either: we go on receiving webhooks for an inbox that no longer exists.
+  describe 'when unsubscribing does not go through' do
+    it 'still lets the channel go, and says we are still subscribed there' do
+      allow(HTTParty).to receive(:delete).and_raise(Net::ReadTimeout)
+      allow(Rails.logger).to receive(:error)
+      channel
+
+      expect { channel.destroy! }.to change(described_class, :count).by(-1)
+      expect(Rails.logger).to have_received(:error).with(/still subscribed there/)
+    end
+  end
+
   describe 'concerns' do
     it_behaves_like 'reauthorizable'
 


### PR DESCRIPTION
Uma caixa de entrada do Instagram que não conseguiu se inscrever nos webhooks existia, parecia funcionando e não recebia mensagem nenhuma. A inscrição nunca lia a resposta, respondia `true` para qualquer falha, e o único rastro era uma linha de `debug`.

São três buracos no mesmo caminho, e só os três juntos fecham o problema:

**A inscrição não reportava nada.** Agora ela lê a resposta e, quando não deu, chama `authorization_error!`, que acende o aviso de reconexão no painel e manda o e-mail de `instagram_disconnect`. Recusa do Instagram e Instagram que não respondeu são reportadas igual, de propósito: deixam a mesma caixa na mesma condição e têm o mesmo remédio.

**O callback apagava o aviso logo em seguida.** `find_or_create_inbox` chamava `reauthorized!` incondicionalmente depois de criar o canal, o que limpava a bandeira que a inscrição falha tinha acabado de acender. Autorizar e estar inscrito são duas coisas diferentes, e esse é o único lugar que limpa a bandeira. Agora ela só é limpa quando a inscrição de fato aconteceu.

**Reconectar não reinscrevia.** O caminho de reconexão trocava as credenciais e parava aí. Ou seja a caixa que o operador reconectou justamente por ter parado de receber continuava sem receber, agora com cara de conectada. Agora a reconexão pede a inscrição de novo, que é o que torna verdadeira a frase "reconectar resolve".

A desinscrição continua não bloqueando a remoção, porque o operador pediu para a caixa ir embora e a cópia da inscrição do lado do Instagram não é nossa para segurar a operação. O que mudou é que ela registra em `error` com conta e instagram id: seguimos recebendo webhook de uma caixa que não existe mais, e ninguém tinha como descobrir.

## Uma correção na própria issue

A #621 lista três pontos, e medindo só dois são defeito. O terceiro, `Instagram::RefreshOauthTokenService#attempt_token_refresh`, **não** é silencioso como eu escrevi: já registra em `error` com a razão, e devolver o token antigo é correto, porque o serviço só tenta renovar enquanto o token ainda é válido. Quando ele vence de fato, a chamada seguinte devolve o erro 190, e `Instagram::BaseSendService` e `Instagram::MessageText` já chamam `channel.authorization_error!` nesse código. O desfecho chega ao operador pelo caminho que já existe, só mais tarde. Antecipar é melhoria, não conserto, e não entra aqui.

## Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/629)
<!-- Reviewable:end -->
