### PR TITLE
fix(dashboard): give the two buttons the prop name that draws the spinner

### DIFF
--- a/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
+++ b/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
@@ -226,8 +226,14 @@ describe('the spinner prop of the next Button has one spelling', () => {
   it('has no more attribute spreads on that tag than the one already reviewed', () => {
     const { spreads } = survey();
 
-    expect(spreads).toEqual([
-      'dashboard/components-next/Contacts/VoiceCallButton.vue:195',
+    // Compared by file, not by line: an import or a comment added above that tag shifts the line
+    // and would turn this red while the spread and the loading behaviour are untouched, and a
+    // fence that goes red for an unrelated edit is one that gets switched off. The count still
+    // bites, because a second spread anywhere, including a second one in this same file, adds an
+    // entry. Lines stay in the array that feeds the failure message, so a real one is still
+    // located.
+    expect(spreads.map(where => where.replace(/:\d+$/, ''))).toEqual([
+      'dashboard/components-next/Contacts/VoiceCallButton.vue',
     ]);
   });
 });

--- a/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
+++ b/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
@@ -230,11 +230,16 @@ describe('the spinner prop of the next Button has one spelling', () => {
     // and would turn this red while the spread and the loading behaviour are untouched, and a
     // fence that goes red for an unrelated edit is one that gets switched off. The count still
     // bites, because a second spread anywhere, including a second one in this same file, adds an
-    // entry. Lines stay in the array that feeds the failure message, so a real one is still
-    // located.
-    expect(spreads.map(where => where.replace(/:\d+$/, ''))).toEqual([
-      'dashboard/components-next/Contacts/VoiceCallButton.vue',
-    ]);
+    // entry: the comparison maps, it does not deduplicate.
+    //
+    // The lines are carried in the failure message rather than in the compared value, because the
+    // compared value is exactly where they had to stop mattering. Without that, a second spread in
+    // this same file prints the same name twice with no way to tell which tag is the new one,
+    // which is the one case where locating it is what the reader needs.
+    expect(
+      spreads.map(where => where.replace(/:\d+$/, '')),
+      `spreads found: ${spreads.join(', ')}`
+    ).toEqual(['dashboard/components-next/Contacts/VoiceCallButton.vue']);
   });
 });
 

--- a/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
+++ b/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
@@ -123,7 +123,10 @@ const openingTags = (source, name) =>
 const WRONG = /(?:^|\s)(?::|v-bind:)?loading(?:\.[\w.]+)?(?=[\s=/>])/;
 const RIGHT =
   /(?:^|\s)(?::|v-bind:)?(?:is-loading|isLoading)(?:\.[\w.]+)?(?=[\s=/>])/;
