### PR TITLE
fix(whatsapp): name the outcome by what Meta answered, not by the class of the error

### DIFF
--- a/app/services/whatsapp/webhook_setup_service.rb
+++ b/app/services/whatsapp/webhook_setup_service.rb
@@ -52,8 +52,26 @@ class Whatsapp::WebhookSetupService
   # A refusal and a silence are different facts and used to share one sentence. Meta answering "no"
   # is something the app knows; a read that never came back is something it does not, and the number
   # may well be registered on Meta's side with the PIN this attempt stored.
+  #
+  # The boundary is what Meta answered, not the class of the exception, because the class is wrong in
+  # both directions. It used to call a `500` a refusal, and an internal error can be raised after the
+  # write took effect, so "Meta holds no PIN of ours" is exactly the claim it cannot support. It also
+  # called an error of our own a refusal: an answer this code could not parse, and the one raised
+  # while storing our own confirmation marker after a registration Meta had accepted, which states
+  # the opposite of what happened.
+  #
+  # So `refused` is reserved for an answer that came back carrying a `4xx`: the request reached Meta
+  # and Meta declined it. That includes the `403` for a WABA in another portfolio and the `429` of a
+  # rate limit, neither of which is about the PIN, because what the operator acts on is the same
+  # fact: Meta answered, and this attempt did not land.
+  #
+  # Asked of the error's own field and guarded by the class that has the field. A predicate that asks
+  # `http_status` of a `Timeout::Error` raises inside the rescue, and then the line that reports the
+  # failure becomes the failure.
   def registration_outcome(error)
-    error.is_a?(Timeout::Error) || error.is_a?(IOError) || error.is_a?(SystemCallError) ? 'outcome unknown' : 'refused'
+    return 'refused' if error.is_a?(Whatsapp::ApiError) && error.http_status.to_i.between?(400, 499)
+
+    'outcome unknown'
   end
 
   def fetch_or_create_pin

--- a/spec/services/whatsapp/webhook_setup_service_spec.rb
+++ b/spec/services/whatsapp/webhook_setup_service_spec.rb
@@ -488,7 +488,10 @@ describe Whatsapp::WebhookSetupService do
         end
       end
 
-      it 'says Meta refused when Meta actually answered' do
+      # This used to assert the opposite, and it was the clearest statement of the old boundary: a bare
+      # `RuntimeError` is not an answer from Meta, and calling it a refusal is the app making a claim
+      # about a system it never heard from.
+      it 'does not call it a refusal when the error is not an answer from Meta' do
         allow(api_client).to receive(:register_phone_number).and_raise('Phone registration failed: {"error":"bad pin"}')
         allow(Rails.logger).to receive(:warn)
 
@@ -496,8 +499,8 @@ describe Whatsapp::WebhookSetupService do
           service.perform
         end
 
-        expect(Rails.logger).to have_received(:warn).with(/refused/)
-        expect(Rails.logger).not_to have_received(:warn).with(/outcome unknown/)
+        expect(Rails.logger).not_to have_received(:warn).with(/refused/)
+        expect(Rails.logger).to have_received(:warn).with(/outcome unknown/)
       end
     end
 
@@ -518,8 +521,31 @@ describe Whatsapp::WebhookSetupService do
         allow(Whatsapp::FacebookApiClient).to receive(:new).and_call_original
         stub_request(:get, status_url)
           .to_return(status: 200, body: { code_verification_status: 'NOT_VERIFIED' }.to_json, headers: json_headers)
+        allow(SecureRandom).to receive(:random_number).with(900_000).and_return(123_456)
         allow(Rails.logger).to receive(:warn)
         allow(Rails.logger).to receive(:error)
+      end
+
+      # Every example below drives the real client over stubbed HTTP, because the question is what the
+      # error that reaches `registration_outcome` carries, and a double raising a hand-built exception
+      # agrees with whatever the code does. The two webhook calls answer 200 throughout, so the only
+      # failure in play is the registration.
+      def register_answering(status:, body:, headers: { 'Content-Type' => 'application/json' })
+        stub_request(:post, register_url).to_return(status: status, body: body, headers: headers)
+        stub_request(:post, waba_subscribe_url).to_return(status: 200, body: '{}', headers: json_headers)
+        stub_request(:post, status_url).to_return(status: 200, body: '{}', headers: json_headers)
+
+        with_modified_env FRONTEND_URL: 'https://app.chatwoot.com' do
+          service.perform
+        end
+      end
+
+      def warn_lines
+        messages = []
+        expect(Rails.logger).to have_received(:warn).at_least(:once) do |line|
+          messages << line
+        end
+        messages.grep(/Phone registration/)
       end
 
       it 'says Meta refused when the refusal is the one the client raised' do
