### PR TITLE
test(enterprise): afirmar o que o job de versão faz, em vez do que ele fazia

### DIFF
--- a/spec/enterprise/jobs/enterprise/internal/check_new_versions_job_spec.rb
+++ b/spec/enterprise/jobs/enterprise/internal/check_new_versions_job_spec.rb
@@ -1,32 +1,59 @@
 require 'rails_helper'
 
+# This spec was red for at least a release, and nothing in this repo ran it:
+# `run_foss_spec.yml` deletes `enterprise` and `spec/enterprise` before the suite.
+#
+# Why it was red, read off the history rather than guessed: it was written against
+# `ChatwootHub.sync_with_hub`, and `dbb41df67e` (fork PR #105) replaced that call with a
+# read of our own GitHub releases, taking `@instance_info` with it. The enterprise
+# override still reads that ivar and was last touched by `390cd756e8`, which came from
+# upstream, so nothing adapted it on this side.
+#
+# What follows from that is only this: `update_plan_info` returns on its first line here
+# and writes no installation config. Whether that is intended, because Pro sets those
+# values somewhere else, or an unnoticed consequence of #105, is not something this repo
+# can answer, and this spec deliberately asserts neither. It asserts what the job does:
+# read the latest release, remember the version, and reconcile the plan config.
 RSpec.describe Internal::CheckNewVersionsJob do
   subject(:job) { described_class.perform_now }
 
-  let(:reconsile_premium_config_service) { instance_double(Internal::ReconcilePlanConfigService) }
+  let(:reconcile_plan_config_service) { instance_double(Internal::ReconcilePlanConfigService) }
+  let(:releases_url) { 'https://api.github.com/repos/fazer-ai/chatwoot/releases/latest' }
 
   before do
-    allow(Internal::ReconcilePlanConfigService).to receive(:new).and_return(reconsile_premium_config_service)
-    allow(reconsile_premium_config_service).to receive(:perform)
+    allow(Internal::ReconcilePlanConfigService).to receive(:new).and_return(reconcile_plan_config_service)
+    allow(reconcile_plan_config_service).to receive(:perform)
     allow(Rails.env).to receive(:production?).and_return(true)
+    Redis::Alfred.delete(Redis::Alfred::LATEST_CHATWOOT_VERSION)
   end
 
-  it 'updates the plan info' do
-    data = { 'version' => '1.2.3', 'plan' => 'enterprise', 'plan_quantity' => 1, 'chatwoot_support_website_token' => '123',
-             'chatwoot_support_identifier_hash' => '123', 'chatwoot_support_script_url' => '123' }
-    allow(ChatwootHub).to receive(:sync_with_hub).and_return(data)
+  it 'remembers the latest released version' do
+    stub_request(:get, releases_url).to_return(status: 200, body: { tag_name: 'v1.2.3' }.to_json,
+                                               headers: { 'Content-Type' => 'application/json' })
+
     job
-    expect(InstallationConfig.find_by(name: 'INSTALLATION_PRICING_PLAN').value).to eq 'enterprise'
-    expect(InstallationConfig.find_by(name: 'INSTALLATION_PRICING_PLAN_QUANTITY').value).to eq 1
-    expect(InstallationConfig.find_by(name: 'CHATWOOT_SUPPORT_WEBSITE_TOKEN').value).to eq '123'
-    expect(InstallationConfig.find_by(name: 'CHATWOOT_SUPPORT_IDENTIFIER_HASH').value).to eq '123'
-    expect(InstallationConfig.find_by(name: 'CHATWOOT_SUPPORT_SCRIPT_URL').value).to eq '123'
+
+    expect(Redis::Alfred.get(Redis::Alfred::LATEST_CHATWOOT_VERSION)).to eq('1.2.3')
   end
 
-  it 'calls Internal::ReconcilePlanConfigService' do
-    data = { 'version' => '1.2.3' }
-    allow(ChatwootHub).to receive(:sync_with_hub).and_return(data)
+  it 'reconciles the plan config' do
+    stub_request(:get, releases_url).to_return(status: 200, body: { tag_name: 'v1.2.3' }.to_json,
+                                               headers: { 'Content-Type' => 'application/json' })
+
     job
-    expect(reconsile_premium_config_service).to have_received(:perform)
+
+    expect(reconcile_plan_config_service).to have_received(:perform)
+  end
+
+  # The reconciliation is the half that has to happen even when GitHub is the thing that
+  # failed: it reads configuration we already hold, and skipping it because a version
+  # lookup timed out would let the plan drift for a day over an unrelated outage.
+  it 'still reconciles when the release lookup fails' do
+    stub_request(:get, releases_url).to_timeout
+
+    job
+
+    expect(reconcile_plan_config_service).to have_received(:perform)
+    expect(Redis::Alfred.get(Redis::Alfred::LATEST_CHATWOOT_VERSION)).to be_nil
   end
 end


### PR DESCRIPTION
`spec/enterprise/jobs/enterprise/internal/check_new_versions_job_spec.rb` estava vermelho há pelo menos uma release, e nenhuma CI deste repositório o executava: `run_foss_spec.yml` roda `rm -rf enterprise spec/enterprise` antes da suíte.

**Um arquivo mudado, e ele é um spec.** Nenhuma linha de `enterprise/` foi alterada.

## O motivo, lido no histórico

O spec foi escrito contra `ChatwootHub.sync_with_hub`. O commit `dbb41df67e` (PR #105 deste fork) trocou essa chamada por uma leitura das nossas releases no GitHub e levou junto o `@instance_info`. O override em `enterprise/app/jobs/enterprise/internal/check_new_versions_job.rb` ainda lê essa variável, e o último commit a tocá-lo foi o `390cd756e8`, que veio do upstream.

Conferido em quatro pontos da história antes de mexer: `v4.17.0-fazer-ai.112`, `fb1a7e7fa2`, `c42851a1cc` e `7343fe84d3`, vermelho nos quatro.

## O que este PR deliberadamente não decide

Do fato acima segue que `update_plan_info` retorna na primeira linha e não escreve nenhuma installation config. **Se isso é intencional, porque o Pro escreve esses valores em outro lugar, ou consequência não percebida da #105, não é pergunta que este repositório responde**, e o spec não afirma nenhuma das duas. Quem souber a resposta decide o que fazer com o override; até lá ele fica como está.

O spec passa a afirmar só o que o job faz hoje: lê a última release, guarda a versão e reconcilia a configuração de plano. Mais um exemplo de que a reconciliação acontece mesmo quando a leitura do GitHub falha, que é comportamento atual e vale prender: pular a reconciliação por causa de uma indisponibilidade do GitHub deixaria o plano à deriva por um dia por um motivo sem relação.

## Verificação

Sem cobertura de CI aqui, pelo mesmo motivo que criou o problema. Local: `bundle exec rspec spec/enterprise`, 2454 exemplos, 0 falhas.

## Closes #627

A segunda metade da issue, se queremos um job no CE que rode `spec/enterprise` ou se a conferência passa a ser obrigatória no Pro antes de qualquer merge que toque aquela árvore, continua em aberto e é decisão de quem cuida do Pro. Registrada lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/631)
<!-- Reviewable:end -->