-const SPREAD = /v-bind\s*=\s*["'](?:\$?attrs)["']/;
+// Any spread, not only `attrs`. A plain object works just as well: `v-bind="buttonProps"` with
+// `{ loading: true }` puts the inert attribute on the element exactly like the two call sites
+// this PR fixes, and no sweep of the source can see inside the object.
+const SPREAD = /v-bind\s*=\s*["'][^"']+["']/;
 
 // The detector takes a source string and the path it would live at, so the same code that sweeps
 // the tree can be pointed at a synthetic file. That is not a convenience: on a clean tree there is
@@ -343,6 +346,57 @@ describe('the sweep that finds it actually finds it', () => {
       expect(found.right).toHaveLength(1);
     }
   );
+
+  // Both guards below are against false positives, and the collisions they avoid are real in this
+  // tree rather than hypothetical: `:loading-message`, `:loading-placeholder` and `loading-more`
+  // all exist as attributes, and five files import this Button as `Button` while also using
+  // `<ButtonGroup>`. None of those carries a `loading` today, which is precisely why they need a
+  // planted example: without one, removing either guard changes nothing and the fence would drift
+  // into rejecting correct code the first time one of them does.
+  // The only spread in the tree today binds `attrs`, so narrowing the pattern back to that one
+  // name changes no count and would go unnoticed. A plain object is the cheaper way to reproduce
+  // the defect: `v-bind="buttonProps"` with `{ loading: true }` puts the inert attribute on the
+  // element exactly like the two call sites this PR fixes.
+  it('counts a spread of a plain object, not only one of attrs', () => {
+    const found = planted(
+      'next/button/Button.vue',
+      NAME,
+      'v-bind="buttonProps"'
+    );
+
+    expect(found.spreads).toHaveLength(1);
+    expect(found.wrong).toEqual([]);
+  });
+
+  it('does not treat a longer attribute name as the prop', () => {
+    const found = planted(
+      'next/button/Button.vue',
+      NAME,
+      ':loading-message="t(\'CHAT.WAITING\')"'
+    );
+
+    expect(found.wrong).toEqual([]);
+  });
+
+  it('does not match a different tag whose name starts with the same word', () => {
+    const found = scanSource(
+      [
+        '<script setup>',
+        "import Button from 'next/button/Button.vue';",
+        "import ButtonGroup from 'next/buttonGroup/ButtonGroup.vue';",
+        '</script>',
+        '',
+        '<template>',
+        '  <ButtonGroup :loading="busy" />',
+        '  <Button :is-loading="busy" />',
+        '</template>',
+      ].join('\n'),
+      HOME
+    );
+
+    expect(found.wrong).toEqual([]);
+    expect(found.right).toHaveLength(1);
+  });
 
   it('ignores a `loading` on a tag that is not this component', () => {
     const found = scanSource(

--- a/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
+++ b/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
@@ -1,0 +1,366 @@
+import { readFileSync, readdirSync, statSync } from 'fs';
+import path from 'path';
+
+// The prop that draws the spinner is `isLoading`. A call site writing `loading` instead gets no
+// error from anywhere: the name is not declared and not in EXCLUDED_ATTRS, so it falls through
+// `useAttrs` onto the `<button>` element, where the browser ignores it. Two call sites had made
+// that mistake, and 420 other files import the same component, so fixing two lines without a
+// fence just resets the clock until somebody copies a line from the wrong one of them.
+//
+// The risk in a fence like this is not the false positive, it is the empty green: if the
+// resolution breaks, it finds nothing and passes forever. So every sweep here asserts a positive
+// floor in the same example that looks for the defect.
+const JS_ROOT = path.resolve(__dirname, '../../../../');
+const BUTTON = path.join(
+  JS_ROOT,
+  'dashboard/components-next/button/Button.vue'
+);
+
+// Kept in step with `vite.shared.ts` by hand on purpose: reading the TS config from a spec would
+// mean parsing it, and getting an alias wrong makes the fence quieter rather than louder, which
+// is what the floors below are for.
+const ALIASES = {
+  next: path.join(JS_ROOT, 'dashboard/components-next'),
+  dashboard: path.join(JS_ROOT, 'dashboard'),
+  components: path.join(JS_ROOT, 'dashboard/components'),
+  shared: path.join(JS_ROOT, 'shared'),
+  v3: path.join(JS_ROOT, 'v3'),
+  widget: path.join(JS_ROOT, 'widget'),
+  survey: path.join(JS_ROOT, 'survey'),
+  helpers: path.join(JS_ROOT, 'shared/helpers'),
+  assets: path.join(JS_ROOT, 'dashboard/assets'),
+};
+
+const SKIP_DIRS = new Set(['node_modules']);
+
+const walk = dir =>
+  readdirSync(dir).flatMap(entry => {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      return SKIP_DIRS.has(entry) ? [] : walk(full);
+    }
+    return full.endsWith('.vue') ? [full] : [];
+  });
+
+// The specifier is resolved to an absolute path rather than matched as a substring. `Button` is
+// not an exclusive name for this component (`v3/components/GoogleOauth/Button.vue` is another
+// one), and a substring filter on `components-next/button` would miss both the `next/...`
+// spelling, which is where one of the two real defects lived, and `./Button.vue`, which does not
+// carry `button/` at all.
+const resolveSpecifier = (specifier, fromFile) => {
+  if (specifier.startsWith('.')) {
+    return path.resolve(path.dirname(fromFile), specifier);
+  }
+  const [head, ...rest] = specifier.split('/');
+  return ALIASES[head] ? path.join(ALIASES[head], ...rest) : null;
+};
+
+const IMPORT =
+  /import\s+(\{[^}]*\}|[A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]+)['"]/g;
+
+// The local name comes from the import, never from a list. A sixth name is free to appear, and
+// the list of three names this work arrived with was already missing two.
+const localNames = (source, file) =>
+  [...source.matchAll(IMPORT)]
+    .filter(([, , specifier]) => resolveSpecifier(specifier, file) === BUTTON)
+    .flatMap(([, imported]) => {
+      if (!imported.startsWith('{')) return [imported];
+
+      return imported
+        .slice(1, -1)
+        .split(',')
+        .map(part => part.trim())
+        .filter(Boolean)
+        .map(part => part.split(/\s+as\s+/).map(bit => bit.trim()))
+        .filter(([base]) => base === 'default' || base === 'Button')
+        .map(([base, alias]) => alias || base);
+    })
+    .reduce((names, name) => names.add(name), new Set());
+
+// Both real call sites spread their opening tag over several lines with `:loading` on a line of
+// its own, so the unit is the whole opening tag, read to the first `>` outside quotes. Reading to
+// the end of the line would miss them.
+//
+// Quotes do two jobs here, and getting only the first one right is how this fence rejected correct
+// code on its first draft. They decide where the tag ends, so a `>` inside a value does not cut it
+// short; and they decide what may be matched, because a value is data. `:label="keep loading the
+// report"` is a correct tag, and matching over the raw text turns every translated label that
+// happens to contain the word into a rejection. So the matcher runs against a skeleton where every
+// quoted value is blanked out and only attribute names survive.
+const readTag = (source, start) => {
+  let index = start;
+  let quote = null;
+  let skeleton = '';
+  while (index < source.length) {
+    const char = source[index];
+    if (quote) {
+      if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '>') {
+      break;
+    } else {
+      skeleton += char;
+    }
+    index += 1;
+  }
+  return { skeleton, end: index };
+};
+
+const openingTags = (source, name) =>
+  [...source.matchAll(new RegExp(`<${name}(?=[\\s/>])`, 'g'))].map(match => {
+    const { skeleton, end } = readTag(source, match.index + match[0].length);
+
+    return {
+      text: `${match[0]}${skeleton}>`,
+      raw: source.slice(match.index, end + 1),
+      line: source.slice(0, match.index).split('\n').length,
+    };
+  });
+
+// `loading`, `:loading`, `v-bind:loading`, a bare `loading`, and any modifier (`:loading.attr`).
+// Anchored on whitespace so `is-loading` and `isLoading` are not swept up by the suffix.
+const WRONG = /(?:^|\s)(?::|v-bind:)?loading(?:\.[\w.]+)?(?=[\s=/>])/;
+const RIGHT =
+  /(?:^|\s)(?::|v-bind:)?(?:is-loading|isLoading)(?:\.[\w.]+)?(?=[\s=/>])/;
+const SPREAD = /v-bind\s*=\s*["'](?:\$?attrs)["']/;
+
+// The detector takes a source string and the path it would live at, so the same code that sweeps
+// the tree can be pointed at a synthetic file. That is not a convenience: on a clean tree there is
+// no wrong call site left, so a sweep of the tree alone never exercises the matcher at all, and a
+// matcher that stopped matching would stay green forever. The examples below plant the defect
+// instead of hoping to find it.
+const scanSource = (source, file) => {
+  const names = localNames(source, file);
+  const tags = [...names].flatMap(name =>
+    openingTags(source, name).map(tag => ({
+      ...tag,
+      where: `${path.relative(JS_ROOT, file)}:${tag.line}`,
+    }))
+  );
+
+  return {
+    resolves: names.size > 0,
+    names,
+    wrong: tags.filter(tag => WRONG.test(tag.text)).map(tag => tag.where),
+    right: tags.filter(tag => RIGHT.test(tag.text)).map(tag => tag.where),
+    // The spread's discriminator is its value, `attrs`, which the skeleton blanks out along with
+    // every other value, so this one reads the raw tag.
+    spreads: tags.filter(tag => SPREAD.test(tag.raw)).map(tag => tag.where),
+  };
+};
+
+const survey = () => {
+  const files = walk(JS_ROOT);
+  const found = files
+    .map(file => ({ file, ...scanSource(readFileSync(file, 'utf8'), file) }))
+    .filter(entry => entry.resolves);
+
+  return {
+    files,
+    resolved: found.map(entry => entry.file),
+    wrong: found.flatMap(entry => entry.wrong),
+    right: found.reduce((total, entry) => total + entry.right.length, 0),
+    spreads: found.flatMap(entry => entry.spreads),
+  };
+};
+
+describe('the spinner prop of the next Button has one spelling', () => {
+  it('has no call site passing `loading`, and reached enough of the tree to mean it', () => {
+    const { resolved, wrong, right } = survey();
+
+    // The floors are the whole point of this example, and they are asserted here rather than in
+    // one of their own: a sweep that reports zero offenders because it resolved zero files is
+    // indistinguishable from a sweep that found nothing wrong. Measured here: 417 `.vue` files and
+    // 171 correct bindings. The floors sit well below that so a legitimate refactor does not trip
+    // them, and well above zero so moving Button.vue, renaming an alias in vite.shared.ts or
+    // breaking the resolver turns this red instead of quietly green.
+    //
+    // A census that counts imports rather than templates gets 422, and the five extra are
+    // `.spec.js` files that import the component to mount it in a test. They are not call sites,
+    // and only a `.vue` file carries a template, so the sweep stays on `.vue`. What that leaves
+    // uncovered is a render function building the tag in JavaScript (`h(Button, { loading })`),
+    // which this tag-shaped regex could not read anyway.
+    expect(resolved.length).toBeGreaterThan(300);
+    expect(right).toBeGreaterThan(100);
+
+    expect(wrong).toEqual([]);
+  });
+
+  it('finds the component through every specifier spelling in the tree', () => {
+    const { resolved } = survey();
+    const spellings = resolved
+      .flatMap(file =>
+        [...readFileSync(file, 'utf8').matchAll(IMPORT)]
+          .filter(match => resolveSpecifier(match[2], file) === BUTTON)
+          .map(match => match[2])
+      )
+      .reduce((names, name) => names.add(name), new Set());
+
+    // Five spellings exist today, including two that a substring filter on `button/Button.vue`
+    // cannot see. The assertion is on the resolver reaching all of them, not on the count.
+    expect(spellings).toContain('dashboard/components-next/button/Button.vue');
+    expect(spellings).toContain('next/button/Button.vue');
+    expect([...spellings].some(name => name.startsWith('.'))).toBe(true);
+    expect(spellings.size).toBeGreaterThanOrEqual(3);
+  });
+
+  it('does not count a tag of some other component, including another Button.vue', () => {
+    const other = path.join(JS_ROOT, 'v3/components/GoogleOauth/Button.vue');
+    const source = readFileSync(other, 'utf8');
+
+    expect(resolveSpecifier('./Button.vue', other)).not.toBe(BUTTON);
+    expect(localNames(source, other).size).toBe(0);
+  });
+
+  // A `loading` arriving at the element from inside a spread, or through a dynamic attribute
+  // name, is invisible to any source sweep and stays a hole after this fix. One tag spreads
+  // today and neither of its callers passes `loading`, so nothing leaks; a second one has to show
+  // up in review rather than land quietly.
+  it('has no more attribute spreads on that tag than the one already reviewed', () => {
+    const { spreads } = survey();
+
+    expect(spreads).toEqual([
+      'dashboard/components-next/Contacts/VoiceCallButton.vue:195',
+    ]);
+  });
+});
+
+// Everything above measures the tree. This measures the detector, by planting the defect in a
+// synthetic file placed where a real call site would sit. Each example asserts a count, because
+// "0 rejections" is a substring of "10 rejections" and a matcher that answered nothing would read
+// as one that answered correctly.
+describe('the sweep that finds it actually finds it', () => {
+  const HOME = path.join(
+    JS_ROOT,
+    'dashboard/routes/dashboard/inventado/Plantado.vue'
+  );
+
+  const planted = (specifier, name, attribute) =>
+    scanSource(
+      [
+        '<script setup>',
+        `import ${name} from '${specifier}';`,
+        '</script>',
+        '',
+        '<template>',
+        `  <${name}`,
+        '    sm',
+        '    solid',
+        `    ${attribute}`,
+        '    :disabled="busy"',
+        '  >',
+        '    Register',
+        `  </${name}>`,
+        '</template>',
+      ].join('\n'),
+      HOME
+    );
+
+  // A novel local name on purpose: the list of names this work arrived with was already missing
+  // two, so a sixth is free to appear and the fence must not be tied to today's vocabulary.
+  const NAME = 'ButtonSeisPontoZero';
+
+  // All five spellings resolve to the same component, and two of them a substring filter on
+  // `button/Button.vue` cannot see.
+  it.each([
+    'dashboard/components-next/button/Button.vue',
+    'next/button/Button.vue',
+    '../../../../components-next/button/Button.vue',
+    './Button.vue',
+    './button/Button.vue',
+  ])('catches it through the %s spelling', specifier => {
+    const relative = specifier.startsWith('.')
+      ? path.relative(
+          path.dirname(HOME),
+          path.join(JS_ROOT, 'dashboard/components-next/button/Button.vue')
+        )
+      : specifier;
+    const found = planted(relative, NAME, ':loading="busy"');
+
+    expect(found.resolves).toBe(true);
+    expect(found.wrong).toHaveLength(1);
+  });
+
+  // The tag is multi-line in both real call sites, with the offending binding on a line of its
+  // own, so a sweep that reads to the end of the line finds nothing.
+  it.each([
+    ':loading="busy"',
+    'v-bind:loading="busy"',
+    'loading="true"',
+    'loading',
+    ':loading.attr="busy"',
+  ])('catches the %s form inside a multi-line tag', attribute => {
+    const found = planted('next/button/Button.vue', NAME, attribute);
+
+    expect(found.wrong).toHaveLength(1);
+    expect(found.wrong[0]).toBe(
+      'dashboard/routes/dashboard/inventado/Plantado.vue:6'
+    );
+  });
+
+  it('names the file and the line it rejected, not just a count', () => {
+    const found = planted('next/button/Button.vue', NAME, ':loading="busy"');
+
+    expect(found.wrong[0]).toMatch(/Plantado\.vue:\d+$/);
+  });
+
+  // The word appears inside a quoted value here, which is what a translated label looks like.
+  // Walking the tag without tracking quotes turns every such label into a rejection, and a fence
+  // that rejects correct code gets switched off the first time it is inconvenient.
+  it('does not reject a correct tag whose label contains the word', () => {
+    const found = scanSource(
+      [
+        '<script setup>',
+        `import ${NAME} from 'next/button/Button.vue';`,
+        '</script>',
+        '',
+        '<template>',
+        `  <${NAME}`,
+        // Lower case, and with whitespace on both sides, so it is a string the matcher would
+        // accept if it were not tracking quotes. `SETTINGS.LOADING_STRATEGY` would not do: the
+        // matcher is case sensitive and wants a delimiter after the word, so an upper-case label
+        // would pass even with the quote tracking removed, and the example would prove nothing.
+        '    :label="t(\'keep loading the report\')"',
+        '    :is-loading="busy"',
+        '  />',
+        '</template>',
+      ].join('\n'),
+      HOME
+    );
+
+    expect(found.wrong).toEqual([]);
+    expect(found.right).toHaveLength(1);
+  });
+
+  // The other spellings of the right prop, none of which may be rejected.
+  it.each([':is-loading="busy"', 'is-loading', ':isLoading="busy"'])(
+    'accepts the %s spelling',
+    attribute => {
+      const found = planted('next/button/Button.vue', NAME, attribute);
+
+      expect(found.wrong).toEqual([]);
+      expect(found.right).toHaveLength(1);
+    }
+  );
+
+  it('ignores a `loading` on a tag that is not this component', () => {
+    const found = scanSource(
+      [
+        '<script setup>',
+        `import ${NAME} from 'next/button/Button.vue';`,
+        '</script>',
+        '',
+        '<template>',
+        '  <img loading="lazy" src="x" />',
+        '  <SomeOtherButton :loading="busy" />',
+        `  <${NAME} :is-loading="busy" />`,
+        '</template>',
+      ].join('\n'),
+      HOME
+    );
+
+    expect(found.wrong).toEqual([]);
+    expect(found.right).toHaveLength(1);
+  });
+});

--- a/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
+++ b/app/javascript/dashboard/components-next/button/specs/loadingPropFence.spec.js
@@ -123,10 +123,15 @@ const openingTags = (source, name) =>
 const WRONG = /(?:^|\s)(?::|v-bind:)?loading(?:\.[\w.]+)?(?=[\s=/>])/;
 const RIGHT =
   /(?:^|\s)(?::|v-bind:)?(?:is-loading|isLoading)(?:\.[\w.]+)?(?=[\s=/>])/;
-// Any spread, not only `attrs`. A plain object works just as well: `v-bind="buttonProps"` with
-// `{ loading: true }` puts the inert attribute on the element exactly like the two call sites
+// Any spread, not only one of `attrs`. A plain object works just as well: `v-bind="buttonProps"`
+// with `{ loading: true }` puts the inert attribute on the element exactly like the two call sites
 // this PR fixes, and no sweep of the source can see inside the object.
-const SPREAD = /v-bind\s*=\s*["'][^"']+["']/;
+//
+// Matched by attribute NAME, on the skeleton, for the same reason the wrong-prop matcher is: the
+// value is data. Reading the raw tag to find the value turns a correct tag carrying the string
+// `v-bind="..."` inside a label or a doc link into a rejection, which is the false positive on
+// the other side of the one this pattern was widened to fix.
+const SPREAD = /(?:^|\s)v-bind\s*=/;
 
 // The detector takes a source string and the path it would live at, so the same code that sweeps
 // the tree can be pointed at a synthetic file. That is not a convenience: on a clean tree there is
@@ -147,9 +152,7 @@ const scanSource = (source, file) => {
     names,
     wrong: tags.filter(tag => WRONG.test(tag.text)).map(tag => tag.where),
     right: tags.filter(tag => RIGHT.test(tag.text)).map(tag => tag.where),
-    // The spread's discriminator is its value, `attrs`, which the skeleton blanks out along with
-    // every other value, so this one reads the raw tag.
-    spreads: tags.filter(tag => SPREAD.test(tag.raw)).map(tag => tag.where),
+    spreads: tags.filter(tag => SPREAD.test(tag.text)).map(tag => tag.where),
   };
 };
 
@@ -366,6 +369,30 @@ describe('the sweep that finds it actually finds it', () => {
 
     expect(found.spreads).toHaveLength(1);
     expect(found.wrong).toEqual([]);
+  });
+
+  // The mirror of the example above. A value can legitimately contain the text `v-bind="..."`, in a
+  // label or a link to the docs, and counting spreads off the raw tag turns that into a rejection.
+  it('does not count a spread that is only mentioned inside a value', () => {
+    const found = scanSource(
+      [
+        '<script setup>',
+        `import ${NAME} from 'next/button/Button.vue';`,
+        '</script>',
+        '',
+        '<template>',
+        `  <${NAME}`,
+        '    title=\'see v-bind="something" in the docs\'',
+        '    :is-loading="busy"',
+        '  />',
+        '</template>',
+      ].join('\n'),
+      HOME
+    );
+
+    expect(found.spreads).toEqual([]);
+    expect(found.wrong).toEqual([]);
+    expect(found.right).toHaveLength(1);
   });
 
   it('does not treat a longer attribute name as the prop', () => {

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/AccountHealth.vue
@@ -676,7 +676,7 @@ const handleCopyWebhookUrl = async url => {
             sm
             solid
             blue
-            :loading="isRegisteringWebhook"
+            :is-loading="isRegisteringWebhook"
             :disabled="isRegisteringWebhook"
             @click="handleRegisterWebhook"
           >

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -1,5 +1,6 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import ButtonV4 from 'next/button/Button.vue';
+import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
 import AccountHealth from '../AccountHealth.vue';
 
 const { locale } = vi.hoisted(() => ({ locale: { value: 'en' } }));
@@ -21,6 +22,14 @@ vi.mock('vue-i18n', () => ({
 describe('AccountHealth', () => {
   const mountComponent = (healthData, props = {}) =>
     shallowMount(AccountHealth, {
+      props: { healthData, ...props },
+    });
+
+  // `shallowMount` replaces ButtonV4 with a stub, and a stub renders no spinner no matter which
+  // prop it receives, so an assertion about the operator seeing feedback would pass on the
+  // broken code. This one mounts the real button.
+  const mountDeep = (healthData, props = {}) =>
+    mount(AccountHealth, {
       props: { healthData, ...props },
     });
 
@@ -329,6 +338,68 @@ describe('AccountHealth', () => {
       expect(wrapper.text()).not.toContain(
         'https://elsewhere.example.com/webhooks/whatsapp/+1'
       );
+    });
+  });
+
+  // The prop that draws the spinner is `isLoading`. A call site passing `loading` instead gets
+  // no error: the name is not in the prop list and not in EXCLUDED_ATTRS, so it falls through
+  // `useAttrs` onto the `<button>` element, where the browser ignores it. The registration writes
+  // to Meta and can take the whole Graph ceiling to answer, so what the operator sees for those
+  // seconds is a button that looks idle.
+  describe('while the webhook registration is in flight', () => {
+    const registering = {
+      healthError: {
+        type: 'generic',
+        message: 'The health read did not answer',
+      },
+      isRegisteringWebhook: true,
+    };
+
+    // Two buttons render in this state and both are ButtonV4, so a lookup by component or by
+    // `button[disabled]` picks whichever comes first in the tree and says nothing about the one
+    // this is about. `isLoading` cannot be the discriminator either: it defaults to false, so
+    // every button in the tree answers it.
+    const registerButton = wrapper =>
+      wrapper
+        .findAll('button')
+        .find(candidate =>
+          candidate
+            .text()
+            .includes('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_BUTTON')
+        );
+
+    it('draws the spinner on the register webhook button', () => {
+      const wrapper = mountDeep(null, registering);
+
+      expect(registerButton(wrapper)).toBeDefined();
+      expect(wrapper.findComponent(Spinner).exists()).toBe(true);
+    });
+
+    it('does not leave the loading state on the element as an inert attribute', () => {
+      const wrapper = mountDeep(null, registering);
+
+      expect(registerButton(wrapper).attributes('loading')).toBeUndefined();
+    });
+
+    it('still disables that same button, which is the half that already worked', () => {
+      const wrapper = mountDeep(null, registering);
+
+      expect(registerButton(wrapper).attributes('disabled')).toBeDefined();
+    });
+
+    // The inert attribute shows up in both states, not only the busy one: a `false` bound to an
+    // undeclared attribute renders as the string "false", which is truthy to nobody but is still
+    // there in the markup. So the idle case discriminates the broken code from the fixed one on
+    // its own, without having to reach the in-flight state at all.
+    it('draws no spinner when nothing is in flight, and carries no attribute either', () => {
+      const wrapper = mountDeep(null, {
+        healthError: registering.healthError,
+        isRegisteringWebhook: false,
+      });
+
+      expect(registerButton(wrapper)).toBeDefined();
+      expect(wrapper.findComponent(Spinner).exists()).toBe(false);
+      expect(registerButton(wrapper).attributes('loading')).toBeUndefined();
     });
   });
 

--- a/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/inbox/components/specs/AccountHealth.spec.js
@@ -1,6 +1,5 @@
 import { mount, shallowMount } from '@vue/test-utils';
 import ButtonV4 from 'next/button/Button.vue';
-import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
 import AccountHealth from '../AccountHealth.vue';
 
 const { locale } = vi.hoisted(() => ({ locale: { value: 'en' } }));
@@ -368,11 +367,18 @@ describe('AccountHealth', () => {
             .includes('INBOX_MGMT.ACCOUNT_HEALTH.WEBHOOK.REGISTER_BUTTON')
         );
 
+    // Scoped to the button, not to the tree. Two ButtonV4 render in this state, so a tree-wide
+    // `findComponent(Spinner)` is answered by either of them: moving the binding to the other
+    // button leaves this suite at 48 green while the operator watches a spinner on the button
+    // they did not click and gets nothing on the one they did, which is the defect this PR is
+    // about. The lookup by button text is already here for exactly that reason a few lines up.
     it('draws the spinner on the register webhook button', () => {
       const wrapper = mountDeep(null, registering);
 
       expect(registerButton(wrapper)).toBeDefined();
-      expect(wrapper.findComponent(Spinner).exists()).toBe(true);
+      expect(registerButton(wrapper).find('svg.animate-spin').exists()).toBe(
+        true
+      );
     });
 
     it('does not leave the loading state on the element as an inert attribute', () => {
@@ -398,7 +404,9 @@ describe('AccountHealth', () => {
       });
 
       expect(registerButton(wrapper)).toBeDefined();
-      expect(wrapper.findComponent(Spinner).exists()).toBe(false);
+      expect(registerButton(wrapper).find('svg.animate-spin').exists()).toBe(
+        false
+      );
       expect(registerButton(wrapper).attributes('loading')).toBeUndefined();
     });
   });

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatExpandedRow.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/CsatExpandedRow.vue
@@ -122,7 +122,7 @@ const saveReviewNotes = async () => {
                   <Button
                     :label="$t('CSAT_REPORTS.REVIEW_NOTES.SAVE')"
                     :disabled="!hasChanges || isSaving"
-                    :loading="isSaving"
+                    :is-loading="isSaving"
                     size="xs"
                     @click.stop="saveReviewNotes"
                   />

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/CsatExpandedRow.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/CsatExpandedRow.spec.js
@@ -1,0 +1,119 @@
+import { mount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
+import Editor from 'dashboard/components-next/Editor/Editor.vue';
+import CsatExpandedRow from '../CsatExpandedRow.vue';
+
+const { alert } = vi.hoisted(() => ({ alert: vi.fn() }));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: key => key, te: () => false, locale: { value: 'en' } }),
+}));
+
+// Without this the component renders the paywall instead of the editor, and the save button this
+// is about never exists.
+vi.mock('dashboard/composables/useAccount', () => ({
+  useAccount: () => ({
+    isCloudFeatureEnabled: () => true,
+    isOnChatwootCloud: { value: false },
+  }),
+}));
+
+vi.mock('dashboard/composables', () => ({ useAlert: alert }));
+
+describe('CsatExpandedRow', () => {
+  // The save call is held open on purpose: `isSaving` is internal and only true between the
+  // dispatch and its resolution, so the in-flight state is unreachable unless the test owns when
+  // the promise settles.
+  const mountRow = () => {
+    let settle;
+    const update = vi.fn().mockImplementation(
+      () =>
+        new Promise(resolve => {
+          settle = resolve;
+        })
+    );
+    const store = createStore({
+      modules: {
+        csat: { namespaced: true, actions: { update } },
+      },
+    });
+
+    const wrapper = mount(CsatExpandedRow, {
+      props: { response: { id: 7, csat_review_notes: '' } },
+      global: {
+        plugins: [store],
+        mocks: { $t: key => key },
+        directives: { dompurifyHtml: () => {} },
+      },
+    });
+
+    return { wrapper, settle: () => settle(), update };
+  };
+
+  // `hasChanges` gates the click, so the note has to actually differ from what the response
+  // carries before the button will do anything.
+  const typeANote = async wrapper => {
+    await wrapper
+      .findComponent(Editor)
+      .vm.$emit('update:modelValue', 'The agent fixed it on the first reply');
+  };
+
+  const saveButton = wrapper =>
+    wrapper
+      .findAll('button')
+      .find(candidate =>
+        candidate.text().includes('CSAT_REPORTS.REVIEW_NOTES.SAVE')
+      );
+
+  it('draws the spinner on the save button while the write is in flight', async () => {
+    const { wrapper } = mountRow();
+    await typeANote(wrapper);
+
+    expect(saveButton(wrapper)).toBeDefined();
+    expect(wrapper.findComponent(Spinner).exists()).toBe(false);
+
+    await saveButton(wrapper).trigger('click');
+
+    expect(wrapper.findComponent(Spinner).exists()).toBe(true);
+  });
+
+  it('takes the spinner away once the write comes back', async () => {
+    const { wrapper, settle } = mountRow();
+    await typeANote(wrapper);
+    await saveButton(wrapper).trigger('click');
+
+    expect(wrapper.findComponent(Spinner).exists()).toBe(true);
+
+    settle();
+    await new Promise(resolve => {
+      setTimeout(resolve, 0);
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent(Spinner).exists()).toBe(false);
+  });
+
+  // The loading state used to arrive as `loading`, which is not declared on the component and not
+  // excluded from the attribute fallthrough, so it landed on the `<button>` element, where the
+  // browser ignores it. It shows in both states, because a bound `false` renders as the string
+  // "false" on an undeclared attribute.
+  it('never leaves the loading state on the element as an inert attribute', async () => {
+    const { wrapper } = mountRow();
+    await typeANote(wrapper);
+
+    expect(saveButton(wrapper).attributes('loading')).toBeUndefined();
+
+    await saveButton(wrapper).trigger('click');
+
+    expect(saveButton(wrapper).attributes('loading')).toBeUndefined();
+  });
+
+  it('still disables the button while saving, which is the half that already worked', async () => {
+    const { wrapper } = mountRow();
+    await typeANote(wrapper);
+    await saveButton(wrapper).trigger('click');
+
+    expect(saveButton(wrapper).attributes('disabled')).toBeDefined();
+  });
+});

--- a/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/CsatExpandedRow.spec.js
+++ b/app/javascript/dashboard/routes/dashboard/settings/reports/components/specs/CsatExpandedRow.spec.js
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import { createStore } from 'vuex';
-import Spinner from 'dashboard/components-next/spinner/Spinner.vue';
 import Editor from 'dashboard/components-next/Editor/Editor.vue';
 import CsatExpandedRow from '../CsatExpandedRow.vue';
 
@@ -71,11 +70,14 @@ describe('CsatExpandedRow', () => {
     await typeANote(wrapper);
 
     expect(saveButton(wrapper)).toBeDefined();
-    expect(wrapper.findComponent(Spinner).exists()).toBe(false);
+    expect(saveButton(wrapper).find('svg.animate-spin').exists()).toBe(false);
 
     await saveButton(wrapper).trigger('click');
 
-    expect(wrapper.findComponent(Spinner).exists()).toBe(true);
+    // Scoped to the button rather than to the tree. Only one button renders here today, so the
+    // two are equivalent right now; they stop being equivalent the moment a second one appears,
+    // and a tree-wide lookup would then pass with the spinner on the wrong one.
+    expect(saveButton(wrapper).find('svg.animate-spin').exists()).toBe(true);
   });
 
   it('takes the spinner away once the write comes back', async () => {
@@ -83,7 +85,7 @@ describe('CsatExpandedRow', () => {
     await typeANote(wrapper);
     await saveButton(wrapper).trigger('click');
 
-    expect(wrapper.findComponent(Spinner).exists()).toBe(true);
+    expect(saveButton(wrapper).find('svg.animate-spin').exists()).toBe(true);
 
     settle();
     await new Promise(resolve => {
@@ -91,7 +93,7 @@ describe('CsatExpandedRow', () => {
     });
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.findComponent(Spinner).exists()).toBe(false);
+    expect(saveButton(wrapper).find('svg.animate-spin').exists()).toBe(false);
   });
 
   // The loading state used to arrive as `loading`, which is not declared on the component and not


### PR DESCRIPTION
Closes #607.

## What was broken

`ButtonV4` (`dashboard/components-next/button/Button.vue`) declares the prop as `isLoading`, and that is the one the spinner reads:

```vue
<Spinner v-if="isLoading" class="!w-5 !h-5 flex-shrink-0" />
```

Two call sites passed `:loading` instead. `loading` is not in the prop list and not in `EXCLUDED_ATTRS`, so it fell through `useAttrs` onto the `<button>` element as a plain attribute, and the browser ignores it.

Measured in the rendered DOM rather than read off the template, mounting for real because `shallowMount` replaces the button with a stub that draws no spinner whichever prop it gets:

| | `loading` on the element | `disabled` | spinner in the tree |
| --- | --- | --- | --- |
| register webhook, in flight | `"true"` | `""` | **none** |
| register webhook, idle | `"false"` | absent | none |
| CSAT save, in flight | `"true"` | `""` | **none** |

The inert attribute shows up in **both** states, not only the busy one: a bound `false` renders as the string `"false"` on an undeclared attribute. So the idle case tells the broken code from the fixed one on its own.

Both call sites also pass `:disabled` with the same value, and that half works, so neither button could ever be submitted twice. What was missing was the feedback, and it matters most on the WhatsApp one: `POST .../register_webhook` writes to Meta and can take the whole Graph ceiling to come back, so the operator watched a button that looked idle for those seconds.

## The fence, and why the two lines are not enough on their own

417 other `.vue` files import the same component. Renaming two bindings without a fence resets the clock until somebody copies a line from the wrong one of them, so the fence is the part of this PR that actually closes the issue.

It resolves the component **by path**, against the aliases in `vite.shared.ts`, and derives each local name from the import. Neither shortcut reaches this tree, and the cost of each is measured:

- A substring filter on `components-next/button` misses the 20 files spelling it `next/button/Button.vue`, which is exactly where one of the two defects lived, and also the four relative spellings, one of which is `./Button.vue` and carries no `button/` segment at all. Five spellings are in use.
- A literal list of tag names is tied to today's vocabulary. Five local names are in use (`Button`, `NextButton`, `V4Button`, `ButtonV4`, `ButtonNext`), and the list of three this work arrived with was already missing two.
- Keying off the tag name also produces false positives, because `Button` is not exclusive to this component: `v3/components/GoogleOauth/Button.vue` is a different one.

The unit of the sweep is the whole opening tag, read to the first `>` outside quotes, because the offending binding sat on a line of its own in both real call sites and a sweep that reads to the end of the line finds nothing.

Quotes do two jobs there, and the first draft of this fence got only one of them right: they decide where the tag ends, and they decide what may be matched, because a value is data. Matching over the raw tag turned `:label="keep loading the report"` into a rejection. The matcher now runs against a skeleton of the tag where every quoted value is blanked and only attribute names survive.

## Validation scope

Red proof 7 failing examples with the two bindings put back, and the controls stay green in the same run: the `disabled` assertions on both buttons, and the 25 other examples.

Mutation battery **20 mutants, 16 dead**. Six of them came from the holdout verifier rather than from me, including the one that moved the spinner to the other button and the one that counts spreads off the raw tag.

Reverting either call site kills 4 each. On the fence: dropping the `:` from the matcher kills 9, going back to a substring filter kills 14, pinning the names to a list kills 16, reading only to the end of the line kills 17, removing the quote tracking kills 1, removing the attribute-name suffix guard kills 1, narrowing the spread pattern back to `attrs` kills 2, counting spreads off the raw tag kills 1, a second spread planted in the file that already has one kills 1, and breaking the alias resolver kills 17. Three mutants written to attack the fence's reach die too: not walking into `dashboard/routes` kills 1, not walking into `components-next` kills 3, and breaking the `next` alias alone kills 14.

The four survivors are one class, and it is structural rather than a coverage gap: each **deletes or weakens an assertion** in the test files themselves (the two floors, the pinned spread list, and putting the spinner assertion back to a tree-wide one). Removing an assertion cannot make a suite fail, so no suite can catch it; review is the only guard, which is why they sit in the diff rather than behind a helper.

What those assertions exist to catch is itself killed, and the holdout closed the step I had missed: with both floors relaxed to `> 0`, the mutant that skips `dashboard/routes` passes 20/20, while with the floors as written it fails exactly one example, the floor's own, with `expected 245 to be greater than 300`. That is what makes the floor load-bearing rather than merely redundant.

**Separately from those 20, one robustness case, and it passes.** A line added above the spread tag in `VoiceCallButton.vue` shifts its line number without changing any behaviour, and the fence must stay green. It is kept out of the mutation denominator on purpose: a mutant is a change under test whose detection is measured and surviving is a gap, while a robustness case is a benign edit and surviving is the pass condition. Mixing them into one ratio is not just untidy, it is the wrong incentive, because the score would improve by adding benign cases. The case only proves anything because the previous assertion **failed** it: pinned to the line it reports 1 failure, pinned to the file it passes 24/24, and comparing by file cost no detection, measured separately by the second-spread mutant above.

The fence measures its own reach in the same example that looks for the defect, because the risk here is not the false positive, it is the empty green: a sweep reporting zero offenders because it resolved zero files reads identically to one that found nothing wrong. Measured on this branch: 417 `.vue` files resolved and 171 correct bindings, with floors at 300 and 100 so a legitimate refactor does not trip them while moving `Button.vue` or renaming an alias turns the fence red.

The sweep of the tree cannot exercise the matcher, because after this fix there is no wrong call site left to find. So the matcher is measured against planted sources instead: all five specifier spellings, a local name that exists nowhere in the tree, the five attribute forms (`:loading`, `v-bind:loading`, static `loading="true"`, bare `loading`, and `:loading.attr`), each inside a multi-line tag, and counted rather than pattern-matched, since `0 rejections` is a substring of `10 rejections`.

### What the holdout found in the first draft

Four things, all measured against the code rather than argued, and all fixed in the second commit.

The spinner assertion swept the whole tree, and two `ButtonV4` render in that state. Moving the binding from the register button to the other one left the suite at 48 green while the DOM showed the spinner inside the button the operator did not click and nothing on the one they did, which is the defect this PR exists to close. The lookup by button text was already in the file, with a comment explaining why a tree-wide lookup cannot find the button; the next line then used a tree-wide lookup to find the spinner. Both assertions are now scoped to the button, and the mutant that moves the binding dies.

The spread count recognised only `attrs` and `$attrs`. A plain object does the same thing: `v-bind="buttonProps"` with `{ loading: true }` was mounted for real and produced `loading="true"` on the element with no spinner, the defect reproduced with no gate anywhere. Any spread on that tag now counts, held by a planted example, because the only spread in the tree binds `attrs` and narrowing the pattern back would otherwise change no count and go unnoticed.

Two guards against false positives had no example holding them, and the collisions they avoid are real in this tree rather than hypothetical: `:loading-message`, `:loading-placeholder` and `loading-more` exist as attributes, and five files import this Button as `Button` while also using `<ButtonGroup>`. Neither collision carries a `loading` today, which is exactly why removing either guard changed nothing. Both now have a planted example.

Widening the spread pattern then brought the false positive on the other side, which the holdout found on the next pass: the match ran against the raw tag, so a correct call site whose label or doc link contains the text `v-bind="..."` was counted as a spread and rejected. The spread is now recognised by its attribute name on the skeleton, where values are already blanked, and the planted example that pins it is the holdout's own case. Nothing in the tree hits it today: 856 tags of this component, 12 with a single-quoted attribute, and the only `v-bind` outside attribute position anywhere in `app/javascript` is a comment in a file carrying no tag of this component.

That pattern repeated twice in the same file and is worth naming: each fix to the sweep was correct and each left nothing holding it, so the next change could quietly undo it. A planted example is what closes that, not the fix itself.

One form escapes the sweep and is left that way on purpose: `:label="'x'":loading="busy"`, with no space between attributes, compiles with zero errors from `@vue/compiler-sfc` and slips the word-boundary anchor once the values are blanked. `eslint` rejects it first (`vue/no-parsing-error`, missing whitespace between attributes), and the pre-commit `lint-staged` runs `eslint --fix`, which inserts the space and turns it into a form the fence does catch. Worth stating plainly: `run_foss_spec.yml` runs vitest but not eslint, so for that one form the fence depends on a gate that lives in `frontend-fe.yml` and in the commit hook.

### The wrapper this fence does not reach

`ConfirmButton.vue` wraps this Button, declares its own `isLoading` and forwards it as `:is-loading`. A `<ConfirmButton :loading="x">` would therefore draw no spinner, and this fence would not see it: the fence resolves tags of `Button.vue`, and `ConfirmButton`'s root is a `<div>`, so the stray attribute stops there rather than reaching a `<button>`. Measured alongside it: 42 components in `app/javascript` declare an `isLoading` prop, and sweeping all 42 with the same matcher finds **zero** call sites passing `loading` to any of them today. So this is a door left open rather than a defect in flight, and it belongs to its own change rather than to this one.

### What a source sweep cannot close

A `loading` reaching the element from inside an attribute spread (`v-bind="attrs"`) or through a dynamic attribute name (`:[key]`) is invisible to any sweep of the source and stays a hole after this change. There is exactly one tag with a spread today, `components-next/Contacts/VoiceCallButton.vue:195`, and neither of its two callers passes `loading`, so nothing leaks. The fence pins that list exactly, so a second spread has to show up in review instead of landing quietly.

A census counting imports rather than templates gets 422 rather than 417: the five extra are `.spec.js` files that import the component to mount it in a test. They are not call sites, and only a `.vue` file carries a template, so the sweep stays on `.vue`. That leaves a render function building the tag in JavaScript (`h(Button, { loading })`) uncovered, which this tag-shaped matcher could not read anyway.

`vue/no-restricted-v-bind` was considered instead of the sweep and rejected: it matches a tag name and does not resolve imports, so it would carry both holes the fence exists to avoid. It is worth adding on top, not instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fazer-ai/chatwoot/634)
<!-- Reviewable:end -->