@@ -564,6 +590,97 @@ describe Whatsapp::WebhookSetupService do
           error = error.cause
         end
         expect(chain.any? { |e| e.is_a?(Whatsapp::ApiError) && e.authorization_error? }).to be(true)
+      end
+
+      # The word for the outcome is a claim, and the claim has to be backed by an answer. "Refused"
+      # says Meta holds no PIN of ours, and only an answer from Meta can say that.
+      context 'when the registration fails without Meta having answered no' do
+        it 'does not call a 500 a refusal, because an internal error can be raised after the write landed' do
+          register_answering(status: 500, body: { error: { message: 'An unknown error occurred', code: 1 } }.to_json)
+
+          expect(warn_lines.size).to eq(1)
+          expect(warn_lines.first).to include('outcome unknown').and include('phone_number_id 123456789')
+          expect(warn_lines.first).not_to include('refused')
+        end
+
+        # Something in front of Meta answering instead of Meta. No code, no verdict.
+        it 'does not call a 5xx that is not even in Meta shape a refusal' do
+          register_answering(status: 502, body: '<html><body>Bad Gateway</body></html>',
+                             headers: { 'Content-Type' => 'text/html' })
+
+          expect(warn_lines.first).to include('outcome unknown')
+          expect(warn_lines.first).not_to include('refused')
+        end
+
+        it 'does not call an answer this code could not read a refusal' do
+          register_answering(status: 200, body: 'this is not json at all')
+
+          expect(warn_lines.first).not_to include('refused')
+        end
+
+        # Our own error, raised on our side: Meta was never heard from, so nothing can be said about it.
+        # The original message stays in the line, which is what shows the operator the fault is ours.
+        [ArgumentError, NoMethodError].each do |klass|
+          it "does not turn a #{klass} of our own into a statement about Meta" do
+            allow_any_instance_of(Whatsapp::FacebookApiClient) # rubocop:disable RSpec/AnyInstance
+              .to receive(:register_phone_number).and_raise(klass, 'algo nosso quebrou')
+            register_answering(status: 200, body: '{"success":true}')
+
+            expect(warn_lines.size).to eq(1)
+            expect(warn_lines.first).to include('outcome unknown').and include('algo nosso quebrou')
+            expect(warn_lines.first).not_to include('refused')
+          end
+        end
+
+        # The strongest form: Meta accepted, and the write of our own marker is what failed. Calling
+        # that a refusal states the opposite of what happened.
+        it 'does not call it a refusal when Meta accepted and only our confirmation failed' do
+          # The first write is the PIN, before the call; the second is the confirmation marker, after
+          # Meta accepted. Only the second fails.
+          writes = 0
+          allow(channel).to receive(:save!).with(validate: false) do
+            writes += 1
+            raise ActiveRecord::RecordInvalid, channel if writes > 1
+
+            true
+          end
+          register_answering(status: 200, body: '{"success":true}')
+
+          expect(warn_lines.first).not_to include('refused')
+          expect(channel.provider_config['verification_pin']).to eq(223_456)
+        end
+      end
+
+      context 'when Meta did answer no' do
+        it 'calls a 400 about the PIN a refusal' do
+          register_answering(status: 400, body: { error: { message: 'Invalid PIN', code: 100 } }.to_json)
+
+          expect(warn_lines.first).to include('refused')
+        end
+
+        # Not a credential verdict, but Meta did answer, and the write did not land.
+        it 'calls a 403 permissions error a refusal' do
+          register_answering(status: 403, body: { error: { message: '(#200) Permissions error', code: 200 } }.to_json)
+
+          expect(warn_lines.first).to include('refused')
+        end
+
+        # The only 4xx where the two honest readings diverge. The boundary here is the status class:
+        # Meta answered and this attempt did not land, which is the same fact the operator acts on.
+        it 'calls a 429 rate limit a refusal' do
+          register_answering(status: 429, body: { error: { message: '(#80007) Rate limit hit', code: 80_007 } }.to_json)
+
+          expect(warn_lines.first).to include('refused')
+        end
+      end
+
+      # Naming the outcome is a log line and nothing else. A registration that fails must not reach
+      # the reauthorization marker, which no human clears and which makes the inbound job discard
+      # every webhook.
+      it 'never marks the channel for reauthorization from a failed registration' do
+        register_answering(status: 500, body: { error: { message: 'An unknown error occurred', code: 1 } }.to_json)
+
+        expect(channel.reload.reauthorization_required?).to be(false)
       end
     end
 


### PR DESCRIPTION
A phone registration that failed always said one of two things in the log, and which one it said was decided by the class of the exception rather than by what Meta answered. The class is wrong in both directions, and both directions make the app state something it is not in a position to state.

## Closes

Fixes #603

## How to reproduce

Point `Whatsapp::FacebookApiClient` at a fake Graph, let the registration be needed, and answer the `POST /{phone_number_id}/register` each of these ways. Measured on `e530c67b31`:

| Meta answers | logged as |
| --- | --- |
| accepts and never answers | `outcome unknown` |
| closes the connection | `outcome unknown` |
| `400` `Invalid PIN` | `refused` |
| `403` `(#200) Permissions error` | `refused` |
| `500` | `refused` |
| an `ArgumentError` of our own, no call made | `refused` |

The last two are the defect. A `500` can be raised after the write took effect, so "Meta holds no PIN of ours" cannot be concluded from it, and an operator reading `refused` goes looking for a rejected PIN instead of for a possible duplicate registration. The `ArgumentError` row is not in the issue and came out of measuring at HEAD: an error raised on our side, with Meta never heard from, was also being reported as Meta's refusal.

The strongest form of the same thing is not in the table because it needs the write to succeed: Meta answers `200`, and the write of our own `verification_pin_confirmed` marker fails. The line then says `refused` about a registration Meta accepted.

## What changed

`refused` is reserved for an answer carrying a `4xx`. Everything else is the app saying it does not know.

The `403` for a WABA in someone else's portfolio and the `429` of a rate limit stay refusals, and that is deliberate: neither is about the PIN, but the fact the operator acts on is the same one, that Meta answered and this attempt did not land. The `429` is the only `4xx` where the two honest readings diverge, and the sealed scenario S15 exists for exactly that choice.

The predicate asks the error's own field and is guarded by the class that carries it, because a predicate that asks `http_status` of a `Timeout::Error` raises inside the rescue, and then the line that reports the failure becomes the failure.

Nothing durable changes. The PIN is still stored before the call and never dropped, the confirmation marker is still absent in every failure shape, the registration stays best effort and nothing is re-raised, so a failed registration still never reaches `prompt_reauthorization!`. That last one is load-bearing: re-raising would hand `ArgumentError` to `Channel::Whatsapp#credentials_refused?`, which reads it at the top as a missing credential, and one misleading word in a log would become a channel marked for reauthorization, an e-mail to the operator and `Webhooks::WhatsappEventsJob` discarding every inbound webhook.

## Validation scope

Red proof 7 failing examples before the change. Mutation battery 11 mutants, and the boundary is pinned from both sides: putting the class back kills 7, letting any `ApiError` be a refusal kills 2, widening the range to `5xx` kills 2, narrowing it to exclude the `429` kills 1, dropping the class guard kills 14 by making the log line disappear instead of being written, and re-raising from the rescue kills 21.

One survivor, and it is equivalent by measurement rather than by assertion: removing the `.to_i` from `http_status`. `HTTParty::Response#code` already returns `response.code.to_i`, and in production `Whatsapp::ApiError` is only ever built by `from_response`, in two places, both from `response.code`. So it is an Integer today and the conversion is a no-op. It stays because what it guards is a direct construction with `http_status: nil`, which the class signature permits, and the failure that would follow is the one sealed scenario S11 names: the warning disappearing instead of being logged.

Every example drives the real `Whatsapp::FacebookApiClient` over stubbed HTTP, one shape per example. That is not a preference: a double raising a hand-built exception agrees with whatever the code does, which is how the example that asserted the old boundary survived #602 changing the class the client raises.

Not exercised against Meta itself. The shapes are the ones Meta documents plus the two this code produces on its own.

### What this does not fix, measured

A `4xx` that Meta never wrote still reads as a refusal. Measured on both trees by the holdout verifier: a `403` whose body is `<html><body>Forbidden by WAF</body></html>`, with none of Meta's vocabulary and no `code`, comes out as `refused` on this branch and on `e530c67b31` alike. It is the same family as the defect this PR closes, and it is not a regression, so it stays out of the diff rather than arriving as a requirement invented after the scenarios were sealed.

The correction path is known and so is its price: require the body to be in Meta's shape, meaning a `code` present, before calling it a refusal. The cost is that a legitimate `4xx` whose body this code cannot read would move from `refused` to `outcome unknown`, which is a real loss on the shape that matters most to an operator fixing a rejected PIN.

The holdout also recorded one weakness in the boundary this PR does implement. When Meta accepted the registration and only our own write of the confirmation failed, the log says the outcome is unknown, while the app is in fact holding a parsed `200` from Meta. Two words cannot say that, and a third one would only be truthful alongside a change to `confirm_pin`, which belongs to #596 and not here. What makes two words defensible is that the durable state now agrees with the log instead of contradicting it: `verification_pin_confirmed` is absent in that shape, because the confirmation write is exactly what failed. Before this change the log said `refused` while the row said nobody knows.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/632)
<!-- Reviewable:end -->

